### PR TITLE
[Chore] #46 전역 API 정상/에러 공통 응답 포맷(ApiResponse) 적용

### DIFF
--- a/common/src/main/java/com/ticketrush/global/response/ApiResponse.java
+++ b/common/src/main/java/com/ticketrush/global/response/ApiResponse.java
@@ -1,0 +1,53 @@
+package com.ticketrush.global.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.ticketrush.global.status.ErrorStatus;
+import com.ticketrush.global.status.SuccessStatus;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.ResponseEntity;
+
+@Getter
+@AllArgsConstructor
+// 성공여부, 상태 코드, 메세지, 실제 데이터값
+@JsonPropertyOrder({"isSuccess", "code", "message", "result"})
+public class ApiResponse<T> {
+
+  private final Boolean isSuccess;
+  private final String code;
+  private final String message;
+
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  private final T result;
+
+  // 성공 - 기본 응답
+  public static ResponseEntity<ApiResponse> onSuccess(SuccessStatus status) {
+    return new ResponseEntity<>(
+        new ApiResponse(true, status.getCode(), status.getMessage(), null), status.getHttpStatus());
+  }
+
+  // 성공 - 데이터 포함
+  public static <T> ResponseEntity<ApiResponse> onSuccess(SuccessStatus status, T result) {
+    return new ResponseEntity<>(
+        new ApiResponse(true, status.getCode(), status.getMessage(), result),
+        status.getHttpStatus());
+  }
+
+  // 실패한 경우 응답 생성
+  public static ResponseEntity<ApiResponse> onFailure(ErrorStatus error) {
+    return new ResponseEntity<>(
+        new ApiResponse(false, error.getCode(), error.getMessage(), null), error.getHttpStatus());
+  }
+
+  public static ResponseEntity<ApiResponse> onFailure(ErrorStatus error, String message) {
+    return new ResponseEntity<>(
+        new ApiResponse(false, error.getCode(), error.getMessage(message), null),
+        error.getHttpStatus());
+  }
+
+  public static ResponseEntity<ApiResponse> onFailure(ErrorStatus error, Object data) {
+    return new ResponseEntity<>(
+        new ApiResponse(false, error.getCode(), error.getMessage(), data), error.getHttpStatus());
+  }
+}

--- a/common/src/main/java/com/ticketrush/global/status/ErrorStatus.java
+++ b/common/src/main/java/com/ticketrush/global/status/ErrorStatus.java
@@ -15,7 +15,7 @@ public enum ErrorStatus {
   FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON_403", "금지된 요청입니다."),
   NOT_FOUND(HttpStatus.NOT_FOUND, "COMMON_404", "페이지를 찾을 수 없습니다."),
   // 입력값 검증 관련 에러
-  VALIDATION_ERROR(HttpStatus.BAD_REQUEST, "VALID_401", "입력값이 올바르지 않습니다.");
+  VALIDATION_ERROR(HttpStatus.BAD_REQUEST, "VALID_400", "입력값이 올바르지 않습니다.");
 
   private final HttpStatus httpStatus;
   private final String code;

--- a/common/src/main/java/com/ticketrush/global/status/ErrorStatus.java
+++ b/common/src/main/java/com/ticketrush/global/status/ErrorStatus.java
@@ -1,0 +1,29 @@
+package com.ticketrush.global.status;
+
+import java.util.Optional;
+import java.util.function.Predicate;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorStatus {
+  INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON_500", "서버 에러, 관리자에게 문의 바랍니다."),
+  BAD_REQUEST(HttpStatus.BAD_REQUEST, "COMMON_400", "잘못된 요청입니다."),
+  UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "COMMON_401", "인증이 필요합니다."),
+  FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON_403", "금지된 요청입니다."),
+  NOT_FOUND(HttpStatus.NOT_FOUND, "COMMON_404", "페이지를 찾을 수 없습니다."),
+  // 입력값 검증 관련 에러
+  VALIDATION_ERROR(HttpStatus.BAD_REQUEST, "VALID_401", "입력값이 올바르지 않습니다.");
+
+  private final HttpStatus httpStatus;
+  private final String code;
+  private final String message;
+
+  public String getMessage(String message) {
+    return Optional.ofNullable(message)
+        .filter(Predicate.not(String::isBlank))
+        .orElse(this.getMessage());
+  }
+}

--- a/common/src/main/java/com/ticketrush/global/status/SuccessStatus.java
+++ b/common/src/main/java/com/ticketrush/global/status/SuccessStatus.java
@@ -1,0 +1,17 @@
+package com.ticketrush.global.status;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum SuccessStatus {
+  OK(HttpStatus.OK, "COMMON_200", "성공입니다."),
+  CREATED(HttpStatus.CREATED, "COMMON_201", "리소스가 성공적으로 생성되었습니다."),
+  NO_CONTENT(HttpStatus.NO_CONTENT, "COMMON_204", "요청이 성공적으로 처리되었습니다.");
+
+  private final HttpStatus httpStatus;
+  private final String code;
+  private final String message;
+}


### PR DESCRIPTION
## 🔗 관련 이슈

- close #46 



## 🛠 상세 구현 내용

- 공통 응답 포맷 ApiResponse 구현
- ErrorStatus, SuccessStatus enum 정의
- ErrorStatus, SuccessStatus 를 통해 적용




### 📸 스크린샷

- 예시
<img width="750" height="308" alt="image" src="https://github.com/user-attachments/assets/946f60b7-157d-415e-809b-f96856d6fecc" />
