### PR TITLE
[Feat] #34 좌석 판매 확정 API 구현

### DIFF
--- a/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/app/dto/request/BookingPendingRequest.java
+++ b/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/app/dto/request/BookingPendingRequest.java
@@ -1,17 +1,33 @@
 package com.ticketrush.boundedcontext.booking.app.dto.request;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 
 @Schema(description = "예약 대기 생성 요청 DTO")
 public record BookingPendingRequest(
     // TODO: 인증 로직 완료 후 컨트롤러 파라미터(예: @AuthenticationPrincipal)로 대체하고 삭제할 필드
-    @Schema(description = "사용자 ID", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("user_id")
+        @Schema(
+            name = "user_id",
+            description = "사용자 ID",
+            example = "1",
+            requiredMode = Schema.RequiredMode.REQUIRED)
         @NotNull
         Long userId,
-    @Schema(description = "공연 ID", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("performance_id")
+        @Schema(
+            name = "performance_id",
+            description = "공연 ID",
+            example = "1",
+            requiredMode = Schema.RequiredMode.REQUIRED)
         @NotNull
         Long performanceId,
-    @Schema(description = "좌석 ID", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
+    @JsonProperty("seat_id")
+        @Schema(
+            name = "seat_id",
+            description = "좌석 ID",
+            example = "1",
+            requiredMode = Schema.RequiredMode.REQUIRED)
         @NotNull
         Long seatId) {}

--- a/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/app/dto/request/SeatSoldConfirmRequest.java
+++ b/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/app/dto/request/SeatSoldConfirmRequest.java
@@ -1,0 +1,25 @@
+package com.ticketrush.boundedcontext.seat.app.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+@Schema(description = "좌석 판매 확정 요청 DTO")
+public record SeatSoldConfirmRequest(
+    @JsonProperty("booking_number")
+        @Schema(
+            name = "booking_number",
+            description = "결제 완료된 예매 번호",
+            example = "X7B29-KLPW1",
+            requiredMode = Schema.RequiredMode.REQUIRED)
+        @NotBlank
+        String bookingNumber,
+    @JsonProperty("seat_id")
+        @Schema(
+            name = "seat_id",
+            description = "판매 확정할 좌석 ID",
+            example = "1",
+            requiredMode = Schema.RequiredMode.REQUIRED)
+        @NotNull
+        Long seatId) {}

--- a/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/app/facade/SeatFacade.java
+++ b/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/app/facade/SeatFacade.java
@@ -1,6 +1,7 @@
 package com.ticketrush.boundedcontext.seat.app.facade;
 
 import com.ticketrush.boundedcontext.seat.app.dto.response.SeatLayoutResponse;
+import com.ticketrush.boundedcontext.seat.app.usecase.SeatConfirmSoldUseCase;
 import com.ticketrush.boundedcontext.seat.app.usecase.SeatGetSeatLayoutsUseCase;
 import com.ticketrush.boundedcontext.seat.app.usecase.SeatHoldUseCase;
 import com.ticketrush.boundedcontext.seat.app.usecase.SeatLockUseCase;
@@ -20,6 +21,7 @@ import org.springframework.stereotype.Service;
 public class SeatFacade {
 
   private final SeatGetSeatLayoutsUseCase seatGetSeatLayoutsUseCase;
+  private final SeatConfirmSoldUseCase seatConfirmSoldUseCase;
   private final SeatHoldUseCase seatHoldUseCase;
   private final SeatLockUseCase seatLockUseCase;
   private final SeatUnlockUseCase seatUnlockUseCase;
@@ -31,6 +33,10 @@ public class SeatFacade {
 
   public void holdSeat(Long seatId, LocalDateTime holdExpiredAt) {
     seatHoldUseCase.execute(seatId, holdExpiredAt);
+  }
+
+  public void confirmSold(String bookingNumber, Long seatId) {
+    seatConfirmSoldUseCase.execute(bookingNumber, seatId);
   }
 
   public void tryLockSeat(Long bookingId, Long seatId, Long userId) {

--- a/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/app/usecase/SeatConfirmSoldUseCase.java
+++ b/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/app/usecase/SeatConfirmSoldUseCase.java
@@ -8,6 +8,8 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 @Slf4j
 @Service
@@ -15,19 +17,37 @@ import org.springframework.transaction.annotation.Transactional;
 public class SeatConfirmSoldUseCase {
 
   private final SeatRepository seatRepository;
+  private final SeatUnlockUseCase seatUnlockUseCase;
 
   @Transactional
   public void execute(String bookingNumber, Long seatId) {
+    int updatedCount = seatRepository.confirmSoldById(seatId, SeatStatus.HOLD, SeatStatus.SOLD);
+
+    if (updatedCount == 1) {
+      forceReleaseAfterCommit(seatId);
+      log.info("좌석 판매 확정 완료. bookingNumber: {}, seatId: {}", bookingNumber, seatId);
+      return;
+    }
+
     if (!seatRepository.existsById(seatId)) {
       throw new BusinessException(ErrorStatus.SEAT_NOT_FOUND);
     }
 
-    int updatedCount = seatRepository.confirmSoldById(seatId, SeatStatus.HOLD, SeatStatus.SOLD);
+    throw new BusinessException(ErrorStatus.SEAT_NOT_AVAILABLE);
+  }
 
-    if (updatedCount != 1) {
-      throw new BusinessException(ErrorStatus.SEAT_NOT_AVAILABLE);
+  private void forceReleaseAfterCommit(Long seatId) {
+    if (!TransactionSynchronizationManager.isSynchronizationActive()) {
+      seatUnlockUseCase.forceRelease(seatId);
+      return;
     }
 
-    log.info("좌석 판매 확정 완료. bookingNumber: {}, seatId: {}", bookingNumber, seatId);
+    TransactionSynchronizationManager.registerSynchronization(
+        new TransactionSynchronization() {
+          @Override
+          public void afterCommit() {
+            seatUnlockUseCase.forceRelease(seatId);
+          }
+        });
   }
 }

--- a/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/app/usecase/SeatConfirmSoldUseCase.java
+++ b/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/app/usecase/SeatConfirmSoldUseCase.java
@@ -1,0 +1,33 @@
+package com.ticketrush.boundedcontext.seat.app.usecase;
+
+import com.ticketrush.boundedcontext.seat.out.repository.SeatRepository;
+import com.ticketrush.global.exception.BusinessException;
+import com.ticketrush.global.status.ErrorStatus;
+import com.ticketrush.global.types.SeatStatus;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class SeatConfirmSoldUseCase {
+
+  private final SeatRepository seatRepository;
+
+  @Transactional
+  public void execute(String bookingNumber, Long seatId) {
+    if (!seatRepository.existsById(seatId)) {
+      throw new BusinessException(ErrorStatus.SEAT_NOT_FOUND);
+    }
+
+    int updatedCount = seatRepository.confirmSoldById(seatId, SeatStatus.HOLD, SeatStatus.SOLD);
+
+    if (updatedCount != 1) {
+      throw new BusinessException(ErrorStatus.SEAT_NOT_AVAILABLE);
+    }
+
+    log.info("좌석 판매 확정 완료. bookingNumber: {}, seatId: {}", bookingNumber, seatId);
+  }
+}

--- a/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/app/usecase/SeatUnlockUseCase.java
+++ b/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/app/usecase/SeatUnlockUseCase.java
@@ -32,4 +32,13 @@ public class SeatUnlockUseCase {
       log.warn("락 해제 스킵: 락을 소유하고 있지 않거나 이미 자동 만료되었습니다. seatId: {}", seatId);
     }
   }
+
+  public void forceRelease(Long seatId) {
+    String lockKey = SEAT_LOCK_PREFIX + seatId;
+    RLock lock = redissonClient.getLock(lockKey);
+
+    if (lock.forceUnlock()) {
+      log.debug("Redisson 락 강제 해제 완료. seatId: {}", seatId);
+    }
+  }
 }

--- a/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/in/api/v1/SeatController.java
+++ b/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/in/api/v1/SeatController.java
@@ -1,14 +1,18 @@
 package com.ticketrush.boundedcontext.seat.in.api.v1;
 
+import com.ticketrush.boundedcontext.seat.app.dto.request.SeatSoldConfirmRequest;
 import com.ticketrush.boundedcontext.seat.app.dto.response.SeatLayoutResponse;
 import com.ticketrush.boundedcontext.seat.app.facade.SeatFacade;
 import com.ticketrush.global.dto.response.ApiResponse;
 import com.ticketrush.global.status.SuccessStatus;
+import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -24,5 +28,12 @@ public class SeatController {
       @PathVariable Long performanceId) {
     List<SeatLayoutResponse> response = seatFacade.getPerformanceSeatLayouts(performanceId);
     return ApiResponse.onSuccess(SuccessStatus.OK, response);
+  }
+
+  @PostMapping("/internal/sold")
+  public ResponseEntity<ApiResponse<Void>> confirmSold(
+      @Valid @RequestBody SeatSoldConfirmRequest request) {
+    seatFacade.confirmSold(request.bookingNumber(), request.seatId());
+    return ApiResponse.onSuccess(SuccessStatus.OK);
   }
 }

--- a/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/in/api/v1/SeatController.java
+++ b/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/in/api/v1/SeatController.java
@@ -4,15 +4,19 @@ import com.ticketrush.boundedcontext.seat.app.dto.request.SeatSoldConfirmRequest
 import com.ticketrush.boundedcontext.seat.app.dto.response.SeatLayoutResponse;
 import com.ticketrush.boundedcontext.seat.app.facade.SeatFacade;
 import com.ticketrush.global.dto.response.ApiResponse;
+import com.ticketrush.global.exception.BusinessException;
+import com.ticketrush.global.status.ErrorStatus;
 import com.ticketrush.global.status.SuccessStatus;
 import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -21,7 +25,12 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class SeatController {
 
+  private static final String INTERNAL_TOKEN_HEADER = "X-Internal-Token";
+
   private final SeatFacade seatFacade;
+
+  @Value("${gateway.internal-token}")
+  private String internalToken;
 
   @GetMapping("/{performanceId}/seat-layouts")
   public ResponseEntity<ApiResponse<List<SeatLayoutResponse>>> getSeatLayouts(
@@ -32,8 +41,16 @@ public class SeatController {
 
   @PostMapping("/internal/sold")
   public ResponseEntity<ApiResponse<Void>> confirmSold(
+      @RequestHeader(value = INTERNAL_TOKEN_HEADER, required = false) String internalTokenHeader,
       @Valid @RequestBody SeatSoldConfirmRequest request) {
+    validateInternalToken(internalTokenHeader);
     seatFacade.confirmSold(request.bookingNumber(), request.seatId());
     return ApiResponse.onSuccess(SuccessStatus.OK);
+  }
+
+  private void validateInternalToken(String internalTokenHeader) {
+    if (!internalToken.equals(internalTokenHeader)) {
+      throw new BusinessException(ErrorStatus.FORBIDDEN);
+    }
   }
 }

--- a/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/out/repository/SeatRepository.java
+++ b/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/out/repository/SeatRepository.java
@@ -29,4 +29,13 @@ public interface SeatRepository extends JpaRepository<Seat, Long> {
       @Param("availableStatus") SeatStatus availableStatus,
       @Param("holdStatus") SeatStatus holdStatus,
       @Param("now") LocalDateTime now);
+
+  @Modifying(clearAutomatically = true)
+  @Query(
+      "UPDATE Seat s SET s.seatStatus = :soldStatus, s.holdExpiredAt = null "
+          + "WHERE s.id = :seatId AND s.seatStatus = :holdStatus")
+  int confirmSoldById(
+      @Param("seatId") Long seatId,
+      @Param("holdStatus") SeatStatus holdStatus,
+      @Param("soldStatus") SeatStatus soldStatus);
 }

--- a/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/app/usecase/SeatConfirmSoldUseCaseTest.java
+++ b/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/app/usecase/SeatConfirmSoldUseCaseTest.java
@@ -22,6 +22,7 @@ class SeatConfirmSoldUseCaseTest {
   @InjectMocks private SeatConfirmSoldUseCase seatConfirmSoldUseCase;
 
   @Mock private SeatRepository seatRepository;
+  @Mock private SeatUnlockUseCase seatUnlockUseCase;
 
   @Test
   @DisplayName("성공: HOLD 상태인 좌석을 SOLD 상태로 확정한다")
@@ -30,15 +31,14 @@ class SeatConfirmSoldUseCaseTest {
     String bookingNumber = "X7B29-KLPW1";
     Long seatId = 1L;
 
-    given(seatRepository.existsById(seatId)).willReturn(true);
     given(seatRepository.confirmSoldById(seatId, SeatStatus.HOLD, SeatStatus.SOLD)).willReturn(1);
 
     // when
     seatConfirmSoldUseCase.execute(bookingNumber, seatId);
 
     // then
-    verify(seatRepository).existsById(seatId);
     verify(seatRepository).confirmSoldById(seatId, SeatStatus.HOLD, SeatStatus.SOLD);
+    verify(seatUnlockUseCase).forceRelease(seatId);
   }
 
   @Test
@@ -47,6 +47,7 @@ class SeatConfirmSoldUseCaseTest {
     // given
     Long seatId = 1L;
 
+    given(seatRepository.confirmSoldById(seatId, SeatStatus.HOLD, SeatStatus.SOLD)).willReturn(0);
     given(seatRepository.existsById(seatId)).willReturn(false);
 
     // when & then
@@ -55,8 +56,9 @@ class SeatConfirmSoldUseCaseTest {
         .extracting("errorStatus")
         .isEqualTo(ErrorStatus.SEAT_NOT_FOUND);
 
+    verify(seatRepository).confirmSoldById(seatId, SeatStatus.HOLD, SeatStatus.SOLD);
     verify(seatRepository).existsById(seatId);
-    verifyNoMoreInteractions(seatRepository);
+    verifyNoMoreInteractions(seatRepository, seatUnlockUseCase);
   }
 
   @Test
@@ -65,13 +67,17 @@ class SeatConfirmSoldUseCaseTest {
     // given
     Long seatId = 1L;
 
-    given(seatRepository.existsById(seatId)).willReturn(true);
     given(seatRepository.confirmSoldById(seatId, SeatStatus.HOLD, SeatStatus.SOLD)).willReturn(0);
+    given(seatRepository.existsById(seatId)).willReturn(true);
 
     // when & then
     assertThatThrownBy(() -> seatConfirmSoldUseCase.execute("X7B29-KLPW1", seatId))
         .isInstanceOf(BusinessException.class)
         .extracting("errorStatus")
         .isEqualTo(ErrorStatus.SEAT_NOT_AVAILABLE);
+
+    verify(seatRepository).confirmSoldById(seatId, SeatStatus.HOLD, SeatStatus.SOLD);
+    verify(seatRepository).existsById(seatId);
+    verifyNoMoreInteractions(seatRepository, seatUnlockUseCase);
   }
 }

--- a/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/app/usecase/SeatConfirmSoldUseCaseTest.java
+++ b/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/app/usecase/SeatConfirmSoldUseCaseTest.java
@@ -1,0 +1,77 @@
+package com.ticketrush.boundedcontext.seat.app.usecase;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import com.ticketrush.boundedcontext.seat.out.repository.SeatRepository;
+import com.ticketrush.global.exception.BusinessException;
+import com.ticketrush.global.status.ErrorStatus;
+import com.ticketrush.global.types.SeatStatus;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class SeatConfirmSoldUseCaseTest {
+
+  @InjectMocks private SeatConfirmSoldUseCase seatConfirmSoldUseCase;
+
+  @Mock private SeatRepository seatRepository;
+
+  @Test
+  @DisplayName("성공: HOLD 상태인 좌석을 SOLD 상태로 확정한다")
+  void execute_success() {
+    // given
+    String bookingNumber = "X7B29-KLPW1";
+    Long seatId = 1L;
+
+    given(seatRepository.existsById(seatId)).willReturn(true);
+    given(seatRepository.confirmSoldById(seatId, SeatStatus.HOLD, SeatStatus.SOLD)).willReturn(1);
+
+    // when
+    seatConfirmSoldUseCase.execute(bookingNumber, seatId);
+
+    // then
+    verify(seatRepository).existsById(seatId);
+    verify(seatRepository).confirmSoldById(seatId, SeatStatus.HOLD, SeatStatus.SOLD);
+  }
+
+  @Test
+  @DisplayName("실패: 존재하지 않는 좌석이면 BusinessException(SEAT_NOT_FOUND)이 발생한다")
+  void execute_fail_seat_not_found() {
+    // given
+    Long seatId = 1L;
+
+    given(seatRepository.existsById(seatId)).willReturn(false);
+
+    // when & then
+    assertThatThrownBy(() -> seatConfirmSoldUseCase.execute("X7B29-KLPW1", seatId))
+        .isInstanceOf(BusinessException.class)
+        .extracting("errorStatus")
+        .isEqualTo(ErrorStatus.SEAT_NOT_FOUND);
+
+    verify(seatRepository).existsById(seatId);
+    verifyNoMoreInteractions(seatRepository);
+  }
+
+  @Test
+  @DisplayName("실패: HOLD 상태가 아닌 좌석이 있으면 BusinessException(SEAT_NOT_AVAILABLE)이 발생한다")
+  void execute_fail_seat_not_hold() {
+    // given
+    Long seatId = 1L;
+
+    given(seatRepository.existsById(seatId)).willReturn(true);
+    given(seatRepository.confirmSoldById(seatId, SeatStatus.HOLD, SeatStatus.SOLD)).willReturn(0);
+
+    // when & then
+    assertThatThrownBy(() -> seatConfirmSoldUseCase.execute("X7B29-KLPW1", seatId))
+        .isInstanceOf(BusinessException.class)
+        .extracting("errorStatus")
+        .isEqualTo(ErrorStatus.SEAT_NOT_AVAILABLE);
+  }
+}

--- a/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/app/usecase/SeatUnlockUseCaseTest.java
+++ b/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/app/usecase/SeatUnlockUseCaseTest.java
@@ -65,4 +65,18 @@ class SeatUnlockUseCaseTest {
     // then
     verify(redissonLock, never()).unlock();
   }
+
+  @Test
+  @DisplayName("성공: 좌석 락을 소유 스레드와 무관하게 강제 해제한다")
+  void forceRelease_success() {
+    // given
+    given(redissonClient.getLock(anyString())).willReturn(redissonLock);
+    given(redissonLock.forceUnlock()).willReturn(true);
+
+    // when
+    seatUnlockUseCase.forceRelease(100L);
+
+    // then
+    verify(redissonLock).forceUnlock();
+  }
 }

--- a/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/in/api/v1/SeatControllerTest.java
+++ b/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/in/api/v1/SeatControllerTest.java
@@ -1,7 +1,10 @@
 package com.ticketrush.boundedcontext.seat.in.api.v1;
 
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -12,6 +15,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
@@ -44,5 +48,31 @@ class SeatControllerTest {
         .andExpect(jsonPath("$.result[0].seatNumber").value("A-1"))
         .andExpect(jsonPath("$.result[1].seatId").value(2))
         .andExpect(jsonPath("$.result[1].seatNumber").value("A-2"));
+  }
+
+  @Test
+  @WithMockUser
+  @DisplayName("좌석 판매 확정 요청을 성공하고 200 OK를 반환한다")
+  void confirmSold() throws Exception {
+    // given
+    String requestBody =
+        """
+        {
+          "booking_number": "X7B29-KLPW1",
+          "seat_id": 1
+        }
+        """;
+
+    // when & then
+    mockMvc
+        .perform(
+            post("/api/v1/seat/internal/sold")
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestBody))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.isSuccess").value(true));
+
+    verify(seatFacade).confirmSold("X7B29-KLPW1", 1L);
   }
 }

--- a/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/in/api/v1/SeatControllerTest.java
+++ b/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/in/api/v1/SeatControllerTest.java
@@ -10,17 +10,23 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.ticketrush.boundedcontext.seat.app.dto.response.SeatLayoutResponse;
 import com.ticketrush.boundedcontext.seat.app.facade.SeatFacade;
+import com.ticketrush.global.config.JacksonConfig;
+import com.ticketrush.global.config.SecurityConfig;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(SeatController.class)
+@Import({JacksonConfig.class, SecurityConfig.class})
+@TestPropertySource(properties = "gateway.internal-token=test-token")
 class SeatControllerTest {
 
   private static final String INTERNAL_TOKEN = "test-token";
@@ -43,13 +49,13 @@ class SeatControllerTest {
     mockMvc
         .perform(get("/api/v1/seat/{performanceId}/seat-layouts", performanceId))
         .andExpect(status().isOk())
-        .andExpect(jsonPath("$.isSuccess").value(true))
+        .andExpect(jsonPath("$.is_success").value(true))
         .andExpect(jsonPath("$.result.length()").value(2))
-        .andExpect(jsonPath("$.result[0].seatId").value(1))
-        .andExpect(jsonPath("$.result[0].seatLayoutId").value(101))
-        .andExpect(jsonPath("$.result[0].seatNumber").value("A-1"))
-        .andExpect(jsonPath("$.result[1].seatId").value(2))
-        .andExpect(jsonPath("$.result[1].seatNumber").value("A-2"));
+        .andExpect(jsonPath("$.result[0].seat_id").value(1))
+        .andExpect(jsonPath("$.result[0].seat_layout_id").value(101))
+        .andExpect(jsonPath("$.result[0].seat_number").value("A-1"))
+        .andExpect(jsonPath("$.result[1].seat_id").value(2))
+        .andExpect(jsonPath("$.result[1].seat_number").value("A-2"));
   }
 
   @Test
@@ -74,7 +80,7 @@ class SeatControllerTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(requestBody))
         .andExpect(status().isOk())
-        .andExpect(jsonPath("$.isSuccess").value(true));
+        .andExpect(jsonPath("$.is_success").value(true));
 
     verify(seatFacade).confirmSold("X7B29-KLPW1", 1L);
   }

--- a/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/in/api/v1/SeatControllerTest.java
+++ b/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/in/api/v1/SeatControllerTest.java
@@ -23,6 +23,8 @@ import org.springframework.test.web.servlet.MockMvc;
 @WebMvcTest(SeatController.class)
 class SeatControllerTest {
 
+  private static final String INTERNAL_TOKEN = "test-token";
+
   @Autowired private MockMvc mockMvc;
 
   @MockitoBean private SeatFacade seatFacade;
@@ -68,11 +70,35 @@ class SeatControllerTest {
         .perform(
             post("/api/v1/seat/internal/sold")
                 .with(csrf())
+                .header("X-Internal-Token", INTERNAL_TOKEN)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(requestBody))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.isSuccess").value(true));
 
     verify(seatFacade).confirmSold("X7B29-KLPW1", 1L);
+  }
+
+  @Test
+  @WithMockUser
+  @DisplayName("좌석 판매 확정 요청에 내부 토큰이 없으면 403 Forbidden을 반환한다")
+  void confirmSold_fail_when_internal_token_missing() throws Exception {
+    // given
+    String requestBody =
+        """
+        {
+          "booking_number": "X7B29-KLPW1",
+          "seat_id": 1
+        }
+        """;
+
+    // when & then
+    mockMvc
+        .perform(
+            post("/api/v1/seat/internal/sold")
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestBody))
+        .andExpect(status().isForbidden());
   }
 }

--- a/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/out/repository/SeatRepositoryTest.java
+++ b/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/out/repository/SeatRepositoryTest.java
@@ -148,4 +148,46 @@ class SeatRepositoryTest {
     assertThat(validSeat.getSeatStatus()).isEqualTo(SeatStatus.HOLD); // 변경되지 않음
     assertThat(updatedSoldSeat.getSeatStatus()).isEqualTo(SeatStatus.SOLD); // 변경되지 않음
   }
+
+  @Test
+  @DisplayName("HOLD 상태인 좌석을 SOLD 상태로 변경하고 선점 만료 시간을 초기화한다")
+  void confirmSoldById_ChangesHoldSeatToSold() {
+    // given
+    LocalDateTime holdExpiredAt = LocalDateTime.now().plusMinutes(5);
+
+    Seat holdSeat1 =
+        Seat.builder()
+            .seatLayoutId(1L)
+            .performanceId(100L)
+            .seatNumber("A1")
+            .seatStatus(SeatStatus.HOLD)
+            .holdExpiredAt(holdExpiredAt)
+            .build();
+
+    Seat availableSeat =
+        Seat.builder()
+            .seatLayoutId(1L)
+            .performanceId(100L)
+            .seatNumber("A3")
+            .seatStatus(SeatStatus.AVAILABLE)
+            .build();
+
+    seatRepository.saveAll(List.of(holdSeat1, availableSeat));
+    entityManager.flush();
+    entityManager.clear();
+
+    // when
+    int updatedCount =
+        seatRepository.confirmSoldById(holdSeat1.getId(), SeatStatus.HOLD, SeatStatus.SOLD);
+
+    // then
+    assertThat(updatedCount).isEqualTo(1);
+
+    Seat updatedSeat1 = seatRepository.findById(holdSeat1.getId()).orElseThrow();
+    Seat notUpdatedSeat = seatRepository.findById(availableSeat.getId()).orElseThrow();
+
+    assertThat(updatedSeat1.getSeatStatus()).isEqualTo(SeatStatus.SOLD);
+    assertThat(updatedSeat1.getHoldExpiredAt()).isNull();
+    assertThat(notUpdatedSeat.getSeatStatus()).isEqualTo(SeatStatus.AVAILABLE);
+  }
 }


