### PR TITLE
[Feat] #173 공연 상태 변경 API 구현

### DIFF
--- a/common/src/main/java/com/ticketrush/global/status/ErrorStatus.java
+++ b/common/src/main/java/com/ticketrush/global/status/ErrorStatus.java
@@ -77,6 +77,11 @@ public enum ErrorStatus {
   PERFORMANCE_MODEL_3D_MISSING(HttpStatus.BAD_REQUEST, "PERFORMANCE_400_002", "3D 모델 파일은 필수입니다."),
   PERFORMANCE_GALLERY_LIMIT_EXCEEDED(
       HttpStatus.BAD_REQUEST, "PERFORMANCE_400_003", "갤러리 이미지는 최대 3개까지 업로드할 수 있습니다."),
+  PERFORMANCE_INVALID_STATUS_TRANSITION(
+      HttpStatus.BAD_REQUEST, "PERFORMANCE_400_004", "유효하지 않은 공연 상태 전환입니다."),
+
+  // Performance 404
+  PERFORMANCE_NOT_FOUND(HttpStatus.NOT_FOUND, "PERFORMANCE_404_001", "공연이 존재하지 않습니다."),
 
   // File 400
   FILE_EMPTY(HttpStatus.BAD_REQUEST, "FILE_400_001", "업로드할 파일이 비어있습니다."),

--- a/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/app/dto/request/PerformanceChangeStatusRequest.java
+++ b/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/app/dto/request/PerformanceChangeStatusRequest.java
@@ -1,0 +1,7 @@
+package com.ticketrush.boundedcontext.performance.app.dto.request;
+
+import com.ticketrush.boundedcontext.performance.domain.types.PerformanceStatus;
+import jakarta.validation.constraints.NotNull;
+
+public record PerformanceChangeStatusRequest(
+    @NotNull(message = "변경할 상태는 필수입니다.") PerformanceStatus status) {}

--- a/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/app/facade/PerformanceFacade.java
+++ b/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/app/facade/PerformanceFacade.java
@@ -1,8 +1,10 @@
 package com.ticketrush.boundedcontext.performance.app.facade;
 
+import com.ticketrush.boundedcontext.performance.app.dto.request.PerformanceChangeStatusRequest;
 import com.ticketrush.boundedcontext.performance.app.dto.request.PerformanceCreateRequest;
 import com.ticketrush.boundedcontext.performance.app.dto.response.PerformanceCreateResponse;
 import com.ticketrush.boundedcontext.performance.app.dto.response.PerformanceListResponse;
+import com.ticketrush.boundedcontext.performance.app.usecase.PerformanceChangeStatusUseCase;
 import com.ticketrush.boundedcontext.performance.app.usecase.PerformanceCreateUseCase;
 import com.ticketrush.boundedcontext.performance.app.usecase.PerformanceGetListUseCase;
 import com.ticketrush.boundedcontext.performance.domain.types.Genre;
@@ -19,6 +21,7 @@ public class PerformanceFacade {
 
   private final PerformanceCreateUseCase performanceCreateUseCase;
   private final PerformanceGetListUseCase performanceGetListUseCase;
+  private final PerformanceChangeStatusUseCase performanceChangeStatusUseCase;
 
   public PerformanceCreateResponse createPerformance(
       PerformanceCreateRequest request,
@@ -31,5 +34,9 @@ public class PerformanceFacade {
 
   public Page<PerformanceListResponse> getPerformances(Genre genre, Pageable pageable) {
     return performanceGetListUseCase.execute(genre, pageable);
+  }
+
+  public void changePerformanceStatus(Long performanceId, PerformanceChangeStatusRequest request) {
+    performanceChangeStatusUseCase.execute(performanceId, request);
   }
 }

--- a/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/app/usecase/PerformanceChangeStatusUseCase.java
+++ b/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/app/usecase/PerformanceChangeStatusUseCase.java
@@ -1,0 +1,34 @@
+package com.ticketrush.boundedcontext.performance.app.usecase;
+
+import com.ticketrush.boundedcontext.performance.app.dto.request.PerformanceChangeStatusRequest;
+import com.ticketrush.boundedcontext.performance.domain.entity.Performance;
+import com.ticketrush.boundedcontext.performance.domain.types.PerformanceStatus;
+import com.ticketrush.boundedcontext.performance.out.repository.PerformanceRepository;
+import com.ticketrush.global.exception.BusinessException;
+import com.ticketrush.global.status.ErrorStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class PerformanceChangeStatusUseCase {
+
+  private final PerformanceRepository performanceRepository;
+
+  @Transactional
+  public void execute(Long performanceId, PerformanceChangeStatusRequest request) {
+    Performance performance =
+        performanceRepository
+            .findById(performanceId)
+            .orElseThrow(() -> new BusinessException(ErrorStatus.PERFORMANCE_NOT_FOUND));
+
+    PerformanceStatus targetStatus = request.status();
+
+    if (!performance.canTransitionTo(targetStatus)) {
+      throw new BusinessException(ErrorStatus.PERFORMANCE_INVALID_STATUS_TRANSITION);
+    }
+
+    performance.changeStatus(targetStatus);
+  }
+}

--- a/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/app/usecase/PerformanceChangeStatusUseCase.java
+++ b/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/app/usecase/PerformanceChangeStatusUseCase.java
@@ -2,7 +2,6 @@ package com.ticketrush.boundedcontext.performance.app.usecase;
 
 import com.ticketrush.boundedcontext.performance.app.dto.request.PerformanceChangeStatusRequest;
 import com.ticketrush.boundedcontext.performance.domain.entity.Performance;
-import com.ticketrush.boundedcontext.performance.domain.types.PerformanceStatus;
 import com.ticketrush.boundedcontext.performance.out.repository.PerformanceRepository;
 import com.ticketrush.global.exception.BusinessException;
 import com.ticketrush.global.status.ErrorStatus;
@@ -23,12 +22,6 @@ public class PerformanceChangeStatusUseCase {
             .findById(performanceId)
             .orElseThrow(() -> new BusinessException(ErrorStatus.PERFORMANCE_NOT_FOUND));
 
-    PerformanceStatus targetStatus = request.status();
-
-    if (!performance.canTransitionTo(targetStatus)) {
-      throw new BusinessException(ErrorStatus.PERFORMANCE_INVALID_STATUS_TRANSITION);
-    }
-
-    performance.changeStatus(targetStatus);
+    performance.changeStatus(request.status());
   }
 }

--- a/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/domain/entity/Performance.java
+++ b/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/domain/entity/Performance.java
@@ -118,4 +118,12 @@ public class Performance extends AutoIdBaseEntity {
     this.image3dUrl = model3dUrl;
     this.imageGalleryUrls = galleryUrls;
   }
+
+  public boolean canTransitionTo(PerformanceStatus target) {
+    return this.performanceStatus.canTransitionTo(target);
+  }
+
+  public void changeStatus(PerformanceStatus newStatus) {
+    this.performanceStatus = newStatus;
+  }
 }

--- a/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/domain/entity/Performance.java
+++ b/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/domain/entity/Performance.java
@@ -2,7 +2,9 @@ package com.ticketrush.boundedcontext.performance.domain.entity;
 
 import com.ticketrush.boundedcontext.performance.domain.types.Genre;
 import com.ticketrush.boundedcontext.performance.domain.types.PerformanceStatus;
+import com.ticketrush.global.exception.BusinessException;
 import com.ticketrush.global.jpa.entity.AutoIdBaseEntity;
+import com.ticketrush.global.status.ErrorStatus;
 import jakarta.persistence.AttributeOverride;
 import jakarta.persistence.CollectionTable;
 import jakarta.persistence.Column;
@@ -124,6 +126,9 @@ public class Performance extends AutoIdBaseEntity {
   }
 
   public void changeStatus(PerformanceStatus newStatus) {
+    if (!canTransitionTo(newStatus)) {
+      throw new BusinessException(ErrorStatus.PERFORMANCE_INVALID_STATUS_TRANSITION);
+    }
     this.performanceStatus = newStatus;
   }
 }

