### PR TITLE
[Feat] #83 티켓 도메인 생성

### DIFF
--- a/ticket-service/build.gradle
+++ b/ticket-service/build.gradle
@@ -29,6 +29,7 @@ ext {
 }
 
 dependencies {
+	implementation project(":common")
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-security'

--- a/ticket-service/src/main/java/com/ticketrush/boundedcontext/ticket/domain/entity/Ticket.java
+++ b/ticket-service/src/main/java/com/ticketrush/boundedcontext/ticket/domain/entity/Ticket.java
@@ -1,0 +1,43 @@
+package com.ticketrush.boundedcontext.ticket.domain.entity;
+
+import com.ticketrush.boundedcontext.ticket.domain.types.TicketStatus;
+import com.ticketrush.global.jpa.entity.AutoIdBaseEntity;
+import jakarta.persistence.AttributeOverride;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "ticket")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AttributeOverride(name = "id", column = @Column(name = "ticket_id"))
+public class Ticket extends AutoIdBaseEntity {
+
+  @Column(name = "booking_id", nullable = false)
+  private Long bookingId;
+
+  @Column(name = "booking_number", length = 50, nullable = false)
+  private String bookingNumber;
+
+  @Column(name = "qr_code_url", length = 255, nullable = false)
+  private String qrCodeUrl;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "ticket_status", length = 20, nullable = false)
+  private TicketStatus ticketStatus;
+
+  @Builder
+  public Ticket(Long bookingId, String bookingNumber, String qrCodeUrl, TicketStatus ticketStatus) {
+    this.bookingId = bookingId;
+    this.bookingNumber = bookingNumber;
+    this.qrCodeUrl = qrCodeUrl;
+    this.ticketStatus = ticketStatus;
+  }
+}

--- a/ticket-service/src/main/java/com/ticketrush/boundedcontext/ticket/domain/types/TicketStatus.java
+++ b/ticket-service/src/main/java/com/ticketrush/boundedcontext/ticket/domain/types/TicketStatus.java
@@ -1,0 +1,14 @@
+package com.ticketrush.boundedcontext.ticket.domain.types;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum TicketStatus {
+  VALID("유효함"), // 예매가 확정되어 발급된 정상 티켓
+  USED("사용 완료"), // 공연장 입구에서 QR 스캔을 통해 입장이 완료된 상태
+  CANCELED("취소됨"); // 사용자가 예매를 취소하여 무효화된 티켓
+
+  private final String description;
+}

--- a/ticket-service/src/main/resources/application-local.yml
+++ b/ticket-service/src/main/resources/application-local.yml
@@ -1,0 +1,10 @@
+spring:
+  datasource:
+    url: jdbc:mysql://localhost:3306/ticket_rush
+    username: ${MYSQL_USERNAME}
+    password: ${MYSQL_PASSWORD}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+  jpa:
+    hibernate:
+      ddl-auto: ${SPRING_JPA_HIBERNATE_DDL_AUTO:update}
+    open-in-view: false


### PR DESCRIPTION
## 🔗 관련 이슈

- close #83 

---

## 📌 주요 변경 사항

- 티켓 도메인 생성
  - `Ticket`
  - `TicketStatus`

<!--
---

## 🛠 상세 구현 내용

-
-
-
-->
---

## ✅ 테스트

### 테스트 방법

- MySQL에서 티켓 테이블 생성 확인

### 테스트 결과

- ERD에 맞게 테이블이 올바르게 생성되었습니다.

### 📸 스크린샷

- ERD 사진

<img width="793" height="206" alt="image" src="https://github.com/user-attachments/assets/f00eedee-3c0b-47d0-9bee-a860c26f017d" />

- MySQL 티켓 테이블 생성 확인 사진

<img width="1161" height="142" alt="스크린샷 2026-03-22 155247" src="https://github.com/user-attachments/assets/f160638a-4dde-4ef4-b25a-fcbadedde36a" />

---

## 👀 리뷰 요청 사항

- 티켓 모듈 (`ticket-service`)을 티켓 및 QR 코드 인증 관련 로직을 모아 놓는 모듈로 사용하겠습니다.
- @calla1102 공연 모듈은 `performanc-service`로 새로 생성해주세요!

<!--
---

## ⚠️ 배포 시 주의사항

- 
-->