### PR TITLE
[Feat] #19 메인 화면용 공연 목록 페이징 및 슬라이드 조회 API 구현

### DIFF
--- a/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/app/dto/response/PerformanceListResponse.java
+++ b/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/app/dto/response/PerformanceListResponse.java
@@ -1,0 +1,18 @@
+package com.ticketrush.boundedcontext.performance.app.dto.response;
+
+import com.ticketrush.boundedcontext.performance.domain.types.Genre;
+import com.ticketrush.boundedcontext.performance.domain.types.PerformanceStatus;
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+public record PerformanceListResponse(
+    Long performanceId,
+    String title,
+    String performer,
+    Genre genre,
+    LocalDate showDate,
+    LocalTime showTime,
+    String address,
+    String imageMainUrl,
+    PerformanceStatus performanceStatus,
+    Long price) {}

--- a/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/app/facade/PerformanceFacade.java
+++ b/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/app/facade/PerformanceFacade.java
@@ -2,9 +2,14 @@ package com.ticketrush.boundedcontext.performance.app.facade;
 
 import com.ticketrush.boundedcontext.performance.app.dto.request.PerformanceCreateRequest;
 import com.ticketrush.boundedcontext.performance.app.dto.response.PerformanceCreateResponse;
+import com.ticketrush.boundedcontext.performance.app.dto.response.PerformanceListResponse;
 import com.ticketrush.boundedcontext.performance.app.usecase.PerformanceCreateUseCase;
