### PR TITLE
[Feat] #174 공연 유효성 검증 내부 API 구현

### DIFF
--- a/common/src/main/java/com/ticketrush/global/status/ErrorStatus.java
+++ b/common/src/main/java/com/ticketrush/global/status/ErrorStatus.java
@@ -79,6 +79,7 @@ public enum ErrorStatus {
       HttpStatus.BAD_REQUEST, "PERFORMANCE_400_003", "갤러리 이미지는 최대 3개까지 업로드할 수 있습니다."),
   PERFORMANCE_INVALID_STATUS_TRANSITION(
       HttpStatus.BAD_REQUEST, "PERFORMANCE_400_004", "유효하지 않은 공연 상태 전환입니다."),
+  PERFORMANCE_NOT_ON_SALE(HttpStatus.BAD_REQUEST, "PERFORMANCE_400_005", "예매 가능한 공연이 아닙니다."),
 
   // Performance 404
   PERFORMANCE_NOT_FOUND(HttpStatus.NOT_FOUND, "PERFORMANCE_404_001", "공연이 존재하지 않습니다."),

--- a/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/app/facade/PerformanceFacade.java
+++ b/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/app/facade/PerformanceFacade.java
@@ -7,6 +7,7 @@ import com.ticketrush.boundedcontext.performance.app.dto.response.PerformanceLis
 import com.ticketrush.boundedcontext.performance.app.usecase.PerformanceChangeStatusUseCase;
 import com.ticketrush.boundedcontext.performance.app.usecase.PerformanceCreateUseCase;
 import com.ticketrush.boundedcontext.performance.app.usecase.PerformanceGetListUseCase;
