### PR TITLE
[Feat] #33 좌석 임시 선점(Hold) 5분 만료 시 자동 해제 로직 구현

### DIFF
--- a/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/app/facade/BookingFacade.java
+++ b/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/app/facade/BookingFacade.java
@@ -17,6 +17,9 @@ public class BookingFacade {
   private final BookingCreateUseCase bookingCreateUseCase;
 
   public Booking createBooking(Long userId, Long performanceId, Long seatId) {
+    // TODO: 예매 생성 전, Performance 모듈을 호출하여 performanceId의 유효성과 예매 가능 상태 검증
+    // TODO: 유저 인증 로직 도입 후 userId 유효성 검증 추가
+
     // 1. 고유 예약 번호 발급
     String bookingNumber = bookingIssueNumberUseCase.execute();
 

--- a/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/app/facade/BookingFacade.java
+++ b/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/app/facade/BookingFacade.java
@@ -19,6 +19,7 @@ public class BookingFacade {
   public Booking createBooking(Long userId, Long performanceId, Long seatId) {
     // TODO: 예매 생성 전, Performance 모듈을 호출하여 performanceId의 유효성과 예매 가능 상태 검증
     // TODO: 유저 인증 로직 도입 후 userId 유효성 검증 추가
+    // TODO: 좌석 존재 여부 검증 로직 추가
 
     // 1. 고유 예약 번호 발급
     String bookingNumber = bookingIssueNumberUseCase.execute();

--- a/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/in/eventlistener/BookingCreatedEventListener.java
+++ b/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/in/eventlistener/BookingCreatedEventListener.java
@@ -1,8 +1,6 @@
 package com.ticketrush.boundedcontext.booking.in.eventlistener;
 
 import com.ticketrush.global.eventpublisher.EventPublisher;
-import com.ticketrush.global.exception.BusinessException;
-import com.ticketrush.global.status.ErrorStatus;
 import com.ticketrush.shared.booking.event.BookingCreatedEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -15,6 +13,7 @@ import org.springframework.transaction.event.TransactionalEventListener;
 @Component
 @RequiredArgsConstructor
 public class BookingCreatedEventListener {
+
   private final EventPublisher eventPublisher;
 
   @Async
@@ -22,10 +21,13 @@ public class BookingCreatedEventListener {
   public void handleBookingCreatedEvent(BookingCreatedEvent event) {
     try {
       eventPublisher.publish(event);
+      log.info("Kafka 이벤트 발행 성공. bookingId: {}", event.bookingId());
     } catch (Exception e) {
-      log.error("Kafka 이벤트 발행 실패. bookingId: {}", event.bookingId(), e);
-
-      throw new BusinessException(ErrorStatus.EVENT_PUBLISH_ERROR, e);
+      // TODO: Outbox 패턴 도입. Kafka 발행 실패 시 실패한 이벤트를 Outbox DB에 저장하고 배치로 재시도하는 로직 추가
+      log.error(
+          "[CRITICAL] Kafka 이벤트 발행 실패. 예매와 좌석 간 데이터 정합성 확인 필요! bookingId: {}",
+          event.bookingId(),
+          e);
     }
   }
 }

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -78,6 +78,9 @@ dependencies {
 
 	// aop
 	implementation 'org.springframework.boot:spring-boot-starter-aspectj'
+
+	// redis
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 
 dependencyManagement {

--- a/common/src/main/java/com/ticketrush/global/config/RedisConfig.java
+++ b/common/src/main/java/com/ticketrush/global/config/RedisConfig.java
@@ -1,0 +1,18 @@
+package com.ticketrush.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+
+@Configuration
+public class RedisConfig {
+
+  @Bean
+  public RedisMessageListenerContainer redisMessageListenerContainer(
+      RedisConnectionFactory connectionFactory) {
+    RedisMessageListenerContainer container = new RedisMessageListenerContainer();
+    container.setConnectionFactory(connectionFactory);
+    return container;
+  }
+}

--- a/config/checkstyle/google_checks.xml
+++ b/config/checkstyle/google_checks.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!DOCTYPE module PUBLIC
-          "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
-          "https://checkstyle.org/dtds/configuration_1_3.dtd">
+  "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
+  "https://checkstyle.org/dtds/configuration_1_3.dtd">
 
 <!--
     Checkstyle configuration that checks the Google coding conventions from Google Java Style
@@ -34,14 +34,14 @@
   <!-- https://checkstyle.org/filters/suppressionfilter.html -->
   <module name="SuppressionFilter">
     <property name="file" value="${org.checkstyle.google.suppressionfilter.config}"
-           default="checkstyle-suppressions.xml" />
+      default="checkstyle-suppressions.xml"/>
     <property name="optional" value="true"/>
   </module>
 
   <!-- https://checkstyle.org/filters/suppresswithnearbytextfilter.html -->
   <module name="SuppressWithNearbyTextFilter">
     <property name="nearbyTextPattern"
-              value="CHECKSTYLE.SUPPRESS\: (\w+) for ([+-]\d+) lines"/>
+      value="CHECKSTYLE.SUPPRESS\: (\w+) for ([+-]\d+) lines"/>
     <property name="checkPattern" value="$1"/>
     <property name="lineRange" value="$2"/>
   </module>
@@ -56,7 +56,7 @@
     <property name="fileExtensions" value="java"/>
     <property name="max" value="100"/>
     <property name="ignorePattern"
-             value="^package.*|^import.*|href\s*=\s*&quot;[^&quot;]*&quot;|http://|https://|ftp://"/>
+      value="^package.*|^import.*|href\s*=\s*&quot;[^&quot;]*&quot;|http://|https://|ftp://"/>
   </module>
   <!--  Suppression to prevent LineLength Check from flagging lines in Text-blocks -->
   <module name="SuppressWithPlainTextCommentFilter">
@@ -69,7 +69,7 @@
     <module name="MatchXpath">
       <property name="id" value="singleLineCommentStartWithSpace"/>
       <property name="query"
-                value="//SINGLE_LINE_COMMENT[./COMMENT_CONTENT[not(starts-with(@text, ' '))
+        value="//SINGLE_LINE_COMMENT[./COMMENT_CONTENT[not(starts-with(@text, ' '))
                        and not(starts-with(@text, '/'))
                        and not(@text = '\n') and not(ends-with(@text, '//\n'))]]"/>
       <message key="matchxpath.match" value="''//'' must be followed by a whitespace."/>
@@ -77,9 +77,9 @@
     <module name="IllegalTokenText">
       <property name="tokens" value="STRING_LITERAL, CHAR_LITERAL, TEXT_BLOCK_CONTENT"/>
       <property name="format"
-          value="\\u00(09|0(a|A)|0(b|B)|(0|1)(c|C)|(0|1)(d|D)|1(d|D)|1(e|E)|1(f|F)|22|27|5(C|c))|\\u1680|\\u3000|\\u20(00|0(a|A)|28|29|(2|5)(f|F))|\\(0(10|11|12|14|15|40|42|47)|134)"/>
+        value="\\u00(09|0(a|A)|0(b|B)|(0|1)(c|C)|(0|1)(d|D)|1(d|D)|1(e|E)|1(f|F)|22|27|5(C|c))|\\u1680|\\u3000|\\u20(00|0(a|A)|28|29|(2|5)(f|F))|\\(0(10|11|12|14|15|40|42|47)|134)"/>
       <property name="message"
-               value="Consider using special escape sequence instead of octal value or Unicode escaped value."/>
+        value="Consider using special escape sequence instead of octal value or Unicode escaped value."/>
     </module>
     <module name="AvoidEscapedUnicodeCharacters">
       <property name="allowEscapesForControlCharacters" value="true"/>
@@ -93,12 +93,12 @@
     </module>
     <module name="NeedBraces">
       <property name="tokens"
-               value="LITERAL_DO, LITERAL_ELSE, LITERAL_FOR, LITERAL_IF, LITERAL_WHILE"/>
+        value="LITERAL_DO, LITERAL_ELSE, LITERAL_FOR, LITERAL_IF, LITERAL_WHILE"/>
     </module>
     <module name="LeftCurly">
       <property name="id" value="LeftCurlyEol"/>
       <property name="tokens"
-                value="ANNOTATION_DEF, CLASS_DEF, CTOR_DEF, ENUM_CONSTANT_DEF, ENUM_DEF,
+        value="ANNOTATION_DEF, CLASS_DEF, CTOR_DEF, ENUM_CONSTANT_DEF, ENUM_DEF,
                     INTERFACE_DEF, LAMBDA, LITERAL_CATCH,
                     LITERAL_DO, LITERAL_ELSE, LITERAL_FINALLY, LITERAL_FOR, LITERAL_IF,
                     LITERAL_SWITCH, LITERAL_SYNCHRONIZED, LITERAL_TRY, LITERAL_WHILE, METHOD_DEF,
@@ -108,7 +108,7 @@
       <property name="id" value="LeftCurlyNl"/>
       <property name="option" value="nl"/>
       <property name="tokens"
-                value="LITERAL_CASE, LITERAL_DEFAULT"/>
+        value="LITERAL_CASE, LITERAL_DEFAULT"/>
     </module>
     <module name="SuppressionXpathSingleFilter">
       <!-- LITERAL_CASE, LITERAL_DEFAULT are reused in SWITCH_RULE  -->
@@ -118,7 +118,7 @@
     <module name="RightCurly">
       <property name="id" value="RightCurlySame"/>
       <property name="tokens"
-                value="LITERAL_TRY, LITERAL_CATCH, LITERAL_IF, LITERAL_ELSE,
+        value="LITERAL_TRY, LITERAL_CATCH, LITERAL_IF, LITERAL_ELSE,
                     LITERAL_DO"/>
     </module>
     <module name="SuppressionXpathSingleFilter">
@@ -130,7 +130,7 @@
       <property name="id" value="RightCurlyAlone"/>
       <property name="option" value="alone"/>
       <property name="tokens"
-               value="CLASS_DEF, METHOD_DEF, CTOR_DEF, LITERAL_FOR, LITERAL_WHILE, STATIC_INIT,
+        value="CLASS_DEF, METHOD_DEF, CTOR_DEF, LITERAL_FOR, LITERAL_WHILE, STATIC_INIT,
                     INSTANCE_INIT, ANNOTATION_DEF, ENUM_DEF, INTERFACE_DEF, RECORD_DEF,
                     COMPACT_CTOR_DEF, LITERAL_SWITCH, LITERAL_CASE, LITERAL_FINALLY,
                     LITERAL_CATCH"/>
@@ -147,7 +147,7 @@
     </module>
     <module name="WhitespaceAfter">
       <property name="tokens"
-               value="COMMA, SEMI, TYPECAST, ELLIPSIS, LITERAL_YIELD, LITERAL_CASE, ANNOTATIONS"/>
+        value="COMMA, SEMI, TYPECAST, ELLIPSIS, LITERAL_YIELD, LITERAL_CASE, ANNOTATIONS"/>
     </module>
     <module name="WhitespaceAround">
       <property name="allowEmptyConstructors" value="true"/>
@@ -158,7 +158,7 @@
       <property name="allowEmptySwitchBlockStatements" value="true"/>
       <property name="ignoreEnhancedForColon" value="false"/>
       <property name="tokens"
-               value="ASSIGN, BAND, BAND_ASSIGN, BOR, BOR_ASSIGN, BSR, BSR_ASSIGN, BXOR,
+        value="ASSIGN, BAND, BAND_ASSIGN, BOR, BOR_ASSIGN, BSR, BSR_ASSIGN, BXOR,
                     BXOR_ASSIGN, COLON, DIV, DIV_ASSIGN, DO_WHILE, EQUAL, GE, GT, LAMBDA, LAND,
                     LCURLY, LE, LITERAL_CATCH, LITERAL_DO, LITERAL_ELSE, LITERAL_FINALLY,
                     LITERAL_FOR, LITERAL_IF, LITERAL_RETURN, LITERAL_SWITCH, LITERAL_SYNCHRONIZED,
@@ -167,10 +167,10 @@
                     SR_ASSIGN, STAR, STAR_ASSIGN, LITERAL_ASSERT,
                     TYPE_EXTENSION_AND, LITERAL_WHEN"/>
       <message key="ws.notFollowed"
-              value="WhitespaceAround: ''{0}'' is not followed by whitespace. Empty blocks
+        value="WhitespaceAround: ''{0}'' is not followed by whitespace. Empty blocks
                may only be represented as '{}' when not part of a multi-block statement (4.1.3)"/>
       <message key="ws.notPreceded"
-              value="WhitespaceAround: ''{0}'' is not preceded with whitespace."/>
+        value="WhitespaceAround: ''{0}'' is not preceded with whitespace."/>
     </module>
     <module name="SuppressionXpathSingleFilter">
       <property name="checks" value="WhitespaceAround"/>
@@ -199,10 +199,10 @@
     <module name="FallThrough"/>
     <module name="UpperEll"/>
     <module name="ModifierOrder"/>
-<!--    <module name="TextBlockGoogleStyleFormatting"/>-->
+    <!--    <module name="TextBlockGoogleStyleFormatting"/>-->
     <module name="EmptyLineSeparator">
       <property name="tokens"
-               value="PACKAGE_DEF, IMPORT, STATIC_IMPORT, CLASS_DEF, INTERFACE_DEF, ENUM_DEF,
+        value="PACKAGE_DEF, IMPORT, STATIC_IMPORT, CLASS_DEF, INTERFACE_DEF, ENUM_DEF,
                     STATIC_INIT, INSTANCE_INIT, METHOD_DEF, CTOR_DEF, VARIABLE_DEF, RECORD_DEF,
                     COMPACT_CTOR_DEF"/>
       <property name="allowNoEmptyLineBetweenFields" value="true"/>
@@ -238,86 +238,86 @@
     <module name="PackageName">
       <property name="format" value="^[a-z]+(\.[a-z][a-z0-9]*)*$"/>
       <message key="name.invalidPattern"
-             value="Package name ''{0}'' must match pattern ''{1}''."/>
+        value="Package name ''{0}'' must match pattern ''{1}''."/>
     </module>
     <module name="TypeName">
       <property name="format" value="^[A-Z][a-zA-Z0-9]*(?:[0-9](?:_[0-9]+)*)?$"/>
       <property name="tokens" value="CLASS_DEF"/>
       <message key="name.invalidPattern"
-             value="Type name ''{0}'' must match pattern ''{1}''."/>
+        value="Type name ''{0}'' must match pattern ''{1}''."/>
     </module>
     <module name="TypeName">
       <property name="tokens" value="INTERFACE_DEF, ENUM_DEF,
                     ANNOTATION_DEF, RECORD_DEF"/>
       <message key="name.invalidPattern"
-             value="Type name ''{0}'' must match pattern ''{1}''."/>
+        value="Type name ''{0}'' must match pattern ''{1}''."/>
     </module>
     <module name="MemberName">
       <property name="format"
         value="^(?![a-z]$)(?![a-z][A-Z])[a-z][a-zA-Z0-9]*(?:_[0-9]+)*$"/>
       <message key="name.invalidPattern"
-             value="Member name ''{0}'' must match pattern ''{1}''."/>
+        value="Member name ''{0}'' must match pattern ''{1}''."/>
     </module>
     <module name="ParameterName">
       <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$"/>
       <message key="name.invalidPattern"
-             value="Parameter name ''{0}'' must match pattern ''{1}''."/>
+        value="Parameter name ''{0}'' must match pattern ''{1}''."/>
     </module>
     <module name="LambdaParameterName">
       <property name="format" value="^(_|[a-z]([a-z0-9][a-zA-Z0-9]*)?)$"/>
       <message key="name.invalidPattern"
-             value="Lambda parameter name ''{0}'' must match pattern ''{1}''."/>
+        value="Lambda parameter name ''{0}'' must match pattern ''{1}''."/>
     </module>
     <module name="CatchParameterName">
       <property name="format" value="^(_|[a-z]([a-z0-9][a-zA-Z0-9]*)?)$"/>
       <message key="name.invalidPattern"
-             value="Catch parameter name ''{0}'' must match pattern ''{1}''."/>
+        value="Catch parameter name ''{0}'' must match pattern ''{1}''."/>
     </module>
     <module name="LocalVariableName">
       <property name="format" value="^(_|[a-z]([a-z0-9][a-zA-Z0-9]*)?)$"/>
       <message key="name.invalidPattern"
-             value="Local variable name ''{0}'' must match pattern ''{1}''."/>
+        value="Local variable name ''{0}'' must match pattern ''{1}''."/>
     </module>
     <module name="PatternVariableName">
       <property name="format" value="^(_|[a-z]([a-z0-9][a-zA-Z0-9]*)?)$"/>
       <message key="name.invalidPattern"
-             value="Pattern variable name ''{0}'' must match pattern ''{1}''."/>
+        value="Pattern variable name ''{0}'' must match pattern ''{1}''."/>
     </module>
     <module name="ClassTypeParameterName">
       <property name="format" value="(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)"/>
       <message key="name.invalidPattern"
-             value="Class type name ''{0}'' must match pattern ''{1}''."/>
+        value="Class type name ''{0}'' must match pattern ''{1}''."/>
     </module>
     <module name="RecordComponentName">
       <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$"/>
       <message key="name.invalidPattern"
-               value="Record component name ''{0}'' must match pattern ''{1}''."/>
+        value="Record component name ''{0}'' must match pattern ''{1}''."/>
     </module>
     <module name="RecordTypeParameterName">
       <property name="format" value="(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)"/>
       <message key="name.invalidPattern"
-               value="Record type name ''{0}'' must match pattern ''{1}''."/>
+        value="Record type name ''{0}'' must match pattern ''{1}''."/>
     </module>
     <module name="MethodTypeParameterName">
       <property name="format" value="(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)"/>
       <message key="name.invalidPattern"
-             value="Method type name ''{0}'' must match pattern ''{1}''."/>
+        value="Method type name ''{0}'' must match pattern ''{1}''."/>
     </module>
     <module name="InterfaceTypeParameterName">
       <property name="format" value="(^[A-Z][0-9]?)$|([A-Z][a-zA-Z0-9]*[T]$)"/>
       <message key="name.invalidPattern"
-             value="Interface type name ''{0}'' must match pattern ''{1}''."/>
+        value="Interface type name ''{0}'' must match pattern ''{1}''."/>
     </module>
     <module name="NoFinalizer"/>
     <module name="GenericWhitespace">
       <message key="ws.followed"
-             value="GenericWhitespace ''{0}'' is followed by whitespace."/>
+        value="GenericWhitespace ''{0}'' is followed by whitespace."/>
       <message key="ws.preceded"
-             value="GenericWhitespace ''{0}'' is preceded with whitespace."/>
+        value="GenericWhitespace ''{0}'' is preceded with whitespace."/>
       <message key="ws.illegalFollow"
-             value="GenericWhitespace ''{0}'' should followed by whitespace."/>
+        value="GenericWhitespace ''{0}'' should followed by whitespace."/>
       <message key="ws.notPreceded"
-             value="GenericWhitespace ''{0}'' is not preceded with whitespace."/>
+        value="GenericWhitespace ''{0}'' is not preceded with whitespace."/>
     </module>
     <module name="Indentation">
       <property name="basicOffset" value="2"/>
@@ -333,7 +333,7 @@
       <property name="allowedAbbreviationLength" value="1"/>
       <property name="allowedAbbreviations" value="OAuth,API,URL,URI,ID,DTO"/>
       <property name="tokens"
-               value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, ANNOTATION_DEF, ANNOTATION_FIELD_DEF,
+        value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, ANNOTATION_DEF, ANNOTATION_FIELD_DEF,
                     PARAMETER_DEF, VARIABLE_DEF, METHOD_DEF, PATTERN_VARIABLE_DEF, RECORD_DEF,
                     RECORD_COMPONENT_DEF"/>
     </module>
@@ -349,40 +349,40 @@
     </module>
     <module name="MethodParamPad">
       <property name="tokens"
-               value="CTOR_DEF, LITERAL_NEW, METHOD_CALL, METHOD_DEF, CTOR_CALL,
+        value="CTOR_DEF, LITERAL_NEW, METHOD_CALL, METHOD_DEF, CTOR_CALL,
                     SUPER_CTOR_CALL, ENUM_CONSTANT_DEF, RECORD_DEF, RECORD_PATTERN_DEF"/>
     </module>
     <module name="NoWhitespaceBefore">
       <property name="tokens"
-               value="COMMA, SEMI, POST_INC, POST_DEC, DOT,
+        value="COMMA, SEMI, POST_INC, POST_DEC, DOT,
                     LABELED_STAT, METHOD_REF, ELLIPSIS"/>
       <property name="allowLineBreaks" value="true"/>
     </module>
     <module name="SuppressionXpathSingleFilter">
       <property name="checks" value="NoWhitespaceBefore"/>
       <property name="query"
-          value="//ELLIPSIS[preceding-sibling::TYPE/ANNOTATIONS[ANNOTATION[LPAREN]
+        value="//ELLIPSIS[preceding-sibling::TYPE/ANNOTATIONS[ANNOTATION[LPAREN]
               or not(following-sibling::*)]]"/>
     </module>
-<!--    <module name="ParenPad">
-      <property name="tokens"
-               value="ANNOTATION, ANNOTATION_FIELD_DEF, CTOR_CALL, CTOR_DEF, DOT, ENUM_CONSTANT_DEF,
-                    EXPR, LITERAL_CATCH, LITERAL_DO, LITERAL_FOR, LITERAL_IF, LITERAL_NEW,
-                    LITERAL_SWITCH, LITERAL_SYNCHRONIZED, LITERAL_WHILE, METHOD_CALL,
-                    METHOD_DEF, QUESTION, RESOURCE_SPECIFICATION, SUPER_CTOR_CALL, LAMBDA,
-                    RECORD_DEF, RECORD_PATTERN_DEF"/>
-    </module>-->
+    <!--    <module name="ParenPad">
+          <property name="tokens"
+                   value="ANNOTATION, ANNOTATION_FIELD_DEF, CTOR_CALL, CTOR_DEF, DOT, ENUM_CONSTANT_DEF,
+                        EXPR, LITERAL_CATCH, LITERAL_DO, LITERAL_FOR, LITERAL_IF, LITERAL_NEW,
+                        LITERAL_SWITCH, LITERAL_SYNCHRONIZED, LITERAL_WHILE, METHOD_CALL,
+                        METHOD_DEF, QUESTION, RESOURCE_SPECIFICATION, SUPER_CTOR_CALL, LAMBDA,
+                        RECORD_DEF, RECORD_PATTERN_DEF"/>
+        </module>-->
     <module name="OperatorWrap">
       <property name="option" value="NL"/>
       <property name="tokens"
-               value="BAND, BOR, BSR, BXOR, DIV, EQUAL, GE, GT, LAND, LE, LITERAL_INSTANCEOF, LOR,
+        value="BAND, BOR, BSR, BXOR, DIV, EQUAL, GE, GT, LAND, LE, LITERAL_INSTANCEOF, LOR,
                     LT, MINUS, MOD, NOT_EQUAL, PLUS, QUESTION, SL, SR, STAR, METHOD_REF,
                     TYPE_EXTENSION_AND"/>
     </module>
     <module name="AnnotationLocation">
       <property name="id" value="AnnotationLocationMostCases"/>
       <property name="tokens"
-               value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, CTOR_DEF,
+        value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, CTOR_DEF,
                       RECORD_DEF, COMPACT_CTOR_DEF, PACKAGE_DEF"/>
     </module>
     <module name="AnnotationLocation">
@@ -393,66 +393,65 @@
     <module name="NonEmptyAtclauseDescription"/>
     <module name="InvalidJavadocPosition"/>
     <module name="JavadocTagContinuationIndentation"/>
-<!--    <module name="SummaryJavadoc">-->
-<!--      <property name="forbiddenSummaryFragments"-->
-<!--        value="^@return the *|^This method returns |^A [{]@code [a-zA-Z0-9]+[}]( is a )|^[a-z]"/>-->
-<!--    </module>-->
-<!--    <module name="JavadocParagraph">-->
-<!--      <property name="allowNewlineParagraph" value="false"/>-->
-<!--    </module>-->
-<!--    <module name="RequireEmptyLineBeforeBlockTagGroup"/>-->
-<!--    <module name="AtclauseOrder">-->
-<!--      <property name="tagOrder" value="@param, @return, @throws, @deprecated"/>-->
-<!--      <property name="target"-->
-<!--               value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, CTOR_DEF, VARIABLE_DEF"/>-->
-<!--    </module>-->
-<!--    <module name="JavadocMethod">-->
-<!--      <property name="accessModifiers" value="public"/>-->
-<!--      <property name="allowMissingParamTags" value="true"/>-->
-<!--      <property name="allowMissingReturnTag" value="true"/>-->
-<!--      <property name="allowedAnnotations" value="Override, Test"/>-->
-<!--      <property name="tokens" value="METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF"/>-->
-<!--    </module>-->
-<!--    <module name="MissingJavadocMethod">-->
-<!--      <property name="scope" value="protected"/>-->
-<!--      <property name="allowMissingPropertyJavadoc" value="true"/>-->
-<!--      <property name="allowedAnnotations" value="Override, Test"/>-->
-<!--      <property name="tokens" value="METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF,-->
-<!--                                   COMPACT_CTOR_DEF"/>-->
-<!--    </module>-->
-<!--    <module name="SuppressionXpathSingleFilter">-->
-<!--      <property name="checks" value="MissingJavadocMethod"/>-->
-<!--      <property name="query" value="//*[self::METHOD_DEF or self::CTOR_DEF-->
-<!--                                 or self::ANNOTATION_FIELD_DEF or self::COMPACT_CTOR_DEF]-->
-<!--                                 [ancestor::*[self::INTERFACE_DEF or self::CLASS_DEF-->
-<!--                                 or self::RECORD_DEF or self::ENUM_DEF]-->
-<!--                                 [not(./MODIFIERS/LITERAL_PUBLIC)]]"/>-->
-<!--    </module>-->
-<!--    <module name="MissingJavadocType">-->
-<!--      <property name="scope" value="protected"/>-->
-<!--      <property name="tokens"-->
-<!--                value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF,-->
-<!--                      RECORD_DEF, ANNOTATION_DEF"/>-->
-<!--      <property name="excludeScope" value="nothing"/>-->
-<!--    </module>-->
+    <!--    <module name="SummaryJavadoc">-->
+    <!--      <property name="forbiddenSummaryFragments"-->
+    <!--        value="^@return the *|^This method returns |^A [{]@code [a-zA-Z0-9]+[}]( is a )|^[a-z]"/>-->
+    <!--    </module>-->
+    <!--    <module name="JavadocParagraph">-->
+    <!--      <property name="allowNewlineParagraph" value="false"/>-->
+    <!--    </module>-->
+    <!--    <module name="RequireEmptyLineBeforeBlockTagGroup"/>-->
+    <!--    <module name="AtclauseOrder">-->
+    <!--      <property name="tagOrder" value="@param, @return, @throws, @deprecated"/>-->
+    <!--      <property name="target"-->
+    <!--               value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, CTOR_DEF, VARIABLE_DEF"/>-->
+    <!--    </module>-->
+    <!--    <module name="JavadocMethod">-->
+    <!--      <property name="accessModifiers" value="public"/>-->
+    <!--      <property name="allowMissingParamTags" value="true"/>-->
+    <!--      <property name="allowMissingReturnTag" value="true"/>-->
+    <!--      <property name="allowedAnnotations" value="Override, Test"/>-->
+    <!--      <property name="tokens" value="METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF, COMPACT_CTOR_DEF"/>-->
+    <!--    </module>-->
+    <!--    <module name="MissingJavadocMethod">-->
+    <!--      <property name="scope" value="protected"/>-->
+    <!--      <property name="allowMissingPropertyJavadoc" value="true"/>-->
+    <!--      <property name="allowedAnnotations" value="Override, Test"/>-->
+    <!--      <property name="tokens" value="METHOD_DEF, CTOR_DEF, ANNOTATION_FIELD_DEF,-->
+    <!--                                   COMPACT_CTOR_DEF"/>-->
+    <!--    </module>-->
+    <!--    <module name="SuppressionXpathSingleFilter">-->
+    <!--      <property name="checks" value="MissingJavadocMethod"/>-->
+    <!--      <property name="query" value="//*[self::METHOD_DEF or self::CTOR_DEF-->
+    <!--                                 or self::ANNOTATION_FIELD_DEF or self::COMPACT_CTOR_DEF]-->
+    <!--                                 [ancestor::*[self::INTERFACE_DEF or self::CLASS_DEF-->
+    <!--                                 or self::RECORD_DEF or self::ENUM_DEF]-->
+    <!--                                 [not(./MODIFIERS/LITERAL_PUBLIC)]]"/>-->
+    <!--    </module>-->
+    <!--    <module name="MissingJavadocType">-->
+    <!--      <property name="scope" value="protected"/>-->
+    <!--      <property name="tokens"-->
+    <!--                value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF,-->
+    <!--                      RECORD_DEF, ANNOTATION_DEF"/>-->
+    <!--      <property name="excludeScope" value="nothing"/>-->
+    <!--    </module>-->
     <module name="MethodName">
       <property name="format"
-          value="^(?![a-z]$)(?![a-z][A-Z])[a-z][a-z0-9]*(?:[A-Z][a-z0-9]*)*(?:_[0-9]+)*$"/>
+        value="^(?![a-z]$)(?![a-z][A-Z])[a-z][a-z0-9]*(?:[A-Z][a-z0-9]*)*(?:_[0-9]+)*$"/>
       <message key="name.invalidPattern"
-             value="Method name ''{0}'' must match pattern ''{1}''."/>
+        value="Method name ''{0}'' must match pattern ''{1}''."/>
     </module>
     <module name="SuppressionXpathSingleFilter">
       <property name="checks" value="MethodName"/>
       <property name="query" value="//METHOD_DEF[
-                                     ./MODIFIERS/ANNOTATION//IDENT[contains(@text, 'Test')]
-                                   ]/IDENT"/>
-      <property name="message" value="'[a-z][a-z0-9][a-zA-Z0-9]*(?:_[a-z][a-z0-9][a-zA-Z0-9]*)*'"/>
+                                 ./MODIFIERS/ANNOTATION//IDENT[contains(@text, 'Test')]
+                               ]/IDENT"/>
     </module>
     <module name="SingleLineJavadoc"/>
     <module name="TodoComment">
       <property name="format" value="^[ \t]*(?!TODO:)(?i:TODO)\b:?"/>
       <message key="todo.match"