+import com.ticketrush.boundedcontext.performance.app.usecase.PerformanceGetListUseCase;
+import com.ticketrush.boundedcontext.performance.domain.types.Genre;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -13,6 +18,7 @@ import org.springframework.web.multipart.MultipartFile;
 public class PerformanceFacade {
 
   private final PerformanceCreateUseCase performanceCreateUseCase;
+  private final PerformanceGetListUseCase performanceGetListUseCase;
 
   public PerformanceCreateResponse createPerformance(
       PerformanceCreateRequest request,
@@ -21,5 +27,9 @@ public class PerformanceFacade {
       List<MultipartFile> gallery) {
 
     return performanceCreateUseCase.execute(request, mainImage, model3d, gallery);
+  }
+
+  public Page<PerformanceListResponse> getPerformances(Genre genre, Pageable pageable) {
+    return performanceGetListUseCase.execute(genre, pageable);
   }
 }

--- a/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/app/mapper/PerformanceMapper.java
+++ b/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/app/mapper/PerformanceMapper.java
@@ -2,6 +2,7 @@ package com.ticketrush.boundedcontext.performance.app.mapper;
 
 import com.ticketrush.boundedcontext.performance.app.dto.request.PerformanceCreateRequest;
 import com.ticketrush.boundedcontext.performance.app.dto.response.PerformanceCreateResponse;
+import com.ticketrush.boundedcontext.performance.app.dto.response.PerformanceListResponse;
 import com.ticketrush.boundedcontext.performance.domain.entity.Performance;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
@@ -16,4 +17,7 @@ public interface PerformanceMapper {
 
   @Mapping(source = "id", target = "performanceId")
   PerformanceCreateResponse toCreateResponse(Performance performance);
+
+  @Mapping(source = "id", target = "performanceId")
+  PerformanceListResponse toListResponse(Performance performance);
 }

--- a/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/app/usecase/PerformanceGetListUseCase.java
+++ b/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/app/usecase/PerformanceGetListUseCase.java
@@ -1,0 +1,30 @@
+package com.ticketrush.boundedcontext.performance.app.usecase;
+
+import com.ticketrush.boundedcontext.performance.app.dto.response.PerformanceListResponse;
+import com.ticketrush.boundedcontext.performance.app.mapper.PerformanceMapper;
+import com.ticketrush.boundedcontext.performance.domain.entity.Performance;
+import com.ticketrush.boundedcontext.performance.domain.types.Genre;
+import com.ticketrush.boundedcontext.performance.out.repository.PerformanceRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class PerformanceGetListUseCase {
+
+  private final PerformanceRepository performanceRepository;
+  private final PerformanceMapper performanceMapper;
+
+  @Transactional(readOnly = true)
+  public Page<PerformanceListResponse> execute(Genre genre, Pageable pageable) {
+    Page<Performance> performances =
+        (genre != null)
+            ? performanceRepository.findByGenre(genre, pageable)
+            : performanceRepository.findAll(pageable);
+
+    return performances.map(performanceMapper::toListResponse);
+  }
+}

--- a/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/in/api/v1/PerformanceController.java
+++ b/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/in/api/v1/PerformanceController.java
@@ -1,0 +1,62 @@
+package com.ticketrush.boundedcontext.performance.in.api.v1;
+
+import com.ticketrush.boundedcontext.performance.app.dto.response.PerformanceListResponse;
+import com.ticketrush.boundedcontext.performance.app.facade.PerformanceFacade;
+import com.ticketrush.boundedcontext.performance.domain.types.Genre;
+import com.ticketrush.boundedcontext.performance.in.api.v1.swagger.PerformanceListApiResponses;
+import com.ticketrush.global.dto.response.ApiResponse;
+import com.ticketrush.global.status.SuccessStatus;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Performance", description = "공연 API")
+@RestController
+@RequestMapping("/api/v1/performance")
+@RequiredArgsConstructor
+public class PerformanceController {
+
+  private final PerformanceFacade performanceFacade;
+
+  @Operation(
+      summary = "공연 목록 조회",
+      description =
+          """
+          메인 화면에 노출될 공연 목록을 조회합니다.
+
+          슬라이드 영역과 그리드 목록 모두 이 API를 사용합니다.
+
+          **장르 코드:**
+          | 코드 | 설명 |
+          |------|------|
+          | MUSICAL | 뮤지컬 |
+          | CONCERT | 콘서트 |
+          | CLASSIC | 클래식 |
+          | JAZZ | 재즈 |
+          | FESTIVAL | 페스티벌 |
+          | BALLET | 발레/무용 |
+          | FANMEETING | 팬미팅 |
+          """)
+  @PerformanceListApiResponses
+  @GetMapping
+  public ResponseEntity<ApiResponse<List<PerformanceListResponse>>> getPerformances(
+      @Parameter(description = "장르 필터 (미입력 시 전체 조회)") @RequestParam(required = false) Genre genre,
+      @PageableDefault(size = 8, sort = "createdAt", direction = Sort.Direction.DESC)
+          Pageable pageable) {
+
+    Page<PerformanceListResponse> performances = performanceFacade.getPerformances(genre, pageable);
+
+    return ApiResponse.onSuccess(SuccessStatus.OK, performances);
+  }
+}

--- a/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/in/api/v1/PerformanceController.java
+++ b/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/in/api/v1/PerformanceController.java
@@ -11,6 +11,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -52,7 +53,8 @@ public class PerformanceController {
   @GetMapping
   public ResponseEntity<ApiResponse<List<PerformanceListResponse>>> getPerformances(
       @Parameter(description = "장르 필터 (미입력 시 전체 조회)") @RequestParam(required = false) Genre genre,
-      @PageableDefault(size = 8, sort = "createdAt", direction = Sort.Direction.DESC)
+      @ParameterObject
+          @PageableDefault(size = 8, sort = "createdAt", direction = Sort.Direction.DESC)
           Pageable pageable) {
 
     Page<PerformanceListResponse> performances = performanceFacade.getPerformances(genre, pageable);

--- a/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/in/api/v1/swagger/PerformanceListApiResponses.java
+++ b/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/in/api/v1/swagger/PerformanceListApiResponses.java
@@ -1,0 +1,40 @@
+package com.ticketrush.boundedcontext.performance.in.api.v1.swagger;
+
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@ApiResponses({
+  @ApiResponse(
+      responseCode = "400",
+      description = "잘못된 요청",
+      content =
+          @Content(
+              mediaType = "application/json",
+              schema =
+                  @Schema(implementation = com.ticketrush.global.dto.response.ApiResponse.class),
+              examples =
+                  @ExampleObject(
+                      name = "InvalidGenre",
+                      summary = "유효하지 않은 장르 값",
+                      value =
+                          """
+                          {
+                            "isSuccess": false,
+                            "code": "COMMON_400",
+                            "message": "잘못된 요청입니다.",
+                            "traceId": "trace-id-example"
+                          }
+                          """)))
+})
+public @interface PerformanceListApiResponses {}

--- a/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/in/api/v1/swagger/PerformanceListApiResponses.java
+++ b/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/in/api/v1/swagger/PerformanceListApiResponses.java
@@ -2,7 +2,6 @@ package com.ticketrush.boundedcontext.performance.in.api.v1.swagger;
 
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
-import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import java.lang.annotation.Documented;
@@ -21,8 +20,6 @@ import java.lang.annotation.Target;
       content =
           @Content(
               mediaType = "application/json",
-              schema =
-                  @Schema(implementation = com.ticketrush.global.dto.response.ApiResponse.class),
               examples =
                   @ExampleObject(
                       name = "InvalidGenre",

--- a/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/out/repository/PerformanceRepository.java
+++ b/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/out/repository/PerformanceRepository.java
@@ -1,6 +1,12 @@
 package com.ticketrush.boundedcontext.performance.out.repository;
 
 import com.ticketrush.boundedcontext.performance.domain.entity.Performance;
+import com.ticketrush.boundedcontext.performance.domain.types.Genre;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface PerformanceRepository extends JpaRepository<Performance, Long> {}
+public interface PerformanceRepository extends JpaRepository<Performance, Long> {
+
+  Page<Performance> findByGenre(Genre genre, Pageable pageable);
+}

--- a/performance-service/src/test/java/com/ticketrush/boundedcontext/performance/in/api/v1/PerformanceGetListTest.java
+++ b/performance-service/src/test/java/com/ticketrush/boundedcontext/performance/in/api/v1/PerformanceGetListTest.java
@@ -1,0 +1,100 @@
+package com.ticketrush.boundedcontext.performance.in.api.v1;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.ticketrush.boundedcontext.performance.app.dto.response.PerformanceListResponse;
+import com.ticketrush.boundedcontext.performance.app.usecase.PerformanceGetListUseCase;
+import com.ticketrush.boundedcontext.performance.domain.entity.Performance;
+import com.ticketrush.boundedcontext.performance.domain.types.Genre;
+import com.ticketrush.boundedcontext.performance.out.repository.PerformanceRepository;
+import com.ticketrush.global.eventpublisher.EventPublisher;
+import com.ticketrush.global.util.S3UploadUtils;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@EnableAutoConfiguration(
+    exclude = {
+      io.awspring.cloud.autoconfigure.s3.S3AutoConfiguration.class,
+      io.awspring.cloud.autoconfigure.core.AwsAutoConfiguration.class
+    })
+@Transactional
+class PerformanceGetListTest {
+
+  @MockitoBean private S3UploadUtils s3UploadUtils;
+  @MockitoBean private EventPublisher eventPublisher;
+
+  @Autowired private PerformanceGetListUseCase performanceGetListUseCase;
+  @Autowired private PerformanceRepository performanceRepository;
+
+  @BeforeEach
+  void setUp() {
+    performanceRepository.saveAll(
+        List.of(
+            buildPerformance(Genre.CONCERT),
+            buildPerformance(Genre.CONCERT),
+            buildPerformance(Genre.MUSICAL),
+            buildPerformance(Genre.JAZZ)));
+  }
+
+  @Test
+  @DisplayName("장르를 지정하지 않으면 전체 공연 목록을 반환한다")
+  void getAll_whenGenreIsNull() {
+    Pageable pageable = PageRequest.of(0, 10, Sort.by(Sort.Direction.DESC, "createdAt"));
+    Page<PerformanceListResponse> result = performanceGetListUseCase.execute(null, pageable);
+    assertThat(result.getTotalElements()).isEqualTo(4);
+  }
+
+  @Test
+  @DisplayName("장르를 지정하면 해당 장르 공연만 반환한다")
+  void getByGenre_whenGenreIsGiven() {
+    Pageable pageable = PageRequest.of(0, 10, Sort.by(Sort.Direction.DESC, "createdAt"));
+    Page<PerformanceListResponse> result =
+        performanceGetListUseCase.execute(Genre.CONCERT, pageable);
+    assertThat(result.getTotalElements()).isEqualTo(2);
+    assertThat(result.getContent()).allMatch(p -> p.genre() == Genre.CONCERT);
+  }
+
+  @Test
+  @DisplayName("페이지 사이즈에 따라 결과가 올바르게 분할된다")
+  void pagination_splitsByPageSize() {
+    Pageable firstPage = PageRequest.of(0, 2, Sort.by(Sort.Direction.DESC, "createdAt"));
+    Pageable secondPage = PageRequest.of(1, 2, Sort.by(Sort.Direction.DESC, "createdAt"));
+
+    Page<PerformanceListResponse> page1 = performanceGetListUseCase.execute(null, firstPage);
+    Page<PerformanceListResponse> page2 = performanceGetListUseCase.execute(null, secondPage);
+
+    assertThat(page1.getContent()).hasSize(2);
+    assertThat(page2.getContent()).hasSize(2);
+    assertThat(page1.getTotalPages()).isEqualTo(2);
+  }
+
+  private Performance buildPerformance(Genre genre) {
+    return Performance.builder()
+        .title("공연명")
+        .performer("가수")
+        .genre(genre)
+        .showDate(LocalDate.now())
+        .showTime(LocalTime.of(19, 0))
+        .durationMinutes(120)
+        .price(50000L)
+        .totalSeats(100)
+        .address("서울")
+        .build();
+  }
+}


### PR DESCRIPTION
## 🔗 관련 이슈

- close #19

---

## 📌 주요 변경 사항

- `GET /api/v1/performance` 공연 목록 조회 API 구현
- 장르 필터링(Genre Enum) 및 최신순(createdAt DESC) 정렬 지원
- 오프셋 기반 페이징 적용 (default size=8), 슬라이드·그리드 모두 동일 엔드포인트 사용

---

## 🛠 상세 구현 내용

- `PerformanceListResponse` — 목록 응답 DTO (performanceId, title, performer, genre, showDate, showTime, address, imageMainUrl, performanceStatus, price)
- `PerformanceGetListUseCase` — genre null 여부에 따라 `findByGenre` / `findAll` 분기 처리
- `PerformanceController` — 공연 목록 조회 엔드포인트, `@PageableDefault(size=8, sort=createdAt, DESC)`
- `PerformanceFacade`, `PerformanceMapper`, `PerformanceRepository` 수정

---

## ✅ 테스트

### 테스트 방법

- `PerformanceGetListTest` 단위 테스트 실행 (`./gradlew :performance-service:test`)
- Swagger(`GET /api/v1/performance`) 직접 호출로 응답 포맷 확인

### 테스트 결과

- 장르 미입력 시 전체 공연 목록 반환 ✅
- 장르 지정 시 해당 장르 공연만 반환 ✅
- 페이지 사이즈에 따라 결과 분할 ✅


### 📸 스크린샷
<img width="1449" height="580" alt="image" src="https://github.com/user-attachments/assets/532d170a-fbdf-4fb7-a86a-b442cbf90347" />
<img width="1449" height="583" alt="image" src="https://github.com/user-attachments/assets/f732b708-299c-48bc-828e-387b1d8371b6" />
<img width="1438" height="562" alt="image" src="https://github.com/user-attachments/assets/a99777b4-1401-4b38-a9b0-b2888d748264" />


---

## 👀 리뷰 요청 사항

- 슬라이드 영역과 그리드 모두 동일 엔드포인트를 사용하는 방식이 적절한지 확인 부탁드립니다.

---

## ⚠️ 배포 시 주의사항

- 잔여석 게이지바 데이터(remainingSeatsRatio)는 이슈 #176 (Kafka 이벤트 동기화)에서 별도 처리 예정
- Redis 캐싱은 API 검증 후 별도 이슈로 분리 예정