### PR TITLE
[Refactor] #170 예매 생성 전 참조 및 좌석 가용성 검증 추가

### DIFF
--- a/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/app/facade/BookingFacade.java
+++ b/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/app/facade/BookingFacade.java
@@ -3,6 +3,8 @@ package com.ticketrush.boundedcontext.booking.app.facade;
 import com.ticketrush.boundedcontext.booking.app.dto.request.BookingCreateRequest;
 import com.ticketrush.boundedcontext.booking.app.usecase.BookingCreateUseCase;
 import com.ticketrush.boundedcontext.booking.app.usecase.BookingIssueNumberUseCase;
+import com.ticketrush.boundedcontext.booking.app.usecase.BookingValidateReferencesUseCase;
+import com.ticketrush.boundedcontext.booking.app.usecase.BookingValidateSeatAvailableUseCase;
 import com.ticketrush.boundedcontext.booking.domain.entity.Booking;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -15,16 +17,18 @@ public class BookingFacade {
 
   private final BookingIssueNumberUseCase bookingIssueNumberUseCase;
   private final BookingCreateUseCase bookingCreateUseCase;
+  private final BookingValidateReferencesUseCase bookingValidateReferencesUseCase;
+  private final BookingValidateSeatAvailableUseCase bookingValidateSeatAvailableUseCase;
 
   public Booking createBooking(Long userId, Long performanceId, Long seatId) {
-    // TODO: 예매 생성 전, Performance 모듈을 호출하여 performanceId의 유효성과 예매 가능 상태 검증
-    // TODO: 유저 인증 로직 도입 후 userId 유효성 검증 추가
-    // TODO: 좌석 존재 여부 검증 로직 추가
+    // 참조 및 좌석 가용성 검증 실행
+    bookingValidateReferencesUseCase.execute(userId, performanceId, seatId);
+    bookingValidateSeatAvailableUseCase.execute(seatId, performanceId);
 
-    // 1. 고유 예약 번호 발급
+    // 고유 예약 번호 발급
     String bookingNumber = bookingIssueNumberUseCase.execute();
 
-    // 2. PENDING 상태로 예매 생성
+    // PENDING 상태로 예매 생성
     BookingCreateRequest request =
         new BookingCreateRequest(userId, performanceId, seatId, bookingNumber);
 

--- a/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/app/usecase/BookingValidateReferencesUseCase.java
+++ b/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/app/usecase/BookingValidateReferencesUseCase.java
@@ -1,0 +1,30 @@
+package com.ticketrush.boundedcontext.booking.app.usecase;
+
+import com.ticketrush.boundedcontext.booking.out.repository.BookingReferenceReader;
+import com.ticketrush.global.exception.BusinessException;
+import com.ticketrush.global.status.ErrorStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class BookingValidateReferencesUseCase {
+
+  private final BookingReferenceReader bookingReferenceReader;
+
+  public void execute(Long userId, Long performanceId, Long seatId) {
+    if (!bookingReferenceReader.existsUserById(userId)) {
+      throw new BusinessException(ErrorStatus.USER_NOT_FOUND);
+    }
+
+    if (!bookingReferenceReader.existsPerformanceById(performanceId)) {
+      throw new BusinessException(ErrorStatus.PERFORMANCE_NOT_FOUND);
+    }
+
+    if (!bookingReferenceReader.existsSeatByIdAndPerformanceId(seatId, performanceId)) {
+      throw new BusinessException(ErrorStatus.SEAT_NOT_FOUND);
+    }
+  }
+}

--- a/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/app/usecase/BookingValidateSeatAvailableUseCase.java
+++ b/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/app/usecase/BookingValidateSeatAvailableUseCase.java
@@ -3,7 +3,7 @@ package com.ticketrush.boundedcontext.booking.app.usecase;
 import com.ticketrush.boundedcontext.booking.out.repository.BookingSeatStatusReader;
 import com.ticketrush.global.exception.BusinessException;
 import com.ticketrush.global.status.ErrorStatus;
-import java.util.Objects;
+import com.ticketrush.global.types.SeatStatus;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -13,19 +13,19 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class BookingValidateSeatAvailableUseCase {
 
-  private static final String AVAILABLE_STATUS = "AVAILABLE";
-  private static final String HOLD_STATUS = "HOLD";
-
   private final BookingSeatStatusReader bookingSeatStatusReader;
 
   public void execute(Long seatId, Long performanceId) {
-    String seatStatus = bookingSeatStatusReader.findSeatStatus(seatId, performanceId);
+    SeatStatus seatStatus =
+        bookingSeatStatusReader
+            .findSeatStatus(seatId, performanceId)
+            .orElseThrow(() -> new BusinessException(ErrorStatus.SEAT_NOT_FOUND));
 
-    if (Objects.equals(seatStatus, HOLD_STATUS)) {
+    if (seatStatus == SeatStatus.HOLD) {
       throw new BusinessException(ErrorStatus.SEAT_ALREADY_LOCKED);
     }
 
-    if (!Objects.equals(seatStatus, AVAILABLE_STATUS)) {
+    if (seatStatus != SeatStatus.AVAILABLE) {
       throw new BusinessException(ErrorStatus.SEAT_NOT_AVAILABLE);
     }
   }

--- a/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/app/usecase/BookingValidateSeatAvailableUseCase.java
+++ b/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/app/usecase/BookingValidateSeatAvailableUseCase.java
@@ -1,0 +1,32 @@
+package com.ticketrush.boundedcontext.booking.app.usecase;
+
+import com.ticketrush.boundedcontext.booking.out.repository.BookingSeatStatusReader;
+import com.ticketrush.global.exception.BusinessException;
+import com.ticketrush.global.status.ErrorStatus;
+import java.util.Objects;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class BookingValidateSeatAvailableUseCase {
+
+  private static final String AVAILABLE_STATUS = "AVAILABLE";
+  private static final String HOLD_STATUS = "HOLD";
+
+  private final BookingSeatStatusReader bookingSeatStatusReader;
+
+  public void execute(Long seatId, Long performanceId) {
+    String seatStatus = bookingSeatStatusReader.findSeatStatus(seatId, performanceId);
+
+    if (Objects.equals(seatStatus, HOLD_STATUS)) {
+      throw new BusinessException(ErrorStatus.SEAT_ALREADY_LOCKED);
+    }
+
+    if (!Objects.equals(seatStatus, AVAILABLE_STATUS)) {
+      throw new BusinessException(ErrorStatus.SEAT_NOT_AVAILABLE);
+    }
+  }
+}

--- a/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/out/repository/BookingReferenceReader.java
+++ b/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/out/repository/BookingReferenceReader.java
@@ -1,0 +1,10 @@
+package com.ticketrush.boundedcontext.booking.out.repository;
+
+public interface BookingReferenceReader {
+
+  boolean existsUserById(Long userId);
+
+  boolean existsPerformanceById(Long performanceId);
+
+  boolean existsSeatByIdAndPerformanceId(Long seatId, Long performanceId);
+}

--- a/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/out/repository/BookingSeatStatusReader.java
+++ b/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/out/repository/BookingSeatStatusReader.java
@@ -1,6 +1,9 @@
 package com.ticketrush.boundedcontext.booking.out.repository;
 
+import com.ticketrush.global.types.SeatStatus;
+import java.util.Optional;
+
 public interface BookingSeatStatusReader {
 
-  String findSeatStatus(Long seatId, Long performanceId);
+  Optional<SeatStatus> findSeatStatus(Long seatId, Long performanceId);
 }

--- a/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/out/repository/BookingSeatStatusReader.java
+++ b/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/out/repository/BookingSeatStatusReader.java
@@ -1,0 +1,6 @@
+package com.ticketrush.boundedcontext.booking.out.repository;
+
+public interface BookingSeatStatusReader {
+
+  String findSeatStatus(Long seatId, Long performanceId);
+}

--- a/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/out/repository/JdbcBookingReferenceReader.java
+++ b/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/out/repository/JdbcBookingReferenceReader.java
@@ -1,0 +1,39 @@
+package com.ticketrush.boundedcontext.booking.out.repository;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class JdbcBookingReferenceReader implements BookingReferenceReader {
+
+  private final JdbcTemplate jdbcTemplate;
+
+  @Override
+  public boolean existsUserById(Long userId) {
+    return exists("SELECT COUNT(*) FROM `user` WHERE id = ?", userId);
+  }
+
+  @Override
+  public boolean existsPerformanceById(Long performanceId) {
+    return exists("SELECT COUNT(*) FROM performance WHERE performance_id = ?", performanceId);
+  }
+
+  @Override
+  public boolean existsSeatByIdAndPerformanceId(Long seatId, Long performanceId) {
+    Long count =
+        jdbcTemplate.queryForObject(
+            "SELECT COUNT(*) FROM seat WHERE seat_id = ? AND performance_id = ?",
+            Long.class,
+            seatId,
+            performanceId);
+
+    return count != null && count > 0L;
+  }
+
+  private boolean exists(String sql, Long id) {
+    Long count = jdbcTemplate.queryForObject(sql, Long.class, id);
+    return count != null && count > 0L;
+  }
+}

--- a/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/out/repository/JdbcBookingReferenceReader.java
+++ b/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/out/repository/JdbcBookingReferenceReader.java
@@ -22,18 +22,19 @@ public class JdbcBookingReferenceReader implements BookingReferenceReader {
 
   @Override
   public boolean existsSeatByIdAndPerformanceId(Long seatId, Long performanceId) {
-    Long count =
-        jdbcTemplate.queryForObject(
-            "SELECT COUNT(*) FROM seat WHERE seat_id = ? AND performance_id = ?",
-            Long.class,
-            seatId,
-            performanceId);
-
-    return count != null && count > 0L;
+    return exists(
+        "SELECT COUNT(*) FROM seat WHERE seat_id = ? AND performance_id = ?",
+        seatId,
+        performanceId);
   }
 
   private boolean exists(String sql, Long id) {
     Long count = jdbcTemplate.queryForObject(sql, Long.class, id);
+    return count != null && count > 0L;
+  }
+
+  private boolean exists(String sql, Long firstId, Long secondId) {
+    Long count = jdbcTemplate.queryForObject(sql, Long.class, firstId, secondId);
     return count != null && count > 0L;
   }
 }

--- a/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/out/repository/JdbcBookingSeatStatusReader.java
+++ b/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/out/repository/JdbcBookingSeatStatusReader.java
@@ -1,0 +1,21 @@
+package com.ticketrush.boundedcontext.booking.out.repository;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class JdbcBookingSeatStatusReader implements BookingSeatStatusReader {
+
+  private final JdbcTemplate jdbcTemplate;
+
+  @Override
+  public String findSeatStatus(Long seatId, Long performanceId) {
+    return jdbcTemplate.queryForObject(
+        "SELECT seat_status FROM seat WHERE seat_id = ? AND performance_id = ?",
+        String.class,
+        seatId,
+        performanceId);
+  }
+}

--- a/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/out/repository/JdbcBookingSeatStatusReader.java
+++ b/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/out/repository/JdbcBookingSeatStatusReader.java
@@ -1,5 +1,7 @@
 package com.ticketrush.boundedcontext.booking.out.repository;
 
+import com.ticketrush.global.types.SeatStatus;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Repository;
@@ -11,11 +13,14 @@ public class JdbcBookingSeatStatusReader implements BookingSeatStatusReader {
   private final JdbcTemplate jdbcTemplate;
 
   @Override
-  public String findSeatStatus(Long seatId, Long performanceId) {
-    return jdbcTemplate.queryForObject(
-        "SELECT seat_status FROM seat WHERE seat_id = ? AND performance_id = ?",
-        String.class,
-        seatId,
-        performanceId);
+  public Optional<SeatStatus> findSeatStatus(Long seatId, Long performanceId) {
+    return jdbcTemplate
+        .query(
+            "SELECT seat_status FROM seat WHERE seat_id = ? AND performance_id = ?",
+            (rs, rowNum) -> SeatStatus.valueOf(rs.getString("seat_status")),
+            seatId,
+            performanceId)
+        .stream()
+        .findFirst();
   }
 }

--- a/booking-service/src/test/java/com/ticketrush/boundedcontext/booking/app/facade/BookingFacadeTest.java
+++ b/booking-service/src/test/java/com/ticketrush/boundedcontext/booking/app/facade/BookingFacadeTest.java
@@ -82,6 +82,7 @@ class BookingFacadeTest {
         .extracting(ex -> ((BusinessException) ex).getErrorStatus())
         .isEqualTo(USER_NOT_FOUND);
 
+    verifyNoInteractions(bookingValidateSeatAvailableUseCase);
     verifyNoInteractions(bookingIssueNumberUseCase, bookingCreateUseCase);
   }
 

--- a/booking-service/src/test/java/com/ticketrush/boundedcontext/booking/app/facade/BookingFacadeTest.java
+++ b/booking-service/src/test/java/com/ticketrush/boundedcontext/booking/app/facade/BookingFacadeTest.java
@@ -1,0 +1,109 @@
+package com.ticketrush.boundedcontext.booking.app.facade;
+
+import static com.ticketrush.global.status.ErrorStatus.SEAT_ALREADY_LOCKED;
+import static com.ticketrush.global.status.ErrorStatus.USER_NOT_FOUND;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import com.ticketrush.boundedcontext.booking.app.dto.request.BookingCreateRequest;
+import com.ticketrush.boundedcontext.booking.app.usecase.BookingCreateUseCase;
+import com.ticketrush.boundedcontext.booking.app.usecase.BookingIssueNumberUseCase;
+import com.ticketrush.boundedcontext.booking.app.usecase.BookingValidateReferencesUseCase;
+import com.ticketrush.boundedcontext.booking.app.usecase.BookingValidateSeatAvailableUseCase;
+import com.ticketrush.boundedcontext.booking.domain.entity.Booking;
+import com.ticketrush.global.exception.BusinessException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class BookingFacadeTest {
+
+  @InjectMocks private BookingFacade bookingFacade;
+
+  @Mock private BookingIssueNumberUseCase bookingIssueNumberUseCase;
+  @Mock private BookingCreateUseCase bookingCreateUseCase;
+  @Mock private BookingValidateReferencesUseCase bookingValidateReferencesUseCase;
+  @Mock private BookingValidateSeatAvailableUseCase bookingValidateSeatAvailableUseCase;
+
+  @Test
+  @DisplayName("성공: 참조 검증 후 예약번호를 발급하고 예매를 생성한다")
+  void createBooking_success() {
+    // given
+    Long userId = 1L;
+    Long performanceId = 2L;
+    Long seatId = 3L;
+    String bookingNumber = "BOOK-1234";
+    Booking booking =
+        Booking.builder()
+            .userId(userId)
+            .performanceId(performanceId)
+            .seatId(seatId)
+            .bookingNumber(bookingNumber)
+            .build();
+
+    given(bookingIssueNumberUseCase.execute()).willReturn(bookingNumber);
+    given(
+            bookingCreateUseCase.execute(
+                new BookingCreateRequest(userId, performanceId, seatId, bookingNumber)))
+        .willReturn(booking);
+
+    // when
+    Booking result = bookingFacade.createBooking(userId, performanceId, seatId);
+
+    // then
+    assertThat(result).isSameAs(booking);
+    verify(bookingValidateReferencesUseCase).execute(userId, performanceId, seatId);
+    verify(bookingValidateSeatAvailableUseCase).execute(seatId, performanceId);
+  }
+
+  @Test
+  @DisplayName("실패: 참조 검증에 실패하면 예약번호 발급과 예매 생성을 하지 않는다")
+  void createBooking_fail_when_reference_validation_fails() {
+    // given
+    Long userId = 1L;
+    Long performanceId = 2L;
+    Long seatId = 3L;
+
+    doThrow(new BusinessException(USER_NOT_FOUND))
+        .when(bookingValidateReferencesUseCase)
+        .execute(userId, performanceId, seatId);
+
+    // when & then
+    assertThatThrownBy(() -> bookingFacade.createBooking(userId, performanceId, seatId))
+        .isInstanceOf(BusinessException.class)
+        .extracting(ex -> ((BusinessException) ex).getErrorStatus())
+        .isEqualTo(USER_NOT_FOUND);
+
+    verifyNoInteractions(bookingIssueNumberUseCase, bookingCreateUseCase);
+  }
+
+  @Test
+  @DisplayName("실패: 좌석 HOLD 검증에 실패하면 예약번호 발급과 예매 생성을 하지 않는다")
+  void createBooking_fail_when_seat_is_held() {
+    // given
+    Long userId = 1L;
+    Long performanceId = 2L;
+    Long seatId = 3L;
+
+    doThrow(new BusinessException(SEAT_ALREADY_LOCKED))
+        .when(bookingValidateSeatAvailableUseCase)
+        .execute(seatId, performanceId);
+
+    // when & then
+    assertThatThrownBy(() -> bookingFacade.createBooking(userId, performanceId, seatId))
+        .isInstanceOf(BusinessException.class)
+        .extracting(ex -> ((BusinessException) ex).getErrorStatus())
+        .isEqualTo(SEAT_ALREADY_LOCKED);
+
+    verify(bookingValidateReferencesUseCase).execute(userId, performanceId, seatId);
+    verifyNoInteractions(bookingIssueNumberUseCase, bookingCreateUseCase);
+  }
+}

--- a/booking-service/src/test/java/com/ticketrush/boundedcontext/booking/app/facade/BookingFacadeTest.java
+++ b/booking-service/src/test/java/com/ticketrush/boundedcontext/booking/app/facade/BookingFacadeTest.java
@@ -105,6 +105,7 @@ class BookingFacadeTest {
         .isEqualTo(SEAT_ALREADY_LOCKED);
 
     verify(bookingValidateReferencesUseCase).execute(userId, performanceId, seatId);
+    verify(bookingValidateSeatAvailableUseCase).execute(seatId, performanceId);
     verifyNoInteractions(bookingIssueNumberUseCase, bookingCreateUseCase);
   }
 }

--- a/booking-service/src/test/java/com/ticketrush/boundedcontext/booking/app/usecase/BookingValidateReferencesUseCaseTest.java
+++ b/booking-service/src/test/java/com/ticketrush/boundedcontext/booking/app/usecase/BookingValidateReferencesUseCaseTest.java
@@ -1,0 +1,117 @@
+package com.ticketrush.boundedcontext.booking.app.usecase;
+
+import static com.ticketrush.global.status.ErrorStatus.PERFORMANCE_NOT_FOUND;
+import static com.ticketrush.global.status.ErrorStatus.SEAT_NOT_FOUND;
+import static com.ticketrush.global.status.ErrorStatus.USER_NOT_FOUND;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import com.ticketrush.boundedcontext.booking.out.repository.BookingReferenceReader;
+import com.ticketrush.global.exception.BusinessException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class BookingValidateReferencesUseCaseTest {
+
+  @InjectMocks private BookingValidateReferencesUseCase bookingValidateReferencesUseCase;
+
+  @Mock private BookingReferenceReader bookingReferenceReader;
+
+  @Test
+  @DisplayName("성공: 사용자, 공연, 좌석이 모두 존재하면 검증을 통과한다")
+  void execute_success() {
+    // given
+    Long userId = 1L;
+    Long performanceId = 2L;
+    Long seatId = 3L;
+
+    given(bookingReferenceReader.existsUserById(userId)).willReturn(true);
+    given(bookingReferenceReader.existsPerformanceById(performanceId)).willReturn(true);
+    given(bookingReferenceReader.existsSeatByIdAndPerformanceId(seatId, performanceId))
+        .willReturn(true);
+
+    // when
+    bookingValidateReferencesUseCase.execute(userId, performanceId, seatId);
+
+    // then
+    verify(bookingReferenceReader).existsUserById(userId);
+    verify(bookingReferenceReader).existsPerformanceById(performanceId);
+    verify(bookingReferenceReader).existsSeatByIdAndPerformanceId(seatId, performanceId);
+  }
+
+  @Test
+  @DisplayName("실패: 사용자가 존재하지 않으면 USER_NOT_FOUND 예외가 발생한다")
+  void execute_fail_when_user_not_found() {
+    // given
+    Long userId = 1L;
+    Long performanceId = 2L;
+    Long seatId = 3L;
+
+    given(bookingReferenceReader.existsUserById(userId)).willReturn(false);
+
+    // when & then
+    assertThatThrownBy(
+            () -> bookingValidateReferencesUseCase.execute(userId, performanceId, seatId))
+        .isInstanceOf(BusinessException.class)
+        .extracting(ex -> ((BusinessException) ex).getErrorStatus())
+        .isEqualTo(USER_NOT_FOUND);
+
+    verify(bookingReferenceReader).existsUserById(userId);
+    verifyNoMoreInteractions(bookingReferenceReader);
+  }
+
+  @Test
+  @DisplayName("실패: 공연이 존재하지 않으면 PERFORMANCE_NOT_FOUND 예외가 발생한다")
+  void execute_fail_when_performance_not_found() {
+    // given
+    Long userId = 1L;
+    Long performanceId = 2L;
+    Long seatId = 3L;
+
+    given(bookingReferenceReader.existsUserById(userId)).willReturn(true);
+    given(bookingReferenceReader.existsPerformanceById(performanceId)).willReturn(false);
+
+    // when & then
+    assertThatThrownBy(
+            () -> bookingValidateReferencesUseCase.execute(userId, performanceId, seatId))
+        .isInstanceOf(BusinessException.class)
+        .extracting(ex -> ((BusinessException) ex).getErrorStatus())
+        .isEqualTo(PERFORMANCE_NOT_FOUND);
+
+    verify(bookingReferenceReader).existsUserById(userId);
+    verify(bookingReferenceReader).existsPerformanceById(performanceId);
+    verifyNoMoreInteractions(bookingReferenceReader);
+  }
+
+  @Test
+  @DisplayName("실패: 공연에 해당 좌석이 존재하지 않으면 SEAT_NOT_FOUND 예외가 발생한다")
+  void execute_fail_when_seat_not_found() {
+    // given
+    Long userId = 1L;
+    Long performanceId = 2L;
+    Long seatId = 3L;
+
+    given(bookingReferenceReader.existsUserById(userId)).willReturn(true);
+    given(bookingReferenceReader.existsPerformanceById(performanceId)).willReturn(true);
+    given(bookingReferenceReader.existsSeatByIdAndPerformanceId(seatId, performanceId))
+        .willReturn(false);
+
+    // when & then
+    assertThatThrownBy(
+            () -> bookingValidateReferencesUseCase.execute(userId, performanceId, seatId))
+        .isInstanceOf(BusinessException.class)
+        .extracting(ex -> ((BusinessException) ex).getErrorStatus())
+        .isEqualTo(SEAT_NOT_FOUND);
+
+    verify(bookingReferenceReader).existsUserById(userId);
+    verify(bookingReferenceReader).existsPerformanceById(performanceId);
+    verify(bookingReferenceReader).existsSeatByIdAndPerformanceId(seatId, performanceId);
+  }
+}

--- a/booking-service/src/test/java/com/ticketrush/boundedcontext/booking/app/usecase/BookingValidateSeatAvailableUseCaseTest.java
+++ b/booking-service/src/test/java/com/ticketrush/boundedcontext/booking/app/usecase/BookingValidateSeatAvailableUseCaseTest.java
@@ -2,12 +2,15 @@ package com.ticketrush.boundedcontext.booking.app.usecase;
 
 import static com.ticketrush.global.status.ErrorStatus.SEAT_ALREADY_LOCKED;
 import static com.ticketrush.global.status.ErrorStatus.SEAT_NOT_AVAILABLE;
+import static com.ticketrush.global.status.ErrorStatus.SEAT_NOT_FOUND;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
 import com.ticketrush.boundedcontext.booking.out.repository.BookingSeatStatusReader;
 import com.ticketrush.global.exception.BusinessException;
+import com.ticketrush.global.types.SeatStatus;
+import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -29,7 +32,8 @@ class BookingValidateSeatAvailableUseCaseTest {
     Long seatId = 1L;
     Long performanceId = 2L;
 
-    given(bookingSeatStatusReader.findSeatStatus(seatId, performanceId)).willReturn("AVAILABLE");
+    given(bookingSeatStatusReader.findSeatStatus(seatId, performanceId))
+        .willReturn(Optional.of(SeatStatus.AVAILABLE));
 
     // when
     bookingValidateSeatAvailableUseCase.execute(seatId, performanceId);
@@ -45,7 +49,8 @@ class BookingValidateSeatAvailableUseCaseTest {
     Long seatId = 1L;
     Long performanceId = 2L;
 
-    given(bookingSeatStatusReader.findSeatStatus(seatId, performanceId)).willReturn("HOLD");
+    given(bookingSeatStatusReader.findSeatStatus(seatId, performanceId))
+        .willReturn(Optional.of(SeatStatus.HOLD));
 
     // when & then
     assertThatThrownBy(() -> bookingValidateSeatAvailableUseCase.execute(seatId, performanceId))
@@ -63,13 +68,33 @@ class BookingValidateSeatAvailableUseCaseTest {
     Long seatId = 1L;
     Long performanceId = 2L;
 
-    given(bookingSeatStatusReader.findSeatStatus(seatId, performanceId)).willReturn("SOLD");
+    given(bookingSeatStatusReader.findSeatStatus(seatId, performanceId))
+        .willReturn(Optional.of(SeatStatus.SOLD));
 
     // when & then
     assertThatThrownBy(() -> bookingValidateSeatAvailableUseCase.execute(seatId, performanceId))
         .isInstanceOf(BusinessException.class)
         .extracting(ex -> ((BusinessException) ex).getErrorStatus())
         .isEqualTo(SEAT_NOT_AVAILABLE);
+
+    verify(bookingSeatStatusReader).findSeatStatus(seatId, performanceId);
+  }
+
+  @Test
+  @DisplayName("실패: 좌석 상태 조회 결과가 없으면 SEAT_NOT_FOUND 예외가 발생한다")
+  void execute_fail_when_seat_status_not_found() {
+    // given
+    Long seatId = 1L;
+    Long performanceId = 2L;
+
+    given(bookingSeatStatusReader.findSeatStatus(seatId, performanceId))
+        .willReturn(Optional.empty());
+
+    // when & then
+    assertThatThrownBy(() -> bookingValidateSeatAvailableUseCase.execute(seatId, performanceId))
+        .isInstanceOf(BusinessException.class)
+        .extracting(ex -> ((BusinessException) ex).getErrorStatus())
+        .isEqualTo(SEAT_NOT_FOUND);
 
     verify(bookingSeatStatusReader).findSeatStatus(seatId, performanceId);
   }

--- a/booking-service/src/test/java/com/ticketrush/boundedcontext/booking/app/usecase/BookingValidateSeatAvailableUseCaseTest.java
+++ b/booking-service/src/test/java/com/ticketrush/boundedcontext/booking/app/usecase/BookingValidateSeatAvailableUseCaseTest.java
@@ -1,0 +1,76 @@
+package com.ticketrush.boundedcontext.booking.app.usecase;
+
+import static com.ticketrush.global.status.ErrorStatus.SEAT_ALREADY_LOCKED;
+import static com.ticketrush.global.status.ErrorStatus.SEAT_NOT_AVAILABLE;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import com.ticketrush.boundedcontext.booking.out.repository.BookingSeatStatusReader;
+import com.ticketrush.global.exception.BusinessException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class BookingValidateSeatAvailableUseCaseTest {
+
+  @InjectMocks private BookingValidateSeatAvailableUseCase bookingValidateSeatAvailableUseCase;
+
+  @Mock private BookingSeatStatusReader bookingSeatStatusReader;
+
+  @Test
+  @DisplayName("성공: 좌석이 AVAILABLE 상태이면 검증을 통과한다")
+  void execute_success() {
+    // given
+    Long seatId = 1L;
+    Long performanceId = 2L;
+
+    given(bookingSeatStatusReader.findSeatStatus(seatId, performanceId)).willReturn("AVAILABLE");
+
+    // when
+    bookingValidateSeatAvailableUseCase.execute(seatId, performanceId);
+
+    // then
+    verify(bookingSeatStatusReader).findSeatStatus(seatId, performanceId);
+  }
+
+  @Test
+  @DisplayName("실패: 좌석이 HOLD 상태이면 SEAT_ALREADY_LOCKED 예외가 발생한다")
+  void execute_fail_when_seat_is_held() {
+    // given
+    Long seatId = 1L;
+    Long performanceId = 2L;
+
+    given(bookingSeatStatusReader.findSeatStatus(seatId, performanceId)).willReturn("HOLD");
+
+    // when & then
+    assertThatThrownBy(() -> bookingValidateSeatAvailableUseCase.execute(seatId, performanceId))
+        .isInstanceOf(BusinessException.class)
+        .extracting(ex -> ((BusinessException) ex).getErrorStatus())
+        .isEqualTo(SEAT_ALREADY_LOCKED);
+
+    verify(bookingSeatStatusReader).findSeatStatus(seatId, performanceId);
+  }
+
+  @Test
+  @DisplayName("실패: 좌석이 AVAILABLE 상태가 아니면 SEAT_NOT_AVAILABLE 예외가 발생한다")
+  void execute_fail_when_seat_is_not_available() {
+    // given
+    Long seatId = 1L;
+    Long performanceId = 2L;
+
+    given(bookingSeatStatusReader.findSeatStatus(seatId, performanceId)).willReturn("SOLD");
+
+    // when & then
+    assertThatThrownBy(() -> bookingValidateSeatAvailableUseCase.execute(seatId, performanceId))
+        .isInstanceOf(BusinessException.class)
+        .extracting(ex -> ((BusinessException) ex).getErrorStatus())
+        .isEqualTo(SEAT_NOT_AVAILABLE);
+
+    verify(bookingSeatStatusReader).findSeatStatus(seatId, performanceId);
+  }
+}

--- a/common/src/main/java/com/ticketrush/global/status/ErrorStatus.java
+++ b/common/src/main/java/com/ticketrush/global/status/ErrorStatus.java
@@ -78,6 +78,9 @@ public enum ErrorStatus {
   PERFORMANCE_GALLERY_LIMIT_EXCEEDED(
       HttpStatus.BAD_REQUEST, "PERFORMANCE_400_003", "갤러리 이미지는 최대 3개까지 업로드할 수 있습니다."),
 
+  // Performance 404
+  PERFORMANCE_NOT_FOUND(HttpStatus.NOT_FOUND, "PERFORMANCE_404_001", "해당 공연을 찾을 수 없습니다."),
+
   // File 400
   FILE_EMPTY(HttpStatus.BAD_REQUEST, "FILE_400_001", "업로드할 파일이 비어있습니다."),
   FILE_INVALID_EXTENSION(HttpStatus.BAD_REQUEST, "FILE_400_002", "파일 확장자가 올바르지 않습니다."),
@@ -87,7 +90,10 @@ public enum ErrorStatus {
   USER_SOCIAL_PROVIDER_REQUIRED(HttpStatus.BAD_REQUEST, "USER_400_001", "socialProvider는 필수입니다."),
   USER_SOCIAL_ID_REQUIRED(HttpStatus.BAD_REQUEST, "USER_400_002", "socialId는 필수입니다."),
   USER_SOCIAL_PROVIDER_INVALID(
-      HttpStatus.BAD_REQUEST, "USER_400_003", "socialProviderId가 유효하지 않습니다.");
+      HttpStatus.BAD_REQUEST, "USER_400_003", "socialProviderId가 유효하지 않습니다."),
+
+  // User 404
+  USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_404_001", "해당 사용자를 찾을 수 없습니다.");
 
   private final HttpStatus httpStatus;
   private final String code;

--- a/common/src/main/java/com/ticketrush/global/status/ErrorStatus.java
+++ b/common/src/main/java/com/ticketrush/global/status/ErrorStatus.java
@@ -83,9 +83,6 @@ public enum ErrorStatus {
   // Performance 404
   PERFORMANCE_NOT_FOUND(HttpStatus.NOT_FOUND, "PERFORMANCE_404_001", "공연이 존재하지 않습니다."),
 
-  // Performance 404
-  PERFORMANCE_NOT_FOUND(HttpStatus.NOT_FOUND, "PERFORMANCE_404_001", "해당 공연을 찾을 수 없습니다."),
-
   // File 400
   FILE_EMPTY(HttpStatus.BAD_REQUEST, "FILE_400_001", "업로드할 파일이 비어있습니다."),
   FILE_INVALID_EXTENSION(HttpStatus.BAD_REQUEST, "FILE_400_002", "파일 확장자가 올바르지 않습니다."),

--- a/common/src/main/java/com/ticketrush/global/types/SeatStatus.java
+++ b/common/src/main/java/com/ticketrush/global/types/SeatStatus.java
@@ -1,4 +1,4 @@
-package com.ticketrush.boundedcontext.seat.domain.types;
+package com.ticketrush.global.types;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/app/usecase/SeatReleaseExpiredUseCase.java
+++ b/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/app/usecase/SeatReleaseExpiredUseCase.java
@@ -1,7 +1,7 @@
 package com.ticketrush.boundedcontext.seat.app.usecase;
 
-import com.ticketrush.boundedcontext.seat.domain.types.SeatStatus;
 import com.ticketrush.boundedcontext.seat.out.repository.SeatRepository;
+import com.ticketrush.global.types.SeatStatus;
 import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;

--- a/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/domain/entity/Seat.java
+++ b/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/domain/entity/Seat.java
@@ -1,9 +1,9 @@
 package com.ticketrush.boundedcontext.seat.domain.entity;
 
-import com.ticketrush.boundedcontext.seat.domain.types.SeatStatus;
 import com.ticketrush.global.exception.BusinessException;
 import com.ticketrush.global.jpa.entity.AutoIdBaseEntity;
 import com.ticketrush.global.status.ErrorStatus;
+import com.ticketrush.global.types.SeatStatus;
 import jakarta.persistence.AttributeOverride;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;

--- a/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/in/datainit/SeatDataInit.java
+++ b/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/in/datainit/SeatDataInit.java
@@ -1,10 +1,10 @@
-package com.ticketrush.boundedcontext.seat.app.init;
+package com.ticketrush.boundedcontext.seat.in.datainit;
 
 import com.ticketrush.boundedcontext.seat.domain.entity.Seat;
 import com.ticketrush.boundedcontext.seat.domain.entity.SeatLayout;
-import com.ticketrush.boundedcontext.seat.domain.types.SeatStatus;
 import com.ticketrush.boundedcontext.seat.out.repository.SeatLayoutRepository;
 import com.ticketrush.boundedcontext.seat.out.repository.SeatRepository;
+import com.ticketrush.global.types.SeatStatus;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;

--- a/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/out/repository/SeatRepository.java
+++ b/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/out/repository/SeatRepository.java
@@ -2,7 +2,7 @@ package com.ticketrush.boundedcontext.seat.out.repository;
 
 import com.ticketrush.boundedcontext.seat.app.dto.response.SeatLayoutResponse;
 import com.ticketrush.boundedcontext.seat.domain.entity.Seat;
-import com.ticketrush.boundedcontext.seat.domain.types.SeatStatus;
+import com.ticketrush.global.types.SeatStatus;
 import java.time.LocalDateTime;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/app/usecase/SeatHoldUseCaseTest.java
+++ b/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/app/usecase/SeatHoldUseCaseTest.java
@@ -5,10 +5,10 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
 
 import com.ticketrush.boundedcontext.seat.domain.entity.Seat;
-import com.ticketrush.boundedcontext.seat.domain.types.SeatStatus;
 import com.ticketrush.boundedcontext.seat.out.repository.SeatRepository;
 import com.ticketrush.global.exception.BusinessException;
 import com.ticketrush.global.status.ErrorStatus;
+import com.ticketrush.global.types.SeatStatus;
 import java.time.LocalDateTime;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;

--- a/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/app/usecase/SeatReleaseExpiredUseCaseTest.java
+++ b/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/app/usecase/SeatReleaseExpiredUseCaseTest.java
@@ -5,8 +5,8 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
-import com.ticketrush.boundedcontext.seat.domain.types.SeatStatus;
 import com.ticketrush.boundedcontext.seat.out.repository.SeatRepository;
+import com.ticketrush.global.types.SeatStatus;
 import java.time.LocalDateTime;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/out/repository/SeatRepositoryTest.java
+++ b/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/out/repository/SeatRepositoryTest.java
@@ -6,7 +6,7 @@ import static org.assertj.core.api.Assertions.tuple;
 import com.ticketrush.boundedcontext.seat.app.dto.response.SeatLayoutResponse;
 import com.ticketrush.boundedcontext.seat.domain.entity.Seat;
 import com.ticketrush.boundedcontext.seat.domain.entity.SeatLayout;
-import com.ticketrush.boundedcontext.seat.domain.types.SeatStatus;
+import com.ticketrush.global.types.SeatStatus;
 import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;


### PR DESCRIPTION
## 🔗 관련 이슈

- close #170

---

## 📌 주요 변경 사항

- 예매 생성 전 사용자, 공연, 좌석 참조 존재 여부 검증 추가
- 예매 생성 전 좌석 상태가 AVAILABLE인지 검증 추가
- 검증 실패 케이스별 예외 상태와 단위 테스트 추가

---

## 🛠 상세 구현 내용

- `BookingValidateReferencesUseCase`에서 user/performance/seat 존재 여부를 확인하도록 구현
- `BookingValidateSeatAvailableUseCase`에서 좌석 상태가 `HOLD`이면 `SEAT_ALREADY_LOCKED`, 그 외 AVAILABLE이 아니면 `SEAT_NOT_AVAILABLE` 처리
- `BookingReferenceReader`, `BookingSeatStatusReader`와 JDBC 기반 구현체를 통해 booking-service에서 필요한 검증 데이터를 조회
- `BookingFacade`에서 검증을 예약번호 발급 및 예매 생성보다 먼저 수행하도록 순서 조정
- `ErrorStatus`에 `USER_NOT_FOUND`, `PERFORMANCE_NOT_FOUND` 추가

---

## ✅ 테스트

### 테스트 방법

- `./gradlew.bat :booking-service:spotlessApply :booking-service:spotlessCheck :booking-service:checkstyleMain :booking-service:checkstyleTest :booking-service:test`

### 테스트 결과

- 통과

<!--
### 📸 스크린샷
-->

---

## 👀 리뷰 요청 사항

- 현재 구조적으로는 "MSA 서비스 분리 + 공유 DB” 상태이므로 우선 현 구조에 맞게 booking-service 안에서 JdbcTemplate으로 관련 테이블을 직접 조회하는 방식으로 구현하였습니다. 추후 필요할 경우 API 호출이나 이벤트 기반 read model로 바꾸도록 하겠습니다.