--- a/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/domain/types/PerformanceStatus.java
+++ b/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/domain/types/PerformanceStatus.java
@@ -1,15 +1,21 @@
 package com.ticketrush.boundedcontext.performance.domain.types;
 
+import java.util.Set;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
 public enum PerformanceStatus {
-  UPCOMING("판매 예정"),
-  ON_SALE("판매 중"),
-  CLOSED("판매 종료"),
-  CANCELED("취소");
+  UPCOMING("판매 예정", Set.of("ON_SALE", "CANCELED")),
+  ON_SALE("판매 중", Set.of("CLOSED", "CANCELED")),
+  CLOSED("판매 종료", Set.of("CANCELED")),
+  CANCELED("취소", Set.of());
 
   private final String description;
+  private final Set<String> allowedTransitions;
+
+  public boolean canTransitionTo(PerformanceStatus target) {
+    return allowedTransitions.contains(target.name());
+  }
 }

--- a/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/domain/types/PerformanceStatus.java
+++ b/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/domain/types/PerformanceStatus.java
@@ -1,21 +1,24 @@
 package com.ticketrush.boundedcontext.performance.domain.types;
 
-import java.util.Set;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
 public enum PerformanceStatus {
-  UPCOMING("판매 예정", Set.of("ON_SALE", "CANCELED")),
-  ON_SALE("판매 중", Set.of("CLOSED", "CANCELED")),
-  CLOSED("판매 종료", Set.of("CANCELED")),
-  CANCELED("취소", Set.of());
+  UPCOMING("판매 예정"),
+  ON_SALE("판매 중"),
+  CLOSED("판매 종료"),
+  CANCELED("취소");
 
   private final String description;
-  private final Set<String> allowedTransitions;
 
   public boolean canTransitionTo(PerformanceStatus target) {
-    return allowedTransitions.contains(target.name());
+    return switch (this) {
+      case UPCOMING -> target == ON_SALE || target == CANCELED;
+      case ON_SALE -> target == CLOSED || target == CANCELED;
+      case CLOSED -> target == CANCELED;
+      case CANCELED -> false;
+    };
   }
 }

