### PR TITLE
[Chore] #3 redis, kafka, kafka-ui 포함한 docker-compose 추가

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,6 @@ services:
     image: apache/kafka:3.7.0
     container_name: kafka
     ports:
-      - "127.0.0.1:9092:9092"
       - "127.0.0.1:29092:29092"
     environment:
       KAFKA_NODE_ID: 1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     image: redis:7-alpine
     container_name: redis
     ports:
-      - "6379:6379"
+      - "127.0.0.1:6379:6379"
     networks:
       - ticketrush-net
     volumes:
@@ -15,8 +15,8 @@ services:
     image: apache/kafka:3.7.0
     container_name: kafka
     ports:
-      - "9092:9092"
-      - "29092:29092"
+      - "127.0.0.1:9092:9092"
+      - "127.0.0.1:29092:29092"
     environment:
       KAFKA_NODE_ID: 1
       KAFKA_PROCESS_ROLES: broker,controller
@@ -46,7 +46,7 @@ services:
     image: provectuslabs/kafka-ui:v0.7.2
     container_name: kafka-ui
     ports:
-      - "8085:8080"
+      - "127.0.0.1:8085:8080"
     environment:
       KAFKA_CLUSTERS_0_NAME: local
       KAFKA_CLUSTERS_0_BOOTSTRAPSERVERS: kafka:9092

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,64 @@
+version: "3.8"
+
+services:
+  redis:
+    image: redis:7-alpine
+    container_name: redis
+    ports:
+      - "6379:6379"
+    networks:
+      - ticketrush-net
+    volumes:
+      - redis_data:/data
+
+  kafka:
+    image: apache/kafka:3.7.0
+    container_name: kafka
+    ports:
+      - "9092:9092"
+      - "29092:29092"
+    environment:
+      KAFKA_NODE_ID: 1
+      KAFKA_PROCESS_ROLES: broker,controller
+      KAFKA_CLUSTER_ID: MkU3OEVBNTcwNTJENDM2Qk
+
+      KAFKA_CONTROLLER_QUORUM_VOTERS: 1@kafka:9093
+
+      KAFKA_LISTENERS: INTERNAL://0.0.0.0:9092,EXTERNAL://0.0.0.0:29092,CONTROLLER://0.0.0.0:9093
+      KAFKA_ADVERTISED_LISTENERS: INTERNAL://kafka:9092,EXTERNAL://localhost:29092
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: INTERNAL:PLAINTEXT,EXTERNAL:PLAINTEXT,CONTROLLER:PLAINTEXT
+      KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
+      KAFKA_INTER_BROKER_LISTENER_NAME: INTERNAL
+
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
+
+      KAFKA_LOG_DIRS: /var/lib/kafka/data
+
+    volumes:
+      - kafka-data:/var/lib/kafka/data
+
+    networks:
+      - ticketrush-net
+
+  kafka-ui:
+    image: provectuslabs/kafka-ui:v0.7.2
+    container_name: kafka-ui
+    ports:
+      - "8085:8080"
+    environment:
+      KAFKA_CLUSTERS_0_NAME: local
+      KAFKA_CLUSTERS_0_BOOTSTRAPSERVERS: kafka:9092
+    depends_on:
+      - kafka
+    networks:
+      - ticketrush-net
+
+volumes:
+  redis_data:
+  kafka-data:
+
+networks:
+  ticketrush-net:
+    driver: bridge

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,6 +41,13 @@ services:
     networks:
       - ticketrush-net
 
+    healthcheck:
+      test: [ "CMD-SHELL", "kafka-topics.sh --bootstrap-server localhost:9092 --list >/dev/null 2>&1 || exit 1" ]
+      interval: 10s
+      timeout: 10s
+      retries: 5
+      start_period: 20s
+
   kafka-ui:
     image: provectuslabs/kafka-ui:v0.7.2
     container_name: kafka-ui
@@ -50,7 +57,8 @@ services:
       KAFKA_CLUSTERS_0_NAME: local
       KAFKA_CLUSTERS_0_BOOTSTRAPSERVERS: kafka:9092
     depends_on:
-      - kafka
+      kafka:
+        condition: service_healthy
     networks:
       - ticketrush-net
 


### PR DESCRIPTION
## 🔗 관련 이슈

- close #3 

---

## 📌 주요 변경 사항

- 공통 환경 조성을 위해 redis, kafka, kafka-ui 포함한 docker-compose 추가
<!--
---

## 🛠 상세 구현 내용

-
-
-
-->
---

## ✅ 테스트

### 테스트 방법

- `docker compose up -d` 명령어로 컨테이너가 잘 뜨는지 확인

### 테스트 결과

- 3개의 컨테이너가 정상적으로 시작됨을 확인 완료

### 📸 스크린샷

<img width="1630" height="212" alt="image" src="https://github.com/user-attachments/assets/9fe07ed8-8aa9-4889-bba4-0218f9bb93f8" />

<img width="1788" height="191" alt="image" src="https://github.com/user-attachments/assets/558c60e6-57e7-4bd2-9d65-6dff99c4166d" />


---

## 👀 리뷰 요청 사항

- MySQL은 로컬에 있는 개인 MySQL로 실행하도록 하겠습니다.
<!--
---

## ⚠️ 배포 시 주의사항

-->
