### PR TITLE
[Refactor] #172 다중 인스턴스 환경에서 SeatStatusScheduler 중복 실행 방지를 위한 분산 락(ShedLock) 도입

### DIFF
--- a/seat-service/build.gradle
+++ b/seat-service/build.gradle
@@ -58,6 +58,10 @@ dependencies {
 
     // Redisson
     implementation 'org.redisson:redisson-spring-boot-starter:4.0.0'
+
+    // ShedLock
+    implementation 'net.javacrumbs.shedlock:shedlock-spring:5.13.0'
+    implementation 'net.javacrumbs.shedlock:shedlock-provider-redis-spring:5.13.0'
 }
 
 dependencyManagement {

--- a/seat-service/src/main/java/com/ticketrush/SeatServiceApplication.java
+++ b/seat-service/src/main/java/com/ticketrush/SeatServiceApplication.java
@@ -2,9 +2,7 @@ package com.ticketrush;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.scheduling.annotation.EnableScheduling;
 
-@EnableScheduling
 @SpringBootApplication
 public class SeatServiceApplication {
 

--- a/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/app/scheduler/SeatStatusScheduler.java
+++ b/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/app/scheduler/SeatStatusScheduler.java
@@ -18,8 +18,9 @@ public class SeatStatusScheduler {
   @Scheduled(fixedDelay = 60000)
   @SchedulerLock(
       name = "scheduleReleaseExpiredHoldsFallbackLock",
-      lockAtLeastFor = "50s",
-      lockAtMostFor = "55s")
+      lockAtLeastFor = "50s", // 서버 간 시계 오차(Clock Skew)로 인한 즉각적인 중복 실행 방지
+      lockAtMostFor = "5m" // 노드가 죽었을 때 락이 자동으로 풀리는 최대 시간 (충분히 길게 설정)
+      )
   public void scheduleReleaseExpiredHoldsFallback() {
     log.debug("Fallback 스케줄러 동작: 유실된 만료 좌석 검사 시작");
     seatReleaseExpiredUseCase.execute();

--- a/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/app/scheduler/SeatStatusScheduler.java
+++ b/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/app/scheduler/SeatStatusScheduler.java
@@ -22,7 +22,7 @@ public class SeatStatusScheduler {
       lockAtMostFor = "5m" // 노드가 죽었을 때 락이 자동으로 풀리는 최대 시간 (충분히 길게 설정)
       )
   public void scheduleReleaseExpiredHoldsFallback() {
-    log.debug("Fallback 스케줄러 동작: 유실된 만료 좌석 검사 시작");
+    log.info("Fallback 스케줄러 동작: 유실된 만료 좌석 검사 시작");
     seatReleaseExpiredUseCase.execute();
   }
 }

--- a/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/app/scheduler/SeatStatusScheduler.java
+++ b/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/app/scheduler/SeatStatusScheduler.java
@@ -3,6 +3,7 @@ package com.ticketrush.boundedcontext.seat.app.scheduler;
 import com.ticketrush.boundedcontext.seat.app.usecase.SeatReleaseExpiredUseCase;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
@@ -14,8 +15,11 @@ public class SeatStatusScheduler {
   private final SeatReleaseExpiredUseCase seatReleaseExpiredUseCase;
 
   // 실시간 처리는 Redis Event Listener가 담당하므로, 스케줄러는 1분(60,000ms) 주기의 Fallback 역할만 수행
-  // TODO: 다중 인스턴스 배포(Scale-Out) 시 중복 벌크 업데이트 방지를 위해 ShedLock 또는 Redis 분산 락 도입 필요
   @Scheduled(fixedDelay = 60000)
+  @SchedulerLock(
+      name = "scheduleReleaseExpiredHoldsFallbackLock",
+      lockAtLeastFor = "50s",
+      lockAtMostFor = "55s")
   public void scheduleReleaseExpiredHoldsFallback() {
     log.debug("Fallback 스케줄러 동작: 유실된 만료 좌석 검사 시작");
     seatReleaseExpiredUseCase.execute();

--- a/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/app/scheduler/SeatStatusScheduler.java
+++ b/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/app/scheduler/SeatStatusScheduler.java
@@ -19,7 +19,7 @@ public class SeatStatusScheduler {
   @SchedulerLock(
       name = "scheduleReleaseExpiredHoldsFallbackLock",
       lockAtLeastFor = "50s", // 서버 간 시계 오차(Clock Skew)로 인한 즉각적인 중복 실행 방지
-      lockAtMostFor = "5m" // 노드가 죽었을 때 락이 자동으로 풀리는 최대 시간 (충분히 길게 설정)
+      lockAtMostFor = "2m" // 노드가 죽었을 때 락이 자동으로 풀리는 최대 시간
       )
   public void scheduleReleaseExpiredHoldsFallback() {
     log.info("Fallback 스케줄러 동작: 유실된 만료 좌석 검사 시작");

--- a/seat-service/src/main/java/com/ticketrush/global/config/ShedLockConfig.java
+++ b/seat-service/src/main/java/com/ticketrush/global/config/ShedLockConfig.java
@@ -3,6 +3,7 @@ package com.ticketrush.global.config;
 import net.javacrumbs.shedlock.core.LockProvider;
 import net.javacrumbs.shedlock.provider.redis.spring.RedisLockProvider;
 import net.javacrumbs.shedlock.spring.annotation.EnableSchedulerLock;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
@@ -11,9 +12,16 @@ import org.springframework.data.redis.connection.RedisConnectionFactory;
 @EnableSchedulerLock(defaultLockAtMostFor = "1m")
 public class ShedLockConfig {
 
+  @Value("${spring.application.name:seat-service}")
+  private String applicationName;
+
+  @Value("${spring.profiles.active:default}")
+  private String activeProfile;
+
   @Bean
   public LockProvider lockProvider(RedisConnectionFactory connectionFactory) {
-    // 환경에 따라 키가 겹치지 않도록 prefix를 지정합니다.
-    return new RedisLockProvider(connectionFactory, "seat-env");
+    // 환경에 따라 키가 겹치지 않도록 동적으로 prefix 지정 (예: "seat-service-dev")
+    String keyPrefix = applicationName + "-" + activeProfile;
+    return new RedisLockProvider(connectionFactory, keyPrefix);
   }
 }

--- a/seat-service/src/main/java/com/ticketrush/global/config/ShedLockConfig.java
+++ b/seat-service/src/main/java/com/ticketrush/global/config/ShedLockConfig.java
@@ -1,0 +1,19 @@
+package com.ticketrush.global.config;
+
+import net.javacrumbs.shedlock.core.LockProvider;
+import net.javacrumbs.shedlock.provider.redis.spring.RedisLockProvider;
+import net.javacrumbs.shedlock.spring.annotation.EnableSchedulerLock;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+
+@Configuration
+@EnableSchedulerLock(defaultLockAtMostFor = "1m")
+public class ShedLockConfig {
+
+  @Bean
+  public LockProvider lockProvider(RedisConnectionFactory connectionFactory) {
+    // 환경에 따라 키가 겹치지 않도록 prefix를 지정합니다.
+    return new RedisLockProvider(connectionFactory, "seat-env");
+  }
+}

--- a/seat-service/src/main/java/com/ticketrush/global/config/ShedLockConfig.java
+++ b/seat-service/src/main/java/com/ticketrush/global/config/ShedLockConfig.java
@@ -7,9 +7,11 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @Configuration
-@EnableSchedulerLock(defaultLockAtMostFor = "1m")
+@EnableScheduling
+@EnableSchedulerLock(defaultLockAtMostFor = "55s")
 public class ShedLockConfig {
 
   @Value("${spring.application.name:seat-service}")

--- a/seat-service/src/main/java/com/ticketrush/global/config/ShedLockConfig.java
+++ b/seat-service/src/main/java/com/ticketrush/global/config/ShedLockConfig.java
@@ -6,24 +6,35 @@ import net.javacrumbs.shedlock.spring.annotation.EnableSchedulerLock;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @Configuration
 @EnableScheduling
-@EnableSchedulerLock(defaultLockAtMostFor = "55s")
+@EnableSchedulerLock(defaultLockAtMostFor = "50s")
 public class ShedLockConfig {
 
   @Value("${spring.application.name:seat-service}")
   private String applicationName;
 
-  @Value("${spring.profiles.active:default}")
-  private String activeProfile;
+  private final Environment env;
+
+  // Environment Bean 주입
+  public ShedLockConfig(Environment env) {
+    this.env = env;
+  }
 
   @Bean
   public LockProvider lockProvider(RedisConnectionFactory connectionFactory) {
-    // 환경에 따라 키가 겹치지 않도록 동적으로 prefix 지정 (예: "seat-service-dev")
-    String keyPrefix = applicationName + "-" + activeProfile;
+    String[] activeProfiles = env.getActiveProfiles();
+
+    // 활성화된 프로파일이 있으면 첫 번째 값을, 없으면 "default"를 사용
+    String profile = activeProfiles.length > 0 ? activeProfiles[0] : "default";
+
+    // "seat-service-local" 형태로 조합됨
+    String keyPrefix = applicationName + "-" + profile;
+
     return new RedisLockProvider(connectionFactory, keyPrefix);
   }
 }


### PR DESCRIPTION
## 🔗 관련 이슈

- close #172

---

## 📌 주요 변경 사항

- 다중 인스턴스(Scale-Out) 확장 시 `SeatStatusScheduler`가 모든 인스턴스에서 동시 실행되는 문제 해결
- Redis 기반의 분산 락(ShedLock)을 도입하여 여러 Seat 서버 중 단 1대의 인스턴스에서만 만료 좌석 롤백(DB 벌크 업데이트) 작업이 수행되도록 개선
- 불필요한 DB 커넥션 및 CPU 리소스 낭비 방지

---

## 🛠 상세 구현 내용

- **의존성 추가**: `seat-service`의 `build.gradle`에 ShedLock 코어 및 Redis Provider 라이브러리 추가 (MSA 모듈 독립성을 위해 `common`이 아닌 `seat-service`에 격리)
- **ShedLock 환경 설정**: `ShedLockConfig`를 생성하여 기존 Redis 연결을 활용하는 `RedisLockProvider` 빈 등록
- **분산 락 적용**: `SeatStatusScheduler`의 `scheduleReleaseExpiredHoldsFallback()` 메서드에 `@SchedulerLock` 적용
- **락 시간 최적화**: 스케줄러 주기(60초)를 고려하여 락 최대 유지 시간(`lockAtMostFor`)을 "2m", 최소 유지 시간(`lockAtLeastFor`)을 "50s"로 설정하여, 중복 실행 방지 및 노드 장애 시의 데드락 방지
- 스케줄러 로직에 명시되어 있던 TODO 주석 제거

---

## ✅ 테스트

### 테스트 방법

- 로컬 환경에서 터미널을 분리하여 Seat 서버 인스턴스를 2대(포트 8080, 8081) 동시에 실행
- 1분 주기의 스케줄러가 동작할 때, 두 서버의 로그를 모니터링하여 중복 실행 여부 검증

### 테스트 결과

- 2대의 인스턴스 중 락을 먼저 획득한 단 1대의 서버에서만 `"Fallback 스케줄러 동작: 유실된 만료 좌석 검사 시작"` 로그가 정상적으로 출력되고 DB 쿼리가 1회만 실행됨을 확인. 

### 📸 스크린샷

<img width="2661" height="788" alt="Capture_2026_0507_150618" src="https://github.com/user-attachments/assets/228773b7-fd6a-457d-b881-bd8d476eafa4" />

cf. 윈도우 PowerShell의 기본 인코딩과 스프링 부트의 UTF-8 인코딩이 맞지 않아서 한글은 깨져서 보입니다.

---

## 👀 리뷰 요청 사항

- 스케줄러 주기가 1분(60초)인 점을 고려하여 `lockAtLeastFor="50s"`, `lockAtMostFor="55s"`로 설정했습니다. 해당 락 유지 시간이 적절한지 리뷰 부탁드립니다.

<!--
---

## ⚠️ 배포 시 주의사항
-->
