### PR TITLE
[Feat] #73 JWT 검증 처리

### DIFF
--- a/auth-service/src/main/java/com/ticketrush/boundedcontext/auth/app/facade/AuthFacade.java
+++ b/auth-service/src/main/java/com/ticketrush/boundedcontext/auth/app/facade/AuthFacade.java
@@ -44,7 +44,6 @@ public class AuthFacade {
 
   // 로그아웃
   public void logout(Long userId) {
-
     socialLogoutUseCase.execute(userId);
   }
 }

--- a/auth-service/src/main/java/com/ticketrush/boundedcontext/auth/app/facade/AuthFacade.java
+++ b/auth-service/src/main/java/com/ticketrush/boundedcontext/auth/app/facade/AuthFacade.java
@@ -9,9 +9,7 @@ import com.ticketrush.boundedcontext.auth.app.usecase.SocialLogoutUseCase;
 import com.ticketrush.boundedcontext.auth.app.usecase.SocialOauthLoginUseCase;
 import com.ticketrush.boundedcontext.auth.app.usecase.TokenReissueUseCase;
 import com.ticketrush.boundedcontext.auth.domain.types.SocialProvider;
-import com.ticketrush.global.exception.BusinessException;
 import com.ticketrush.global.security.JwtTokenProvider;
-import com.ticketrush.global.status.ErrorStatus;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -44,24 +42,9 @@ public class AuthFacade {
     return tokenReissueUseCase.execute(refreshToken);
   }
 
-  // 로그아웃 (요청 전처리 과정이기 때문에 facade에서 검증합니다. UseCase는 “이미 정제된 값”을 가지고 비즈니스 로직만 수행해야 합니다.)
-  public void logout(String bearerToken) {
+  // 로그아웃
+  public void logout(Long userId) {
 
-    // 1. null 또는 형식 검증
-    if (bearerToken == null || !bearerToken.startsWith("Bearer ")) {
-      throw new BusinessException(ErrorStatus.UNAUTHORIZED);
-    }
-
-    // 2. "Bearer " 이후 토큰 추출
-    String accessToken = bearerToken.substring(7);
-
-    // 3. 빈 문자열 검증 (혹시 모를 케이스)
-    if (accessToken.isBlank()) {
-      throw new BusinessException(ErrorStatus.UNAUTHORIZED);
-    }
-
-    // 4. userId 추출 및 로그아웃 처리
-    Long userId = jwtTokenProvider.getUserId(accessToken);
-    socialLogoutUseCase.execute(userId, accessToken);
+    socialLogoutUseCase.execute(userId);
   }
 }