+import com.ticketrush.boundedcontext.performance.app.usecase.PerformanceValidateUseCase;
 import com.ticketrush.boundedcontext.performance.domain.types.Genre;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -22,6 +23,7 @@ public class PerformanceFacade {
   private final PerformanceCreateUseCase performanceCreateUseCase;
   private final PerformanceGetListUseCase performanceGetListUseCase;
   private final PerformanceChangeStatusUseCase performanceChangeStatusUseCase;
+  private final PerformanceValidateUseCase performanceValidateUseCase;
 
   public PerformanceCreateResponse createPerformance(
       PerformanceCreateRequest request,
@@ -38,5 +40,9 @@ public class PerformanceFacade {
 
   public void changePerformanceStatus(Long performanceId, PerformanceChangeStatusRequest request) {
     performanceChangeStatusUseCase.execute(performanceId, request);
+  }
+
+  public void validatePerformance(Long performanceId) {
+    performanceValidateUseCase.execute(performanceId);
   }
 }

--- a/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/app/usecase/PerformanceValidateUseCase.java
+++ b/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/app/usecase/PerformanceValidateUseCase.java
@@ -1,0 +1,29 @@
+package com.ticketrush.boundedcontext.performance.app.usecase;
+
+import com.ticketrush.boundedcontext.performance.domain.entity.Performance;
+import com.ticketrush.boundedcontext.performance.domain.types.PerformanceStatus;
+import com.ticketrush.boundedcontext.performance.out.repository.PerformanceRepository;
+import com.ticketrush.global.exception.BusinessException;
+import com.ticketrush.global.status.ErrorStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class PerformanceValidateUseCase {
+
+  private final PerformanceRepository performanceRepository;
+
+  @Transactional(readOnly = true)
+  public void execute(Long performanceId) {
+    Performance performance =
+        performanceRepository
+            .findById(performanceId)
+            .orElseThrow(() -> new BusinessException(ErrorStatus.PERFORMANCE_NOT_FOUND));
+
+    if (performance.getPerformanceStatus() != PerformanceStatus.ON_SALE) {
+      throw new BusinessException(ErrorStatus.PERFORMANCE_NOT_ON_SALE);
+    }
+  }
+}

--- a/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/in/api/v1/PerformanceAdminController.java
+++ b/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/in/api/v1/PerformanceAdminController.java
@@ -4,9 +4,6 @@ import com.ticketrush.boundedcontext.performance.app.dto.request.PerformanceChan
 import com.ticketrush.boundedcontext.performance.app.dto.request.PerformanceCreateRequest;
 import com.ticketrush.boundedcontext.performance.app.dto.response.PerformanceCreateResponse;
 import com.ticketrush.boundedcontext.performance.app.facade.PerformanceFacade;
-import com.ticketrush.boundedcontext.performance.in.api.v1.swagger.PerformanceChangeStatusApiResponses;
-import com.ticketrush.boundedcontext.performance.in.api.v1.swagger.PerformanceCreateApiResponses;
-import com.ticketrush.boundedcontext.performance.in.api.v1.swagger.PerformanceCreateSwaggerBody;
 import com.ticketrush.global.dto.response.ApiResponse;
 import com.ticketrush.global.status.SuccessStatus;
 import io.swagger.v3.oas.annotations.Operation;

--- a/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/in/api/v1/PerformanceChangeStatusApiResponses.java
+++ b/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/in/api/v1/PerformanceChangeStatusApiResponses.java
@@ -1,4 +1,4 @@
-package com.ticketrush.boundedcontext.performance.in.api.v1.swagger;
+package com.ticketrush.boundedcontext.performance.in.api.v1;
 
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
@@ -26,53 +26,50 @@ import java.lang.annotation.Target;
               examples = {
                 @ExampleObject(
                     name = "ValidationError",
-                    summary = "필수값 누락 또는 유효성 검증 실패",
+                    summary = "status 필드 누락",
                     value =
                         """
                         {
                           "isSuccess": false,
                           "code": "VALID_400_001",
-                          "message": "입력값이 올바르지 않습니다.",
+                          "message": "status: 변경할 상태는 필수입니다.",
                           "traceId": "trace-id-example"
                         }
                         """),
                 @ExampleObject(
-                    name = "MainImageMissing",
-                    summary = "메인 이미지 누락",
+                    name = "InvalidStatusTransition",
+                    summary = "유효하지 않은 상태 전환",
                     value =
                         """
                         {
                           "isSuccess": false,
-                          "code": "PERFORMANCE_400_001",
-                          "message": "메인 이미지는 필수입니다.",
-                          "traceId": "trace-id-example"
-                        }
-                        """),
-                @ExampleObject(
-                    name = "Model3dMissing",
-                    summary = "3D 모델 파일 누락",
-                    value =
-                        """
-                        {
-                          "isSuccess": false,
-                          "code": "PERFORMANCE_400_002",
-                          "message": "3D 모델 파일은 필수입니다.",
-                          "traceId": "trace-id-example"
-                        }
-                        """),
-                @ExampleObject(
-                    name = "GalleryLimitExceeded",
-                    summary = "갤러리 이미지 3개 초과",
-                    value =
-                        """
-                        {
-                          "isSuccess": false,
-                          "code": "PERFORMANCE_400_003",
-                          "message": "갤러리 이미지는 최대 3개까지 업로드할 수 있습니다.",
+                          "code": "PERFORMANCE_400_004",
+                          "message": "유효하지 않은 공연 상태 전환입니다.",
                           "traceId": "trace-id-example"
                         }
                         """)
               })),
