### PR TITLE
[Infra] #107 Spring AOP 기반 API/Kafka 요청·응답 로깅 인프라 구성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,8 +11,8 @@ allprojects {
     }
 }
 
-// 2. 루트 checkstyle(Java 21) 제외할 서브프로젝트.
-def checkstyleExcludeProjects = ['kafka-connector'] as Set
+// 2. 필요 시 루트 checkstyle(Java 21) 제외할 서브프로젝트 지정
+//def checkstyleExcludeProjects = ['kafka-connector'] as Set
 
 subprojects { subproject ->
     apply plugin: 'java'
@@ -43,7 +43,6 @@ subprojects { subproject ->
     spotless {
         java {
             googleJavaFormat("1.33.0")
-            // diff 안정화를 위해 하기 옵션 추가
             trimTrailingWhitespace() // 줄 끝 공백 제거
             endWithNewline() // 파일 끝에 newline 강제
         }

--- a/build.gradle
+++ b/build.gradle
@@ -11,13 +11,14 @@ allprojects {
     }
 }
 
-// 2. (필요 시) 루트 checkstyle 제외할 서브프로젝트 지정
+// 2. (선택) 루트 checkstyle 제외할 서브프로젝트 지정
 //def checkstyleExcludeProjects = ['kafka-connector'] as Set
 
 subprojects { subproject ->
     apply plugin: 'java'
     apply plugin: 'com.diffplug.spotless'
 
+    // 특정 모듈 checkstyle 제외 로직 (사용 시 활성화)
 //    if (checkstyleExcludeProjects.contains(subproject.name)) {
 //        subproject.ext.skipCheckstyle = true
 //    }

--- a/build.gradle
+++ b/build.gradle
@@ -11,16 +11,16 @@ allprojects {
     }
 }
 
-// 2. 필요 시 루트 checkstyle(Java 21) 제외할 서브프로젝트 지정
+// 2. (필요 시) 루트 checkstyle 제외할 서브프로젝트 지정
 //def checkstyleExcludeProjects = ['kafka-connector'] as Set
 
 subprojects { subproject ->
     apply plugin: 'java'
     apply plugin: 'com.diffplug.spotless'
 
-    if (checkstyleExcludeProjects.contains(subproject.name)) {
-        subproject.ext.skipCheckstyle = true
-    }
+//    if (checkstyleExcludeProjects.contains(subproject.name)) {
+//        subproject.ext.skipCheckstyle = true
+//    }
 
     if (!subproject.findProperty('skipCheckstyle')) {
         apply plugin: 'checkstyle'

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -73,6 +73,9 @@ dependencies {
 	}
 	implementation 'tools.jackson.core:jackson-core:3.1.0'
 	implementation 'tools.jackson.core:jackson-databind:3.1.0'
+
+	// aop
+	implementation 'org.springframework.boot:spring-boot-starter-aop'
 }
 
 dependencyManagement {

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -38,7 +38,6 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-webmvc'
 	compileOnly 'org.projectlombok:lombok'
-	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'com.h2database:h2'
@@ -75,7 +74,7 @@ dependencies {
 	implementation 'tools.jackson.core:jackson-databind:3.1.0'
 
 	// aop
-	implementation 'org.springframework.boot:spring-boot-starter-aop'
+	implementation 'org.springframework.boot:spring-boot-starter-aspectj'
 }
 
 dependencyManagement {

--- a/common/src/main/java/com/ticketrush/global/aop/AopExtractUtils.java
+++ b/common/src/main/java/com/ticketrush/global/aop/AopExtractUtils.java
@@ -1,0 +1,34 @@
+package com.ticketrush.global.aop;
+
+import java.lang.annotation.Annotation;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.reflect.MethodSignature;
+
+public class AopExtractUtils {
+
+  // 인스턴스화 방지
+  private AopExtractUtils() {}
+
+  /**
+   * 메서드 파라미터 중 특정 어노테이션이 선언된 인자의 값을 추출합니다.
+   *
+   * @param joinPoint AOP ProceedingJoinPoint
+   * @param targetAnnotation 찾고자 하는 어노테이션 클래스 (예: RequestBody.class)
+   * @return 어노테이션이 선언된 인자 객체. 없을 경우 null 반환
+   */
+  public static Object extractArgByAnnotation(
+      ProceedingJoinPoint joinPoint, Class<? extends Annotation> targetAnnotation) {
+    MethodSignature methodSignature = (MethodSignature) joinPoint.getSignature();
+    Annotation[][] parameterAnnotations = methodSignature.getMethod().getParameterAnnotations();
+    Object[] args = joinPoint.getArgs();
+
+    for (int i = 0; i < parameterAnnotations.length; i++) {
+      for (Annotation annotation : parameterAnnotations[i]) {
+        if (annotation.annotationType().equals(targetAnnotation)) {
+          return args[i];
+        }
+      }
+    }
+    return null;
+  }
+}

--- a/common/src/main/java/com/ticketrush/global/aop/ApiLoggingAspect.java
+++ b/common/src/main/java/com/ticketrush/global/aop/ApiLoggingAspect.java
@@ -9,6 +9,7 @@ import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.annotation.Pointcut;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
@@ -54,9 +55,14 @@ public class ApiLoggingAspect {
       Object result = joinPoint.proceed();
       long elapsedTime = System.currentTimeMillis() - startTime;
 
-      // 응답 상태 코드 추출
-      HttpServletResponse response = attributes.getResponse();
-      int status = (response != null) ? response.getStatus() : 200;
+      // ResponseEntity면 거기서 status 추출, 아니면 HttpServletResponse fallback
+      int status;
+      if (result instanceof ResponseEntity<?> responseEntity) {
+        status = responseEntity.getStatusCode().value();
+      } else {
+        HttpServletResponse response = attributes.getResponse();
+        status = (response != null) ? response.getStatus() : 200;
+      }
 
       // 3. 정상 응답 로깅
       log.info(

--- a/common/src/main/java/com/ticketrush/global/aop/ApiLoggingAspect.java
+++ b/common/src/main/java/com/ticketrush/global/aop/ApiLoggingAspect.java
@@ -40,7 +40,7 @@ public class ApiLoggingAspect {
     HttpServletRequest request = attributes.getRequest();
     String method = request.getMethod();
     String requestURI = request.getRequestURI();
-    long startTime = System.currentTimeMillis();
+    long startTime = System.nanoTime();
 
     // 1. 요청 로깅
     Object[] args = joinPoint.getArgs();
@@ -53,7 +53,7 @@ public class ApiLoggingAspect {
     try {
       // 2. 실제 컨트롤러 메서드 실행
       Object result = joinPoint.proceed();
-      long elapsedTime = System.currentTimeMillis() - startTime;
+      long elapsedTime = System.nanoTime() - startTime;
 
       // ResponseEntity면 거기서 status 추출, 아니면 HttpServletResponse fallback
       int status;
@@ -75,7 +75,7 @@ public class ApiLoggingAspect {
 
     } catch (Exception e) {
       // 4. 예외 발생 시 로깅
-      long elapsedTime = System.currentTimeMillis() - startTime;
+      long elapsedTime = System.nanoTime() - startTime;
       log.error(
           "[API ERROR] [{}] {} | Time: {}ms | Exception: {}",
           method,

--- a/common/src/main/java/com/ticketrush/global/aop/ApiLoggingAspect.java
+++ b/common/src/main/java/com/ticketrush/global/aop/ApiLoggingAspect.java
@@ -1,0 +1,83 @@
+package com.ticketrush.global.aop;
+
+import com.ticketrush.global.json.JsonConverter;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Pointcut;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+@Slf4j
+@Aspect
+@Component
+@RequiredArgsConstructor
+public class ApiLoggingAspect {
+
+  private final JsonConverter jsonConverter;
+
+  private static final int MAX_LOG_LENGTH = 1000;
+
+  @Pointcut("within(@org.springframework.web.bind.annotation.RestController *)")
+  public void restControllerPointcut() {}
+
+  @Around("restControllerPointcut()")
+  public Object logApi(ProceedingJoinPoint joinPoint) throws Throwable {
+    ServletRequestAttributes attributes =
+        (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
+
+    // HTTP 요청 컨텍스트가 없는 경우 (예: 내부 스케줄러 등) 바로 진행
+    if (attributes == null) {
+      return joinPoint.proceed();
+    }
+
+    HttpServletRequest request = attributes.getRequest();
+    String method = request.getMethod();
+    String requestURI = request.getRequestURI();
+    long startTime = System.currentTimeMillis();
+
+    // 1. 요청 로깅
+    Object[] args = joinPoint.getArgs();
+    String requestBody =
+        (args != null && args.length > 0)
+            ? jsonConverter.serializeForLog(args[0], MAX_LOG_LENGTH)
+            : "none";
+    log.info("[API REQUEST] [{}] {} | Payload: {}", method, requestURI, requestBody);
+
+    try {
+      // 2. 실제 컨트롤러 메서드 실행
+      Object result = joinPoint.proceed();
+      long elapsedTime = System.currentTimeMillis() - startTime;
+
+      // 응답 상태 코드 추출
+      HttpServletResponse response = attributes.getResponse();
+      int status = (response != null) ? response.getStatus() : 200;
+
+      // 3. 정상 응답 로깅
+      log.info(
+          "[API RESPONSE] [{}] {} | Status: {} | Time: {}ms",
+          method,
+          requestURI,
+          status,
+          elapsedTime);
+      return result;
+
+    } catch (Exception e) {
+      // 4. 예외 발생 시 로깅
+      long elapsedTime = System.currentTimeMillis() - startTime;
+      log.error(
+          "[API ERROR] [{}] {} | Time: {}ms | Exception: {}",
+          method,
+          requestURI,
+          elapsedTime,
+          e.getClass().getSimpleName(),
+          e);
+      throw e; // GlobalExceptionHandler 처리를 위해 예외를 다시 던짐
+    }
+  }
+}

--- a/common/src/main/java/com/ticketrush/global/aop/ApiLoggingAspect.java
+++ b/common/src/main/java/com/ticketrush/global/aop/ApiLoggingAspect.java
@@ -20,9 +20,10 @@ import org.springframework.web.context.request.ServletRequestAttributes;
 @RequiredArgsConstructor
 public class ApiLoggingAspect {
 
-  private final JsonConverter jsonConverter;
-
   private static final int MAX_LOG_LENGTH = 1000;
+  private static final String NO_REQUEST_BODY = "none";
+
+  private final JsonConverter jsonConverter;
 
   @Pointcut("within(@org.springframework.web.bind.annotation.RestController *)")
   public void restControllerPointcut() {}
@@ -47,7 +48,7 @@ public class ApiLoggingAspect {
     String requestBody =
         (args != null && args.length > 0)
             ? jsonConverter.serializeForLog(args[0], MAX_LOG_LENGTH)
-            : "none";
+            : NO_REQUEST_BODY;
     log.info("[API REQUEST] [{}] {} | Payload: {}", method, requestURI, requestBody);
 
     try {
@@ -70,7 +71,8 @@ public class ApiLoggingAspect {
           method,
           requestURI,
           status,
-          elapsedTime);
+          elapsedTime / 1_000_000);
+
       return result;
 
     } catch (Exception e) {
@@ -80,7 +82,7 @@ public class ApiLoggingAspect {
           "[API ERROR] [{}] {} | Time: {}ms | Exception: {}",
           method,
           requestURI,
-          elapsedTime,
+          elapsedTime / 1_000_000,
           e.getClass().getSimpleName(),
           e);
       throw e; // GlobalExceptionHandler 처리를 위해 예외를 다시 던짐

--- a/common/src/main/java/com/ticketrush/global/aop/KafkaLoggingAspect.java
+++ b/common/src/main/java/com/ticketrush/global/aop/KafkaLoggingAspect.java
@@ -10,6 +10,7 @@ import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.annotation.Pointcut;
 import org.slf4j.MDC;
+import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 
@@ -44,10 +45,13 @@ public class KafkaLoggingAspect {
       mdcModified = true;
     }
 
+    Object payloadArg = AopExtractUtils.extractArgByAnnotation(joinPoint, Payload.class);
+    if (payloadArg == null && args != null && args.length > 0) {
+      payloadArg = args[0];
+    }
+
     String payload =
-        (args != null && args.length > 0)
-            ? jsonConverter.serializeForLog(args[0], MAX_LOG_LENGTH)
-            : "none";
+        payloadArg != null ? jsonConverter.serializeForLog(payloadArg, MAX_LOG_LENGTH) : "none";
     log.info("[KAFKA CONSUME START] {}.{} | Payload: {}", targetClass, methodName, payload);
 
     try {

--- a/common/src/main/java/com/ticketrush/global/aop/KafkaLoggingAspect.java
+++ b/common/src/main/java/com/ticketrush/global/aop/KafkaLoggingAspect.java
@@ -32,7 +32,7 @@ public class KafkaLoggingAspect {
     String targetClass = joinPoint.getTarget().getClass().getSimpleName();
     String methodName = joinPoint.getSignature().getName();
     Object[] args = joinPoint.getArgs();
-    long startTime = System.currentTimeMillis();
+    long startTime = System.nanoTime();
 
     // Kafka 메시지(Envelope)에서 Trace ID 추출 및 MDC 주입
     String eventTraceId = extractTraceId(args);
@@ -52,13 +52,13 @@ public class KafkaLoggingAspect {
 
     try {
       Object result = joinPoint.proceed();
-      long elapsedTime = System.currentTimeMillis() - startTime;
+      long elapsedTime = System.nanoTime() - startTime;
 
       log.info("[KAFKA CONSUME SUCCESS] {}.{} | Time: {}ms", targetClass, methodName, elapsedTime);
       return result;
 
     } catch (Exception e) {
-      long elapsedTime = System.currentTimeMillis() - startTime;
+      long elapsedTime = System.nanoTime() - startTime;
       log.error(
           "[KAFKA CONSUME FAILED] {}.{} | Time: {}ms | Error: {}",
           targetClass,

--- a/common/src/main/java/com/ticketrush/global/aop/KafkaLoggingAspect.java
+++ b/common/src/main/java/com/ticketrush/global/aop/KafkaLoggingAspect.java
@@ -1,0 +1,96 @@
+package com.ticketrush.global.aop;
+
+import com.ticketrush.global.constants.TraceIdConstants;
+import com.ticketrush.global.event.DomainEventEnvelope;
+import com.ticketrush.global.json.JsonConverter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Pointcut;
+import org.slf4j.MDC;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+@Slf4j
+@Aspect
+@Component
+@RequiredArgsConstructor
+public class KafkaLoggingAspect {
+
+  private final JsonConverter jsonConverter;
+
+  private static final int MAX_LOG_LENGTH = 1000;
+  private static final String UNKNOWN_TRACE_ID = "Unknown";
+
+  @Pointcut("@annotation(org.springframework.kafka.annotation.KafkaListener)")
+  public void kafkaListenerPointcut() {}
+
+  @Around("kafkaListenerPointcut()")
+  public Object logKafkaEvent(ProceedingJoinPoint joinPoint) throws Throwable {
+    String targetClass = joinPoint.getTarget().getClass().getSimpleName();
+    String methodName = joinPoint.getSignature().getName();
+    Object[] args = joinPoint.getArgs();
+    long startTime = System.currentTimeMillis();
+
+    // Kafka 메시지(Envelope)에서 Trace ID 추출 및 MDC 주입
+    String eventTraceId = extractTraceId(args);
+    String originalTraceId = MDC.get(TraceIdConstants.TRACE_ID_KEY);
+    boolean mdcModified = false;
+
+    if (StringUtils.hasText(eventTraceId) && !eventTraceId.equals(UNKNOWN_TRACE_ID)) {
+      MDC.put(TraceIdConstants.TRACE_ID_KEY, eventTraceId);
+      mdcModified = true;
+    }
+
+    String payload =
+        (args != null && args.length > 0)
+            ? jsonConverter.serializeForLog(args[0], MAX_LOG_LENGTH)
+            : "none";
+    log.info("[KAFKA CONSUME START] {}.{} | Payload: {}", targetClass, methodName, payload);
+
+    try {
+      Object result = joinPoint.proceed();
+      long elapsedTime = System.currentTimeMillis() - startTime;
+
+      log.info("[KAFKA CONSUME SUCCESS] {}.{} | Time: {}ms", targetClass, methodName, elapsedTime);
+      return result;
+
+    } catch (Exception e) {
+      long elapsedTime = System.currentTimeMillis() - startTime;
+      log.error(
+          "[KAFKA CONSUME FAILED] {}.{} | Time: {}ms | Error: {}",
+          targetClass,
+          methodName,
+          elapsedTime,
+          e.getMessage(),
+          e);
+      throw e;
+
+    } finally {
+      // 스레드 풀 오염을 방지하기 위한 MDC 복구 처리
+      if (mdcModified) {
+        if (originalTraceId != null) {
+          MDC.put(TraceIdConstants.TRACE_ID_KEY, originalTraceId);
+        } else {
+          MDC.remove(TraceIdConstants.TRACE_ID_KEY);
+        }
+      }
+    }
+  }
+
+  // 인자에서 Trace ID 추출
+  private String extractTraceId(Object[] args) {
+    if (args == null || args.length == 0) {
+      return UNKNOWN_TRACE_ID;
+    }
+
+    if (args[0] instanceof DomainEventEnvelope envelope
+        && StringUtils.hasText(envelope.traceId())) {
+      return envelope.traceId();
+    }
+
+    return UNKNOWN_TRACE_ID;
+  }
+}

--- a/common/src/main/java/com/ticketrush/global/json/JsonConverter.java
+++ b/common/src/main/java/com/ticketrush/global/json/JsonConverter.java
@@ -50,4 +50,19 @@ public class JsonConverter {
       throw new DeserializationException(e);
     }
   }
+
+  public String serializeForLog(Object value, int maxLength) {
+    if (value == null) {
+      return "none";
+    }
+    try {
+      String serialized = objectMapper.writeValueAsString(value);
+      if (serialized.length() > maxLength) {
+        return serialized.substring(0, maxLength) + "...(truncated)";
+      }
+      return serialized;
+    } catch (Exception e) {
+      return "un-serializable object";
+    }
+  }
 }

--- a/common/src/main/java/com/ticketrush/global/json/JsonConverter.java
+++ b/common/src/main/java/com/ticketrush/global/json/JsonConverter.java
@@ -62,7 +62,11 @@ public class JsonConverter {
       }
       return serialized;
     } catch (Exception e) {
-      return "un-serializable object";
+      String typeName = value.getClass().getName();
+      String exceptionName = e.getClass().getSimpleName();
+      log.debug(
+          "Failed to serialize value for log. type={}, exception={}", typeName, exceptionName);
+      return "un-serializable object(type=" + typeName + ", exception=" + exceptionName + ")";
     }
   }
 }

--- a/config/checkstyle/google_checks.xml
+++ b/config/checkstyle/google_checks.xml
@@ -331,7 +331,7 @@
     <module name="AbbreviationAsWordInName">
       <property name="ignoreFinal" value="false"/>
       <property name="allowedAbbreviationLength" value="1"/>
-      <property name="allowedAbbreviations" value="OAuth,API,URL,ID,DTO,VO"/>
+      <property name="allowedAbbreviations" value="OAuth,API,URL,URI,ID,DTO"/>
       <property name="tokens"
                value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, ANNOTATION_DEF, ANNOTATION_FIELD_DEF,
                     PARAMETER_DEF, VARIABLE_DEF, METHOD_DEF, PATTERN_VARIABLE_DEF, RECORD_DEF,


### PR DESCRIPTION
## 🔗 관련 이슈

- close #107 

---

## 📌 주요 변경 사항

- `ApiLoggingAspect` 추가 — `@RestController` 전체 대상 API 요청/응답/예외 AOP 로깅
- `KafkaLoggingAspect` 추가 — `@KafkaListener` 전체 대상 Kafka consume AOP 로깅 및 MDC traceId 주입/복구

---

## 🛠 상세 구현 내용

- `ApiLoggingAspect`: `RequestContextHolder`로 HTTP 컨텍스트를 확인하고, 컨텍스트가 없는 경우(스케줄러 등) AOP 바이패스 처리. 요청 시 메서드/URI/페이로드, 응답 시 상태코드/소요시간, 예외 시 예외 클래스명을 로깅
- `KafkaLoggingAspect`: consume 시 `DomainEventEnvelope`에서 `traceId`를 추출해 MDC에 주입하고, `finally` 블록에서 원본 값으로 복구하여 스레드 풀 오염 방지. consume 시작/성공/실패 및 소요시간 로깅

<!--
---

## ✅ 테스트

### 테스트 방법

- 

### 테스트 결과

- 

### 📸 스크린샷

---

## 👀 리뷰 요청 사항

- 

---

## ⚠️ 배포 시 주의사항

-
-->