--- a/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/in/api/v1/PerformanceAdminController.java
+++ b/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/in/api/v1/PerformanceAdminController.java
@@ -1,8 +1,10 @@
 package com.ticketrush.boundedcontext.performance.in.api.v1;
 
+import com.ticketrush.boundedcontext.performance.app.dto.request.PerformanceChangeStatusRequest;
 import com.ticketrush.boundedcontext.performance.app.dto.request.PerformanceCreateRequest;
 import com.ticketrush.boundedcontext.performance.app.dto.response.PerformanceCreateResponse;
 import com.ticketrush.boundedcontext.performance.app.facade.PerformanceFacade;
+import com.ticketrush.boundedcontext.performance.in.api.v1.swagger.PerformanceChangeStatusApiResponses;
 import com.ticketrush.boundedcontext.performance.in.api.v1.swagger.PerformanceCreateApiResponses;
 import com.ticketrush.boundedcontext.performance.in.api.v1.swagger.PerformanceCreateSwaggerBody;
 import com.ticketrush.global.dto.response.ApiResponse;
@@ -18,6 +20,8 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestPart;
@@ -74,5 +78,18 @@ public class PerformanceAdminController {
         performanceFacade.createPerformance(request, mainImage, model3d, gallery);
 
     return ApiResponse.onSuccess(SuccessStatus.CREATED, response);
+  }
+
+  @Operation(summary = "공연 상태 변경", description = "공연의 상태를 변경합니다.")
+  @PerformanceChangeStatusApiResponses
+  @PatchMapping("/{id}/status")
+  public ResponseEntity<ApiResponse<Void>> changePerformanceStatus(
+      @PathVariable Long id,
+      @org.springframework.web.bind.annotation.RequestBody @Valid
+          PerformanceChangeStatusRequest request) {
+
+    performanceFacade.changePerformanceStatus(id, request);
+
+    return ApiResponse.onSuccess(SuccessStatus.OK);
   }
 }

