### PR TITLE
[Infra] #51 전역 JSON 직렬화/역직렬화(Jackson) 환경 설정 및 포맷 통일

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -57,9 +57,6 @@ dependencies {
 	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 	testAnnotationProcessor "io.github.openfeign.querydsl:querydsl-apt:${queryDslVersion}:jpa"
 	testAnnotationProcessor "jakarta.persistence:jakarta.persistence-api"
-
-	// Jackson
-	implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
 }
 
 dependencyManagement {

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -36,7 +36,6 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-webmvc'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -36,6 +36,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-webmvc'
+	implementation 'org.springframework.boot:spring-boot-starter-web'
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
@@ -57,6 +58,9 @@ dependencies {
 	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 	testAnnotationProcessor "io.github.openfeign.querydsl:querydsl-apt:${queryDslVersion}:jpa"
 	testAnnotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
+	// Jackson
+	implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
 }
 
 dependencyManagement {

--- a/common/src/main/java/com/ticketrush/global/config/JacksonConfig.java
+++ b/common/src/main/java/com/ticketrush/global/config/JacksonConfig.java
@@ -1,14 +1,15 @@
 package com.ticketrush.global.config;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.PropertyNamingStrategies;
-import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
+import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import org.springframework.boot.jackson.autoconfigure.JsonMapperBuilderCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import tools.jackson.databind.PropertyNamingStrategies;
+import tools.jackson.databind.ext.javatime.deser.LocalDateTimeDeserializer;
+import tools.jackson.databind.ext.javatime.ser.LocalDateTimeSerializer;
+import tools.jackson.databind.module.SimpleModule;
 
 @Configuration
 public class JacksonConfig {
@@ -16,25 +17,22 @@ public class JacksonConfig {
   private static final String DATETIME_FORMAT = "yyyy-MM-dd HH:mm:ss";
 
   @Bean
-  public ObjectMapper objectMapper() {
-    ObjectMapper objectMapper = new ObjectMapper();
+  public JsonMapperBuilderCustomizer jacksonCustomizer() {
+    return builder -> {
+      // 1. Naming Strategy 설정 (camelCase -> snake_case)
+      builder.propertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE);
 
-    // 1. Naming Strategy 설정 (camelCase -> snake_case)
-    objectMapper.setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE);
+      // 2. Null 값 제외 설정 (응답에서 제외)
+      builder.changeDefaultPropertyInclusion(
+          incl -> incl.withValueInclusion(JsonInclude.Include.NON_NULL));
 
-    // 2. Null 값 제외 설정 (응답에서 제외)
-    objectMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+      // 3. Java 8 날짜 포맷 전역 설정
+      DateTimeFormatter formatter = DateTimeFormatter.ofPattern(DATETIME_FORMAT);
 
-    // 3. Java 8 날짜 포맷 전역 설정
-    JavaTimeModule javaTimeModule = new JavaTimeModule();
-    javaTimeModule.addSerializer(
-        java.time.LocalDateTime.class,
-        new LocalDateTimeSerializer(DateTimeFormatter.ofPattern(DATETIME_FORMAT)));
-    objectMapper.registerModule(javaTimeModule);
-
-    // 4. 날짜를 Timestamp(배열이나 숫자) 형태로 쓰지 않도록 방지
-    objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
-
-    return objectMapper;
+      SimpleModule timeModule = new SimpleModule();
+      timeModule.addSerializer(LocalDateTime.class, new LocalDateTimeSerializer(formatter));
+      timeModule.addDeserializer(LocalDateTime.class, new LocalDateTimeDeserializer(formatter));
+      builder.addModule(timeModule);
+    };
   }
 }

--- a/common/src/main/java/com/ticketrush/global/config/JacksonConfig.java
+++ b/common/src/main/java/com/ticketrush/global/config/JacksonConfig.java
@@ -1,0 +1,40 @@
+package com.ticketrush.global.config;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
+import java.time.format.DateTimeFormatter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class JacksonConfig {
+
+  private static final String DATETIME_FORMAT = "yyyy-MM-dd HH:mm:ss";
+
+  @Bean
+  public ObjectMapper objectMapper() {
+    ObjectMapper objectMapper = new ObjectMapper();
+
+    // 1. Naming Strategy 설정 (camelCase -> snake_case)
+    objectMapper.setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE);
+
+    // 2. Null 값 제외 설정 (응답에서 제외)
+    objectMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+
+    // 3. Java 8 날짜 포맷 전역 설정
+    JavaTimeModule javaTimeModule = new JavaTimeModule();
+    javaTimeModule.addSerializer(
+        java.time.LocalDateTime.class,
+        new LocalDateTimeSerializer(DateTimeFormatter.ofPattern(DATETIME_FORMAT)));
+    objectMapper.registerModule(javaTimeModule);
+
+    // 4. 날짜를 Timestamp(배열이나 숫자) 형태로 쓰지 않도록 방지
+    objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+
+    return objectMapper;
+  }
+}

--- a/common/src/main/java/com/ticketrush/global/json/DeserializationException.java
+++ b/common/src/main/java/com/ticketrush/global/json/DeserializationException.java
@@ -1,0 +1,7 @@
+package com.ticketrush.global.json;
+
+public class DeserializationException extends RuntimeException {
+  public DeserializationException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/common/src/main/java/com/ticketrush/global/json/DeserializationException.java
+++ b/common/src/main/java/com/ticketrush/global/json/DeserializationException.java
@@ -1,7 +1,10 @@
 package com.ticketrush.global.json;
 
-public class DeserializationException extends RuntimeException {
-  public DeserializationException(String message, Throwable cause) {
-    super(message, cause);
+import com.ticketrush.global.exception.BusinessException;
+import com.ticketrush.global.status.ErrorStatus;
+
+public class DeserializationException extends BusinessException {
+  public DeserializationException(Throwable cause) {
+    super(ErrorStatus.JSON_PROCESSING_ERROR, cause);
   }
 }

--- a/common/src/main/java/com/ticketrush/global/json/JsonConverter.java
+++ b/common/src/main/java/com/ticketrush/global/json/JsonConverter.java
@@ -1,10 +1,10 @@
 package com.ticketrush.global.json;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.ObjectMapper;
 
 @Slf4j
 @Component
@@ -17,7 +17,8 @@ public class JsonConverter {
     try {
       return objectMapper.writeValueAsString(value);
     } catch (Exception e) {
-      log.error("Failed to serialize value: {}", value, e);
+      String typeName = (value != null) ? value.getClass().getName() : "null";
+      log.error("Failed to serialize value of type: {}", typeName, e);
       throw new SerializationException("failed serialization error", e);
     }
   }
@@ -26,7 +27,12 @@ public class JsonConverter {
     try {
       return objectMapper.readValue(payload, type);
     } catch (Exception e) {
-      log.error("Failed to deserialize payload: {}", payload, e);
+      int payloadLength = (payload != null) ? payload.length() : 0;
+      log.error(
+          "Failed to deserialize payload. Expected Type: {}, Payload Length: {}",
+          type.getName(),
+          payloadLength,
+          e);
       throw new DeserializationException("failed deserialization error", e);
     }
   }
@@ -35,7 +41,12 @@ public class JsonConverter {
     try {
       return objectMapper.readValue(payload, type);
     } catch (Exception e) {
-      log.error("Failed to deserialize payload: {}", payload, e);
+      int payloadLength = (payload != null) ? payload.length() : 0;
+      log.error(
+          "Failed to deserialize payload. Expected Type Reference: {}, Payload Length: {}",
+          type.getType().getTypeName(),
+          payloadLength,
+          e);
       throw new DeserializationException("failed deserialization error", e);
     }
   }

--- a/common/src/main/java/com/ticketrush/global/json/JsonConverter.java
+++ b/common/src/main/java/com/ticketrush/global/json/JsonConverter.java
@@ -1,0 +1,42 @@
+package com.ticketrush.global.json;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JsonConverter {
+
+  private final ObjectMapper objectMapper;
+
+  public String serialize(Object value) {
+    try {
+      return objectMapper.writeValueAsString(value);
+    } catch (Exception e) {
+      log.error("Failed to serialize value: {}", value, e);
+      throw new SerializationException("failed serialization error", e);
+    }
+  }
+
+  public <T> T deserialize(String payload, Class<T> type) {
+    try {
+      return objectMapper.readValue(payload, type);
+    } catch (Exception e) {
+      log.error("Failed to deserialize payload: {}", payload, e);
+      throw new DeserializationException("failed deserialization error", e);
+    }
+  }
+
+  public <T> T deserialize(String payload, TypeReference<T> type) {
+    try {
+      return objectMapper.readValue(payload, type);
+    } catch (Exception e) {
+      log.error("Failed to deserialize payload: {}", payload, e);
+      throw new DeserializationException("failed deserialization error", e);
+    }
+  }
+}

--- a/common/src/main/java/com/ticketrush/global/json/JsonConverter.java
+++ b/common/src/main/java/com/ticketrush/global/json/JsonConverter.java
@@ -19,7 +19,7 @@ public class JsonConverter {
     } catch (Exception e) {
       String typeName = (value != null) ? value.getClass().getName() : "null";
       log.error("Failed to serialize value of type: {}", typeName, e);
-      throw new SerializationException("failed serialization error", e);
+      throw new SerializationException(e);
     }
   }
 
@@ -33,7 +33,7 @@ public class JsonConverter {
           type.getName(),
           payloadLength,
           e);
-      throw new DeserializationException("failed deserialization error", e);
+      throw new DeserializationException(e);
     }
   }
 
@@ -47,7 +47,7 @@ public class JsonConverter {
           type.getType().getTypeName(),
           payloadLength,
           e);
-      throw new DeserializationException("failed deserialization error", e);
+      throw new DeserializationException(e);
     }
   }
 }

