### PR TITLE
[Feat] #136 MapStruct 기반 Mapper 구조 도입

### DIFF
--- a/common/src/main/java/com/ticketrush/global/status/ErrorStatus.java
+++ b/common/src/main/java/com/ticketrush/global/status/ErrorStatus.java
@@ -34,7 +34,7 @@ public enum ErrorStatus {
   FILE_EXTENSION_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "FILE_400_003", "허용되지 않은 파일 형식입니다."),
 
   // USER 400
-  USER_SOCIAL_PROVIDER_REQUIRED(HttpStatus.BAD_REQUEST, "USER_400_001", "socialProvider는 필수입니다");
+  USER_SOCIAL_PROVIDER_REQUIRED(HttpStatus.BAD_REQUEST, "USER_400_001", "socialProvider는 필수입니다.");
 
   private final HttpStatus httpStatus;
   private final String code;

--- a/common/src/main/java/com/ticketrush/global/status/ErrorStatus.java
+++ b/common/src/main/java/com/ticketrush/global/status/ErrorStatus.java
@@ -31,7 +31,10 @@ public enum ErrorStatus {
   // 파일 업로드 공통 에라
   FILE_EMPTY(HttpStatus.BAD_REQUEST, "FILE_400_001", "업로드할 파일이 비어있습니다."),
   FILE_INVALID_EXTENSION(HttpStatus.BAD_REQUEST, "FILE_400_002", "파일 확장자가 올바르지 않습니다."),
-  FILE_EXTENSION_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "FILE_400_003", "허용되지 않은 파일 형식입니다.");
+  FILE_EXTENSION_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "FILE_400_003", "허용되지 않은 파일 형식입니다."),
+
+  // USER 400
+  USER_SOCIAL_PROVIDER_REQUIRED(HttpStatus.BAD_REQUEST, "USER_400_001", "socialProvider는 필수입니다");
 
   private final HttpStatus httpStatus;
   private final String code;