+  @ApiResponse(
+      responseCode = "404",
+      description = "공연 없음",
+      content =
+          @Content(
+              mediaType = "application/json",
+              schema =
+                  @Schema(implementation = com.ticketrush.global.dto.response.ApiResponse.class),
+              examples =
+                  @ExampleObject(
+                      name = "PerformanceNotFound",
+                      summary = "공연이 존재하지 않음",
+                      value =
+                          """
+                          {
+                            "isSuccess": false,
+                            "code": "PERFORMANCE_404_001",
+                            "message": "공연이 존재하지 않습니다.",
+                            "traceId": "trace-id-example"
+                          }
+                          """))),
   @ApiResponse(
       responseCode = "500",
       description = "서버 오류",
@@ -95,4 +92,4 @@ import java.lang.annotation.Target;
                           }
                           """)))
 })
-public @interface PerformanceCreateApiResponses {}
+public @interface PerformanceChangeStatusApiResponses {}

--- a/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/in/api/v1/PerformanceController.java
+++ b/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/in/api/v1/PerformanceController.java
@@ -3,7 +3,6 @@ package com.ticketrush.boundedcontext.performance.in.api.v1;
 import com.ticketrush.boundedcontext.performance.app.dto.response.PerformanceListResponse;
 import com.ticketrush.boundedcontext.performance.app.facade.PerformanceFacade;
 import com.ticketrush.boundedcontext.performance.domain.types.Genre;
-import com.ticketrush.boundedcontext.performance.in.api.v1.swagger.PerformanceListApiResponses;
 import com.ticketrush.global.dto.response.ApiResponse;
 import com.ticketrush.global.status.SuccessStatus;
 import io.swagger.v3.oas.annotations.Operation;

--- a/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/in/api/v1/PerformanceCreateApiResponses.java
+++ b/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/in/api/v1/PerformanceCreateApiResponses.java
@@ -1,4 +1,4 @@
-package com.ticketrush.boundedcontext.performance.in.api.v1.swagger;
+package com.ticketrush.boundedcontext.performance.in.api.v1;
 
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
@@ -26,50 +26,53 @@ import java.lang.annotation.Target;
               examples = {
                 @ExampleObject(
                     name = "ValidationError",
-                    summary = "status 필드 누락",
+                    summary = "필수값 누락 또는 유효성 검증 실패",
                     value =
                         """
                         {
                           "isSuccess": false,
                           "code": "VALID_400_001",
-                          "message": "status: 변경할 상태는 필수입니다.",
+                          "message": "입력값이 올바르지 않습니다.",
                           "traceId": "trace-id-example"
                         }
                         """),
                 @ExampleObject(
-                    name = "InvalidStatusTransition",
-                    summary = "유효하지 않은 상태 전환",
+                    name = "MainImageMissing",
+                    summary = "메인 이미지 누락",
                     value =
                         """
                         {
                           "isSuccess": false,
-                          "code": "PERFORMANCE_400_004",
-                          "message": "유효하지 않은 공연 상태 전환입니다.",
+                          "code": "PERFORMANCE_400_001",
+                          "message": "메인 이미지는 필수입니다.",
+                          "traceId": "trace-id-example"
+                        }
+                        """),
+                @ExampleObject(
+                    name = "Model3dMissing",
+                    summary = "3D 모델 파일 누락",
+                    value =
+                        """
+                        {
+                          "isSuccess": false,
+                          "code": "PERFORMANCE_400_002",
+                          "message": "3D 모델 파일은 필수입니다.",
+                          "traceId": "trace-id-example"
+                        }
+                        """),
+                @ExampleObject(
+                    name = "GalleryLimitExceeded",
+                    summary = "갤러리 이미지 3개 초과",
+                    value =
+                        """
+                        {
+                          "isSuccess": false,
+                          "code": "PERFORMANCE_400_003",
+                          "message": "갤러리 이미지는 최대 3개까지 업로드할 수 있습니다.",
                           "traceId": "trace-id-example"
                         }
                         """)
               })),
-  @ApiResponse(
-      responseCode = "404",
-      description = "공연 없음",
-      content =
-          @Content(
-              mediaType = "application/json",
-              schema =
-                  @Schema(implementation = com.ticketrush.global.dto.response.ApiResponse.class),
-              examples =
-                  @ExampleObject(
-                      name = "PerformanceNotFound",
-                      summary = "공연이 존재하지 않음",
-                      value =
-                          """
-                          {
-                            "isSuccess": false,
-                            "code": "PERFORMANCE_404_001",
-                            "message": "공연이 존재하지 않습니다.",
-                            "traceId": "trace-id-example"
-                          }
-                          """))),
   @ApiResponse(
       responseCode = "500",
       description = "서버 오류",
@@ -92,4 +95,4 @@ import java.lang.annotation.Target;
                           }
                           """)))
 })
