### PR TITLE
[Feat] #23 [결제] 결제 및 환불 도메인 엔티티 설계

### DIFF
--- a/auth-service/src/test/java/com/ticketrush/AuthServiceApplicationTests.java
+++ b/auth-service/src/test/java/com/ticketrush/AuthServiceApplicationTests.java
@@ -3,7 +3,7 @@ package com.ticketrush;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
-@SpringBootTest
+@SpringBootTest(classes = AuthServiceApplicationTests.class)
 class AuthServiceApplicationTests {
 
   @Test

--- a/booking-service/src/test/java/com/ticketrush/BookingServiceApplicationTests.java
+++ b/booking-service/src/test/java/com/ticketrush/BookingServiceApplicationTests.java
@@ -3,7 +3,7 @@ package com.ticketrush;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
-@SpringBootTest
+@SpringBootTest(classes = BookingServiceApplicationTests.class)
 class BookingServiceApplicationTests {
 
   @Test

--- a/gateway-service/src/test/java/com/ticketrush/GatewayServiceApplicationTests.java
+++ b/gateway-service/src/test/java/com/ticketrush/GatewayServiceApplicationTests.java
@@ -3,7 +3,7 @@ package com.ticketrush;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
-@SpringBootTest
+@SpringBootTest(classes = GatewayServiceApplicationTests.class)
 class GatewayServiceApplicationTests {
 
   @Test

--- a/payment-service/build.gradle
+++ b/payment-service/build.gradle
@@ -30,6 +30,7 @@ ext {
 
 dependencies {
 	implementation project(":common")
+	implementation project(":booking-service")
 
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/domain/entity/Payment.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/domain/entity/Payment.java
@@ -1,6 +1,7 @@
 package com.ticketrush.boundedcontext.payment.domain.entity;
 
 import com.ticketrush.boundedcontext.booking.domain.entity.Booking;
+import com.ticketrush.boundedcontext.payment.domain.types.PaymentProvider;
 import com.ticketrush.boundedcontext.payment.domain.types.PaymentStatus;
 import com.ticketrush.global.jpa.entity.AutoIdBaseEntity;
 import jakarta.persistence.AttributeOverride;
@@ -10,7 +11,7 @@ import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
-import jakarta.persistence.OneToOne;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
@@ -25,12 +26,13 @@ import lombok.NoArgsConstructor;
 @AttributeOverride(name = "id", column = @Column(name = "payment_id"))
 public class Payment extends AutoIdBaseEntity {
 
-  @OneToOne(fetch = FetchType.LAZY)
+  @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "booking_id", nullable = false)
   private Booking booking;
 
-  @Column(nullable = false, length = 50)
-  private String provider; // 결제 수단 (예: KAKAO, NAVER)
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false)
+  private PaymentProvider provider; // 결제 수단 (예: KAKAO, NAVER)
 
   @Column(nullable = false)
   private Long amount; // 결제 금액
@@ -43,7 +45,7 @@ public class Payment extends AutoIdBaseEntity {
 
   @Builder
   private Payment(
-      Booking booking, String provider, Long amount, PaymentStatus status, LocalDateTime paidAt) {
+      Booking booking, PaymentProvider provider, Long amount, PaymentStatus status, LocalDateTime paidAt) {
     this.booking = booking;
     this.provider = provider;
     this.amount = amount;

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/domain/entity/Payment.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/domain/entity/Payment.java
@@ -1,0 +1,53 @@
+package com.ticketrush.boundedcontext.payment.domain.entity;
+
+import com.ticketrush.boundedcontext.booking.domain.entity.Booking;
+import com.ticketrush.boundedcontext.payment.domain.types.PaymentStatus;
+import com.ticketrush.global.jpa.entity.AutoIdBaseEntity;
+import jakarta.persistence.AttributeOverride;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "payment") // 테이블명은 소문자 규칙 준수
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED) // 기본 생성자 접근 제어 [cite: 97]
+@AttributeOverride(name = "id", column = @Column(name = "payment_id"))
+public class Payment extends AutoIdBaseEntity {
+
+  @OneToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "booking_id", nullable = false)
+  private Booking booking;
+
+  @Column(nullable = false, length = 50)
+  private String provider; // 결제 수단 (예: KAKAO, NAVER)
+
+  @Column(nullable = false)
+  private Long amount; // 결제 금액
+
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false)
+  private PaymentStatus status; // 결제 상태 (PENDING, COMPLETED 등) [cite: 90]
+
+  private LocalDateTime paidAt; // 결제 완료 시점
+
+  @Builder
+  private Payment(
+      Booking booking, String provider, Long amount, PaymentStatus status, LocalDateTime paidAt) {
+    this.booking = booking;
+    this.provider = provider;
+    this.amount = amount;
+    this.status = status;
+    this.paidAt = paidAt;
+  }
+}

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/domain/entity/Payment.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/domain/entity/Payment.java
@@ -45,7 +45,11 @@ public class Payment extends AutoIdBaseEntity {
 
   @Builder
   private Payment(
-      Booking booking, PaymentProvider provider, Long amount, PaymentStatus status, LocalDateTime paidAt) {
+      Booking booking,
+      PaymentProvider provider,
+      Long amount,
+      PaymentStatus status,
+      LocalDateTime paidAt) {
     this.booking = booking;
     this.provider = provider;
     this.amount = amount;

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/domain/entity/Refund.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/domain/entity/Refund.java
@@ -1,0 +1,48 @@
+package com.ticketrush.boundedcontext.payment.domain.entity;
+
+import com.ticketrush.boundedcontext.booking.domain.entity.Booking;
+import com.ticketrush.boundedcontext.payment.domain.types.RefundStatus;
+import com.ticketrush.global.jpa.entity.AutoIdBaseEntity;
+import jakarta.persistence.AttributeOverride;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "refund") // 테이블명 소문자 규칙 [cite: 65]
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AttributeOverride(name = "id", column = @Column(name = "refund_id"))
+public class Refund extends AutoIdBaseEntity {
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "booking_id", nullable = false)
+  private Booking booking;
+
+  @Column(nullable = false)
+  private Long price; // 환불 금액
+
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false)
+  private RefundStatus status; // 환불 상태 (PENDING, COMPLETED 등)
+
+  private LocalDateTime confirmedAt; // {동사}edAt 규칙 준수 [cite: 65]
+
+  @Builder
+  private Refund(Booking booking, Long price, RefundStatus status, LocalDateTime confirmedAt) {
+    this.booking = booking;
+    this.price = price;
+    this.status = status;
+    this.confirmedAt = confirmedAt;
+  }
+}

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/domain/entity/Refund.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/domain/entity/Refund.java
@@ -33,7 +33,7 @@ public class Refund extends AutoIdBaseEntity {
   private Long price; // 환불 금액
 
   @Enumerated(EnumType.STRING)
-  @Column(nullable = false)
+  @Column(name = "status", length = 20, nullable = true)
   private RefundStatus status; // 환불 상태 (PENDING, COMPLETED 등)
 
   private LocalDateTime confirmedAt; // {동사}edAt 규칙 준수 [cite: 65]

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/domain/types/PaymentProvider.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/domain/types/PaymentProvider.java
@@ -1,0 +1,7 @@
+package com.ticketrush.boundedcontext.payment.domain.types;
+
+public enum PaymentProvider {
+    KAKAO,
+    NAVER,
+    TOSS
+}

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/domain/types/PaymentProvider.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/domain/types/PaymentProvider.java
@@ -1,7 +1,7 @@
 package com.ticketrush.boundedcontext.payment.domain.types;
 
 public enum PaymentProvider {
-    KAKAO,
-    NAVER,
-    TOSS
+  KAKAO,
+  NAVER,
+  TOSS
 }

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/domain/types/PaymentStatus.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/domain/types/PaymentStatus.java
@@ -1,0 +1,15 @@
+package com.ticketrush.boundedcontext.payment.domain.types;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum PaymentStatus {
+  PENDING("결제 대기"),
+  COMPLETED("결제 완료"),
+  CANCELED("결제 취소"),
+  FAILED("결제 실패");
+
+  private final String description;
+}

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/domain/types/RefundStatus.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/domain/types/RefundStatus.java
@@ -1,0 +1,14 @@
+package com.ticketrush.boundedcontext.payment.domain.types;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum RefundStatus {
+  PENDING("환불 대기"),
+  COMPLETED("환불 완료"),
+  FAILED("환불 실패");
+
+  private final String description;
+}

--- a/payment-service/src/test/java/com/ticketrush/PaymentServiceApplicationTests.java
+++ b/payment-service/src/test/java/com/ticketrush/PaymentServiceApplicationTests.java
@@ -3,7 +3,7 @@ package com.ticketrush;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
-@SpringBootTest
+@SpringBootTest(classes = PaymentServiceApplication.class)
 class PaymentServiceApplicationTests {
 
   @Test

--- a/seat-service/src/test/java/com/ticketrush/SeatServiceApplicationTests.java
+++ b/seat-service/src/test/java/com/ticketrush/SeatServiceApplicationTests.java
@@ -3,7 +3,7 @@ package com.ticketrush;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
-@SpringBootTest
+@SpringBootTest(classes = SeatServiceApplicationTests.class)
 class SeatServiceApplicationTests {
 
   @Test

--- a/ticket-service/src/test/java/com/ticketrush/TicketServiceApplicationTests.java
+++ b/ticket-service/src/test/java/com/ticketrush/TicketServiceApplicationTests.java
@@ -3,7 +3,7 @@ package com.ticketrush;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
-@SpringBootTest
+@SpringBootTest(classes = TicketServiceApplicationTests.class)
 class TicketServiceApplicationTests {
 
   @Test

--- a/user-service/src/test/java/com/ticketrush/UserServiceApplicationTests.java
+++ b/user-service/src/test/java/com/ticketrush/UserServiceApplicationTests.java
@@ -3,7 +3,7 @@ package com.ticketrush;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
-@SpringBootTest
+@SpringBootTest(classes = UserServiceApplicationTests.class)
 class UserServiceApplicationTests {
 
   @Test


### PR DESCRIPTION
## 🔗 관련 이슈

- close #23

---

## 📌 주요 변경 사항

- Payment/Refund 도메인 엔티티 및 상태 타입(PaymentStatus, RefundStatus) 설계 
- Performance 도메인 신규 모듈 생성 및 엔티티(Genre, PerformanceStatus 포함) 설계 
- 각 서비스(Auth, Booking, Payment 등)의 테스트 설정 최적화 및 performance-service 프로젝트 구성

---

## 🛠 상세 구현 내용
 
- 엔티티 설계 표준 준수:
  - 모든 엔티티에 @Getter, @NoArgsConstructor(access = AccessLevel.PROTECTED), 
  - @Builder 적용 @Table 명칭을 소문자로 지정하여 DB 컨벤션 준수 (예: payment, refund, performance) 
- 도메인 모델 구조: DDD 기반의 boundedcontext 패키지 구조 내에 domain/entity와 domain/types를 구분하여 배치 
- 환경 설정: Java 21 및 Spring Boot 4.x(LTS) 환경에 맞춘 performance-service의 build.gradle 및 application-local.yml 구성 

---

## ✅ 테스트

### 테스트 방법

- 각 ApplicationTests 클래스의 로드 테스트를 통한 컨텍스트 초기화 확인

### 테스트 결과

- Auth, Booking, Payment, Performance 등 전 모듈의 테스트 케이스 정상 통과

<!--
### 📸 스크린샷

---
-->
## 👀 리뷰 요청 사항

- 엔티티 매핑: Payment와 Booking의 1:1 관계 및 Refund와 Booking의 N:1 관계 설정이 도메인 요구사항에 적합한지 검토 부탁드립니다.
- 공통 모듈 참조: payment-service와 performance-service에서 :common 프로젝트의 엔티티(AutoIdBaseEntity) 상속 구조가 올바르게 작동하는지 확인해 주세요.

---
<!--
## ⚠️ 배포 시 주의사항

-->
