### PR TITLE
[Chore] #13 GitHub Actions를 이용한 CI 파이프라인 구축

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,9 @@
 name: CI
 
 on:
-  push:
-    branches: [ "develop" ]
   pull_request:
     branches: [ "develop" ]
+    types: [opened, synchronize, reopened]
 
 jobs:
   build:
@@ -19,9 +18,33 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '21'
+          cache: 'gradle'
 
       - name: Gradle 권한 부여
         run: chmod +x gradlew
 
-      - name: 빌드 실행 (테스트 제외)
+      - name: Spotless Check
+        run: ./gradlew spotlessCheck
+
+      - name: Checkstyle
+        run: ./gradlew checkstyleMain checkstyleTest
+
+      - name: 테스트 실행 (Test)
+        run: ./gradlew test
+
+      - name: 테스트 결과 업로드
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-report
+          path: build/reports/tests/test/
+
+      - name: 빌드 실행 (Build)
         run: ./gradlew build -x test
+
+      - name: Checkstyle 리포트 업로드
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: checkstyle-report
+          path: build/reports/checkstyle/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  push:
+    branches: [ "develop" ]
+  pull_request:
+    branches: [ "develop" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: 코드 가져오기
+        uses: actions/checkout@v4
+
+      - name: JDK 21 설치
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+
+      - name: Gradle 권한 부여
+        run: chmod +x gradlew
+
+      - name: 빌드 실행 (테스트 제외)
+        run: ./gradlew build -x test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,13 @@ jobs:
       - name: Checkstyle
         run: ./gradlew checkstyleMain checkstyleTest
 
+      - name: Checkstyle 리포트 업로드
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: checkstyle-report
+          path: build/reports/checkstyle/
+
       - name: 테스트 실행 (Test)
         run: ./gradlew test
 
@@ -41,10 +48,3 @@ jobs:
 
       - name: 빌드 실행 (Build)
         run: ./gradlew build -x test
-
-      - name: Checkstyle 리포트 업로드
-        if: failure()
-        uses: actions/upload-artifact@v4
-        with:
-          name: checkstyle-report
-          path: build/reports/checkstyle/

--- a/auth-service/build.gradle
+++ b/auth-service/build.gradle
@@ -38,6 +38,7 @@ dependencies {
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
 	annotationProcessor 'org.projectlombok:lombok'
+	testImplementation 'com.h2database:h2'
 	testImplementation 'org.springframework.boot:spring-boot-starter-actuator-test'
 	testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
 	testImplementation 'org.springframework.boot:spring-boot-starter-security-test'

--- a/auth-service/src/test/java/com/ticketrush/AuthServiceApplicationTests.java
+++ b/auth-service/src/test/java/com/ticketrush/AuthServiceApplicationTests.java
@@ -9,6 +9,5 @@ import org.springframework.test.context.ActiveProfiles;
 class AuthServiceApplicationTests {
 
   @Test
-  void contextLoads() {
-  }
+  void contextLoads() {}
 }

--- a/auth-service/src/test/java/com/ticketrush/AuthServiceApplicationTests.java
+++ b/auth-service/src/test/java/com/ticketrush/AuthServiceApplicationTests.java
@@ -2,10 +2,13 @@ package com.ticketrush;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles("test")
 class AuthServiceApplicationTests {
 
   @Test
-  void contextLoads() {}
+  void contextLoads() {
+  }
 }

--- a/auth-service/src/test/java/com/ticketrush/AuthServiceApplicationTests.java
+++ b/auth-service/src/test/java/com/ticketrush/AuthServiceApplicationTests.java
@@ -2,10 +2,8 @@ package com.ticketrush;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
-@ActiveProfiles("test")
 class AuthServiceApplicationTests {
 
   @Test

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -38,6 +38,7 @@ dependencies {
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
 	annotationProcessor 'org.projectlombok:lombok'
+	testImplementation 'com.h2database:h2'
 	testImplementation 'org.springframework.boot:spring-boot-starter-actuator-test'
 	testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
 	testImplementation 'org.springframework.boot:spring-boot-starter-security-test'

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -54,3 +54,11 @@ dependencyManagement {
 tasks.named('test') {
 	useJUnitPlatform()
 }
+
+bootJar {
+	enabled = false
+}
+
+jar {
+	enabled = true
+}

--- a/common/src/test/java/com/ticketrush/AuthServiceApplicationTests.java
+++ b/common/src/test/java/com/ticketrush/AuthServiceApplicationTests.java
@@ -1,9 +1,7 @@
 package com.ticketrush;
 
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.context.SpringBootTest;
 
-@SpringBootTest
 class AuthServiceApplicationTests {
 
   @Test

--- a/gateway-service/build.gradle
+++ b/gateway-service/build.gradle
@@ -39,6 +39,7 @@ dependencies {
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
 	annotationProcessor 'org.projectlombok:lombok'
+	testImplementation 'com.h2database:h2'
 	testImplementation 'org.springframework.boot:spring-boot-starter-actuator-test'
 	testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
 	testImplementation 'org.springframework.boot:spring-boot-starter-security-test'

--- a/order-service/build.gradle
+++ b/order-service/build.gradle
@@ -38,6 +38,7 @@ dependencies {
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
 	annotationProcessor 'org.projectlombok:lombok'
+	testImplementation 'com.h2database:h2'
 	testImplementation 'org.springframework.boot:spring-boot-starter-actuator-test'
 	testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
 	testImplementation 'org.springframework.boot:spring-boot-starter-security-test'

--- a/payment-service/build.gradle
+++ b/payment-service/build.gradle
@@ -38,6 +38,7 @@ dependencies {
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
 	annotationProcessor 'org.projectlombok:lombok'
+	testImplementation 'com.h2database:h2'
 	testImplementation 'org.springframework.boot:spring-boot-starter-actuator-test'
 	testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
 	testImplementation 'org.springframework.boot:spring-boot-starter-security-test'

--- a/ticket-service/build.gradle
+++ b/ticket-service/build.gradle
@@ -38,6 +38,7 @@ dependencies {
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
 	annotationProcessor 'org.projectlombok:lombok'
+	testImplementation 'com.h2database:h2'
 	testImplementation 'org.springframework.boot:spring-boot-starter-actuator-test'
 	testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
 	testImplementation 'org.springframework.boot:spring-boot-starter-security-test'

--- a/user-service/build.gradle
+++ b/user-service/build.gradle
@@ -38,6 +38,7 @@ dependencies {
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
 	annotationProcessor 'org.projectlombok:lombok'
+	testImplementation 'com.h2database:h2'
 	testImplementation 'org.springframework.boot:spring-boot-starter-actuator-test'
 	testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
 	testImplementation 'org.springframework.boot:spring-boot-starter-security-test'


### PR DESCRIPTION
## 🔗 관련 이슈

- close #14 

---

## 📌 주요 변경 사항

**Branch 명 수정하여 PR재요청** 
- GitHub Actions 기반 CI 파이프라인 구축
- develop 브랜치 대상 push 및 pull request 시 자동 빌드 실행 설정
- Gradle Wrapper 기반 빌드 환경 구성
- Java 21 환경 자동 설정
---

## 🛠 상세 구현 내용

- .github/workflows/ci.yml 파일 생성 및 CI 파이프라인 구축
- 코드 품질 관리 도구 도입: Spotless 및 Checkstyle 단계를 추가하여 코드 컨벤션 자동 검증
- 테스트 환경 구축: * 리뷰어 피드백을 반영하여 CI 단계 내 ./gradlew test 명시적 실행
- test 프로필 분리를 통해 CI 환경에서는 H2 인메모리 DB를 사용하도록 설정 (실제 DB 의존성 제거)
- 테스트 실패 시 원인 파악을 위한 Test Report 아티팩트 업로드 설정 추가
- 빌드 최적화: actions/setup-java의 캐싱 기능을 활용하고, 최종 빌드 시 중복 테스트 방지 (-x test)

---

## ✅ 테스트

### 테스트 방법

- chore/ci-setup 브랜치 push 시 GitHub Actions 워크플로우 자동 트리거 확인
- Spotless, Checkstyle, Test, Build 각 단계의 순차적 성공 여부 검증

### 테스트 결과

- GitHub Actions에서 build 단계 정상 수행
- Gradle build 성공 (BUILD SUCCESSFUL 확인)

<!--### 📸 스크린샷-->

---  

<!--## 👀 리뷰 요청 사항

리뷰어가 특히 봐주었으면 하는 부분이 있다면 작성해주세요.

- CI 파이프라인 구조 및 설정 방식 검토 요청


---
-->
## ⚠️ 배포 시 주의사항
- 테스트 프로필 분리: 테스트 실행 시 전용 프로필(test)을 사용하며, H2 인메모리 DB를 바라보도록 설정되어 있습니다.
- 의존성 관리: 각 모듈의 build.gradle에 testImplementation 'com.h2database:h2'가 추가되어 있으므로, 로컬 환경에서도 테스트 실행 시 별도의 DB 설치 없이 즉시 검증이 가능합니다.
- 컨벤션 체크: Spotless와 Checkstyle이 파이프라인에 포함되어 있습니다. 빌드 실패 시 GitHub Actions의 Artifacts 탭에서 상세 리포트를 확인하여 수정 후 재푸시가 필요합니다.