### PR TITLE
[Feat] #76 소셜로그인 로그아웃 구현

### DIFF
--- a/auth-service/src/main/java/com/ticketrush/boundedcontext/auth/app/facade/AuthFacade.java
+++ b/auth-service/src/main/java/com/ticketrush/boundedcontext/auth/app/facade/AuthFacade.java
@@ -9,7 +9,9 @@ import com.ticketrush.boundedcontext.auth.app.usecase.SocialLogoutUseCase;
 import com.ticketrush.boundedcontext.auth.app.usecase.SocialOauthLoginUseCase;
 import com.ticketrush.boundedcontext.auth.app.usecase.TokenReissueUseCase;
 import com.ticketrush.boundedcontext.auth.domain.types.SocialProvider;
+import com.ticketrush.global.exception.BusinessException;
 import com.ticketrush.global.security.JwtTokenProvider;
+import com.ticketrush.global.status.ErrorStatus;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -42,18 +44,24 @@ public class AuthFacade {
     return tokenReissueUseCase.execute(refreshToken);
   }
 
-  // 로그아웃
+  // 로그아웃 (요청 전처리 과정이기 때문에 facade에서 검증합니다. UseCase는 “이미 정제된 값”을 가지고 비즈니스 로직만 수행해야 합니다.)
   public void logout(String bearerToken) {
-    log.info("🔥 [Facade] bearerToken = {}", bearerToken);
 
-    // "Bearer xxx" → "xxx"
+    // 1. null 또는 형식 검증
+    if (bearerToken == null || !bearerToken.startsWith("Bearer ")) {
+      throw new BusinessException(ErrorStatus.UNAUTHORIZED);
+    }
+
+    // 2. "Bearer " 이후 토큰 추출
     String accessToken = bearerToken.substring(7);
-    log.info("🔥 [Facade] accessToken = {}", accessToken);
 
-    // 토큰에서 userId 추출
+    // 3. 빈 문자열 검증 (혹시 모를 케이스)
+    if (accessToken.isBlank()) {
+      throw new BusinessException(ErrorStatus.UNAUTHORIZED);
+    }
+
+    // 4. userId 추출 및 로그아웃 처리
     Long userId = jwtTokenProvider.getUserId(accessToken);
-    log.info("🔥 [Facade] userId = {}", userId);
-
     socialLogoutUseCase.execute(userId, accessToken);
   }
 }

--- a/auth-service/src/main/java/com/ticketrush/boundedcontext/auth/app/facade/AuthFacade.java
+++ b/auth-service/src/main/java/com/ticketrush/boundedcontext/auth/app/facade/AuthFacade.java
@@ -5,12 +5,16 @@ import com.ticketrush.boundedcontext.auth.app.dto.response.OauthLoginResponse;
 import com.ticketrush.boundedcontext.auth.app.dto.response.TokenReissueResponse;
 import com.ticketrush.boundedcontext.auth.app.support.ProviderParser;
 import com.ticketrush.boundedcontext.auth.app.usecase.OauthLoginUrlUseCase;
+import com.ticketrush.boundedcontext.auth.app.usecase.SocialLogoutUseCase;
 import com.ticketrush.boundedcontext.auth.app.usecase.SocialOauthLoginUseCase;
 import com.ticketrush.boundedcontext.auth.app.usecase.TokenReissueUseCase;
 import com.ticketrush.boundedcontext.auth.domain.types.SocialProvider;