-public @interface PerformanceChangeStatusApiResponses {}
+public @interface PerformanceCreateApiResponses {}

--- a/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/in/api/v1/PerformanceCreateSwaggerBody.java
+++ b/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/in/api/v1/PerformanceCreateSwaggerBody.java
@@ -1,4 +1,4 @@
-package com.ticketrush.boundedcontext.performance.in.api.v1.swagger;
+package com.ticketrush.boundedcontext.performance.in.api.v1;
 
 import com.ticketrush.boundedcontext.performance.app.dto.request.PerformanceCreateRequest;
 import io.swagger.v3.oas.annotations.media.Schema;

--- a/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/in/api/v1/PerformanceInternalController.java
+++ b/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/in/api/v1/PerformanceInternalController.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@Tag(name = "Performance Internal", description = "공연 내부 서비스 간 API")
+@Tag(name = "Performance", description = "공연 API")
 @RestController
 @RequestMapping("/api/v1/performance")
 @RequiredArgsConstructor
@@ -21,9 +21,7 @@ public class PerformanceInternalController {
 
   private final PerformanceFacade performanceFacade;
 
-  @Operation(
-      summary = "공연 유효성 검증",
-      description = "공연이 존재하고 예매 가능(ON_SALE) 상태인지 검증합니다. Booking 서비스 내부 호출용.")
+  @Operation(summary = "공연 유효성 검증", description = "공연이 존재하고 예매 가능(ON_SALE) 상태인지 검증합니다.")
   @PerformanceValidateApiResponses
   @GetMapping("/{id}/validate")
   public ResponseEntity<ApiResponse<Void>> validatePerformance(@PathVariable Long id) {

--- a/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/in/api/v1/PerformanceInternalController.java
+++ b/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/in/api/v1/PerformanceInternalController.java
@@ -1,0 +1,33 @@
+package com.ticketrush.boundedcontext.performance.in.api.v1;
+
+import com.ticketrush.boundedcontext.performance.app.facade.PerformanceFacade;
+import com.ticketrush.boundedcontext.performance.in.api.v1.swagger.PerformanceValidateApiResponses;
+import com.ticketrush.global.dto.response.ApiResponse;
+import com.ticketrush.global.status.SuccessStatus;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Performance Internal", description = "공연 내부 서비스 간 API")
+@RestController
+@RequestMapping("/api/v1/performance")
+@RequiredArgsConstructor
+public class PerformanceInternalController {
+
+  private final PerformanceFacade performanceFacade;
+
+  @Operation(
+      summary = "공연 유효성 검증",
+      description = "공연이 존재하고 예매 가능(ON_SALE) 상태인지 검증합니다. Booking 서비스 내부 호출용.")
+  @PerformanceValidateApiResponses
+  @GetMapping("/{id}/validate")
+  public ResponseEntity<ApiResponse<Void>> validatePerformance(@PathVariable Long id) {
+    performanceFacade.validatePerformance(id);
+    return ApiResponse.onSuccess(SuccessStatus.OK);
+  }
+}

--- a/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/in/api/v1/PerformanceInternalController.java
+++ b/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/in/api/v1/PerformanceInternalController.java
@@ -1,7 +1,6 @@
 package com.ticketrush.boundedcontext.performance.in.api.v1;
 
 import com.ticketrush.boundedcontext.performance.app.facade.PerformanceFacade;
-import com.ticketrush.boundedcontext.performance.in.api.v1.swagger.PerformanceValidateApiResponses;
 import com.ticketrush.global.dto.response.ApiResponse;
 import com.ticketrush.global.status.SuccessStatus;
 import io.swagger.v3.oas.annotations.Operation;

--- a/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/in/api/v1/PerformanceListApiResponses.java
+++ b/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/in/api/v1/PerformanceListApiResponses.java
@@ -1,4 +1,4 @@
-package com.ticketrush.boundedcontext.performance.in.api.v1.swagger;
+package com.ticketrush.boundedcontext.performance.in.api.v1;
 
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;

--- a/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/in/api/v1/PerformanceValidateApiResponses.java
+++ b/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/in/api/v1/PerformanceValidateApiResponses.java
@@ -1,4 +1,4 @@
-package com.ticketrush.boundedcontext.performance.in.api.v1.swagger;
+package com.ticketrush.boundedcontext.performance.in.api.v1;
 
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;

--- a/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/in/api/v1/swagger/PerformanceValidateApiResponses.java
+++ b/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/in/api/v1/swagger/PerformanceValidateApiResponses.java
@@ -1,0 +1,82 @@
+package com.ticketrush.boundedcontext.performance.in.api.v1.swagger;
+
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@ApiResponses({
+  @ApiResponse(
+      responseCode = "400",
+      description = "예매 불가 상태",
+      content =
+          @Content(
+              mediaType = "application/json",
+              schema =
+                  @Schema(implementation = com.ticketrush.global.dto.response.ApiResponse.class),
+              examples =
+                  @ExampleObject(
+                      name = "PerformanceNotOnSale",
+                      summary = "예매 가능한 공연이 아님",
+                      value =
+                          """
+                          {
+                            "isSuccess": false,
+                            "code": "PERFORMANCE_400_005",
+                            "message": "예매 가능한 공연이 아닙니다.",
+                            "traceId": "trace-id-example"
+                          }
+                          """))),
+  @ApiResponse(
+      responseCode = "404",
+      description = "공연 없음",
+      content =
+          @Content(
+              mediaType = "application/json",
+              schema =
+                  @Schema(implementation = com.ticketrush.global.dto.response.ApiResponse.class),
+              examples =
+                  @ExampleObject(
+                      name = "PerformanceNotFound",
+                      summary = "공연이 존재하지 않음",
+                      value =
+                          """
+                          {
+                            "isSuccess": false,
+                            "code": "PERFORMANCE_404_001",
+                            "message": "공연이 존재하지 않습니다.",
+                            "traceId": "trace-id-example"
+                          }
+                          """))),
+  @ApiResponse(
+      responseCode = "500",
+      description = "서버 오류",
+      content =
+          @Content(
+              mediaType = "application/json",
+              schema =
+                  @Schema(implementation = com.ticketrush.global.dto.response.ApiResponse.class),
+              examples =
+                  @ExampleObject(
+                      name = "InternalServerError",
+                      summary = "서버 내부 오류",
+                      value =
+                          """
+                          {
+                            "isSuccess": false,
+                            "code": "COMMON_500",
+                            "message": "서버 에러, 관리자에게 문의 바랍니다.",
+                            "traceId": "trace-id-example"
+                          }
+                          """)))
+})
+public @interface PerformanceValidateApiResponses {}

--- a/performance-service/src/test/java/com/ticketrush/boundedcontext/performance/in/api/v1/PerformanceInternalControllerTest.java
+++ b/performance-service/src/test/java/com/ticketrush/boundedcontext/performance/in/api/v1/PerformanceInternalControllerTest.java
@@ -1,0 +1,70 @@
+package com.ticketrush.boundedcontext.performance.in.api.v1;
+
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.ticketrush.boundedcontext.performance.app.facade.PerformanceFacade;
+import com.ticketrush.global.exception.BusinessException;
+import com.ticketrush.global.status.ErrorStatus;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(PerformanceInternalController.class)
+class PerformanceInternalControllerTest {
+
+  @Autowired private MockMvc mockMvc;
+
+  @MockitoBean private PerformanceFacade performanceFacade;
+
+  final String baseUrl = "/api/v1/performance";
+
+  @Test
+  @WithMockUser
+  @DisplayName("ON_SALE 상태 공연이면 200을 반환한다")
+  void validateOnSalePerformance() throws Exception {
+    doNothing().when(performanceFacade).validatePerformance(1L);
+
+    mockMvc
+        .perform(get(baseUrl + "/1/validate"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.isSuccess").value(true));
+  }
+
+  @Test
+  @WithMockUser
+  @DisplayName("ON_SALE이 아닌 공연이면 400을 반환한다")
+  void validateNotOnSalePerformance() throws Exception {
+    doThrow(new BusinessException(ErrorStatus.PERFORMANCE_NOT_ON_SALE))
+        .when(performanceFacade)
+        .validatePerformance(2L);
+
+    mockMvc
+        .perform(get(baseUrl + "/2/validate"))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.isSuccess").value(false))
+        .andExpect(jsonPath("$.code").value("PERFORMANCE_400_005"));
+  }
+
+  @Test
+  @WithMockUser
+  @DisplayName("존재하지 않는 공연이면 404를 반환한다")
+  void validateNotFoundPerformance() throws Exception {
+    doThrow(new BusinessException(ErrorStatus.PERFORMANCE_NOT_FOUND))
+        .when(performanceFacade)
+        .validatePerformance(999L);
+
+    mockMvc
+        .perform(get(baseUrl + "/999/validate"))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.isSuccess").value(false))
+        .andExpect(jsonPath("$.code").value("PERFORMANCE_404_001"));
+  }
+}


### PR DESCRIPTION
## 🔗 관련 이슈

- close #174

---

## 📌 주요 변경 사항

- `GET /api/v1/performance/{id}/validate` 내부 API 엔드포인트 추가
- `PerformanceInternalController` 신규 생성 (사용자/관리자 컨트롤러와 분리)
- `ErrorStatus`에 `PERFORMANCE_400_005` (예매 가능한 공연이 아닙니다.) 추가

---

## 🛠 상세 구현 내용

- `PerformanceValidateUseCase` — 공연 존재 여부 + ON_SALE 상태 검증, `@Transactional(readOnly = true)` 적용
- `PerformanceInternalController` — 서비스 간 내부 통신 전용 컨트롤러로 분리
- `PerformanceValidateApiResponses` — 400(예매 불가)/404(공연 없음)/500 Swagger 어노테이션
- `PerformanceFacade` — `validatePerformance()` 위임 메서드 추가

> BookingFacade 연동(FeignClient vs Kafka)은 팀 논의 후 별도 이슈로 처리 예정

---

## ✅ 테스트

### 테스트 방법

- Swagger UI에서 `GET /api/v1/performance/{id}/validate` 호출
  - ON_SALE 상태 공연 ID → 200 OK
  - ON_SALE 아닌 공연 ID → 400 `PERFORMANCE_400_005`
  - 존재하지 않는 공연 ID → 404 `PERFORMANCE_404_001`

### 테스트 결과

- 빌드 검증 통과 (spotlessApply → checkstyleMain → compileJava)

### 📸 스크린샷
<img width="1461" height="937" alt="image" src="https://github.com/user-attachments/assets/4b6eba43-c487-41df-9797-430f9253f968" />
<img width="1465" height="973" alt="image" src="https://github.com/user-attachments/assets/8bbb31fe-e4e8-4891-b17e-3dd450e24d4e" />

---

## 👀 리뷰 요청 사항

- `PerformanceInternalController` 분리 방식이 적절한지 확인 부탁드립니다

---

## ⚠️ 배포 시 주의사항

- `common` 모듈 `ErrorStatus`에 `PERFORMANCE_400_005` 추가됨 — 다른 서비스 재빌드 필요