--- a/auth-service/src/main/java/com/ticketrush/boundedcontext/auth/app/usecase/SocialLogoutUseCase.java
+++ b/auth-service/src/main/java/com/ticketrush/boundedcontext/auth/app/usecase/SocialLogoutUseCase.java
@@ -14,13 +14,9 @@ public class SocialLogoutUseCase {
   private final RedisRepository redisRepository;
   private final JwtTokenProvider jwtTokenProvider;
 
-  public void execute(Long userId, String accessToken) {
+  public void execute(Long userId) {
 
-    // 1. Refresh Token 삭제
+    // Refresh Token 삭제
     redisRepository.deleteRefreshToken(userId);
-
-    // 2. Access Token 블랙리스트 등록
-    long remainingTime = jwtTokenProvider.getRemainingTime(accessToken);
-    redisRepository.blacklistAccessToken(accessToken, remainingTime);
   }
 }

--- a/auth-service/src/main/java/com/ticketrush/boundedcontext/auth/app/usecase/SocialLogoutUseCase.java
+++ b/auth-service/src/main/java/com/ticketrush/boundedcontext/auth/app/usecase/SocialLogoutUseCase.java
@@ -1,7 +1,6 @@
 package com.ticketrush.boundedcontext.auth.app.usecase;
 
 import com.ticketrush.boundedcontext.auth.out.repository.RedisRepository;
-import com.ticketrush.global.security.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -12,7 +11,6 @@ import org.springframework.transaction.annotation.Transactional;
 public class SocialLogoutUseCase {
 
   private final RedisRepository redisRepository;
-  private final JwtTokenProvider jwtTokenProvider;
 
   public void execute(Long userId) {
 

--- a/auth-service/src/main/java/com/ticketrush/boundedcontext/auth/in/api/v1/AuthController.java
+++ b/auth-service/src/main/java/com/ticketrush/boundedcontext/auth/in/api/v1/AuthController.java
@@ -6,17 +6,18 @@ import com.ticketrush.boundedcontext.auth.app.dto.response.OauthLoginResponse;
 import com.ticketrush.boundedcontext.auth.app.dto.response.TokenReissueResponse;
 import com.ticketrush.boundedcontext.auth.app.facade.AuthFacade;
 import com.ticketrush.global.dto.response.ApiResponse;
+import com.ticketrush.global.security.CustomUserDetails;
 import com.ticketrush.global.status.SuccessStatus;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -60,10 +61,10 @@ public class AuthController {
 
   @Operation(summary = "소셜 로그아웃", description = "Refresh token 삭제를 통해 로그아웃합니다.")
   @PostMapping("/logout")
-  public ResponseEntity<ApiResponse<Void>> logout(
-      @RequestHeader(value = "Authorization", required = false) String bearerToken) {
+  public ResponseEntity<ApiResponse<Void>> logout(@AuthenticationPrincipal CustomUserDetails user) {
 
-    authFacade.logout(bearerToken);
+    authFacade.logout(user.getUserId());
+
     return ApiResponse.onSuccess(SuccessStatus.OK);
   }
 }

--- a/auth-service/src/main/java/com/ticketrush/boundedcontext/auth/in/api/v1/AuthController.java
+++ b/auth-service/src/main/java/com/ticketrush/boundedcontext/auth/in/api/v1/AuthController.java
@@ -6,7 +6,9 @@ import com.ticketrush.boundedcontext.auth.app.dto.response.OauthLoginResponse;
 import com.ticketrush.boundedcontext.auth.app.dto.response.TokenReissueResponse;
 import com.ticketrush.boundedcontext.auth.app.facade.AuthFacade;
 import com.ticketrush.global.dto.response.ApiResponse;
+import com.ticketrush.global.exception.BusinessException;
 import com.ticketrush.global.security.CustomUserDetails;
+import com.ticketrush.global.status.ErrorStatus;
 import com.ticketrush.global.status.SuccessStatus;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
@@ -62,6 +64,10 @@ public class AuthController {
   @Operation(summary = "소셜 로그아웃", description = "Refresh token 삭제를 통해 로그아웃합니다.")
   @PostMapping("/logout")
   public ResponseEntity<ApiResponse<Void>> logout(@AuthenticationPrincipal CustomUserDetails user) {
+
+    if (user == null) {
+      throw new BusinessException(ErrorStatus.UNAUTHORIZED);
+    }
 
     authFacade.logout(user.getUserId());
 

--- a/auth-service/src/main/java/com/ticketrush/boundedcontext/auth/out/repository/RedisRepository.java
+++ b/auth-service/src/main/java/com/ticketrush/boundedcontext/auth/out/repository/RedisRepository.java
@@ -38,15 +38,4 @@ public class RedisRepository {
 
     return saved != null && saved.equals(refreshToken);
   }
-
-  // 블랙리스트 등록
-  public void blacklistAccessToken(String accessToken, long expiration) {
-    String key = "BL:" + accessToken;
-    redisTemplate.opsForValue().set(key, "logout", Duration.ofMillis(expiration));
-  }
-
-  // 블랙리스트 확인
-  public boolean isBlacklisted(String accessToken) {
-    return Boolean.TRUE.equals(redisTemplate.hasKey("BL:" + accessToken));
-  }
 }

--- a/auth-service/src/main/java/com/ticketrush/global/config/SecurityConfig.java
+++ b/auth-service/src/main/java/com/ticketrush/global/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.ticketrush.global.config;
 
+import com.ticketrush.global.security.GatewayHeaderFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.security.autoconfigure.SecurityProperties;
@@ -9,6 +10,7 @@ import org.springframework.security.config.annotation.method.configuration.Enabl
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
 @EnableWebSecurity
@@ -17,10 +19,13 @@ import org.springframework.security.web.SecurityFilterChain;
 @RequiredArgsConstructor
 public class SecurityConfig {
 
+  private final GatewayHeaderFilter gatewayHeaderFilter;
+
   @Bean
   public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
     http.csrf(csrf -> csrf.disable())
         .cors(cors -> {})
+        .addFilterBefore(gatewayHeaderFilter, UsernamePasswordAuthenticationFilter.class)
         .authorizeHttpRequests(
             auth ->
                 auth.requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html")

--- a/auth-service/src/main/java/com/ticketrush/global/security/JwtTokenProvider.java
+++ b/auth-service/src/main/java/com/ticketrush/global/security/JwtTokenProvider.java
@@ -8,8 +8,8 @@ import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
 import java.nio.charset.StandardCharsets;
-import java.security.Key;
 import java.util.Date;
+import javax.crypto.SecretKey;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -18,7 +18,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class JwtTokenProvider {
 
-  private final Key key;
+  private final SecretKey key;
   private final long accessTokenExpiration;
   private final long refreshTokenExpiration;
 
@@ -75,7 +75,7 @@ public class JwtTokenProvider {
 
   public boolean validateToken(String token) {
     try {
-      Jwts.parser().verifyWith((javax.crypto.SecretKey) key).build().parseSignedClaims(token);
+      Jwts.parser().verifyWith(key).build().parseSignedClaims(token);
       return true;
     } catch (JwtException | IllegalArgumentException e) {
       log.warn("JWT 검증 실패: {}", e.getClass().getSimpleName());
@@ -84,11 +84,7 @@ public class JwtTokenProvider {
   }
 
   public Claims getClaims(String token) {
-    return Jwts.parser()
-        .verifyWith((javax.crypto.SecretKey) key)
-        .build()
-        .parseSignedClaims(token)
-        .getPayload();
+    return Jwts.parser().verifyWith(key).build().parseSignedClaims(token).getPayload();
   }
 
   public Long getUserId(String token) {

--- a/auth-service/src/main/java/com/ticketrush/global/security/JwtTokenProvider.java
+++ b/auth-service/src/main/java/com/ticketrush/global/security/JwtTokenProvider.java
@@ -77,9 +77,13 @@ public class JwtTokenProvider {
     try {
       Jwts.parser().verifyWith(key).build().parseSignedClaims(token);
       return true;
+    } catch (ExpiredJwtException e) {
+
+      throw new BusinessException(ErrorStatus.AUTH_EXPIRED_TOKEN);
+
     } catch (JwtException | IllegalArgumentException e) {
       log.warn("JWT 검증 실패: {}", e.getClass().getSimpleName());
-      return false;
+      throw new BusinessException(ErrorStatus.AUTH_INVALID_TOKEN);
     }
   }
 

--- a/auth-service/src/main/resources/application.yml
+++ b/auth-service/src/main/resources/application.yml
@@ -30,9 +30,11 @@ jwt:
   access-token-expiration: 3600000      # 1시간(ms)
   refresh-token-expiration: 1209600000  # 14일(ms)
 
-
 springdoc:
   api-docs:
     enabled: true
   swagger-ui:
     enabled: false
+
+gateway:
+  internal-token: ${GATEWAY_INTERNAL_TOKEN:test-token}

--- a/booking-service/src/main/resources/application.yml
+++ b/booking-service/src/main/resources/application.yml
@@ -19,3 +19,6 @@ springdoc:
     enabled: true
   swagger-ui:
     enabled: false
+
+gateway:
+  internal-token: ${GATEWAY_INTERNAL_TOKEN:test-token}

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -81,6 +81,11 @@ dependencies {
 
 	// redis
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+	// JWT
+	implementation 'io.jsonwebtoken:jjwt-api:0.12.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.5'
 }
 
 dependencyManagement {

--- a/common/src/main/java/com/ticketrush/global/security/CustomUserDetails.java
+++ b/common/src/main/java/com/ticketrush/global/security/CustomUserDetails.java
@@ -1,0 +1,16 @@
+package com.ticketrush.global.security;
+
+import lombok.Getter;
+
+// 로그인한 사용자 정보 담는 객체
+@Getter
+public class CustomUserDetails {
+
+  private final Long userId;
+  private final String role;
+
+  public CustomUserDetails(Long userId, String role) {
+    this.userId = userId;
+    this.role = role;
+  }
+}

--- a/common/src/main/java/com/ticketrush/global/security/GatewayHeaderFilter.java
+++ b/common/src/main/java/com/ticketrush/global/security/GatewayHeaderFilter.java
@@ -15,25 +15,38 @@ import org.springframework.web.filter.OncePerRequestFilter;
 @Component
 public class GatewayHeaderFilter extends OncePerRequestFilter {
 
+  private static final String USER_ID_HEADER = "X-User-Id";
+  private static final String USER_ROLE_HEADER = "X-User-Role";
+
   @Override
   protected void doFilterInternal(
       HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
       throws ServletException, IOException {
 
-    String userId = request.getHeader("X-User-Id");
-    String role = request.getHeader("X-User-Role");
+    String userIdHeader = request.getHeader(USER_ID_HEADER);
+    String roleHeader = request.getHeader(USER_ROLE_HEADER);
 
-    if (userId != null && role != null) {
+    // 헤더가 모두 존재할 때만 인증 처리
+    if (userIdHeader != null && roleHeader != null) {
 
-      List<SimpleGrantedAuthority> authorities =
-          List.of(new SimpleGrantedAuthority("ROLE_" + role));
+      try {
+        Long userId = Long.valueOf(userIdHeader);
 
-      CustomUserDetails principal = new CustomUserDetails(Long.valueOf(userId), role);
+        List<SimpleGrantedAuthority> authorities =
+            List.of(new SimpleGrantedAuthority("ROLE_" + roleHeader));
 
-      UsernamePasswordAuthenticationToken authentication =
-          new UsernamePasswordAuthenticationToken(principal, null, authorities);
+        CustomUserDetails principal = new CustomUserDetails(userId, roleHeader);
 
-      SecurityContextHolder.getContext().setAuthentication(authentication);
+        UsernamePasswordAuthenticationToken authentication =
+            new UsernamePasswordAuthenticationToken(principal, null, authorities);
+
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+
+      } catch (NumberFormatException e) {
+
+        // 잘못된 헤더 값이면 인증 세팅 없이 통과
+        SecurityContextHolder.clearContext();
+      }
     }
 
     filterChain.doFilter(request, response);

--- a/common/src/main/java/com/ticketrush/global/security/GatewayHeaderFilter.java
+++ b/common/src/main/java/com/ticketrush/global/security/GatewayHeaderFilter.java
@@ -1,0 +1,41 @@
+package com.ticketrush.global.security;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.List;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Component
+public class GatewayHeaderFilter extends OncePerRequestFilter {
+
+  @Override
+  protected void doFilterInternal(
+      HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+      throws ServletException, IOException {
+
+    String userId = request.getHeader("X-User-Id");
+    String role = request.getHeader("X-User-Role");
+
+    if (userId != null && role != null) {
+
+      List<SimpleGrantedAuthority> authorities =
+          List.of(new SimpleGrantedAuthority("ROLE_" + role));
+
+      CustomUserDetails principal = new CustomUserDetails(Long.valueOf(userId), role);
+
+      UsernamePasswordAuthenticationToken authentication =
+          new UsernamePasswordAuthenticationToken(principal, null, authorities);
+
+      SecurityContextHolder.getContext().setAuthentication(authentication);
+    }
+
+    filterChain.doFilter(request, response);
+  }
+}

--- a/common/src/main/java/com/ticketrush/global/security/GatewayHeaderFilter.java
+++ b/common/src/main/java/com/ticketrush/global/security/GatewayHeaderFilter.java
@@ -6,6 +6,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.List;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -17,11 +18,24 @@ public class GatewayHeaderFilter extends OncePerRequestFilter {
 
   private static final String USER_ID_HEADER = "X-User-Id";
   private static final String USER_ROLE_HEADER = "X-User-Role";
+  private static final String INTERNAL_TOKEN_HEADER = "X-Internal-Token";
+
+  @Value("${gateway.internal-token}")
+  private String internalToken;
 
   @Override
   protected void doFilterInternal(
       HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
       throws ServletException, IOException {
+
+    String internalHeader = request.getHeader(INTERNAL_TOKEN_HEADER);
+
+    // Gateway 내부 토큰 검증 실패 시 인증 무효
+    if (!internalToken.equals(internalHeader)) {
+      SecurityContextHolder.clearContext();
+      filterChain.doFilter(request, response);
+      return;
+    }
 
     String userIdHeader = request.getHeader(USER_ID_HEADER);
     String roleHeader = request.getHeader(USER_ROLE_HEADER);
@@ -44,7 +58,6 @@ public class GatewayHeaderFilter extends OncePerRequestFilter {
 
       } catch (NumberFormatException e) {
 
-        // 잘못된 헤더 값이면 인증 세팅 없이 통과
         SecurityContextHolder.clearContext();
       }
     }

--- a/gateway-service/build.gradle
+++ b/gateway-service/build.gradle
@@ -45,6 +45,11 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 	implementation 'org.springframework.cloud:spring-cloud-starter-gateway-server-webflux'
 	implementation 'org.springdoc:springdoc-openapi-starter-webflux-ui:3.0.1'
+
+	// JWT
+	implementation 'io.jsonwebtoken:jjwt-api:0.12.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.5'
 }
 
 dependencyManagement {

--- a/gateway-service/src/main/java/com/ticketrush/config/JacksonConfig.java
+++ b/gateway-service/src/main/java/com/ticketrush/config/JacksonConfig.java
@@ -1,0 +1,50 @@
+package com.ticketrush.config;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+import org.springframework.boot.jackson.autoconfigure.JsonMapperBuilderCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import tools.jackson.databind.PropertyNamingStrategies;
+import tools.jackson.databind.ext.javatime.deser.LocalDateDeserializer;
+import tools.jackson.databind.ext.javatime.deser.LocalDateTimeDeserializer;
+import tools.jackson.databind.ext.javatime.deser.LocalTimeDeserializer;
+import tools.jackson.databind.ext.javatime.ser.LocalDateSerializer;
+import tools.jackson.databind.ext.javatime.ser.LocalDateTimeSerializer;
+import tools.jackson.databind.ext.javatime.ser.LocalTimeSerializer;
+import tools.jackson.databind.module.SimpleModule;
+
+@Configuration
+public class JacksonConfig {
+
+  private static final String DATETIME_FORMAT = "yyyy-MM-dd HH:mm:ss";
+  private static final String DATE_FORMAT = "yyyy-MM-dd";
+  private static final String TIME_FORMAT = "HH:mm:ss";
+
+  @Bean
+  public JsonMapperBuilderCustomizer jacksonCustomizer() {
+    return builder -> {
+      builder.propertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE);
+
+      builder.changeDefaultPropertyInclusion(
+          incl -> incl.withValueInclusion(JsonInclude.Include.NON_NULL));
+
+      DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern(DATETIME_FORMAT);
+      DateTimeFormatter dateFormatter = DateTimeFormatter.ofPattern(DATE_FORMAT);
+      DateTimeFormatter timeFormatter = DateTimeFormatter.ofPattern(TIME_FORMAT);
+
+      SimpleModule timeModule = new SimpleModule();
+      timeModule.addSerializer(LocalDateTime.class, new LocalDateTimeSerializer(dateTimeFormatter));
+      timeModule.addDeserializer(
+          LocalDateTime.class, new LocalDateTimeDeserializer(dateTimeFormatter));
+      timeModule.addSerializer(LocalDate.class, new LocalDateSerializer(dateFormatter));
+      timeModule.addDeserializer(LocalDate.class, new LocalDateDeserializer(dateFormatter));
+      timeModule.addSerializer(LocalTime.class, new LocalTimeSerializer(timeFormatter));
+      timeModule.addDeserializer(LocalTime.class, new LocalTimeDeserializer(timeFormatter));
+      builder.addModule(timeModule);
+    };
+  }
+}

--- a/gateway-service/src/main/java/com/ticketrush/config/JwtAuthenticationFilter.java
+++ b/gateway-service/src/main/java/com/ticketrush/config/JwtAuthenticationFilter.java
@@ -1,0 +1,89 @@
+package com.ticketrush.config;
+
+import com.ticketrush.security.JwtTokenProvider;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.cloud.gateway.filter.GatewayFilterChain;
+import org.springframework.cloud.gateway.filter.GlobalFilter;
+import org.springframework.core.Ordered;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Mono;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter implements GlobalFilter, Ordered {
+
+  private final JwtTokenProvider jwtTokenProvider;
+
+  @Override
+  public Mono<Void> filter(ServerWebExchange exchange, GatewayFilterChain chain) {
+
+    log.info("🔥 JwtAuthenticationFilter 실행");
+
+    String token = resolveToken(exchange);
+
+    // 토큰 없으면 그냥 통과 (로그인 API 등)
+    if (token == null) {
+      log.info("🔥 토큰 없음");
+      return chain.filter(exchange);
+    }
+
+    // JWT 검증
+    if (!jwtTokenProvider.validateToken(token)) {
+      log.info("🔥 토큰 검증 실패");
+
+      exchange.getResponse().setStatusCode(HttpStatus.UNAUTHORIZED);
+      return exchange.getResponse().setComplete();
+    }
+
+    // AccessToken 여부 검증
+    String type = jwtTokenProvider.getType(token);
+
+    if (!"access".equals(type)) {
+      log.info("🔥 AccessToken 아님");
+
+      exchange.getResponse().setStatusCode(HttpStatus.UNAUTHORIZED);
+      return exchange.getResponse().setComplete();
+    }
+
+    log.info("🔥 토큰 검증 성공");
+
+    // 토큰에서 사용자 정보 추출
+    Long userId = jwtTokenProvider.getUserId(token);
+    String role = jwtTokenProvider.getRole(token);
+
+    log.info("🔥 userId = {}", userId);
+    log.info("🔥 role = {}", role);
+
+    // 내부 서비스로 사용자 정보 전달
+    ServerHttpRequest request =
+        exchange
+            .getRequest()
+            .mutate()
+            .header("X-User-Id", String.valueOf(userId))
+            .header("X-User-Role", role)
+            .build();
+
+    return chain.filter(exchange.mutate().request(request).build());
+  }
+
+  private String resolveToken(ServerWebExchange exchange) {
+
+    String bearer = exchange.getRequest().getHeaders().getFirst("Authorization");
+
+    if (bearer != null && bearer.startsWith("Bearer ")) {
+      return bearer.substring(7);
+    }
+
+    return null;
+  }
+
+  @Override
+  public int getOrder() {
+    return -1;
+  }
+}

--- a/gateway-service/src/main/java/com/ticketrush/dto/response/ApiResponse.java
+++ b/gateway-service/src/main/java/com/ticketrush/dto/response/ApiResponse.java
@@ -1,0 +1,60 @@
+package com.ticketrush.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.ticketrush.status.ErrorStatus;
+import com.ticketrush.status.SuccessStatus;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.http.ResponseEntity;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@JsonPropertyOrder({"isSuccess", "code", "message", "traceId", "pagination", "result"})
+public class ApiResponse<T> {
+
+  private Boolean isSuccess;
+  private String code;
+  private String message;
+  private String traceId;
+
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  private T result;
+
+  // 성공 - 기본 응답
+  public static ResponseEntity<ApiResponse<Void>> onSuccess(SuccessStatus status) {
+    return new ResponseEntity<>(
+        new ApiResponse<>(true, status.getCode(), status.getMessage(), null, null),
+        status.getHttpStatus());
+  }
+
+  // 성공 - 데이터 포함
+  public static <T> ResponseEntity<ApiResponse<T>> onSuccess(SuccessStatus status, T result) {
+    return new ResponseEntity<>(
+        new ApiResponse<>(true, status.getCode(), status.getMessage(), null, result),
+        status.getHttpStatus());
+  }
+
+  // 실패 - 기본 응답
+  public static ResponseEntity<ApiResponse<?>> onFailure(ErrorStatus error) {
+    return new ResponseEntity<>(
+        new ApiResponse<>(false, error.getCode(), error.getMessage(), null, null),
+        error.getHttpStatus());
+  }
+
+  // 실패 - 커스텀 메시지 포함
+  public static ResponseEntity<ApiResponse<?>> onFailure(ErrorStatus error, String message) {
+    return new ResponseEntity<>(
+        new ApiResponse<>(false, error.getCode(), error.getMessage(message), null, null),
+        error.getHttpStatus());
+  }
+
+  // 실패 - 데이터 포함
+  public static ResponseEntity<ApiResponse<?>> onFailure(ErrorStatus error, Object data) {
+    return new ResponseEntity<>(
+        new ApiResponse<>(false, error.getCode(), error.getMessage(), null, data),
+        error.getHttpStatus());
+  }
+}

--- a/gateway-service/src/main/java/com/ticketrush/exception/BusinessException.java
+++ b/gateway-service/src/main/java/com/ticketrush/exception/BusinessException.java
@@ -1,0 +1,46 @@
+package com.ticketrush.exception;
+
+import com.ticketrush.status.ErrorStatus;
+import lombok.Getter;
+
+@Getter
+public class BusinessException extends RuntimeException {
+
+  private final ErrorStatus errorStatus;
+  private final Object data;
+
+  // 메세지만
+  public BusinessException(String message) {
+    super(message);
+    this.errorStatus = ErrorStatus.INTERNAL_SERVER_ERROR;
+    this.data = null;
+  }
+
+  // 메세지 + 원인 - 개발자용 메세지
+  public BusinessException(String message, Throwable cause) {
+    super(message, cause);
+    this.errorStatus = ErrorStatus.INTERNAL_SERVER_ERROR;
+    this.data = null;
+  }
+
+  // ErrorStatus 기반
+  public BusinessException(ErrorStatus errorStatus) {
+    super(errorStatus.getMessage());
+    this.errorStatus = errorStatus;
+    this.data = null;
+  }
+
+  // ErrorStatus + 추가 데이터
+  public BusinessException(ErrorStatus errorStatus, Object data) {
+    super(errorStatus.getMessage());
+    this.errorStatus = errorStatus;
+    this.data = data;
+  }
+
+  // ErrorStatus + cause
+  public BusinessException(ErrorStatus errorStatus, Throwable cause) {
+    super(errorStatus.getMessage(), cause);
+    this.errorStatus = errorStatus;
+    this.data = null;
+  }
+}

--- a/gateway-service/src/main/java/com/ticketrush/security/JwtAuthenticationFilter.java
+++ b/gateway-service/src/main/java/com/ticketrush/security/JwtAuthenticationFilter.java
@@ -1,6 +1,5 @@
-package com.ticketrush.config;
+package com.ticketrush.security;
 
-import com.ticketrush.security.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.cloud.gateway.filter.GatewayFilterChain;
@@ -28,13 +27,11 @@ public class JwtAuthenticationFilter implements GlobalFilter, Ordered {
 
     // 토큰 없으면 그냥 통과 (로그인 API 등)
     if (token == null) {
-      log.info("🔥 토큰 없음");
       return chain.filter(exchange);
     }
 
     // JWT 검증
     if (!jwtTokenProvider.validateToken(token)) {
-      log.info("🔥 토큰 검증 실패");
 
       exchange.getResponse().setStatusCode(HttpStatus.UNAUTHORIZED);
       return exchange.getResponse().setComplete();
@@ -44,13 +41,10 @@ public class JwtAuthenticationFilter implements GlobalFilter, Ordered {
     String type = jwtTokenProvider.getType(token);
 
     if (!"access".equals(type)) {
-      log.info("🔥 AccessToken 아님");
 
       exchange.getResponse().setStatusCode(HttpStatus.UNAUTHORIZED);
       return exchange.getResponse().setComplete();
     }
-
-    log.info("🔥 토큰 검증 성공");
 
     // 토큰에서 사용자 정보 추출
     Long userId = jwtTokenProvider.getUserId(token);
@@ -64,8 +58,13 @@ public class JwtAuthenticationFilter implements GlobalFilter, Ordered {
         exchange
             .getRequest()
             .mutate()
-            .header("X-User-Id", String.valueOf(userId))
-            .header("X-User-Role", role)
+            .headers(
+                headers -> {
+                  headers.remove("X-User-Id");
+                  headers.remove("X-User-Role");
+                  headers.set("X-User-Id", String.valueOf(userId));
+                  headers.set("X-User-Role", role);
+                })
             .build();
 
     return chain.filter(exchange.mutate().request(request).build());

--- a/gateway-service/src/main/java/com/ticketrush/security/JwtAuthenticationFilter.java
+++ b/gateway-service/src/main/java/com/ticketrush/security/JwtAuthenticationFilter.java
@@ -1,11 +1,13 @@
 package com.ticketrush.security;
 
+import com.ticketrush.exception.BusinessException;
+import com.ticketrush.status.ErrorStatus;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cloud.gateway.filter.GatewayFilterChain;
 import org.springframework.cloud.gateway.filter.GlobalFilter;
 import org.springframework.core.Ordered;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.server.reactive.ServerHttpRequest;
 import org.springframework.stereotype.Component;
 import org.springframework.web.server.ServerWebExchange;
@@ -18,6 +20,9 @@ public class JwtAuthenticationFilter implements GlobalFilter, Ordered {
 
   private final JwtTokenProvider jwtTokenProvider;
 
+  @Value("${gateway.internal-token}")
+  private String internalToken;
+
   @Override
   public Mono<Void> filter(ServerWebExchange exchange, GatewayFilterChain chain) {
 
@@ -25,25 +30,19 @@ public class JwtAuthenticationFilter implements GlobalFilter, Ordered {
 
     String token = resolveToken(exchange);
 
-    // 토큰 없으면 그냥 통과 (로그인 API 등)
+    // 토큰 없으면 그냥 통과
     if (token == null) {
       return chain.filter(exchange);
     }
 
     // JWT 검증
-    if (!jwtTokenProvider.validateToken(token)) {
-
-      exchange.getResponse().setStatusCode(HttpStatus.UNAUTHORIZED);
-      return exchange.getResponse().setComplete();
-    }
+    jwtTokenProvider.validateToken(token);
 
     // AccessToken 여부 검증
     String type = jwtTokenProvider.getType(token);
 
     if (!"access".equals(type)) {
-
-      exchange.getResponse().setStatusCode(HttpStatus.UNAUTHORIZED);
-      return exchange.getResponse().setComplete();
+      throw new BusinessException(ErrorStatus.AUTH_INVALID_TOKEN_TYPE);
     }
 
     // 토큰에서 사용자 정보 추출
@@ -60,10 +59,16 @@ public class JwtAuthenticationFilter implements GlobalFilter, Ordered {
             .mutate()
             .headers(
                 headers -> {
+
+                  // 외부 헤더 제거
                   headers.remove("X-User-Id");
                   headers.remove("X-User-Role");
+                  headers.remove("X-Internal-Token");
+
+                  // Gateway가 다시 세팅
                   headers.set("X-User-Id", String.valueOf(userId));
                   headers.set("X-User-Role", role);
+                  headers.set("X-Internal-Token", internalToken);
                 })
             .build();
 

--- a/gateway-service/src/main/java/com/ticketrush/security/JwtTokenProvider.java
+++ b/gateway-service/src/main/java/com/ticketrush/security/JwtTokenProvider.java
@@ -1,0 +1,124 @@
+package com.ticketrush.security;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import java.nio.charset.StandardCharsets;
+import java.security.Key;
+import java.util.Date;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class JwtTokenProvider {
+
+  private final Key key;
+  private final long accessTokenExpiration;
+  private final long refreshTokenExpiration;
+
+  public JwtTokenProvider(
+      @Value("${jwt.secret}") String secret,
+      @Value("${jwt.access-token-expiration}") long accessTokenExpiration,
+      @Value("${jwt.refresh-token-expiration}") long refreshTokenExpiration) {
+
+    if (secret.length() < 32) {
+      throw new IllegalArgumentException("JWT secret key는 최소 32자 이상이어야 합니다.");
+    }
+
+    this.key = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+    this.accessTokenExpiration = accessTokenExpiration;
+    this.refreshTokenExpiration = refreshTokenExpiration;
+  }
+
+  // AccessToken 생성
+  public String createAccessToken(Long userId, String role) {
+    Date now = new Date();
+    Date expiry = new Date(now.getTime() + accessTokenExpiration);
+
+    return Jwts.builder()
+        .subject(String.valueOf(userId))
+        .claim("role", role)
+        .claim("type", "access")
+        .issuedAt(now)
+        .expiration(expiry)
+        .signWith(key)
+        .compact();
+  }
+
+  // RefreshToken 생성
+  public String createRefreshToken(Long userId) {
+    Date now = new Date();
+    Date expiry = new Date(now.getTime() + refreshTokenExpiration);
+
+    return Jwts.builder()
+        .subject(String.valueOf(userId))
+        .claim("type", "refresh")
+        .issuedAt(now)
+        .expiration(expiry)
+        .signWith(key)
+        .compact();
+  }
+
+  public long getAccessTokenExpiration() {
+    return accessTokenExpiration;
+  }
+
+  public long getRefreshTokenExpiration() {
+    return refreshTokenExpiration;
+  }
+
+  // JWT 유효성 검증
+  public boolean validateToken(String token) {
+    try {
+      Jwts.parser().verifyWith((javax.crypto.SecretKey) key).build().parseSignedClaims(token);
+
+      return true;
+
+    } catch (JwtException | IllegalArgumentException e) {
+      log.warn("JWT 검증 실패: {}", e.getClass().getSimpleName());
+      return false;
+    }
+  }
+
+  // Claims 추출
+  public Claims getClaims(String token) {
+    return Jwts.parser()
+        .verifyWith((javax.crypto.SecretKey) key)
+        .build()
+        .parseSignedClaims(token)
+        .getPayload();
+  }
+
+  // UserId 추출
+  public Long getUserId(String token) {
+    return Long.valueOf(getClaims(token).getSubject());
+  }
+
+  // Role 추출
+  public String getRole(String token) {
+    return getClaims(token).get("role", String.class);
+  }
+
+  // 토큰 타입 추출
+  public String getType(String token) {
+    return getClaims(token).get("type", String.class);
+  }
+
+  // 남은 만료 시간(ms)
+  public long getRemainingTime(String token) {
+    try {
+      Date expiration = getClaims(token).getExpiration();
+      return expiration.getTime() - System.currentTimeMillis();
+
+    } catch (ExpiredJwtException e) {
+      return 0L;
+
+    } catch (JwtException | IllegalArgumentException e) {
+      return 0L;
+    }
+  }
+}

--- a/gateway-service/src/main/java/com/ticketrush/status/ErrorStatus.java
+++ b/gateway-service/src/main/java/com/ticketrush/status/ErrorStatus.java
@@ -1,4 +1,4 @@
-package com.ticketrush.global.status;
+package com.ticketrush.status;
 
 import java.util.Optional;
 import java.util.function.Predicate;

--- a/gateway-service/src/main/java/com/ticketrush/status/SuccessStatus.java
+++ b/gateway-service/src/main/java/com/ticketrush/status/SuccessStatus.java
@@ -1,0 +1,17 @@
+package com.ticketrush.status;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum SuccessStatus {
+  OK(HttpStatus.OK, "COMMON_200", "성공입니다."),
+  CREATED(HttpStatus.CREATED, "COMMON_201", "리소스가 성공적으로 생성되었습니다."),
+  NO_CONTENT(HttpStatus.NO_CONTENT, "COMMON_204", "요청이 성공적으로 처리되었습니다.");
+
+  private final HttpStatus httpStatus;
+  private final String code;
+  private final String message;
+}

--- a/gateway-service/src/main/resources/application.yml
+++ b/gateway-service/src/main/resources/application.yml
@@ -86,3 +86,8 @@ springdoc:
         url: /v3/api-docs/seat
       - name: ticket-service
         url: /v3/api-docs/ticket
+
+jwt:
+  secret: ${JWT_SECRET}
+  access-token-expiration: 3600000      # 1시간(ms)
+  refresh-token-expiration: 1209600000  # 14일(ms)

--- a/gateway-service/src/main/resources/application.yml
+++ b/gateway-service/src/main/resources/application.yml
@@ -91,3 +91,6 @@ jwt:
   secret: ${JWT_SECRET}
   access-token-expiration: 3600000      # 1시간(ms)
   refresh-token-expiration: 1209600000  # 14일(ms)
+
+gateway:
+  internal-token: ${GATEWAY_INTERNAL_TOKEN:test-token}

--- a/payment-service/src/main/resources/application.yml
+++ b/payment-service/src/main/resources/application.yml
@@ -19,3 +19,6 @@ springdoc:
     enabled: true
   swagger-ui:
     enabled: false
+
+gateway:
+  internal-token: ${GATEWAY_INTERNAL_TOKEN:test-token}

--- a/performance-service/src/main/resources/application.yml
+++ b/performance-service/src/main/resources/application.yml
@@ -19,3 +19,6 @@ springdoc:
     enabled: true
   swagger-ui:
     enabled: false
+
+gateway:
+  internal-token: ${GATEWAY_INTERNAL_TOKEN:test-token}

--- a/seat-service/src/main/resources/application.yml
+++ b/seat-service/src/main/resources/application.yml
@@ -19,3 +19,6 @@ springdoc:
     enabled: true
   swagger-ui:
     enabled: false
+
+gateway:
+  internal-token: ${GATEWAY_INTERNAL_TOKEN:test-token}

--- a/ticket-service/src/main/resources/application.yml
+++ b/ticket-service/src/main/resources/application.yml
@@ -19,3 +19,6 @@ springdoc:
     enabled: true
   swagger-ui:
     enabled: false
+
+gateway:
+  internal-token: ${GATEWAY_INTERNAL_TOKEN:test-token}

--- a/user-service/src/main/java/com/ticketrush/boundedcontext/user/in/api/v1/UserController.java
+++ b/user-service/src/main/java/com/ticketrush/boundedcontext/user/in/api/v1/UserController.java
@@ -6,13 +6,11 @@ import com.ticketrush.boundedcontext.user.app.facade.UserFacade;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@Slf4j
 @Tag(name = "User", description = "회원 로그인 API")
 @RestController
 @RequestMapping("/api/v1/user")

--- a/user-service/src/main/java/com/ticketrush/boundedcontext/user/in/api/v1/UserController.java
+++ b/user-service/src/main/java/com/ticketrush/boundedcontext/user/in/api/v1/UserController.java
@@ -6,11 +6,13 @@ import com.ticketrush.boundedcontext.user.app.facade.UserFacade;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Slf4j
 @Tag(name = "User", description = "회원 로그인 API")
 @RestController
 @RequestMapping("/api/v1/user")

--- a/user-service/src/main/java/com/ticketrush/global/config/SecurityConfig.java
+++ b/user-service/src/main/java/com/ticketrush/global/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.ticketrush.global.config;
 
+import com.ticketrush.global.security.GatewayHeaderFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.security.autoconfigure.SecurityProperties;
@@ -9,6 +10,7 @@ import org.springframework.security.config.annotation.method.configuration.Enabl
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
 @EnableWebSecurity
@@ -17,10 +19,13 @@ import org.springframework.security.web.SecurityFilterChain;
 @RequiredArgsConstructor
 public class SecurityConfig {
 
+  private final GatewayHeaderFilter gatewayHeaderFilter;
+
   @Bean
   public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
     http.csrf(csrf -> csrf.disable())
         .cors(cors -> {})
+        .addFilterBefore(gatewayHeaderFilter, UsernamePasswordAuthenticationFilter.class)
         .authorizeHttpRequests(
             auth ->
                 auth.requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html")

--- a/user-service/src/main/resources/application.yml
+++ b/user-service/src/main/resources/application.yml
@@ -19,3 +19,6 @@ springdoc:
     enabled: true
   swagger-ui:
     enabled: false
+
+gateway:
+  internal-token: ${GATEWAY_INTERNAL_TOKEN:test-token}


### PR DESCRIPTION
## 🔗 관련 이슈

- close #73 

---

## 📌 주요 변경 사항

- authcontroller에서 /logout에 @AuthenticationPrincipal을 사용할 수 있도록 수정했습니다. 

---

## 🛠 상세 구현 내용

- Gateway-service에서도 JwtTokenProvider가 필요하여 추가하였습니다.
- common에 GatewayHeaderFilter, CustmUserDetails 클래스 추가하였습니다.
- 로그인된 사용자가 다른 api를 호출할 시 gateway에서 token을 검증하고 다른 모듈로 내려보낼 수 있도록, gateway에서 token 검증 과정을 추가하였습니다. 
- 앞으로 다른 모듈에서도 로그인된 사용자가 필요할 시, @AuthenticationPrincipal를 사용하도록 하였습니다. 

---

## ✅ 테스트

### 테스트 방법

- swagger에서 로그인에 성공한 뒤, Authorize를 하고 바로 로그아웃을 하였을 때 되는지 테스트해보았습니다. 

### 테스트 결과

- 로그아웃 결과 성공이었습니다. 

### 📸 스크린샷

--- 
<img width="827" height="817" alt="Pasted Graphic 4" src="https://github.com/user-attachments/assets/6be27577-2e78-4fea-823d-1e25dd028292" />
<img width="3074" height="452" alt="image" src="https://github.com/user-attachments/assets/cfc2a64d-d701-40af-a951-41b3b0f614e3" />


## 👀 리뷰 요청 사항

- GatewayHeaderFilter를 잘 구현하였는지를 중심으로 리뷰해주시면 좋을 것 같습니다.

---

<!--- ## ⚠️ 배포 시 주의사항 --->