-               value="''TODO:'' must be written in all caps and followed by a colon."/>
+        value="''TODO:'' must be written in all caps and followed by a colon."/>
     </module>
     <module name="EmptyCatchBlock">
       <property name="commentFormat" value="\w+"/>
@@ -463,14 +462,14 @@
     <!-- https://checkstyle.org/filters/suppressionxpathfilter.html -->
     <module name="SuppressionXpathFilter">
       <property name="file" value="${org.checkstyle.google.suppressionxpathfilter.config}"
-             default="checkstyle-xpath-suppressions.xml" />
+        default="checkstyle-xpath-suppressions.xml"/>
       <property name="optional" value="true"/>
     </module>
-    <module name="SuppressWarningsHolder" />
+    <module name="SuppressWarningsHolder"/>
     <module name="SuppressionCommentFilter">
-      <property name="offCommentFormat" value="CHECKSTYLE.OFF\: ([\w\|]+)" />
-      <property name="onCommentFormat" value="CHECKSTYLE.ON\: ([\w\|]+)" />
-      <property name="checkFormat" value="$1" />
+      <property name="offCommentFormat" value="CHECKSTYLE.OFF\: ([\w\|]+)"/>
+      <property name="onCommentFormat" value="CHECKSTYLE.ON\: ([\w\|]+)"/>
+      <property name="checkFormat" value="$1"/>
     </module>
     <module name="SuppressWithNearbyCommentFilter">
       <property name="commentFormat" value="CHECKSTYLE.SUPPRESS\: ([\w\|]+)"/>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,11 +42,11 @@ services:
       - ticketrush-net
 
     healthcheck:
-      test: [ "CMD-SHELL", "kafka-topics.sh --bootstrap-server localhost:9092 --list >/dev/null 2>&1 || exit 1" ]
+      test: [ "CMD-SHELL", "/opt/kafka/bin/kafka-topics.sh --bootstrap-server localhost:9092 --list >/dev/null 2>&1 || exit 1" ]
       interval: 10s
       timeout: 10s
       retries: 5
-      start_period: 20s
+      start_period: 30s
 
   kafka-ui:
     image: provectuslabs/kafka-ui:v0.7.2

--- a/seat-service/build.gradle
+++ b/seat-service/build.gradle
@@ -57,7 +57,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
     // Redisson
-    implementation 'org.redisson:redisson-spring-boot-starter:3.27.0'
+    implementation 'org.redisson:redisson-spring-boot-starter:4.0.0'
 }
 
 dependencyManagement {

--- a/seat-service/src/main/java/com/ticketrush/SeatServiceApplication.java
+++ b/seat-service/src/main/java/com/ticketrush/SeatServiceApplication.java
@@ -2,7 +2,9 @@ package com.ticketrush;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @SpringBootApplication
 public class SeatServiceApplication {
 

--- a/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/app/dto/response/SeatLayoutResponse.java
+++ b/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/app/dto/response/SeatLayoutResponse.java
@@ -1,3 +1,3 @@
 package com.ticketrush.boundedcontext.seat.app.dto.response;
 
-public record SeatLayoutResponse(Long seatId, Long seatLayoutId, String rowNo, Integer colNo) {}
+public record SeatLayoutResponse(Long seatId, Long seatLayoutId, String seatNumber) {}

--- a/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/app/scheduler/SeatStatusScheduler.java
+++ b/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/app/scheduler/SeatStatusScheduler.java
@@ -14,6 +14,7 @@ public class SeatStatusScheduler {
   private final SeatReleaseExpiredUseCase seatReleaseExpiredUseCase;
 
   // 실시간 처리는 Redis Event Listener가 담당하므로, 스케줄러는 1분(60,000ms) 주기의 Fallback 역할만 수행
+  // TODO: 다중 인스턴스 배포(Scale-Out) 시 중복 벌크 업데이트 방지를 위해 ShedLock 또는 Redis 분산 락 도입 필요
   @Scheduled(fixedDelay = 60000)
   public void scheduleReleaseExpiredHoldsFallback() {
     log.debug("Fallback 스케줄러 동작: 유실된 만료 좌석 검사 시작");

--- a/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/app/scheduler/SeatStatusScheduler.java
+++ b/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/app/scheduler/SeatStatusScheduler.java
@@ -2,18 +2,21 @@ package com.ticketrush.boundedcontext.seat.app.scheduler;
 
 import com.ticketrush.boundedcontext.seat.app.usecase.SeatReleaseExpiredUseCase;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class SeatStatusScheduler {
 
   private final SeatReleaseExpiredUseCase seatReleaseExpiredUseCase;
 
-  /** 10초마다 만료된 좌석을 검사하여 롤백 (트래픽 상황에 맞춰 주기 조정) */
-  @Scheduled(fixedDelay = 10000)
-  public void scheduleReleaseExpiredHolds() {
+  // 실시간 처리는 Redis Event Listener가 담당하므로, 스케줄러는 1분(60,000ms) 주기의 Fallback 역할만 수행
+  @Scheduled(fixedDelay = 60000)
+  public void scheduleReleaseExpiredHoldsFallback() {
+    log.debug("Fallback 스케줄러 동작: 유실된 만료 좌석 검사 시작");
     seatReleaseExpiredUseCase.execute();
   }
 }

--- a/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/app/scheduler/SeatStatusScheduler.java
+++ b/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/app/scheduler/SeatStatusScheduler.java
@@ -1,0 +1,19 @@
+package com.ticketrush.boundedcontext.seat.app.scheduler;
+
+import com.ticketrush.boundedcontext.seat.app.usecase.SeatReleaseExpiredUseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class SeatStatusScheduler {
+
+  private final SeatReleaseExpiredUseCase seatReleaseExpiredUseCase;
+
+  /** 10초마다 만료된 좌석을 검사하여 롤백 (트래픽 상황에 맞춰 주기 조정) */
+  @Scheduled(fixedDelay = 10000)
+  public void scheduleReleaseExpiredHolds() {
+    seatReleaseExpiredUseCase.execute();
+  }
+}

--- a/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/app/usecase/SeatReleaseExpiredUseCase.java
+++ b/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/app/usecase/SeatReleaseExpiredUseCase.java
@@ -1,0 +1,29 @@
+package com.ticketrush.boundedcontext.seat.app.usecase;
+
+import com.ticketrush.boundedcontext.seat.domain.types.SeatStatus;
+import com.ticketrush.boundedcontext.seat.out.repository.SeatRepository;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class SeatReleaseExpiredUseCase {
+
+  private final SeatRepository seatRepository;
+
+  @Transactional
+  public void execute() {
+    LocalDateTime now = LocalDateTime.now();
+    // 만료 시간이 현재 시간보다 이전이면서 상태가 HOLD인 좌석을 AVAILABLE로 변경
+    int releasedCount =
+        seatRepository.releaseExpiredSeats(SeatStatus.AVAILABLE, SeatStatus.HOLD, now);
+
+    if (releasedCount > 0) {
+      log.info("만료된 좌석 {}개의 상태를 AVAILABLE로 롤백했습니다. 기준 시간: {}", releasedCount, now);
+    }
+  }
+}

--- a/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/app/usecase/SeatReleaseSingleUseCase.java
+++ b/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/app/usecase/SeatReleaseSingleUseCase.java
@@ -17,10 +17,14 @@ public class SeatReleaseSingleUseCase {
   public void execute(Long seatId) {
     seatRepository
         .findById(seatId)
-        .ifPresent(
+        .ifPresentOrElse(
             seat -> {
               seat.releaseHold();
               log.info("Redis 만료 이벤트 수신: 좌석 {} 상태를 AVAILABLE로 즉시 롤백했습니다.", seatId);
+            },
+            () -> {
+              log.warn(
+                  "Redis 만료 이벤트 수신: 대상 좌석을 DB에서 찾을 수 없습니다. (데이터 정합성 확인 필요) seatId: {}", seatId);
             });
   }
 }

--- a/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/app/usecase/SeatReleaseSingleUseCase.java
+++ b/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/app/usecase/SeatReleaseSingleUseCase.java
@@ -1,0 +1,26 @@
+package com.ticketrush.boundedcontext.seat.app.usecase;
+
+import com.ticketrush.boundedcontext.seat.out.repository.SeatRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class SeatReleaseSingleUseCase {
+
+  private final SeatRepository seatRepository;
+
+  @Transactional
+  public void execute(Long seatId) {
+    seatRepository
+        .findById(seatId)
+        .ifPresent(
+            seat -> {
+              seat.releaseHold();
+              log.info("Redis 만료 이벤트 수신: 좌석 {} 상태를 AVAILABLE로 즉시 롤백했습니다.", seatId);
+            });
+  }
+}

--- a/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/domain/entity/Seat.java
+++ b/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/domain/entity/Seat.java
@@ -68,11 +68,4 @@ public class Seat extends AutoIdBaseEntity {
     this.seatStatus = SeatStatus.HOLD;
     this.holdExpiredAt = expiredAt;
   }
-
-  public void releaseHold() {
-    if (this.seatStatus == SeatStatus.HOLD) {
-      this.seatStatus = SeatStatus.AVAILABLE;
-      this.holdExpiredAt = null;
-    }
-  }
 }

--- a/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/domain/entity/Seat.java
+++ b/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/domain/entity/Seat.java
@@ -68,4 +68,11 @@ public class Seat extends AutoIdBaseEntity {
     this.seatStatus = SeatStatus.HOLD;
     this.holdExpiredAt = expiredAt;
   }
+
+  public void releaseHold() {
+    if (this.seatStatus == SeatStatus.HOLD) {
+      this.seatStatus = SeatStatus.AVAILABLE;
+      this.holdExpiredAt = null;
+    }
+  }
 }

--- a/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/domain/entity/SeatLayout.java
+++ b/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/domain/entity/SeatLayout.java
@@ -20,16 +20,16 @@ public class SeatLayout extends AutoIdBaseEntity {
   @Column(nullable = false)
   private Long performanceId;
 
-  @Column(nullable = false, length = 10)
-  private String rowNo;
+  @Column(nullable = false)
+  private Integer totalRows; // 총 행의 개수 (예: 10)
 
   @Column(nullable = false)
-  private Integer colNo;
+  private Integer maxCols; // 열의 최대 개수 (예: 12)
 
   @Builder
-  public SeatLayout(Long performanceId, String rowNo, Integer colNo) {
+  public SeatLayout(Long performanceId, Integer totalRows, Integer maxCols) {
     this.performanceId = performanceId;
-    this.rowNo = rowNo;
-    this.colNo = colNo;
+    this.totalRows = totalRows;
+    this.maxCols = maxCols;
   }
 }

--- a/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/in/datainit/SeatDataInit.java
+++ b/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/in/datainit/SeatDataInit.java
@@ -1,0 +1,77 @@
+package com.ticketrush.boundedcontext.seat.app.init;
+
+import com.ticketrush.boundedcontext.seat.domain.entity.Seat;
+import com.ticketrush.boundedcontext.seat.domain.entity.SeatLayout;
+import com.ticketrush.boundedcontext.seat.domain.types.SeatStatus;
+import com.ticketrush.boundedcontext.seat.out.repository.SeatLayoutRepository;
+import com.ticketrush.boundedcontext.seat.out.repository.SeatRepository;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Profile({"local", "dev"})
+@Component
+@RequiredArgsConstructor
+public class SeatDataInit implements ApplicationRunner {
+
+  private final SeatRepository seatRepository;
+  private final SeatLayoutRepository seatLayoutRepository;
+
+  @Override
+  @Transactional
+  public void run(ApplicationArguments args) {
+    // 1. 이미 데이터가 존재하면 실행하지 않음 (중복 방지)
+    if (seatRepository.count() > 0) {
+      log.info("좌석 더미 데이터가 이미 존재하여 초기화를 스킵합니다.");
+      return;
+    }
+
+    Long performanceId = 1L; // 테스트용 공연 ID
+
+    // 2. 공연의 '도면(Layout)'을 1개 생성
+    SeatLayout masterLayout =
+        SeatLayout.builder().performanceId(performanceId).totalRows(10).maxCols(12).build();
+    SeatLayout savedLayout = seatLayoutRepository.save(masterLayout);
+
+    // 3. 저장된 도면 정보를 읽어와서 좌석 생성 기준 설정
+    int totalRows = savedLayout.getTotalRows();
+    int maxCols = savedLayout.getMaxCols();
+
+    List<Seat> seatsToSave = new ArrayList<>();
+
+    // 4. 1번 도면을 참조하는 120개(10x12)의 낱개 좌석(Seat) 생성
+    for (int i = 0; i < totalRows; i++) {
+      char rowChar = (char) ('A' + i); // 0 -> A, 1 -> B ...
+
+      for (int col = 1; col <= maxCols; col++) {
+        String seatNumber = rowChar + "-" + col;
+
+        Seat seat =
+            Seat.builder()
+                .seatLayoutId(savedLayout.getId())
+                .performanceId(performanceId)
+                .seatNumber(seatNumber)
+                .seatStatus(SeatStatus.AVAILABLE)
+                .holdExpiredAt(null)
+                .build();
+
+        seatsToSave.add(seat);
+      }
+    }
+
+    // 5. 생성된 120개 좌석 일괄 DB 저장
+    seatRepository.saveAll(seatsToSave);
+    log.info(
+        "도면 ID {}를 바탕으로 공연 ID {}의 더미 좌석 데이터 {}개가 모두 AVAILABLE 상태로 생성되었습니다.",
+        savedLayout.getId(),
+        performanceId,
+        seatsToSave.size());
+  }
+}

--- a/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/in/eventlistener/SeatLockExpirationListener.java
+++ b/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/in/eventlistener/SeatLockExpirationListener.java
@@ -1,6 +1,7 @@
 package com.ticketrush.boundedcontext.seat.in.eventlistener;
 
 import com.ticketrush.boundedcontext.seat.app.usecase.SeatReleaseSingleUseCase;
+import java.nio.charset.StandardCharsets;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.connection.Message;
 import org.springframework.data.redis.listener.KeyExpirationEventMessageListener;
@@ -23,7 +24,7 @@ public class SeatLockExpirationListener extends KeyExpirationEventMessageListene
 
   @Override
   public void onMessage(Message message, byte[] pattern) {
-    String expiredKey = message.toString();
+    String expiredKey = new String(message.getBody(), StandardCharsets.UTF_8);
 
     // 만료된 키가 좌석 락(seat:lock:)인지 확인
     if (expiredKey.startsWith(SEAT_LOCK_PREFIX)) {

--- a/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/in/eventlistener/SeatLockExpirationListener.java
+++ b/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/in/eventlistener/SeatLockExpirationListener.java
@@ -1,0 +1,47 @@
+package com.ticketrush.boundedcontext.seat.in.eventlistener;
+
+import com.ticketrush.boundedcontext.seat.app.usecase.SeatReleaseSingleUseCase;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.connection.Message;
+import org.springframework.data.redis.listener.KeyExpirationEventMessageListener;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class SeatLockExpirationListener extends KeyExpirationEventMessageListener {
+
+  private static final String SEAT_LOCK_PREFIX = "seat:lock:";
+  private final SeatReleaseSingleUseCase seatReleaseSingleUseCase;
+
+  public SeatLockExpirationListener(
+      RedisMessageListenerContainer listenerContainer,
+      SeatReleaseSingleUseCase seatReleaseSingleUseCase) {
+    super(listenerContainer);
+    this.seatReleaseSingleUseCase = seatReleaseSingleUseCase;
+  }
+
+  @Override
+  public void onMessage(Message message, byte[] pattern) {
+    String expiredKey = message.toString();
+
+    // 만료된 키가 좌석 락(seat:lock:)인지 확인
+    if (expiredKey.startsWith(SEAT_LOCK_PREFIX)) {
+      try {
+        // "seat:lock:123" 형태에서 "123" 추출
+        String seatIdStr = expiredKey.replace(SEAT_LOCK_PREFIX, "");
+        Long seatId = Long.valueOf(seatIdStr);
+
+        log.debug("Redis 락 만료 감지됨. seatId: {}", seatId);
+
+        // 즉각적인 상태 롤백 실행
+        seatReleaseSingleUseCase.execute(seatId);
+
+      } catch (NumberFormatException e) {
+        log.error("만료된 Redis 키에서 좌석 ID를 파싱할 수 없습니다. key: {}", expiredKey, e);
+      } catch (Exception e) {
+        log.error("Redis 만료 이벤트 처리 중 오류 발생. seatId 파싱키: {}", expiredKey, e);
+      }
+    }
+  }
+}

--- a/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/out/repository/SeatLayoutRepository.java
+++ b/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/out/repository/SeatLayoutRepository.java
@@ -1,0 +1,6 @@
+package com.ticketrush.boundedcontext.seat.out.repository;
+
+import com.ticketrush.boundedcontext.seat.domain.entity.SeatLayout;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SeatLayoutRepository extends JpaRepository<SeatLayout, Long> {}

--- a/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/out/repository/SeatRepository.java
+++ b/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/out/repository/SeatRepository.java
@@ -2,8 +2,11 @@ package com.ticketrush.boundedcontext.seat.out.repository;
 
 import com.ticketrush.boundedcontext.seat.app.dto.response.SeatLayoutResponse;
 import com.ticketrush.boundedcontext.seat.domain.entity.Seat;
+import com.ticketrush.boundedcontext.seat.domain.types.SeatStatus;
+import java.time.LocalDateTime;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -17,4 +20,13 @@ public interface SeatRepository extends JpaRepository<Seat, Long> {
           + "WHERE s.performanceId = :performanceId")
   List<SeatLayoutResponse> findSeatLayoutsByPerformanceId(
       @Param("performanceId") Long performanceId);
+
+  @Modifying(clearAutomatically = true)
+  @Query(
+      "UPDATE Seat s SET s.seatStatus = :availableStatus, s.holdExpiredAt = null "
+          + "WHERE s.seatStatus = :holdStatus AND s.holdExpiredAt <= :now")
+  int releaseExpiredSeats(
+      @Param("availableStatus") SeatStatus availableStatus,
+      @Param("holdStatus") SeatStatus holdStatus,
+      @Param("now") LocalDateTime now);
 }

--- a/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/out/repository/SeatRepository.java
+++ b/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/out/repository/SeatRepository.java
@@ -14,7 +14,7 @@ public interface SeatRepository extends JpaRepository<Seat, Long> {
 
   @Query(
       "SELECT new com.ticketrush.boundedcontext.seat.app.dto.response.SeatLayoutResponse("
-          + "s.id, sl.id, sl.rowNo, sl.colNo) "
+          + "s.id, sl.id, s.seatNumber) "
           + "FROM Seat s "
           + "JOIN SeatLayout sl ON s.seatLayoutId = sl.id "
           + "WHERE s.performanceId = :performanceId")

--- a/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/app/usecase/SeatGetSeatLayoutsUseCaseTest.java
+++ b/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/app/usecase/SeatGetSeatLayoutsUseCaseTest.java
@@ -16,17 +16,18 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class SeatGetSeatLayoutsUseCaseTest {
 
-  @InjectMocks private SeatGetSeatLayoutsUseCase useCase; // 테스트 대상
+  @InjectMocks private SeatGetSeatLayoutsUseCase useCase;
 
-  @Mock private SeatRepository seatRepository; // 가짜 객체
+  @Mock private SeatRepository seatRepository;
 
   @Test
   @DisplayName("공연 ID에 해당하는 정적 좌석 맵 리스트를 반환한다")
   void executeReturnsSeatLayouts() {
     // given
     Long performanceId = 1L;
+    // DTO 변경 반영: (seatId, layoutId, seatNumber)
     List<SeatLayoutResponse> expectedResponses =
-        List.of(new SeatLayoutResponse(1L, 101L, "A", 1), new SeatLayoutResponse(2L, 102L, "A", 2));
+        List.of(new SeatLayoutResponse(1L, 101L, "A-1"), new SeatLayoutResponse(2L, 101L, "A-2"));
     given(seatRepository.findSeatLayoutsByPerformanceId(performanceId))
         .willReturn(expectedResponses);
 
@@ -36,6 +37,6 @@ class SeatGetSeatLayoutsUseCaseTest {
     // then
     assertThat(actualResponses).hasSize(2);
     assertThat(actualResponses.getFirst().seatId()).isEqualTo(1L);
-    assertThat(actualResponses.getFirst().rowNo()).isEqualTo("A");
+    assertThat(actualResponses.getFirst().seatNumber()).isEqualTo("A-1");
   }
 }

--- a/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/app/usecase/SeatReleaseExpiredUseCaseTest.java
+++ b/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/app/usecase/SeatReleaseExpiredUseCaseTest.java
@@ -1,0 +1,39 @@
+package com.ticketrush.boundedcontext.seat.app.usecase;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import com.ticketrush.boundedcontext.seat.domain.types.SeatStatus;
+import com.ticketrush.boundedcontext.seat.out.repository.SeatRepository;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class SeatReleaseExpiredUseCaseTest {
+
+  @Mock private SeatRepository seatRepository;
+
+  @InjectMocks private SeatReleaseExpiredUseCase seatReleaseExpiredUseCase;
+
+  @Test
+  @DisplayName("만료된 좌석을 조회하여 상태를 롤백하는 레포지토리 메서드를 호출한다")
+  void execute_ReleasesExpiredSeats() {
+    // given
+    given(seatRepository.releaseExpiredSeats(any(), any(), any())).willReturn(5);
+
+    // when
+    seatReleaseExpiredUseCase.execute();
+
+    // then
+    verify(seatRepository)
+        .releaseExpiredSeats(
+            eq(SeatStatus.AVAILABLE), eq(SeatStatus.HOLD), any(LocalDateTime.class));
+  }
+}

--- a/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/app/usecase/SeatReleaseSingleUseCaseTest.java
+++ b/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/app/usecase/SeatReleaseSingleUseCaseTest.java
@@ -1,0 +1,55 @@
+package com.ticketrush.boundedcontext.seat.app.usecase;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.ticketrush.boundedcontext.seat.domain.entity.Seat;
+import com.ticketrush.boundedcontext.seat.out.repository.SeatRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class SeatReleaseSingleUseCaseTest {
+
+  @Mock private SeatRepository seatRepository;
+
+  @InjectMocks private SeatReleaseSingleUseCase seatReleaseSingleUseCase;
+
+  @Test
+  @DisplayName("존재하는 좌석의 만료 이벤트 수신 시 상태를 AVAILABLE로 롤백한다")
+  void execute_WhenSeatExists_ReleasesHold() {
+    // given
+    Long seatId = 1L;
+    Seat mockSeat = mock(Seat.class);
+    given(seatRepository.findById(seatId)).willReturn(Optional.of(mockSeat));
+
+    // when
+    seatReleaseSingleUseCase.execute(seatId);
+
+    // then
+    verify(seatRepository).findById(seatId);
+    verify(mockSeat).releaseHold(); // 엔티티의 상태 변경 메서드가 호출되었는지 검증
+  }
+
+  @Test
+  @DisplayName("존재하지 않는 좌석의 만료 이벤트 수신 시 예외를 던지지 않고 경고 로그만 남긴다")
+  void execute_WhenSeatDoesNotExist_DoesNotThrow() {
+    // given
+    Long seatId = 999L;
+    given(seatRepository.findById(seatId)).willReturn(Optional.empty());
+
+    // when
+    seatReleaseSingleUseCase.execute(seatId);
+
+    // then
+    verify(seatRepository).findById(seatId);
+    verify(mock(Seat.class), never()).releaseHold();
+  }
+}

--- a/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/in/api/v1/SeatControllerTest.java
+++ b/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/in/api/v1/SeatControllerTest.java
@@ -30,7 +30,7 @@ class SeatControllerTest {
     // given
     Long performanceId = 1L;
     List<SeatLayoutResponse> mockResponse =
-        List.of(new SeatLayoutResponse(1L, 101L, "A", 1), new SeatLayoutResponse(2L, 102L, "A", 2));
+        List.of(new SeatLayoutResponse(1L, 101L, "A-1"), new SeatLayoutResponse(2L, 101L, "A-2"));
     given(seatFacade.getPerformanceSeatLayouts(performanceId)).willReturn(mockResponse);
 
     // when & then
@@ -40,8 +40,9 @@ class SeatControllerTest {
         .andExpect(jsonPath("$.isSuccess").value(true))
         .andExpect(jsonPath("$.result.length()").value(2))
         .andExpect(jsonPath("$.result[0].seatId").value(1))
-        .andExpect(jsonPath("$.result[0].rowNo").value("A"))
-        .andExpect(jsonPath("$.result[0].colNo").value(1))
-        .andExpect(jsonPath("$.result[1].seatId").value(2));
+        .andExpect(jsonPath("$.result[0].seatLayoutId").value(101))
+        .andExpect(jsonPath("$.result[0].seatNumber").value("A-1"))
+        .andExpect(jsonPath("$.result[1].seatId").value(2))
+        .andExpect(jsonPath("$.result[1].seatNumber").value("A-2"));
   }
 }

--- a/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/in/eventlistener/SeatLockExpirationListenerTest.java
+++ b/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/in/eventlistener/SeatLockExpirationListenerTest.java
@@ -1,0 +1,54 @@
+package com.ticketrush.boundedcontext.seat.in.eventlistener;
+
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.ticketrush.boundedcontext.seat.app.usecase.SeatReleaseSingleUseCase;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.connection.DefaultMessage;
+import org.springframework.data.redis.connection.Message;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+
+@ExtendWith(MockitoExtension.class)
+class SeatLockExpirationListenerTest {
+
+  @Mock private RedisMessageListenerContainer listenerContainer;
+
+  @Mock private SeatReleaseSingleUseCase seatReleaseSingleUseCase;
+
+  @InjectMocks private SeatLockExpirationListener seatLockExpirationListener;
+
+  @Test
+  @DisplayName("올바른 키(seat:lock:) 만료 이벤트 수신 시 useCase를 호출한다")
+  void onMessage_WithValidKey_CallsUseCase() {
+    // given
+    String expiredKey = "seat:lock:123";
+    Message message = new DefaultMessage(new byte[0], expiredKey.getBytes());
+
+    // when
+    seatLockExpirationListener.onMessage(message, null);
+
+    // then
+    verify(seatReleaseSingleUseCase).execute(123L);
+  }
+
+  @Test
+  @DisplayName("다른 접두사의 키 만료 이벤트 수신 시 useCase를 호출하지 않는다")
+  void onMessage_WithInvalidPrefix_DoesNotCallUseCase() {
+    // given
+    String expiredKey = "some:other:key:123";
+    Message message = new DefaultMessage(new byte[0], expiredKey.getBytes());
+
+    // when
+    seatLockExpirationListener.onMessage(message, null);
+
+    // then
+    verify(seatReleaseSingleUseCase, never()).execute(anyLong());
+  }
+}

--- a/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/out/repository/SeatRepositoryTest.java
+++ b/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/out/repository/SeatRepositoryTest.java
@@ -22,44 +22,41 @@ class SeatRepositoryTest {
   @Autowired private TestEntityManager entityManager;
 
   @Test
-  @DisplayName("Seat과 SeatLayout을 조인하여 해당하는 공연의 DTO만 조회한다")
+  @DisplayName("Seat과 마스터 SeatLayout을 조인하여 해당하는 공연의 좌석 정보(DTO)만 조회한다")
   void findSeatLayoutsByPerformanceId() {
     // given
     Long targetPerformanceId = 1L;
     Long otherPerformanceId = 99L;
 
-    // 1. SeatLayout 데이터 세팅
-    SeatLayout layout1 =
-        SeatLayout.builder().performanceId(targetPerformanceId).rowNo("A").colNo(1).build();
-    SeatLayout layout2 =
-        SeatLayout.builder().performanceId(targetPerformanceId).rowNo("A").colNo(2).build();
+    // 1. 공연당 1개의 마스터 SeatLayout 세팅 (1대N 구조 반영)
+    SeatLayout targetLayout =
+        SeatLayout.builder().performanceId(targetPerformanceId).totalRows(10).maxCols(12).build();
     SeatLayout otherLayout =
-        SeatLayout.builder().performanceId(otherPerformanceId).rowNo("B").colNo(1).build();
+        SeatLayout.builder().performanceId(otherPerformanceId).totalRows(5).maxCols(5).build();
 
-    layout1 = entityManager.persist(layout1);
-    layout2 = entityManager.persist(layout2);
+    targetLayout = entityManager.persist(targetLayout);
     otherLayout = entityManager.persist(otherLayout);
 
-    // 2. Seat 데이터 세팅
+    // 2. 단일 마스터 레이아웃을 참조하는 여러 개의 Seat 데이터 세팅
     Seat seat1 =
         Seat.builder()
-            .seatLayoutId(layout1.getId())
+            .seatLayoutId(targetLayout.getId())
             .performanceId(targetPerformanceId)
-            .seatNumber("A1")
+            .seatNumber("A-1")
             .seatStatus(SeatStatus.AVAILABLE)
             .build();
     Seat seat2 =
         Seat.builder()
-            .seatLayoutId(layout2.getId())
+            .seatLayoutId(targetLayout.getId())
             .performanceId(targetPerformanceId)
-            .seatNumber("A2")
+            .seatNumber("A-2")
             .seatStatus(SeatStatus.AVAILABLE)
             .build();
     Seat otherSeat =
         Seat.builder()
             .seatLayoutId(otherLayout.getId())
             .performanceId(otherPerformanceId)
-            .seatNumber("B1")
+            .seatNumber("A-1")
             .seatStatus(SeatStatus.AVAILABLE)
             .build();
 
@@ -81,10 +78,9 @@ class SeatRepositoryTest {
         .extracting(
             SeatLayoutResponse::seatId,
             SeatLayoutResponse::seatLayoutId,
-            SeatLayoutResponse::rowNo,
-            SeatLayoutResponse::colNo)
+            SeatLayoutResponse::seatNumber)
         .containsExactlyInAnyOrder(
-            tuple(seat1.getId(), layout1.getId(), "A", 1),
-            tuple(seat2.getId(), layout2.getId(), "A", 2));
+            tuple(seat1.getId(), targetLayout.getId(), "A-1"),
+            tuple(seat2.getId(), targetLayout.getId(), "A-2"));
   }
 }

--- a/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/out/repository/SeatRepositoryTest.java
+++ b/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/out/repository/SeatRepositoryTest.java
@@ -7,6 +7,7 @@ import com.ticketrush.boundedcontext.seat.app.dto.response.SeatLayoutResponse;
 import com.ticketrush.boundedcontext.seat.domain.entity.Seat;
 import com.ticketrush.boundedcontext.seat.domain.entity.SeatLayout;
 import com.ticketrush.boundedcontext.seat.domain.types.SeatStatus;
+import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -82,5 +83,69 @@ class SeatRepositoryTest {
         .containsExactlyInAnyOrder(
             tuple(seat1.getId(), targetLayout.getId(), "A-1"),
             tuple(seat2.getId(), targetLayout.getId(), "A-2"));
+  }
+
+  @Test
+  @DisplayName("벌크 업데이트 쿼리로 시간이 만료된 HOLD 상태의 좌석을 AVAILABLE로 변경한다")
+  void releaseExpiredSeats_ChangesStatusToAvailable() {
+    // given
+    LocalDateTime now = LocalDateTime.now();
+
+    // 1. 이미 만료된 좌석 (HOLD 상태) -> 업데이트 대상 O
+    Seat expiredHoldSeat1 =
+        Seat.builder()
+            .seatLayoutId(1L)
+            .performanceId(100L)
+            .seatNumber("A1")
+            .seatStatus(SeatStatus.HOLD)
+            .holdExpiredAt(now.minusMinutes(1))
+            .build();
+
+    Seat expiredHoldSeat2 =
+        Seat.builder()
+            .seatLayoutId(1L)
+            .performanceId(100L)
+            .seatNumber("A2")
+            .seatStatus(SeatStatus.HOLD)
+            .holdExpiredAt(now.minusMinutes(5))
+            .build();
+
+    // 2. 만료되지 않은 좌석 (HOLD 상태) -> 업데이트 대상 X
+    Seat validHoldSeat =
+        Seat.builder()
+            .seatLayoutId(1L)
+            .performanceId(100L)
+            .seatNumber("A3")
+            .seatStatus(SeatStatus.HOLD)
+            .holdExpiredAt(now.plusMinutes(5))
+            .build();
+
+    // 3. 이미 결제 완료된 좌석 (SOLD 상태) -> 업데이트 대상 X
+    Seat soldSeat =
+        Seat.builder()
+            .seatLayoutId(1L)
+            .performanceId(100L)
+            .seatNumber("A4")
+            .seatStatus(SeatStatus.SOLD)
+            .holdExpiredAt(now.minusMinutes(1))
+            .build();
+
+    seatRepository.saveAll(List.of(expiredHoldSeat1, expiredHoldSeat2, validHoldSeat, soldSeat));
+
+    // when
+    int updatedCount =
+        seatRepository.releaseExpiredSeats(SeatStatus.AVAILABLE, SeatStatus.HOLD, now);
+
+    // then
+    assertThat(updatedCount).isEqualTo(2); // 만료된 HOLD 좌석 2개만 업데이트되어야 함
+
+    // DB에서 다시 조회하여 실제 상태 검증 (영속성 컨텍스트를 거치지 않고 DB에서 직접 확인하기 위해 벌크 연산 결과 검증)
+    Seat updatedSeat1 = seatRepository.findById(expiredHoldSeat1.getId()).orElseThrow();
+    Seat validSeat = seatRepository.findById(validHoldSeat.getId()).orElseThrow();
+    Seat updatedSoldSeat = seatRepository.findById(soldSeat.getId()).orElseThrow();
+
+    assertThat(updatedSeat1.getSeatStatus()).isEqualTo(SeatStatus.AVAILABLE); // AVAILABLE로 변경됨
+    assertThat(validSeat.getSeatStatus()).isEqualTo(SeatStatus.HOLD); // 변경되지 않음
+    assertThat(updatedSoldSeat.getSeatStatus()).isEqualTo(SeatStatus.SOLD); // 변경되지 않음
   }
 }


### PR DESCRIPTION
## 🔗 관련 이슈

- close #33 

---

## 📌 주요 변경 사항

- 좌석 선점 후 5분 만료 시 '정확한 즉각 해제'와 '데이터 정합성'을 모두 보장하기 위해 **하이브리드 방식(Redis KeySpace Notification + DB 스케줄러 Fallback)** 을 도입했습니다.
- Redis의 TTL 만료 이벤트를 실시간으로 리스닝하여, 지연 시간 없이 좌석 상태를 즉각 예매 가능 상태로 복구합니다.
- Redis Pub/Sub의 한계인 데이터 유실(Event Loss) 위험에 대비하기 위해, DB 벌크 업데이트 기반의 폴링 스케줄러를 주기를 늘려 '안전망(Fallback)'으로 병행 운영합니다.
- 좌석 배치도(`SeatLayout`) 엔티티 구조를 '단일 좌석 좌표'에서 '공연장 전체 마스터 도면(1대N)' 구조로 리팩토링하여 데이터베이스 확장성과 참조 무결성을 개선했습니다.

---

## 🛠 상세 구현 내용

### 1. 좌석 선점 및 만료 (Redis + Scheduler)
- **Config (`RedisConfig`)**: Redis KeySpace Notification 수신을 위한 `RedisMessageListenerContainer` 빈 등록
- **Listener (`SeatLockExpirationListener`)**: `KeyExpirationEventMessageListener`를 상속받아 `seat:lock:*` 키의 TTL 만료 이벤트를 감지하도록 구현
- **UseCase (`SeatReleaseSingleUseCase`)**: Redis 이벤트 수신 시 대상 좌석 1건의 상태를 즉각 롤백(`releaseHold()`)하는 비즈니스 로직 구현
- **Scheduler (`SeatStatusScheduler`)**: 메인 처리는 Redis가 담당하므로, DB 부하 최소화를 위해 `@Scheduled(fixedDelay = 60000)`를 적용하여 1분 주기의 유실 이벤트 검사(Fallback) 용도로만 동작하도록 수정
- **Domain (`Seat`)**: 상태 복구 의도를 명확히 드러내는 `releaseHold()` 도메인 메서드 추가
- **Repository (`SeatRepository`)**: `@Modifying`을 활용하여 만료된 좌석의 상태와 시간을 한 번에 업데이트하는 `releaseExpiredSeats` 벌크 쿼리 구현 (Fallback용)
- **Config (`SeatServiceApplication`)**: 스케줄링 기능 활성화를 위해 `@EnableScheduling` 어노테이션 추가

### 2. 도메인 구조 개선 및 데이터 초기화
- **Domain (`SeatLayout`)**: 개별 좌석의 `rowNo`, `colNo`를 저장하던 방식에서, 도면 전체의 크기를 의미하는 `totalRows`, `maxCols` (Integer)로 필드 변경 및 마스터 도면화
- **DTO & Repository**: 프론트엔드 요구사항에 맞춰 `SeatLayoutResponse`가 행/열 조합 대신 고유 좌석 번호(`seatNumber`)를 직접 반환하도록 수정하고 관련 JPQL 업데이트
- **Init (`SeatDataInit`)**: 로컬(`local`) 및 개발(`dev`) 환경 실행 시, 1개의 마스터 도면과 120개(10x12)의 예매 가능(AVAILABLE) 좌석 더미 데이터를 자동 생성하도록 구성
- **Test**: 엔티티 및 DTO 구조 변경에 맞추어 `SeatRepositoryTest`, `SeatControllerTest`, `SeatGetSeatLayoutsUseCaseTest` 등 관련 테스트 코드 전면 수정

---

## ✅ 테스트

### 테스트 방법

1. **[데이터 초기화 테스트]** 로컬 환경 실행 시 `SeatDataInit`이 동작하여 120개의 좌석이 모두 `AVAILABLE` 상태로 DB에 삽입되는지 확인
2. **[실시간 해제 테스트]** 특정 좌석에 대해 임시 예매(HOLD) 처리
3. TTL 만료 즉시 애플리케이션 콘솔에 리스너 롤백 성공 로그(`Redis 만료 이벤트 수신...`)가 출력되는지 확인

### 테스트 결과

- 서버 기동 시 도면(1개)과 좌석(120개) 더미 데이터가 정상적으로 생성됨을 DB에서 확인
- TTL 만료 시 즉각적으로 리스너가 동작하여 딜레이 없이 좌석 롤백 처리 완료됨을 확인

### 📸 스크린샷

<img alt="{B95312FB-E880-4020-8611-AD1F918916B7}" src="https://github.com/user-attachments/assets/c386a5c7-21b1-4cd1-8be2-696081d4a0d1"  width="50%" />

<img width="1964" height="46" alt="{7E2D95F0-8EB7-4EBF-9735-A87E46870160}" src="https://github.com/user-attachments/assets/a4de3d59-b3d2-4da5-96e1-c8d779df6e1b" />


---

## 👀 리뷰 참고 사항

- UseCase와 별도로 Scheduler(`SeatStatusScheduler`)를 분리하여 단일 책임 원칙(SRP)을 지키고자 했습니다.

---

## ⚠️ 배포 시 주의사항

- **[인프라 설정]** Redis 서버(또는 AWS ElastiCache)의 설정 파일이나 CLI에서 `notify-keyspace-events Ex` 옵션이 켜져 있어야 만료 이벤트가 애플리케이션으로 정상 발행됩니다. 배포 전 환경 설정 확인이 필수입니다.
- 향후 Seat 서버가 다중 인스턴스(Scale-Out)로 배포될 경우, 여러 서버에서 동시에 스케줄러가 동작하거나 동일한 이벤트를 중복 수신할 수 있습니다. 확장이 진행된다면 `ShedLock`이나 **Redis 분산 락**을 도입하여 중복 실행 방지 처리가 추가로 필요합니다.