--- a/common/src/main/java/com/ticketrush/global/json/SerializationException.java
+++ b/common/src/main/java/com/ticketrush/global/json/SerializationException.java
@@ -1,0 +1,7 @@
+package com.ticketrush.global.json;
+
+public class SerializationException extends RuntimeException {
+  public SerializationException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/common/src/main/java/com/ticketrush/global/json/SerializationException.java
+++ b/common/src/main/java/com/ticketrush/global/json/SerializationException.java
@@ -1,7 +1,10 @@
 package com.ticketrush.global.json;
 
-public class SerializationException extends RuntimeException {
-  public SerializationException(String message, Throwable cause) {
-    super(message, cause);
+import com.ticketrush.global.exception.BusinessException;
+import com.ticketrush.global.status.ErrorStatus;
+
+public class SerializationException extends BusinessException {
+  public SerializationException(Throwable cause) {
+    super(ErrorStatus.JSON_PROCESSING_ERROR, cause);
   }
 }

--- a/common/src/main/java/com/ticketrush/global/status/ErrorStatus.java
+++ b/common/src/main/java/com/ticketrush/global/status/ErrorStatus.java
@@ -16,6 +16,8 @@ public enum ErrorStatus {
   NOT_FOUND(HttpStatus.NOT_FOUND, "COMMON_404", "페이지를 찾을 수 없습니다."),
   // 입력값 검증 관련 에러
   VALIDATION_ERROR(HttpStatus.BAD_REQUEST, "VALID_400", "입력값이 올바르지 않습니다."),
+  // Json 변환 관련 에러
+  JSON_PROCESSING_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "JSON_501", "데이터 변환 중 오류가 발생했습니다."),
 
   // Auth 403
   AUTH_ACCESS_DENIED(HttpStatus.FORBIDDEN, "AUTH_403_001", "접근 권한이 없습니다.");


### PR DESCRIPTION
## 🔗 관련 이슈

- close #51 

---

## 📌 주요 변경 사항

- 애플리케이션 전역 JSON 데이터 포맷 및 명명 규칙(Jackson) 설정 적용
- Kafka 메시지, Redis, 로깅 등에서 수동으로 JSON을 변환할 수 있는 공통 유틸리티 추가
- JSON 파싱/변환 과정에서 발생하는 예외를 전역으로 캐치하기 위한 커스텀 Exception 정의

---

## 🛠 상세 구현 내용

- **`JacksonConfig`**: 전역 `ObjectMapper` Bean 커스터마이징
  - Naming Strategy를 Snake Case(`SNAKE_CASE`)로 통일
  - 응답 시 Null 값이나 비어있는 필드 제외 (`Include.NON_NULL`)
  - Java 8 `LocalDateTime` 포맷을 `yyyy-MM-dd HH:mm:ss`로 전역 설정 및 Timestamp 출력 방지
- **`JsonConverter`**: 직렬화/역직렬화 유틸리티 컴포넌트 추가
  - 커스텀 설정된 `ObjectMapper`를 주입받아 동작
  - 제네릭 타입(List, Map 등) 변환을 지원하는 `TypeReference` 오버로딩 메서드 구현
- **`SerializationException` & `DeserializationException`**: 
  - Jackson 라이브러리의 복잡한 기본 예외를 감싸기(Wrapping) 위한 커스텀 런타임 예외 추가

<!--
---

## ✅ 테스트

### 테스트 방법

-

### 테스트 결과

-

### 📸 스크린샷

---

## 👀 리뷰 요청 사항

-

---

## ⚠️ 배포 시 주의사항

- 
-->