+import com.ticketrush.global.security.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class AuthFacade {
@@ -18,6 +22,8 @@ public class AuthFacade {
   private final SocialOauthLoginUseCase socialOauthLoginUseCase;
   private final OauthLoginUrlUseCase oauthLoginUrlUseCase;
   private final TokenReissueUseCase tokenReissueUseCase;
+  private final SocialLogoutUseCase socialLogoutUseCase;
+  private final JwtTokenProvider jwtTokenProvider;
   private final ProviderParser providerParser;
 
   // OAuth 로그인 URL 생성
@@ -34,5 +40,20 @@ public class AuthFacade {
   // JWT 재발급
   public TokenReissueResponse reissue(String refreshToken) {
     return tokenReissueUseCase.execute(refreshToken);
+  }
+
+  // 로그아웃
+  public void logout(String bearerToken) {
+    log.info("🔥 [Facade] bearerToken = {}", bearerToken);
+
+    // "Bearer xxx" → "xxx"
+    String accessToken = bearerToken.substring(7);
+    log.info("🔥 [Facade] accessToken = {}", accessToken);
+
+    // 토큰에서 userId 추출
+    Long userId = jwtTokenProvider.getUserId(accessToken);
+    log.info("🔥 [Facade] userId = {}", userId);
+
+    socialLogoutUseCase.execute(userId, accessToken);
   }
 }

--- a/auth-service/src/main/java/com/ticketrush/boundedcontext/auth/app/usecase/SocialLogoutUseCase.java
+++ b/auth-service/src/main/java/com/ticketrush/boundedcontext/auth/app/usecase/SocialLogoutUseCase.java
@@ -7,7 +7,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
-@Transactional(readOnly = true)
+@Transactional
 @RequiredArgsConstructor
 public class SocialLogoutUseCase {
 

--- a/auth-service/src/main/java/com/ticketrush/boundedcontext/auth/app/usecase/SocialLogoutUseCase.java
+++ b/auth-service/src/main/java/com/ticketrush/boundedcontext/auth/app/usecase/SocialLogoutUseCase.java
@@ -1,0 +1,26 @@
+package com.ticketrush.boundedcontext.auth.app.usecase;
+
+import com.ticketrush.boundedcontext.auth.out.repository.RedisRepository;
+import com.ticketrush.global.security.JwtTokenProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class SocialLogoutUseCase {
+
+  private final RedisRepository redisRepository;
+  private final JwtTokenProvider jwtTokenProvider;
+
+  public void execute(Long userId, String accessToken) {
+
+    // 1. Refresh Token 삭제
+    redisRepository.deleteRefreshToken(userId);
+
+    // 2. Access Token 블랙리스트 등록
+    long remainingTime = jwtTokenProvider.getRemainingTime(accessToken);
+    redisRepository.blacklistAccessToken(accessToken, remainingTime);
+  }
+}

--- a/auth-service/src/main/java/com/ticketrush/boundedcontext/auth/in/api/v1/AuthController.java
+++ b/auth-service/src/main/java/com/ticketrush/boundedcontext/auth/in/api/v1/AuthController.java
@@ -62,7 +62,6 @@ public class AuthController {
   @PostMapping("/logout")
   public ResponseEntity<ApiResponse<Void>> logout(
       @RequestHeader(value = "Authorization", required = false) String bearerToken) {
-    log.info("🔥 [Controller] Authorization header = {}", bearerToken);
 
     authFacade.logout(bearerToken);
     return ApiResponse.onSuccess(SuccessStatus.OK);

--- a/auth-service/src/main/java/com/ticketrush/boundedcontext/auth/in/api/v1/AuthController.java
+++ b/auth-service/src/main/java/com/ticketrush/boundedcontext/auth/in/api/v1/AuthController.java
@@ -10,15 +10,18 @@ import com.ticketrush.global.status.SuccessStatus;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+@Slf4j
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/auth")
@@ -53,5 +56,15 @@ public class AuthController {
 
     TokenReissueResponse response = authFacade.reissue(request.refreshToken());
     return ApiResponse.onSuccess(SuccessStatus.OK, response);
+  }
+
+  @Operation(summary = "소셜 로그아웃", description = "Refresh token 삭제를 통해 로그아웃합니다.")
+  @PostMapping("/logout")
+  public ResponseEntity<ApiResponse<Void>> logout(
+      @RequestHeader(value = "Authorization", required = false) String bearerToken) {
+    log.info("🔥 [Controller] Authorization header = {}", bearerToken);
+
+    authFacade.logout(bearerToken);
+    return ApiResponse.onSuccess(SuccessStatus.OK);
   }
 }

--- a/auth-service/src/main/java/com/ticketrush/boundedcontext/auth/out/repository/RedisRepository.java
+++ b/auth-service/src/main/java/com/ticketrush/boundedcontext/auth/out/repository/RedisRepository.java
@@ -38,4 +38,15 @@ public class RedisRepository {
 
     return saved != null && saved.equals(refreshToken);
   }
+
+  // 블랙리스트 등록
+  public void blacklistAccessToken(String accessToken, long expiration) {
+    String key = "BL:" + accessToken;
+    redisTemplate.opsForValue().set(key, "logout", Duration.ofMillis(expiration));
+  }
+
+  // 블랙리스트 확인
+  public boolean isBlacklisted(String accessToken) {
+    return Boolean.TRUE.equals(redisTemplate.hasKey("BL:" + accessToken));
+  }
 }

--- a/auth-service/src/main/java/com/ticketrush/global/security/JwtTokenProvider.java
+++ b/auth-service/src/main/java/com/ticketrush/global/security/JwtTokenProvider.java
@@ -3,6 +3,7 @@ package com.ticketrush.global.security;
 import com.ticketrush.global.exception.BusinessException;
 import com.ticketrush.global.status.ErrorStatus;
 import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
@@ -94,13 +95,8 @@ public class JwtTokenProvider {
     try {
       return Long.valueOf(getClaims(token).getSubject());
     } catch (JwtException | IllegalArgumentException e) {
-      log.error("🔥 [JwtTokenProvider] JWT 파싱 실패", e);
       throw new BusinessException(ErrorStatus.UNAUTHORIZED);
     }
-  }
-
-  public String getTokenType(String token) {
-    return getClaims(token).get("type", String.class);
   }
 
   public String getRole(String token) {
@@ -108,7 +104,16 @@ public class JwtTokenProvider {
   }
 
   public long getRemainingTime(String token) {
-    Date expiration = getClaims(token).getExpiration();
-    return expiration.getTime() - System.currentTimeMillis();
+    try {
+      Date expiration = getClaims(token).getExpiration();
+      return expiration.getTime() - System.currentTimeMillis();
+
+    } catch (ExpiredJwtException e) {
+      // 이미 만료 → 블랙리스트 의미 없음
+      return 0L;
+
+    } catch (JwtException | IllegalArgumentException e) {
+      throw new BusinessException(ErrorStatus.AUTH_INVALID_ACCESS_TOKEN);
+    }
   }
 }

--- a/auth-service/src/main/java/com/ticketrush/global/security/JwtTokenProvider.java
+++ b/auth-service/src/main/java/com/ticketrush/global/security/JwtTokenProvider.java
@@ -1,5 +1,7 @@
 package com.ticketrush.global.security;
 
+import com.ticketrush.global.exception.BusinessException;
+import com.ticketrush.global.status.ErrorStatus;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
@@ -89,7 +91,12 @@ public class JwtTokenProvider {
   }
 
   public Long getUserId(String token) {
-    return Long.valueOf(getClaims(token).getSubject());
+    try {
+      return Long.valueOf(getClaims(token).getSubject());
+    } catch (JwtException | IllegalArgumentException e) {
+      log.error("🔥 [JwtTokenProvider] JWT 파싱 실패", e);
+      throw new BusinessException(ErrorStatus.UNAUTHORIZED);
+    }
   }
 
   public String getTokenType(String token) {
@@ -98,5 +105,10 @@ public class JwtTokenProvider {
 
   public String getRole(String token) {
     return getClaims(token).get("role", String.class);
+  }
+
+  public long getRemainingTime(String token) {
+    Date expiration = getClaims(token).getExpiration();
+    return expiration.getTime() - System.currentTimeMillis();
   }
 }

--- a/common/src/main/java/com/ticketrush/global/config/SwaggerConfig.java
+++ b/common/src/main/java/com/ticketrush/global/config/SwaggerConfig.java
@@ -1,20 +1,33 @@
 package com.ticketrush.global.config;
 
+import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 import io.swagger.v3.oas.models.servers.Server;
-import org.springframework.beans.factory.annotation.Value;
+import java.util.List;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class SwaggerConfig {
 
-  @Value("${server.port:8080}")
-  private int serverPort;
-
   @Bean
   public OpenAPI openAPI() {
     return new OpenAPI()
-        .addServersItem(new Server().url("http://localhost:" + serverPort).description("로컬 서버"));
+        .servers(List.of(new Server().url("http://localhost:8080")))
+
+        // 🔥 1. Security 설정 추가
+        .components(
+            new Components()
+                .addSecuritySchemes(
+                    "bearerAuth",
+                    new SecurityScheme()
+                        .type(SecurityScheme.Type.HTTP)
+                        .scheme("bearer")
+                        .bearerFormat("JWT")))
+
+        // 🔥 2. 전역 적용 (모든 API에 Authorization 붙음)
+        .addSecurityItem(new SecurityRequirement().addList("bearerAuth"));
   }
 }

--- a/common/src/main/java/com/ticketrush/global/config/SwaggerConfig.java
+++ b/common/src/main/java/com/ticketrush/global/config/SwaggerConfig.java
@@ -17,7 +17,7 @@ public class SwaggerConfig {
     return new OpenAPI()
         .servers(List.of(new Server().url("http://localhost:8080")))
 
-        // 🔥 1. Security 설정 추가
+        // 1. Security 설정 추가
         .components(
             new Components()
                 .addSecuritySchemes(
@@ -27,7 +27,7 @@ public class SwaggerConfig {
                         .scheme("bearer")
                         .bearerFormat("JWT")))
 
-        // 🔥 2. 전역 적용 (모든 API에 Authorization 붙음)
+        // 2. 전역 적용 (모든 API에 Authorization 붙음)
         .addSecurityItem(new SecurityRequirement().addList("bearerAuth"));
   }
 }

--- a/common/src/main/java/com/ticketrush/global/status/ErrorStatus.java
+++ b/common/src/main/java/com/ticketrush/global/status/ErrorStatus.java
@@ -33,6 +33,7 @@ public enum ErrorStatus {
 
   // Auth 401
   AUTH_INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH_401_001", "유효하지 않은 Refresh Token입니다."),
+  AUTH_INVALID_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH_401_002", "유효하지 않은 Access Token입니다."),
 
   // Auth 403
   AUTH_ACCESS_DENIED(HttpStatus.FORBIDDEN, "AUTH_403_001", "접근 권한이 없습니다."),


### PR DESCRIPTION
## 🔗 관련 이슈

- close #76 

---

<!--- ## 📌 주요 변경 사항

- 
-
-

--->

## 🛠 상세 구현 내용

- Access Token을 통해 사용자 식별 후, Redis에 저장된 Refresh Token을 삭제하는 방식으로 로그아웃을 처리하였습니다.  
- 로그아웃 이후에는 Refresh Token을 이용한 토큰 재발급이 불가능하도록 검증 로직을 적용하였습니다. 
- Swagger 환경에서 Authorization 헤더가 정상적으로 전달되도록 SecurityScheme 설정을 추가하였습니다.  
- API 응답은 공통 ApiResponse 구조(void)를 사용하여 일관된 형식으로 반환되도록 구성하였습니다.

---

## ✅ 테스트

### 테스트 방법

- swagger를 통해 테스트하였습니다.

### 테스트 결과

- 로그아웃이 완료된 후, refresh token을 이용한 재발급도 모두 안 되는 것을 확인하였습니다. 

### 📸 스크린샷
<img width="816" height="731" alt="Pasted Graphic" src="https://github.com/user-attachments/assets/b276576e-9e3b-493f-bb6e-f46979622b8d" />


---

<!--- ## 👀 리뷰 요청 사항

-

---

## ⚠️ 배포 시 주의사항

- 
--->