--- a/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/in/api/v1/swagger/PerformanceChangeStatusApiResponses.java
+++ b/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/in/api/v1/swagger/PerformanceChangeStatusApiResponses.java
@@ -32,7 +32,7 @@ import java.lang.annotation.Target;
                         {
                           "isSuccess": false,
                           "code": "VALID_400_001",
-                          "message": "입력값이 올바르지 않습니다.",
+                          "message": "status: 변경할 상태는 필수입니다.",
                           "traceId": "trace-id-example"
                         }
                         """),

--- a/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/in/api/v1/swagger/PerformanceChangeStatusApiResponses.java
+++ b/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/in/api/v1/swagger/PerformanceChangeStatusApiResponses.java
@@ -1,0 +1,95 @@
+package com.ticketrush.boundedcontext.performance.in.api.v1.swagger;
+
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@ApiResponses({
+  @ApiResponse(
+      responseCode = "400",
+      description = "잘못된 요청",
+      content =
+          @Content(
+              mediaType = "application/json",
+              schema =
+                  @Schema(implementation = com.ticketrush.global.dto.response.ApiResponse.class),
+              examples = {
+                @ExampleObject(
+                    name = "ValidationError",
+                    summary = "status 필드 누락",
+                    value =
+                        """
+                        {
+                          "isSuccess": false,
+                          "code": "VALID_400_001",
+                          "message": "입력값이 올바르지 않습니다.",
+                          "traceId": "trace-id-example"
+                        }
+                        """),
+                @ExampleObject(
+                    name = "InvalidStatusTransition",
+                    summary = "유효하지 않은 상태 전환",
+                    value =
+                        """
+                        {
+                          "isSuccess": false,
+                          "code": "PERFORMANCE_400_004",
+                          "message": "유효하지 않은 공연 상태 전환입니다.",
+                          "traceId": "trace-id-example"
+                        }
+                        """)
+              })),
+  @ApiResponse(
+      responseCode = "404",
+      description = "공연 없음",
+      content =
+          @Content(
+              mediaType = "application/json",
+              schema =
+                  @Schema(implementation = com.ticketrush.global.dto.response.ApiResponse.class),
+              examples =
+                  @ExampleObject(
+                      name = "PerformanceNotFound",
+                      summary = "공연이 존재하지 않음",
+                      value =
+                          """
+                          {
+                            "isSuccess": false,
+                            "code": "PERFORMANCE_404_001",
+                            "message": "공연이 존재하지 않습니다.",
+                            "traceId": "trace-id-example"
+                          }
+                          """))),
+  @ApiResponse(
+      responseCode = "500",
+      description = "서버 오류",
+      content =
+          @Content(
+              mediaType = "application/json",
+              schema =
+                  @Schema(implementation = com.ticketrush.global.dto.response.ApiResponse.class),
+              examples =
+                  @ExampleObject(
+                      name = "InternalServerError",
+                      summary = "서버 내부 오류",
+                      value =
+                          """
+                          {
+                            "isSuccess": false,
+                            "code": "COMMON_500",
+                            "message": "서버 에러, 관리자에게 문의 바랍니다.",
+                            "traceId": "trace-id-example"
+                          }
+                          """)))
+})
+public @interface PerformanceChangeStatusApiResponses {}

--- a/performance-service/src/test/java/com/ticketrush/boundedcontext/performance/in/api/v1/PerformanceChangeStatusTest.java
+++ b/performance-service/src/test/java/com/ticketrush/boundedcontext/performance/in/api/v1/PerformanceChangeStatusTest.java
@@ -56,9 +56,15 @@ class PerformanceChangeStatusTest {
             .address("서울")
             .build();
 
-    // 기본 상태(UPCOMING)에서 원하는 상태로 강제 설정이 필요한 경우 직접 전환
-    if (status != PerformanceStatus.UPCOMING) {
-      performance.changeStatus(status);
+    // 실제 정책에 따라 단계적으로 전환
+    switch (status) {
+      case ON_SALE -> performance.changeStatus(PerformanceStatus.ON_SALE);
+      case CLOSED -> {
+        performance.changeStatus(PerformanceStatus.ON_SALE);
+        performance.changeStatus(PerformanceStatus.CLOSED);
+      }
+      case CANCELED -> performance.changeStatus(PerformanceStatus.CANCELED);
+      default -> {}
     }
 
     return performanceRepository.save(performance);

--- a/performance-service/src/test/java/com/ticketrush/boundedcontext/performance/in/api/v1/PerformanceChangeStatusTest.java
+++ b/performance-service/src/test/java/com/ticketrush/boundedcontext/performance/in/api/v1/PerformanceChangeStatusTest.java
@@ -1,0 +1,143 @@
+package com.ticketrush.boundedcontext.performance.in.api.v1;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.ticketrush.boundedcontext.performance.app.dto.request.PerformanceChangeStatusRequest;
+import com.ticketrush.boundedcontext.performance.app.usecase.PerformanceChangeStatusUseCase;
+import com.ticketrush.boundedcontext.performance.domain.entity.Performance;
+import com.ticketrush.boundedcontext.performance.domain.types.Genre;
+import com.ticketrush.boundedcontext.performance.domain.types.PerformanceStatus;
+import com.ticketrush.boundedcontext.performance.out.repository.PerformanceRepository;
+import com.ticketrush.global.eventpublisher.EventPublisher;
+import com.ticketrush.global.exception.BusinessException;
+import com.ticketrush.global.status.ErrorStatus;
+import com.ticketrush.global.util.S3UploadUtils;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@EnableAutoConfiguration(
+    exclude = {
+      io.awspring.cloud.autoconfigure.s3.S3AutoConfiguration.class,
+      io.awspring.cloud.autoconfigure.core.AwsAutoConfiguration.class
+    })
+@Transactional
+class PerformanceChangeStatusTest {
+
+  @MockitoBean private S3UploadUtils s3UploadUtils;
+  @MockitoBean private EventPublisher eventPublisher;
+
+  @Autowired private PerformanceChangeStatusUseCase performanceChangeStatusUseCase;
+  @Autowired private PerformanceRepository performanceRepository;
+
+  private Performance savedPerformance(PerformanceStatus status) {
+    Performance performance =
+        Performance.builder()
+            .title("테스트 공연")
+            .performer("테스터")
+            .genre(Genre.CONCERT)
+            .description("설명")
+            .showDate(LocalDate.now().plusDays(30))
+            .showTime(LocalTime.of(19, 0))
+            .durationMinutes(120)
+            .price(50000L)
+            .totalSeats(100)
+            .address("서울")
+            .build();
+
+    // 기본 상태(UPCOMING)에서 원하는 상태로 강제 설정이 필요한 경우 직접 전환
+    if (status != PerformanceStatus.UPCOMING) {
+      performance.changeStatus(status);
+    }
+
+    return performanceRepository.save(performance);
+  }
+
+  @Test
+  @DisplayName("UPCOMING → ON_SALE 전환 성공")
+  void upcomingToOnSale() {
+    Performance performance = savedPerformance(PerformanceStatus.UPCOMING);
+
+    performanceChangeStatusUseCase.execute(
+        performance.getId(), new PerformanceChangeStatusRequest(PerformanceStatus.ON_SALE));
+
+    Performance updated = performanceRepository.findById(performance.getId()).orElseThrow();
+    assertThat(updated.getPerformanceStatus()).isEqualTo(PerformanceStatus.ON_SALE);
+  }
+
+  @Test
+  @DisplayName("UPCOMING → CANCELED 전환 성공")
+  void upcomingToCanceled() {
+    Performance performance = savedPerformance(PerformanceStatus.UPCOMING);
+
+    performanceChangeStatusUseCase.execute(
+        performance.getId(), new PerformanceChangeStatusRequest(PerformanceStatus.CANCELED));
+
+    Performance updated = performanceRepository.findById(performance.getId()).orElseThrow();
+    assertThat(updated.getPerformanceStatus()).isEqualTo(PerformanceStatus.CANCELED);
+  }
+
+  @Test
+  @DisplayName("ON_SALE → CLOSED 전환 성공")
+  void onSaleToClosed() {
+    Performance performance = savedPerformance(PerformanceStatus.ON_SALE);
+
+    performanceChangeStatusUseCase.execute(
+        performance.getId(), new PerformanceChangeStatusRequest(PerformanceStatus.CLOSED));
+
+    Performance updated = performanceRepository.findById(performance.getId()).orElseThrow();
+    assertThat(updated.getPerformanceStatus()).isEqualTo(PerformanceStatus.CLOSED);
+  }
+
+  @Test
+  @DisplayName("CLOSED → ON_SALE 전환 불가")
+  void closedToOnSaleIsNotAllowed() {
+    Performance performance = savedPerformance(PerformanceStatus.CLOSED);
+
+    assertThatThrownBy(
+            () ->
+                performanceChangeStatusUseCase.execute(
+                    performance.getId(),
+                    new PerformanceChangeStatusRequest(PerformanceStatus.ON_SALE)))
+        .isInstanceOf(BusinessException.class)
+        .hasMessage(ErrorStatus.PERFORMANCE_INVALID_STATUS_TRANSITION.getMessage());
+  }
+
+  @Test
+  @DisplayName("CANCELED → 모든 상태 전환 불가")
+  void canceledIsTerminalState() {
+    Performance performance = savedPerformance(PerformanceStatus.CANCELED);
+
+    for (PerformanceStatus target :
+        List.of(PerformanceStatus.UPCOMING, PerformanceStatus.ON_SALE, PerformanceStatus.CLOSED)) {
+      assertThatThrownBy(
+              () ->
+                  performanceChangeStatusUseCase.execute(
+                      performance.getId(), new PerformanceChangeStatusRequest(target)))
+          .isInstanceOf(BusinessException.class)
+          .hasMessage(ErrorStatus.PERFORMANCE_INVALID_STATUS_TRANSITION.getMessage());
+    }
+  }
+
+  @Test
+  @DisplayName("존재하지 않는 공연 ID로 요청 시 예외 발생")
+  void performanceNotFound() {
+    assertThatThrownBy(
+            () ->
+                performanceChangeStatusUseCase.execute(
+                    999L, new PerformanceChangeStatusRequest(PerformanceStatus.ON_SALE)))
+        .isInstanceOf(BusinessException.class)
+        .hasMessage(ErrorStatus.PERFORMANCE_NOT_FOUND.getMessage());
+  }
+}

--- a/performance-service/src/test/java/com/ticketrush/boundedcontext/performance/in/api/v1/PerformanceValidationTest.java
+++ b/performance-service/src/test/java/com/ticketrush/boundedcontext/performance/in/api/v1/PerformanceValidationTest.java
@@ -6,9 +6,11 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.ticketrush.boundedcontext.performance.app.dto.request.PerformanceChangeStatusRequest;
 import com.ticketrush.boundedcontext.performance.app.dto.request.PerformanceCreateRequest;
 import com.ticketrush.boundedcontext.performance.app.facade.PerformanceFacade;
 import com.ticketrush.boundedcontext.performance.domain.types.Genre;
+import com.ticketrush.boundedcontext.performance.domain.types.PerformanceStatus;
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
 import java.time.LocalTime;
@@ -22,6 +24,7 @@ import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import tools.jackson.databind.ObjectMapper;
 
 @WebMvcTest(PerformanceAdminController.class)
@@ -161,6 +164,37 @@ class PerformanceValidationTest {
 
     performMultipartRequest(request)
         .andExpect(status().isCreated())
+        .andExpect(jsonPath("$.isSuccess").value(true));
+  }
+
+  @Test
+  @WithMockUser
+  @DisplayName("status 필드가 누락되면 400 에러가 발생한다")
+  void changeStatusValidationFail() throws Exception {
+    mockMvc
+        .perform(
+            MockMvcRequestBuilders.patch(baseUrl + "/1/status")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{}")
+                .with(csrf()))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.code").value("VALID_400_001"));
+  }
+
+  @Test
+  @WithMockUser
+  @DisplayName("status 필드가 올바르면 200 응답을 반환한다")
+  void changeStatusSuccess() throws Exception {
+    PerformanceChangeStatusRequest request =
+        new PerformanceChangeStatusRequest(PerformanceStatus.ON_SALE);
+
+    mockMvc
+        .perform(
+            MockMvcRequestBuilders.patch(baseUrl + "/1/status")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request))
+                .with(csrf()))
+        .andExpect(status().isOk())
         .andExpect(jsonPath("$.isSuccess").value(true));
   }
 }


### PR DESCRIPTION
## 🔗 관련 이슈

- close #173

---

## 📌 주요 변경 사항

- `PATCH /api/v1/performance/{id}/status` 엔드포인트 추가
- 유효하지 않은 상태 전환 예외 처리 (`CLOSED → ON_SALE` 불가 등)
- `ErrorStatus`에 공연 관련 에러코드 추가 (`PERFORMANCE_400_004`, `PERFORMANCE_404_001`)

---

## 🛠 상세 구현 내용

- `PerformanceStatus` enum에 `allowedTransitions` 및 `canTransitionTo()` 추가
- `Performance` 엔티티에 `changeStatus()`, `canTransitionTo()` 메서드 추가
- `PerformanceChangeStatusUseCase` 신규 구현 (공연 조회 → 전환 가능 여부 검증 → 상태 변경)
- `PerformanceFacade`에 위임 메서드 추가
- `PerformanceAdminController`에 `PATCH /{id}/status` 엔드포인트 추가
- `PerformanceChangeStatusApiResponses` Swagger 어노테이션 추가

### 상태 전환 정책

| 현재 상태 | 가능한 전환 |
|----------|-----------|
| UPCOMING | ON_SALE, CANCELED |
| ON_SALE  | CLOSED, CANCELED |
| CLOSED   | CANCELED |
| CANCELED | (없음 - 최종 상태) |

---

## ✅ 테스트

### 테스트 방법

- `PerformanceChangeStatusTest` 실행

### 테스트 결과

- UPCOMING → ON_SALE 전환 성공
- UPCOMING → CANCELED 전환 성공
- ON_SALE → CLOSED 전환 성공
- CLOSED → ON_SALE 전환 불가 (예외 확인)
- CANCELED → 모든 상태 전환 불가 (예외 확인)
- 존재하지 않는 공연 ID 요청 시 예외 확인

### 📸 스크린샷
<img width="1661" height="657" alt="image" src="https://github.com/user-attachments/assets/89a6a6e0-e724-4e45-baa7-0b02c3b7404d" />
<img width="1638" height="918" alt="image" src="https://github.com/user-attachments/assets/5e755b67-2f4b-4cce-9da2-888ba414c587" />

---

## 👀 리뷰 요청 사항

- 상태 전환 정책 검토 부탁드립니다

---

## ⚠️ 배포 시 주의사항

- 없음