### PR DESCRIPTION
## 🔗 관련 이슈

 - close #34

---

## 📌 주요 변경 사항

- 결제 완료 후 HOLD 상태 좌석을 SOLD로 확정하는 내부 API 추가
- 예매 번호(`booking_number`)와 단일 좌석 ID(`seat_id`) 기반 요청 DTO
추가
- HOLD 상태 좌석만 SOLD로 변경하고 `holdExpiredAt`을 초기화하는
repository 업데이트 쿼리 추가
- 좌석 존재 여부와 HOLD 상태 검증 로직 추가

---

## 🛠 상세 구현 내용

- `POST /api/v1/seat/internal/sold` 추가
- `SeatSoldConfirmRequest` 추가
  - `booking_number`: 예매 번호
  - `seat_id`: 판매 확정할 단일 좌석 ID
- `SeatConfirmSoldUseCase` 추가
  - 좌석 미존재 시 `SEAT_NOT_FOUND`
  - 좌석이 HOLD 상태가 아니면 `SEAT_NOT_AVAILABLE`
- `SeatRepository#confirmSoldById` 추가
  - `HOLD -> SOLD`
  - `holdExpiredAt = null`

---

## ✅ 테스트

### 테스트 방법

- `SeatControllerTest`
- `SeatConfirmSoldUseCaseTest`
- `SeatRepositoryTest`

### 테스트 결과

- `./gradlew.bat :seat-service:check` 통과

<!--
### 📸 스크린샷


---

## 👀 리뷰 요청 사항

-

---

## ⚠️ 배포 시 주의사항

- 
-->