--- a/user-service/build.gradle
+++ b/user-service/build.gradle
@@ -49,6 +49,12 @@ dependencies {
 
 	// swagger
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.1'
+
+	// mapstruct
+	implementation 'org.mapstruct:mapstruct:1.5.5.Final'
+	annotationProcessor "org.projectlombok:lombok-mapstruct-binding:0.2.0"
+	annotationProcessor 'org.mapstruct:mapstruct-processor:1.5.5.Final'
+	testAnnotationProcessor 'org.mapstruct:mapstruct-processor:1.5.5.Final'
 }
 
 dependencyManagement {

--- a/user-service/src/main/java/com/ticketrush/boundedcontext/user/app/dto/request/SocialCreateRequest.java
+++ b/user-service/src/main/java/com/ticketrush/boundedcontext/user/app/dto/request/SocialCreateRequest.java
@@ -1,10 +1,8 @@
 package com.ticketrush.boundedcontext.user.app.dto.request;
 
 import com.ticketrush.boundedcontext.user.domain.types.SocialProvider;
-import com.ticketrush.boundedcontext.user.domain.types.UserRole;
 
-public record UserCreateRequest(
+public record SocialCreateRequest(
     String socialId, // 사용자 고유 ID (처음 로그인했기 때문에 socialId)
     SocialProvider socialProvider, // 카카오, 네이버, 구글
-    String name, // 닉네임
-    UserRole userRole) {}
+    String name) {}

--- a/user-service/src/main/java/com/ticketrush/boundedcontext/user/app/dto/response/SocialCreateResponse.java
+++ b/user-service/src/main/java/com/ticketrush/boundedcontext/user/app/dto/response/SocialCreateResponse.java
@@ -1,4 +1,4 @@
 package com.ticketrush.boundedcontext.user.app.dto.response;
 
-public record UserCreateResponse(
+public record SocialCreateResponse(
     Long userId, String name, boolean isNewUser) {} // true = 회원가입 직후, false = 기존 유저

--- a/user-service/src/main/java/com/ticketrush/boundedcontext/user/app/facade/UserFacade.java
+++ b/user-service/src/main/java/com/ticketrush/boundedcontext/user/app/facade/UserFacade.java
@@ -1,7 +1,7 @@
 package com.ticketrush.boundedcontext.user.app.facade;
 
-import com.ticketrush.boundedcontext.user.app.dto.request.UserCreateRequest;
-import com.ticketrush.boundedcontext.user.app.dto.response.UserCreateResponse;
+import com.ticketrush.boundedcontext.user.app.dto.request.SocialCreateRequest;
+import com.ticketrush.boundedcontext.user.app.dto.response.SocialCreateResponse;
 import com.ticketrush.boundedcontext.user.app.usecase.SocialLoginUseCase;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -13,7 +13,7 @@ public class UserFacade {
   private final SocialLoginUseCase socialLoginUseCase;
 
   // 소셜 로그인
-  public UserCreateResponse socialLogin(UserCreateRequest request) {
+  public SocialCreateResponse socialLogin(SocialCreateRequest request) {
     return socialLoginUseCase.execute(request);
   }
 }

--- a/user-service/src/main/java/com/ticketrush/boundedcontext/user/app/mapper/SocialMapper.java
+++ b/user-service/src/main/java/com/ticketrush/boundedcontext/user/app/mapper/SocialMapper.java
@@ -1,0 +1,22 @@
+package com.ticketrush.boundedcontext.user.app.mapper;
+
+import com.ticketrush.boundedcontext.user.app.dto.request.SocialCreateRequest;
+import com.ticketrush.boundedcontext.user.domain.entity.SocialAccount;
+import com.ticketrush.boundedcontext.user.domain.entity.User;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper(componentModel = "spring")
+public interface SocialMapper {
+
+  // SocialCreateRequest → User Entity 변환
+  @Mapping(source = "name", target = "name")
+  @Mapping(target = "userRole", constant = "MEMBER")
+  User toUser(SocialCreateRequest request);
+
+  // SocialCreateRequest → SocialAccount Entity 변환
+  @Mapping(target = "user", ignore = true) // 서비스에서 연결
+  @Mapping(source = "socialId", target = "providerUserId")
+  @Mapping(source = "socialProvider", target = "socialProvider")
+  SocialAccount toSocialAccount(SocialCreateRequest request);
+}

--- a/user-service/src/main/java/com/ticketrush/boundedcontext/user/app/usecase/SocialLoginUseCase.java
+++ b/user-service/src/main/java/com/ticketrush/boundedcontext/user/app/usecase/SocialLoginUseCase.java
@@ -1,12 +1,14 @@
 package com.ticketrush.boundedcontext.user.app.usecase;
 
-import com.ticketrush.boundedcontext.user.app.dto.request.UserCreateRequest;
-import com.ticketrush.boundedcontext.user.app.dto.response.UserCreateResponse;
+import com.ticketrush.boundedcontext.user.app.dto.request.SocialCreateRequest;
+import com.ticketrush.boundedcontext.user.app.dto.response.SocialCreateResponse;
+import com.ticketrush.boundedcontext.user.app.mapper.SocialMapper;
 import com.ticketrush.boundedcontext.user.domain.entity.SocialAccount;
 import com.ticketrush.boundedcontext.user.domain.entity.User;
-import com.ticketrush.boundedcontext.user.domain.types.UserRole;
 import com.ticketrush.boundedcontext.user.out.SocialAccountRepository;
 import com.ticketrush.boundedcontext.user.out.UserRepository;
+import com.ticketrush.global.exception.BusinessException;
+import com.ticketrush.global.status.ErrorStatus;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -18,9 +20,12 @@ public class SocialLoginUseCase {
 
   private final SocialAccountRepository socialAccountRepository;
   private final UserRepository userRepository;
+  private final SocialMapper socialMapper;
 
   @Transactional
-  public UserCreateResponse execute(UserCreateRequest request) {
+  public SocialCreateResponse execute(SocialCreateRequest request) {
+
+    validation(request);
 
     // 1. 소셜 계정 조회
     Optional<SocialAccount> account =
@@ -31,24 +36,27 @@ public class SocialLoginUseCase {
     if (account.isPresent()) {
       User user = account.get().getUser();
 
-      return new UserCreateResponse(user.getId(), user.getName(), false);
+      return new SocialCreateResponse(user.getId(), user.getName(), false);
     }
 
     // 3. 신규 유저 생성
-    User newUser = User.builder().name(request.name()).userRole(UserRole.MEMBER).build();
-
+    User newUser = socialMapper.toUser(request);
     userRepository.save(newUser);
 
     // 4. 소셜 계정 생성
-    SocialAccount socialAccount =
-        SocialAccount.builder()
-            .user(newUser)
-            .socialProvider(request.socialProvider())
-            .providerUserId(request.socialId())
-            .build();
+    SocialAccount socialAccount = socialMapper.toSocialAccount(request); // newRequest =
+    socialAccount.setUser(newUser);
 
     socialAccountRepository.save(socialAccount);
 
-    return new UserCreateResponse(newUser.getId(), newUser.getName(), true);
+    return new SocialCreateResponse(
+        newUser.getId(), newUser.getName(), true // isNewUser는 서비스에서 결정
+        );
+  }
+
+  private void validation(SocialCreateRequest request) {
+    if (request.socialProvider() == null) {
+      throw new BusinessException(ErrorStatus.USER_SOCIAL_PROVIDER_REQUIRED);
+    }
   }
 }

--- a/user-service/src/main/java/com/ticketrush/boundedcontext/user/app/usecase/SocialLoginUseCase.java
+++ b/user-service/src/main/java/com/ticketrush/boundedcontext/user/app/usecase/SocialLoginUseCase.java
@@ -44,7 +44,7 @@ public class SocialLoginUseCase {
     userRepository.save(newUser);
 
     // 4. 소셜 계정 생성
-    SocialAccount socialAccount = socialMapper.toSocialAccount(request); // newRequest =
+    SocialAccount socialAccount = socialMapper.toSocialAccount(request);
     socialAccount.setUser(newUser);
 
     socialAccountRepository.save(socialAccount);

--- a/user-service/src/main/java/com/ticketrush/boundedcontext/user/domain/entity/SocialAccount.java
+++ b/user-service/src/main/java/com/ticketrush/boundedcontext/user/domain/entity/SocialAccount.java
@@ -44,6 +44,10 @@ public class SocialAccount extends AutoIdBaseEntity {
   public SocialAccount(User user, SocialProvider socialProvider, String providerUserId) {
     this.user = user;
     this.socialProvider = socialProvider;
-    this.providerUserId = providerUserId;
+    this.providerUserId = providerUserId; // 소셜로그인이 준 고유 ID
+  }
+
+  public void setUser(User user) {
+    this.user = user;
   }
 }

--- a/user-service/src/main/java/com/ticketrush/boundedcontext/user/in/api/v1/UserController.java
+++ b/user-service/src/main/java/com/ticketrush/boundedcontext/user/in/api/v1/UserController.java
@@ -1,14 +1,17 @@
 package com.ticketrush.boundedcontext.user.in.api.v1;
 
-import com.ticketrush.boundedcontext.user.app.dto.request.UserCreateRequest;
-import com.ticketrush.boundedcontext.user.app.dto.response.UserCreateResponse;
+import com.ticketrush.boundedcontext.user.app.dto.request.SocialCreateRequest;
+import com.ticketrush.boundedcontext.user.app.dto.response.SocialCreateResponse;
 import com.ticketrush.boundedcontext.user.app.facade.UserFacade;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "User", description = "회원 로그인 API")
 @RestController
 @RequestMapping("/api/v1/user")
 @RequiredArgsConstructor
@@ -16,8 +19,9 @@ public class UserController {
 
   private final UserFacade userFacade;
 
+  @Operation(summary = "소셜로그인 회원 등록", description = "소셜로그인을 통해 회원을 등록합니다.")
   @PostMapping("/social-login")
-  public UserCreateResponse socialLogin(@RequestBody UserCreateRequest request) {
+  public SocialCreateResponse socialLogin(@RequestBody SocialCreateRequest request) {
     return userFacade.socialLogin(request);
   }
 }


### PR DESCRIPTION
## 🔗 관련 이슈

- close #136 

---

## 📌 주요 변경 사항

- 기존의 UserCreateRequest, UserCreateResponse 는 SocialCreateRequest, SocialCreateResponse로 변경하였습니다.
- SocialCreateRequest, SocialCreateResponse를 직접적으로 쓰던 코드를 SocialMapper 이용으로 변경하였습니다.
- 이에 따라, SocialLoginUseCase에 있던 Request, Response를 Mapper로 변경하였습니다.
- userRole은 request로 들어가기 보다 대부분이 MEMBER이기 때문에 Mapper에서 처리하였습니다.

---

## 🛠 상세 구현 내용

- MapStruct 의존성 추가
- SocialMapper에서는,  SocialCreateRequest → User Entity 변환, SocialCreateRequest → SocialAccount Entity 변환

---

<!--- ## ✅ 테스트

### 테스트 방법

-

### 테스트 결과

-
--->
### 📸 스크린샷
<img width="1119" height="434" alt="image" src="https://github.com/user-attachments/assets/9d92c61c-dbb7-4e46-a63c-89214c4018fb" />

---

## 👀 리뷰 요청 사항

- 현재 socialId 및 socialProvider 값이 요청에 포함되지 않아 null로 전달되며, 이로 인해 DB의 NOT NULL 제약 조건 위반으로 서버 에러가 발생하고 있습니다.
- 이는 소셜 로그인 기능이 아직 구현되지 않아 해당 값들을 전달받지 못하기 때문이며, 소셜 로그인 구현 완료 후에는 정상적으로 값이 전달되어 문제 없이 동작할 것으로 예상됩니다.


---

<!--- ## ⚠️ 배포 시 주의사항

- 
--->