### PR TITLE
[Feat] #26 BaseEntity 생성

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -28,6 +28,9 @@ ext {
 	set('springCloudVersion', "2025.1.0")
 }
 
+// OpenFeign QueryDSL version
+def queryDslVersion = "6.10.1"
+
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
@@ -45,11 +48,13 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
-	// QueryDSL
-	implementation 'com.querydsl:querydsl-jpa:5.1.0:jakarta'
-	annotationProcessor "com.querydsl:querydsl-apt:5.1.0:jakarta"
+	// OpenFeign QueryDSL
+	implementation "io.github.openfeign.querydsl:querydsl-jpa:${queryDslVersion}"
+	annotationProcessor "io.github.openfeign.querydsl:querydsl-apt:${queryDslVersion}:jpa"
 	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
 	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+	testAnnotationProcessor "io.github.openfeign.querydsl:querydsl-apt:${queryDslVersion}:jpa"
+	testAnnotationProcessor "jakarta.persistence:jakarta.persistence-api"
 }
 
 dependencyManagement {

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -44,6 +44,12 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-security-test'
 	testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	// QueryDSL
+	implementation 'com.querydsl:querydsl-jpa:5.1.0:jakarta'
+	annotationProcessor "com.querydsl:querydsl-apt:5.1.0:jakarta"
+	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 }
 
 dependencyManagement {

--- a/common/src/main/java/com/ticketrush/global/jpa/config/JpaConfig.java
+++ b/common/src/main/java/com/ticketrush/global/jpa/config/JpaConfig.java
@@ -1,0 +1,21 @@
+package com.ticketrush.global.jpa.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+@RequiredArgsConstructor
+public class JpaConfig {
+
+  private final EntityManager entityManager;
+
+  @Bean
+  public JPAQueryFactory jpaQueryFactory() {
+    return new JPAQueryFactory(entityManager);
+  }
+}

--- a/common/src/main/java/com/ticketrush/global/jpa/entity/AutoIdBaseEntity.java
+++ b/common/src/main/java/com/ticketrush/global/jpa/entity/AutoIdBaseEntity.java
@@ -1,0 +1,16 @@
+package com.ticketrush.global.jpa.entity;
+
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+
+@Getter
+@MappedSuperclass
+public abstract class AutoIdBaseEntity extends BaseTimeEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+}

--- a/common/src/main/java/com/ticketrush/global/jpa/entity/BaseTimeEntity.java
+++ b/common/src/main/java/com/ticketrush/global/jpa/entity/BaseTimeEntity.java
@@ -1,0 +1,22 @@
+package com.ticketrush.global.jpa.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTimeEntity {
+
+  @CreatedDate
+  @Column(updatable = false)
+  private LocalDateTime createdAt;
+
+  @LastModifiedDate private LocalDateTime updatedAt;
+}

--- a/common/src/main/java/com/ticketrush/global/jpa/entity/ManualIdBaseEntity.java
+++ b/common/src/main/java/com/ticketrush/global/jpa/entity/ManualIdBaseEntity.java
@@ -1,0 +1,23 @@
+package com.ticketrush.global.jpa.entity;
+
+import jakarta.persistence.Id;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.domain.Persistable;
+
+@Getter
+@MappedSuperclass
+public abstract class ManualIdBaseEntity extends BaseTimeEntity implements Persistable<Long> {
+
+  @Id private Long id;
+
+  protected void assignId(Long id) {
+    this.id = id;
+  }
+
+  // JPA에게 새로운 엔티티인지 판단하는 기준을 제공
+  @Override
+  public boolean isNew() {
+    return getCreatedAt() == null;
+  }
+}


### PR DESCRIPTION
## 🔗 관련 이슈

- close #26 

---

## 📌 주요 변경 사항
- `JpaConfig` 전역 설정 클래스 추가
- JPA Auditing을 활용한 공통 엔티티(BaseEntity) 3단계 구조 셋업
- ID 자동 생성 엔티티와 수동 할당 엔티티를 분리하여 구현

---

## 🛠 상세 구현 내용
- `JpaConfig` 전역 설정 클래스 추가
  - `@EnableJpaAuditing` 어노테이션을 추가하여 Spring Data JPA Auditing 기능 활성화
  - QueryDSL 사용을 위한 `JPAQueryFactory` 빈(`Bean`) 등록
- `BaseTimeEntity` : 모든 엔티티가 상속받는 최상위 클래스로, 생성일(createdAt)과 수정일(updatedAt)을 자동 관리합니다.

- `AutoIdBaseEntity` : 가장 범용적으로 쓰이는 엔티티입니다. `GenerationType.IDENTITY`를 사용하여 ID를 자동 생성합니다.

- `ManualIdBaseEntity` : 외부 식별자나 비즈니스 키를 PK로 사용할 때 적용합니다.
  - 수동으로 ID를 할당할 때 발생하는 JPA의 불필요한 SELECT 쿼리를 방지하기 위해 Persistable<Long>을 implement했습니다.
  - `isNew()` 메서드를 오버라이딩하여, `createdAt`이 null일 경우 새로운 엔티티로 인식하도록 최적화했습니다.

- `build.gradle`에 QueryDSL 관련 의존성(dependency) 추가

<!--
---

## ✅ 테스트

### 테스트 방법

-

### 테스트 결과

-

### 📸 스크린샷
-->
---

## 👀 리뷰 요청 사항

- 추후 모듈별 도메인 생성 시 목적에 맞게 `AutoIdBaseEntity` 혹은 `ManualIdBaseEntity`를 extends 해서 사용해 주세요!

<!--
---

## ⚠️ 배포 시 주의사항

- 

-->