### PR TITLE
[Feat] #164 NAVER OAuth2 로그인 API 연동 구현

### DIFF
--- a/auth-service/src/main/java/com/ticketrush/boundedcontext/auth/app/dto/request/SocialOauthLoginRequest.java
+++ b/auth-service/src/main/java/com/ticketrush/boundedcontext/auth/app/dto/request/SocialOauthLoginRequest.java
@@ -7,5 +7,4 @@ import jakarta.validation.constraints.NotNull;
 // 클라이언트 -> 서버
 public record SocialOauthLoginRequest(
     @NotNull(message = "소셜 제공자는 필수입니다.") SocialProvider provider,
-    @NotBlank(message = "인가 코드는 필수입니다.") String code,
-    @NotBlank(message = "redirect Uri는 필수입니다.") String redirectUri) {}
+    @NotBlank(message = "인가 코드는 필수입니다.") String code) {}

--- a/auth-service/src/main/java/com/ticketrush/boundedcontext/auth/app/dto/response/NaverUserInfoResponse.java
+++ b/auth-service/src/main/java/com/ticketrush/boundedcontext/auth/app/dto/response/NaverUserInfoResponse.java
@@ -1,0 +1,6 @@
+package com.ticketrush.boundedcontext.auth.app.dto.response;
+
+public record NaverUserInfoResponse(String resultcode, String message, Response response) {
+
+  public record Response(String id, String name) {}
+}

--- a/auth-service/src/main/java/com/ticketrush/boundedcontext/auth/app/facade/AuthFacade.java
+++ b/auth-service/src/main/java/com/ticketrush/boundedcontext/auth/app/facade/AuthFacade.java
@@ -27,9 +27,9 @@ public class AuthFacade {
   private final ProviderParser providerParser;
 
   // OAuth 로그인 URL 생성
-  public String getOAuthLoginUrl(String provider, String redirectUri) {
+  public String getOAuthLoginUrl(String provider) {
     SocialProvider socialProvider = providerParser.parse(provider);
-    return oauthLoginUrlUseCase.generateOAuthUrl(socialProvider, redirectUri);
+    return oauthLoginUrlUseCase.generateOAuthUrl(socialProvider);
   }
 
   // 소셜 로그인 + JWT 발급

--- a/auth-service/src/main/java/com/ticketrush/boundedcontext/auth/app/usecase/OauthLoginUrlUseCase.java
+++ b/auth-service/src/main/java/com/ticketrush/boundedcontext/auth/app/usecase/OauthLoginUrlUseCase.java
@@ -17,32 +17,32 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class OauthLoginUrlUseCase {
+
   private final SocialOauthApiClientFactory socialOauthApiClientFactory;
   private final AuthSecurityProperties securityProperties;
 
   // 어느 provider로 로그인할 지를 받아서 그 로그인에 필요한 OAuth 인증 URL을 만들어 반환
-  public String generateOAuthUrl(SocialProvider provider, String redirectUri) {
+  public String generateOAuthUrl(SocialProvider provider) {
 
-    SocialOauthApiClient service = socialOauthApiClientFactory.getClient(provider);
+    SocialOauthApiClient oauthClient = socialOauthApiClientFactory.getClient(provider);
 
-    if (redirectUri == null) {
-      redirectUri = service.getDefaultRedirectUri();
-    }
+    String redirectUri = oauthClient.getDefaultRedirectUri();
 
     validateRedirectUri(redirectUri);
 
-    return socialOauthApiClientFactory.getClient(provider).generateOAuthUrl(redirectUri);
+    return oauthClient.generateOAuthUrl();
   }
 
   private void validateRedirectUri(String redirectUri) {
-    if (redirectUri == null) {
-      return;
+
+    if (redirectUri == null || redirectUri.isBlank()) {
+      throw new BusinessException(ErrorStatus.AUTH_OAUTH_INVALID_REDIRECT_URI);
     }
 
     List<String> allowedRedirectDomains =
         securityProperties.getOauth2().getAllowedRedirectDomains();
 
-    if (allowedRedirectDomains.isEmpty()) {
+    if (allowedRedirectDomains == null || allowedRedirectDomains.isEmpty()) {
       throw new BusinessException(ErrorStatus.AUTH_OAUTH_INVALID_REDIRECT_URI);
     }
 
@@ -54,7 +54,8 @@ public class OauthLoginUrlUseCase {
     }
 
     String host = uri.getHost();
-    if (host == null) {
+
+    if (host == null || host.isBlank()) {
       throw new BusinessException(ErrorStatus.AUTH_OAUTH_INVALID_REDIRECT_URI);
     }
 

--- a/auth-service/src/main/java/com/ticketrush/boundedcontext/auth/app/usecase/SocialOauthLoginUseCase.java
+++ b/auth-service/src/main/java/com/ticketrush/boundedcontext/auth/app/usecase/SocialOauthLoginUseCase.java
@@ -13,11 +13,9 @@ import com.ticketrush.global.security.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Component
-@Transactional(readOnly = true)
 @RequiredArgsConstructor
 /*
 1. provider에 맞는 OAuth 서비스 선택

--- a/auth-service/src/main/java/com/ticketrush/boundedcontext/auth/app/usecase/SocialOauthLoginUseCase.java
+++ b/auth-service/src/main/java/com/ticketrush/boundedcontext/auth/app/usecase/SocialOauthLoginUseCase.java
@@ -37,7 +37,7 @@ public class SocialOauthLoginUseCase {
     // 1. OAuth 사용자 정보 조회
     SocialOauthApiClient oauthClient = socialOauthApiClientFactory.getClient(request.provider());
 
-    SocialUserInfo socialUserInfo = oauthClient.getUserInfo(request.code(), request.redirectUri());
+    SocialUserInfo socialUserInfo = oauthClient.getUserInfo(request.code());
 
     // 2. user-service 호출
     UserServiceSocialLoginResponse userResponse =

--- a/auth-service/src/main/java/com/ticketrush/boundedcontext/auth/in/api/v1/AuthController.java
+++ b/auth-service/src/main/java/com/ticketrush/boundedcontext/auth/in/api/v1/AuthController.java
@@ -21,7 +21,6 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Slf4j
@@ -34,10 +33,9 @@ public class AuthController {
 
   @Operation(summary = "OAuth2 로그인 URL 조회", description = "OAuth2 로그인 URL을 반환합니다.")
   @GetMapping("/oauth/{provider}/url")
-  public ResponseEntity<ApiResponse<String>> getOAuthLoginUrl(
-      @PathVariable String provider, @RequestParam String redirectUri) {
+  public ResponseEntity<ApiResponse<String>> getOAuthLoginUrl(@PathVariable String provider) {
 
-    String url = authFacade.getOAuthLoginUrl(provider, redirectUri);
+    String url = authFacade.getOAuthLoginUrl(provider);
     return ApiResponse.onSuccess(SuccessStatus.OK, url);
   }
 

--- a/auth-service/src/main/java/com/ticketrush/boundedcontext/auth/out/apiclient/GoogleOauthApiClient.java
+++ b/auth-service/src/main/java/com/ticketrush/boundedcontext/auth/out/apiclient/GoogleOauthApiClient.java
@@ -37,15 +37,12 @@ public class GoogleOauthApiClient implements SocialOauthApiClient {
   }
 
   @Override
-  public SocialUserInfo getUserInfo(String code, String redirectUri) {
+  public SocialUserInfo getUserInfo(String code) {
 
     try {
 
-      // redirectUri가 없으면 기본값 사용
-      String uri = redirectUri != null ? redirectUri : defaultRedirectUri;
-
       // 1. 인가 코드로 access token 요청
-      OauthTokenResponse tokenResponse = requestToken(code, uri);
+      OauthTokenResponse tokenResponse = requestToken(code, defaultRedirectUri);
 
       if (tokenResponse == null || tokenResponse.accessToken() == null) {
         throw new BusinessException(ErrorStatus.AUTH_GOOGLE_TOKEN_FAILED);
@@ -59,8 +56,7 @@ public class GoogleOauthApiClient implements SocialOauthApiClient {
       }
 
       // 3. 공통 객체로 변환
-      return new SocialUserInfo(
-          userInfoResponse.id(), SocialProvider.GOOGLE, userInfoResponse.name());
+      return new SocialUserInfo(userInfoResponse.id(), getProvider(), userInfoResponse.name());
 
     } catch (BusinessException e) {
 
@@ -74,13 +70,11 @@ public class GoogleOauthApiClient implements SocialOauthApiClient {
   }
 
   @Override
-  public String generateOAuthUrl(String redirectUri) {
-
-    String uri = redirectUri != null ? redirectUri : defaultRedirectUri;
+  public String generateOAuthUrl() {
 
     return UriComponentsBuilder.fromUriString("https://accounts.google.com/o/oauth2/v2/auth")
         .queryParam("client_id", clientId)
-        .queryParam("redirect_uri", uri)
+        .queryParam("redirect_uri", defaultRedirectUri)
         .queryParam("response_type", "code")
         .queryParam("scope", "profile")
         .build()

--- a/auth-service/src/main/java/com/ticketrush/boundedcontext/auth/out/apiclient/GoogleOauthApiClient.java
+++ b/auth-service/src/main/java/com/ticketrush/boundedcontext/auth/out/apiclient/GoogleOauthApiClient.java
@@ -31,6 +31,15 @@ public class GoogleOauthApiClient implements SocialOauthApiClient {
   @Value("${oauth.google.redirect-uri}")
   private String defaultRedirectUri;
 
+  @Value("${oauth.google.auth-uri}")
+  private String authUri;
+
+  @Value("${oauth.google.token-uri}")
+  private String tokenUri;
+
+  @Value("${oauth.google.user-info-uri}")
+  private String userInfoUri;
+
   @Override
   public SocialProvider getProvider() {
     return SocialProvider.GOOGLE;
@@ -72,7 +81,7 @@ public class GoogleOauthApiClient implements SocialOauthApiClient {
   @Override
   public String generateOAuthUrl() {
 
-    return UriComponentsBuilder.fromUriString("https://accounts.google.com/o/oauth2/v2/auth")
+    return UriComponentsBuilder.fromUriString(authUri)
         .queryParam("client_id", clientId)
         .queryParam("redirect_uri", defaultRedirectUri)
         .queryParam("response_type", "code")
@@ -90,7 +99,7 @@ public class GoogleOauthApiClient implements SocialOauthApiClient {
 
     return restClient
         .post()
-        .uri("https://oauth2.googleapis.com/token")
+        .uri(tokenUri)
         .contentType(MediaType.APPLICATION_FORM_URLENCODED)
         .body(
             "code="
@@ -110,7 +119,7 @@ public class GoogleOauthApiClient implements SocialOauthApiClient {
 
     return restClient
         .get()
-        .uri("https://www.googleapis.com/oauth2/v2/userinfo")
+        .uri(userInfoUri)
         .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
         .retrieve()
         .body(GoogleUserInfoResponse.class);

--- a/auth-service/src/main/java/com/ticketrush/boundedcontext/auth/out/apiclient/KakaoOauthApiClient.java
+++ b/auth-service/src/main/java/com/ticketrush/boundedcontext/auth/out/apiclient/KakaoOauthApiClient.java
@@ -10,13 +10,13 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.MediaType;
-import org.springframework.stereotype.Service;
+import org.springframework.stereotype.Component;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestClient;
 
 @Slf4j
-@Service
+@Component
 @RequiredArgsConstructor
 public class KakaoOauthApiClient implements SocialOauthApiClient {
 

--- a/auth-service/src/main/java/com/ticketrush/boundedcontext/auth/out/apiclient/KakaoOauthApiClient.java
+++ b/auth-service/src/main/java/com/ticketrush/boundedcontext/auth/out/apiclient/KakaoOauthApiClient.java
@@ -80,11 +80,11 @@ public class KakaoOauthApiClient implements SocialOauthApiClient {
   public String generateOAuthUrl() {
 
     return UriComponentsBuilder.fromUriString(authUri)
-      .queryParam("client_id", clientId)
-      .queryParam("redirect_uri", redirectUri)
-      .queryParam("response_type", "code")
-      .build()
-      .toUriString();
+        .queryParam("client_id", clientId)
+        .queryParam("redirect_uri", redirectUri)
+        .queryParam("response_type", "code")
+        .build()
+        .toUriString();
   }
 
   private OauthTokenResponse getToken(String code) {

--- a/auth-service/src/main/java/com/ticketrush/boundedcontext/auth/out/apiclient/KakaoOauthApiClient.java
+++ b/auth-service/src/main/java/com/ticketrush/boundedcontext/auth/out/apiclient/KakaoOauthApiClient.java
@@ -14,6 +14,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestClient;
+import org.springframework.web.util.UriComponentsBuilder;
 
 @Slf4j
 @Component
@@ -36,6 +37,9 @@ public class KakaoOauthApiClient implements SocialOauthApiClient {
 
   @Value("${oauth.kakao.user-info-uri}")
   private String userInfoUri;
+
+  @Value("${oauth.kakao.auth-uri}")
+  private String authUri;
 
   @Override
   public SocialProvider getProvider() {
@@ -75,12 +79,12 @@ public class KakaoOauthApiClient implements SocialOauthApiClient {
   @Override
   public String generateOAuthUrl() {
 
-    return "https://kauth.kakao.com/oauth/authorize"
-        + "?client_id="
-        + clientId
-        + "&redirect_uri="
-        + redirectUri
-        + "&response_type=code";
+    return UriComponentsBuilder.fromUriString(authUri)
+      .queryParam("client_id", clientId)
+      .queryParam("redirect_uri", redirectUri)
+      .queryParam("response_type", "code")
+      .build()
+      .toUriString();
   }
 
   private OauthTokenResponse getToken(String code) {

--- a/auth-service/src/main/java/com/ticketrush/boundedcontext/auth/out/apiclient/KakaoOauthApiClient.java
+++ b/auth-service/src/main/java/com/ticketrush/boundedcontext/auth/out/apiclient/KakaoOauthApiClient.java
@@ -10,13 +10,13 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.MediaType;
-import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestClient;
 
 @Slf4j
-@Component
+@Service
 @RequiredArgsConstructor
 public class KakaoOauthApiClient implements SocialOauthApiClient {
 
@@ -29,7 +29,7 @@ public class KakaoOauthApiClient implements SocialOauthApiClient {
   private String clientSecret;
 
   @Value("${oauth.kakao.redirect-uri}")
-  private String defaultRedirectUri;
+  private String redirectUri;
 
   @Value("${oauth.kakao.token-uri}")
   private String tokenUri;
@@ -43,14 +43,9 @@ public class KakaoOauthApiClient implements SocialOauthApiClient {
   }
 
   @Override
-  public SocialUserInfo getUserInfo(String code, String redirectUri) {
-
+  public SocialUserInfo getUserInfo(String code) {
     try {
-
-      // redirectUri가 없으면 기본값 사용
-      String uri = redirectUri != null ? redirectUri : defaultRedirectUri;
-
-      OauthTokenResponse tokenResponse = getToken(code, uri);
+      OauthTokenResponse tokenResponse = getToken(code);
 
       if (tokenResponse == null || tokenResponse.accessToken() == null) {
         throw new BusinessException(ErrorStatus.AUTH_KAKAO_TOKEN_FAILED);
@@ -63,7 +58,6 @@ public class KakaoOauthApiClient implements SocialOauthApiClient {
       }
 
       String socialId = String.valueOf(userInfoResponse.id());
-
       String nickname =
           userInfoResponse.properties() != null ? userInfoResponse.properties().nickname() : null;
 
@@ -72,35 +66,30 @@ public class KakaoOauthApiClient implements SocialOauthApiClient {
     } catch (BusinessException e) {
 
       throw e;
-
     } catch (Exception e) {
-
       log.error("Kakao OAuth 처리 중 에러 발생", e);
       throw new BusinessException(ErrorStatus.AUTH_KAKAO_INFO_FAILED);
     }
   }
 
   @Override
-  public String generateOAuthUrl(String redirectUri) {
-
-    String uri = redirectUri != null ? redirectUri : defaultRedirectUri;
+  public String generateOAuthUrl() {
 
     return "https://kauth.kakao.com/oauth/authorize"
         + "?client_id="
         + clientId
         + "&redirect_uri="
-        + uri
+        + redirectUri
         + "&response_type=code";
   }
 
-  private OauthTokenResponse getToken(String code, String redirectUri) {
+  private OauthTokenResponse getToken(String code) {
 
     log.info("clientId = {}", clientId);
     log.info("clientSecret = {}", clientSecret);
     log.info("redirectUri = {}", redirectUri);
 
     MultiValueMap<String, String> form = new LinkedMultiValueMap<>();
-
     form.add("grant_type", "authorization_code");
     form.add("client_id", clientId);
     form.add("client_secret", clientSecret);
@@ -117,7 +106,6 @@ public class KakaoOauthApiClient implements SocialOauthApiClient {
   }
 
   private KakaoUserInfoResponse getProfile(String accessToken) {
-
     return restClient
         .get()
         .uri(userInfoUri)
@@ -128,6 +116,6 @@ public class KakaoOauthApiClient implements SocialOauthApiClient {
 
   @Override
   public String getDefaultRedirectUri() {
-    return defaultRedirectUri;
+    return redirectUri;
   }
 }

--- a/auth-service/src/main/java/com/ticketrush/boundedcontext/auth/out/apiclient/NaverOauthApiClient.java
+++ b/auth-service/src/main/java/com/ticketrush/boundedcontext/auth/out/apiclient/NaverOauthApiClient.java
@@ -10,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.util.LinkedMultiValueMap;
@@ -51,21 +52,17 @@ public class NaverOauthApiClient implements SocialOauthApiClient {
   public SocialUserInfo getUserInfo(String code) {
 
     try {
-
-      // 1. 인가 코드로 access token 요청
       OauthTokenResponse tokenResponse = getToken(code, defaultRedirectUri);
 
       if (tokenResponse == null || tokenResponse.accessToken() == null) {
         throw new BusinessException(ErrorStatus.AUTH_NAVER_TOKEN_FAILED);
       }
 
-      // 2. access token으로 사용자 정보 요청
       NaverUserInfoResponse userInfoResponse = getProfile(tokenResponse.accessToken());
 
       if (userInfoResponse == null
-          || userInfoResponse.response() == null
-          || userInfoResponse.response().id() == null) {
-
+        || userInfoResponse.response() == null
+        || userInfoResponse.response().id() == null) {
         throw new BusinessException(ErrorStatus.AUTH_NAVER_INFO_FAILED);
       }
 
@@ -75,12 +72,10 @@ public class NaverOauthApiClient implements SocialOauthApiClient {
       return new SocialUserInfo(socialId, getProvider(), nickname);
 
     } catch (BusinessException e) {
-
       throw e;
 
     } catch (Exception e) {
-
-      log.error("Naver OAuth 처리 중 에러 발생", e);
+      log.error("Naver OAuth 처리 중 예상하지 못한 에러 발생", e);
       throw new BusinessException(ErrorStatus.AUTH_NAVER_INFO_FAILED);
     }
   }
@@ -88,22 +83,17 @@ public class NaverOauthApiClient implements SocialOauthApiClient {
   @Override
   public String generateOAuthUrl() {
 
-    log.info("NAVER clientId = {}", clientId);
-    log.info("NAVER redirectUri = {}", defaultRedirectUri);
-
     return UriComponentsBuilder.fromUriString(authorizationUri)
-        .queryParam("response_type", "code")
-        .queryParam("client_id", clientId)
-        .queryParam("redirect_uri", defaultRedirectUri)
-        .queryParam("state", "test")
-        .build()
-        .encode()
-        .toUriString();
+      .queryParam("response_type", "code")
+      .queryParam("client_id", clientId)
+      .queryParam("redirect_uri", defaultRedirectUri)
+      .queryParam("state", "test")
+      .build()
+      .encode()
+      .toUriString();
   }
 
   private OauthTokenResponse getToken(String code, String redirectUri) {
-
-    log.info("NAVER token 요청 redirectUri = {}", redirectUri);
 
     MultiValueMap<String, String> form = new LinkedMultiValueMap<>();
 
@@ -115,22 +105,54 @@ public class NaverOauthApiClient implements SocialOauthApiClient {
     form.add("state", "test");
 
     return restClient
-        .post()
-        .uri(tokenUri)
-        .contentType(MediaType.APPLICATION_FORM_URLENCODED)
-        .body(form)
-        .retrieve()
-        .body(OauthTokenResponse.class);
+      .post()
+      .uri(tokenUri)
+      .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+      .body(form)
+      .retrieve()
+      .onStatus(
+        HttpStatusCode::is4xxClientError,
+        (request, response) -> {
+          log.warn(
+            "Naver OAuth 토큰 발급 요청 실패 - 클라이언트 오류. status={}",
+            response.getStatusCode());
+          throw new BusinessException(ErrorStatus.AUTH_NAVER_TOKEN_FAILED);
+        })
+      .onStatus(
+        HttpStatusCode::is5xxServerError,
+        (request, response) -> {
+          log.error(
+            "Naver OAuth 토큰 발급 요청 실패 - 서버 오류. status={}",
+            response.getStatusCode());
+          throw new BusinessException(ErrorStatus.AUTH_NAVER_TOKEN_FAILED);
+        })
+      .body(OauthTokenResponse.class);
   }
 
   private NaverUserInfoResponse getProfile(String accessToken) {
 
     return restClient
-        .get()
-        .uri(userInfoUri)
-        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
-        .retrieve()
-        .body(NaverUserInfoResponse.class);
+      .get()
+      .uri(userInfoUri)
+      .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+      .retrieve()
+      .onStatus(
+        HttpStatusCode::is4xxClientError,
+        (request, response) -> {
+          log.warn(
+            "Naver OAuth 사용자 정보 조회 실패 - 클라이언트 오류. status={}",
+            response.getStatusCode());
+          throw new BusinessException(ErrorStatus.AUTH_NAVER_INFO_FAILED);
+        })
+      .onStatus(
+        HttpStatusCode::is5xxServerError,
+        (request, response) -> {
+          log.error(
+            "Naver OAuth 사용자 정보 조회 실패 - 서버 오류. status={}",
+            response.getStatusCode());
+          throw new BusinessException(ErrorStatus.AUTH_NAVER_INFO_FAILED);
+        })
+      .body(NaverUserInfoResponse.class);
   }
 
   @Override

--- a/auth-service/src/main/java/com/ticketrush/boundedcontext/auth/out/apiclient/NaverOauthApiClient.java
+++ b/auth-service/src/main/java/com/ticketrush/boundedcontext/auth/out/apiclient/NaverOauthApiClient.java
@@ -61,8 +61,8 @@ public class NaverOauthApiClient implements SocialOauthApiClient {
       NaverUserInfoResponse userInfoResponse = getProfile(tokenResponse.accessToken());
 
       if (userInfoResponse == null
-        || userInfoResponse.response() == null
-        || userInfoResponse.response().id() == null) {
+          || userInfoResponse.response() == null
+          || userInfoResponse.response().id() == null) {
         throw new BusinessException(ErrorStatus.AUTH_NAVER_INFO_FAILED);
       }
 
@@ -84,13 +84,13 @@ public class NaverOauthApiClient implements SocialOauthApiClient {
   public String generateOAuthUrl() {
 
     return UriComponentsBuilder.fromUriString(authorizationUri)
-      .queryParam("response_type", "code")
-      .queryParam("client_id", clientId)
-      .queryParam("redirect_uri", defaultRedirectUri)
-      .queryParam("state", "test")
-      .build()
-      .encode()
-      .toUriString();
+        .queryParam("response_type", "code")
+        .queryParam("client_id", clientId)
+        .queryParam("redirect_uri", defaultRedirectUri)
+        .queryParam("state", "test")
+        .build()
+        .encode()
+        .toUriString();
   }
 
   private OauthTokenResponse getToken(String code, String redirectUri) {
@@ -105,54 +105,46 @@ public class NaverOauthApiClient implements SocialOauthApiClient {
     form.add("state", "test");
 
     return restClient
-      .post()
-      .uri(tokenUri)
-      .contentType(MediaType.APPLICATION_FORM_URLENCODED)
-      .body(form)
-      .retrieve()
-      .onStatus(
-        HttpStatusCode::is4xxClientError,
-        (request, response) -> {
-          log.warn(
-            "Naver OAuth 토큰 발급 요청 실패 - 클라이언트 오류. status={}",
-            response.getStatusCode());
-          throw new BusinessException(ErrorStatus.AUTH_NAVER_TOKEN_FAILED);
-        })
-      .onStatus(
-        HttpStatusCode::is5xxServerError,
-        (request, response) -> {
-          log.error(
-            "Naver OAuth 토큰 발급 요청 실패 - 서버 오류. status={}",
-            response.getStatusCode());
-          throw new BusinessException(ErrorStatus.AUTH_NAVER_TOKEN_FAILED);
-        })
-      .body(OauthTokenResponse.class);
+        .post()
+        .uri(tokenUri)
+        .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+        .body(form)
+        .retrieve()
+        .onStatus(
+            HttpStatusCode::is4xxClientError,
+            (request, response) -> {
+              log.warn("Naver OAuth 토큰 발급 요청 실패 - 클라이언트 오류. status={}", response.getStatusCode());
+              throw new BusinessException(ErrorStatus.AUTH_NAVER_TOKEN_FAILED);
+            })
+        .onStatus(
+            HttpStatusCode::is5xxServerError,
+            (request, response) -> {
+              log.error("Naver OAuth 토큰 발급 요청 실패 - 서버 오류. status={}", response.getStatusCode());
+              throw new BusinessException(ErrorStatus.AUTH_NAVER_TOKEN_FAILED);
+            })
+        .body(OauthTokenResponse.class);
   }
 
   private NaverUserInfoResponse getProfile(String accessToken) {
 
     return restClient
-      .get()
-      .uri(userInfoUri)
-      .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
-      .retrieve()
-      .onStatus(
-        HttpStatusCode::is4xxClientError,
-        (request, response) -> {
-          log.warn(
-            "Naver OAuth 사용자 정보 조회 실패 - 클라이언트 오류. status={}",
-            response.getStatusCode());
-          throw new BusinessException(ErrorStatus.AUTH_NAVER_INFO_FAILED);
-        })
-      .onStatus(
-        HttpStatusCode::is5xxServerError,
-        (request, response) -> {
-          log.error(
-            "Naver OAuth 사용자 정보 조회 실패 - 서버 오류. status={}",
-            response.getStatusCode());
-          throw new BusinessException(ErrorStatus.AUTH_NAVER_INFO_FAILED);
-        })
-      .body(NaverUserInfoResponse.class);
+        .get()
+        .uri(userInfoUri)
+        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+        .retrieve()
+        .onStatus(
+            HttpStatusCode::is4xxClientError,
+            (request, response) -> {
+              log.warn("Naver OAuth 사용자 정보 조회 실패 - 클라이언트 오류. status={}", response.getStatusCode());
+              throw new BusinessException(ErrorStatus.AUTH_NAVER_INFO_FAILED);
+            })
+        .onStatus(
+            HttpStatusCode::is5xxServerError,
+            (request, response) -> {
+              log.error("Naver OAuth 사용자 정보 조회 실패 - 서버 오류. status={}", response.getStatusCode());
+              throw new BusinessException(ErrorStatus.AUTH_NAVER_INFO_FAILED);
+            })
+        .body(NaverUserInfoResponse.class);
   }
 
   @Override

--- a/auth-service/src/main/java/com/ticketrush/boundedcontext/auth/out/apiclient/NaverOauthApiClient.java
+++ b/auth-service/src/main/java/com/ticketrush/boundedcontext/auth/out/apiclient/NaverOauthApiClient.java
@@ -1,0 +1,140 @@
+package com.ticketrush.boundedcontext.auth.out.apiclient;
+
+import com.ticketrush.boundedcontext.auth.app.dto.response.NaverUserInfoResponse;
+import com.ticketrush.boundedcontext.auth.app.dto.response.OauthTokenResponse;
+import com.ticketrush.boundedcontext.auth.domain.types.SocialProvider;
+import com.ticketrush.boundedcontext.auth.domain.types.SocialUserInfo;
+import com.ticketrush.global.exception.BusinessException;
+import com.ticketrush.global.status.ErrorStatus;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class NaverOauthApiClient implements SocialOauthApiClient {
+
+  private final RestClient restClient;
+
+  @Value("${oauth.naver.client-id}")
+  private String clientId;
+
+  @Value("${oauth.naver.client-secret}")
+  private String clientSecret;
+
+  @Value("${oauth.naver.redirect-uri}")
+  private String defaultRedirectUri;
+
+  @Value("${oauth.naver.authorization-uri}")
+  private String authorizationUri;
+
+  @Value("${oauth.naver.token-uri}")
+  private String tokenUri;
+
+  @Value("${oauth.naver.user-info-uri}")
+  private String userInfoUri;
+
+  @Override
+  public SocialProvider getProvider() {
+    return SocialProvider.NAVER;
+  }
+
+  @Override
+  public SocialUserInfo getUserInfo(String code) {
+
+    try {
+
+      // 1. 인가 코드로 access token 요청
+      OauthTokenResponse tokenResponse = getToken(code, defaultRedirectUri);
+
+      if (tokenResponse == null || tokenResponse.accessToken() == null) {
+        throw new BusinessException(ErrorStatus.AUTH_NAVER_TOKEN_FAILED);
+      }
+
+      // 2. access token으로 사용자 정보 요청
+      NaverUserInfoResponse userInfoResponse = getProfile(tokenResponse.accessToken());
+
+      if (userInfoResponse == null
+          || userInfoResponse.response() == null
+          || userInfoResponse.response().id() == null) {
+
+        throw new BusinessException(ErrorStatus.AUTH_NAVER_INFO_FAILED);
+      }
+
+      String socialId = userInfoResponse.response().id();
+      String nickname = userInfoResponse.response().name();
+
+      return new SocialUserInfo(socialId, getProvider(), nickname);
+
+    } catch (BusinessException e) {
+
+      throw e;
+
+    } catch (Exception e) {
+
+      log.error("Naver OAuth 처리 중 에러 발생", e);
+      throw new BusinessException(ErrorStatus.AUTH_NAVER_INFO_FAILED);
+    }
+  }
+
+  @Override
+  public String generateOAuthUrl() {
+
+    log.info("NAVER clientId = {}", clientId);
+    log.info("NAVER redirectUri = {}", defaultRedirectUri);
+
+    return UriComponentsBuilder.fromUriString(authorizationUri)
+        .queryParam("response_type", "code")
+        .queryParam("client_id", clientId)
+        .queryParam("redirect_uri", defaultRedirectUri)
+        .queryParam("state", "test")
+        .build()
+        .encode()
+        .toUriString();
+  }
+
+  private OauthTokenResponse getToken(String code, String redirectUri) {
+
+    log.info("NAVER token 요청 redirectUri = {}", redirectUri);
+
+    MultiValueMap<String, String> form = new LinkedMultiValueMap<>();
+
+    form.add("grant_type", "authorization_code");
+    form.add("client_id", clientId);
+    form.add("client_secret", clientSecret);
+    form.add("redirect_uri", redirectUri);
+    form.add("code", code);
+    form.add("state", "test");
+
+    return restClient
+        .post()
+        .uri(tokenUri)
+        .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+        .body(form)
+        .retrieve()
+        .body(OauthTokenResponse.class);
+  }
+
+  private NaverUserInfoResponse getProfile(String accessToken) {
+
+    return restClient
+        .get()
+        .uri(userInfoUri)
+        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+        .retrieve()
+        .body(NaverUserInfoResponse.class);
+  }
+
+  @Override
+  public String getDefaultRedirectUri() {
+    return defaultRedirectUri;
+  }
+}

--- a/auth-service/src/main/java/com/ticketrush/boundedcontext/auth/out/apiclient/SocialOauthApiClient.java
+++ b/auth-service/src/main/java/com/ticketrush/boundedcontext/auth/out/apiclient/SocialOauthApiClient.java
@@ -7,9 +7,9 @@ public interface SocialOauthApiClient {
 
   SocialProvider getProvider();
 
-  SocialUserInfo getUserInfo(String code, String redirectUri);
+  SocialUserInfo getUserInfo(String code);
 
-  String generateOAuthUrl(String redirectUri);
+  String generateOAuthUrl();
 
   String getDefaultRedirectUri();
 }

--- a/auth-service/src/main/resources/application-local.yml
+++ b/auth-service/src/main/resources/application-local.yml
@@ -23,6 +23,9 @@ oauth:
     client-id: ${GOOGLE_CLIENT_ID}
     client-secret: ${GOOGLE_CLIENT_SECRET}
     redirect-uri: ${GOOGLE_REDIRECT_URI}
+    auth-uri: https://accounts.google.com/o/oauth2/v2/auth
+    token-uri: https://oauth2.googleapis.com/token
+    user-info-uri: https://www.googleapis.com/oauth2/v2/userinfo
 
   naver:
     client-id: ${NAVER_CLIENT_ID}

--- a/auth-service/src/main/resources/application-local.yml
+++ b/auth-service/src/main/resources/application-local.yml
@@ -19,6 +19,19 @@ oauth:
     token-uri: https://kauth.kakao.com/oauth/token
     user-info-uri: https://kapi.kakao.com/v2/user/me
 
+  google:
+    client-id: ${GOOGLE_CLIENT_ID}
+    client-secret: ${GOOGLE_CLIENT_SECRET}
+    redirect-uri: ${GOOGLE_REDIRECT_URI}
+
+  naver:
+    client-id: ${NAVER_CLIENT_ID}
+    client-secret: ${NAVER_CLIENT_SECRET}
+    redirect-uri: ${NAVER_REDIRECT_URI}
+    authorization-uri: https://nid.naver.com/oauth2.0/authorize
+    token-uri: https://nid.naver.com/oauth2.0/token
+    user-info-uri: https://openapi.naver.com/v1/nid/me
+
 app:
   event-publisher:
     type: kafka

--- a/auth-service/src/main/resources/application-local.yml
+++ b/auth-service/src/main/resources/application-local.yml
@@ -18,6 +18,7 @@ oauth:
     redirect-uri: ${KAKAO_REDIRECT_URI}
     token-uri: https://kauth.kakao.com/oauth/token
     user-info-uri: https://kapi.kakao.com/v2/user/me
+    auth-uri: https://kauth.kakao.com/oauth/authorize
 
   google:
     client-id: ${GOOGLE_CLIENT_ID}

--- a/auth-service/src/main/resources/application.yml
+++ b/auth-service/src/main/resources/application.yml
@@ -16,9 +16,16 @@ oauth:
     user-name-attribute: id
 
   google:
-    client-id: ${GOOGLE_CLIENT_ID}
-    client-secret: ${GOOGLE_CLIENT_SECRET}
-    redirect-uri: ${GOOGLE_REDIRECT_URI}
+    authorization-uri: https://accounts.google.com/o/oauth2/v2/auth
+    token-uri: https://oauth2.googleapis.com/token
+    user-info-uri: https://www.googleapis.com/oauth2/v2/userinfo
+
+
+  naver:
+    authorization-uri: https://nid.naver.com/oauth2.0/authorize
+    token-uri: https://nid.naver.com/oauth2.0/token
+    user-info-uri: https://openapi.naver.com/v1/nid/me
+    user-name-attribute: response
 
 custom:
   global:

--- a/common/src/main/java/com/ticketrush/global/status/ErrorStatus.java
+++ b/common/src/main/java/com/ticketrush/global/status/ErrorStatus.java
@@ -32,6 +32,8 @@ public enum ErrorStatus {
       HttpStatus.BAD_REQUEST, "AUTH_400_004", "유효하지 않은 Redirect URI입니다."),
   AUTH_GOOGLE_TOKEN_FAILED(HttpStatus.BAD_REQUEST, "AUTH_400_005", "잘못된 구글 토큰입니다."),
   AUTH_GOOGLE_INFO_FAILED(HttpStatus.BAD_REQUEST, "AUTH_400_006", "잘못된 구글 정보입니다."),
+  AUTH_NAVER_TOKEN_FAILED(HttpStatus.BAD_REQUEST, "AUTH_400_007", "네이버 토큰 요청에 실패했습니다."),
+  AUTH_NAVER_INFO_FAILED(HttpStatus.BAD_REQUEST, "AUTH_400_008", "네이버 사용자 정보 조회에 실패했습니다."),
 
   // Auth 401
   AUTH_INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH_401_001", "유효하지 않은 Refresh Token입니다."),

--- a/common/src/main/java/com/ticketrush/global/status/ErrorStatus.java
+++ b/common/src/main/java/com/ticketrush/global/status/ErrorStatus.java
@@ -34,6 +34,7 @@ public enum ErrorStatus {
   AUTH_GOOGLE_INFO_FAILED(HttpStatus.BAD_REQUEST, "AUTH_400_006", "잘못된 구글 정보입니다."),
   AUTH_NAVER_TOKEN_FAILED(HttpStatus.BAD_REQUEST, "AUTH_400_007", "네이버 토큰 요청에 실패했습니다."),
   AUTH_NAVER_INFO_FAILED(HttpStatus.BAD_REQUEST, "AUTH_400_008", "네이버 사용자 정보 조회에 실패했습니다."),
+  AUTH_KAKAO_INFO_FAILED(HttpStatus.NOT_FOUND, "AUTH_400_009", "카카오 사용자 정보 조회를 실패하였습니다."),
 
   // Auth 401
   AUTH_INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH_401_001", "유효하지 않은 Refresh Token입니다."),
@@ -44,9 +45,6 @@ public enum ErrorStatus {
 
   // Auth 403
   AUTH_ACCESS_DENIED(HttpStatus.FORBIDDEN, "AUTH_403_001", "접근 권한이 없습니다."),
-
-  // Auth 404
-  AUTH_KAKAO_INFO_FAILED(HttpStatus.NOT_FOUND, "AUTH_404_001", "카카오 사용자 정보 조회를 실패하였습니다."),
 
   // Auth 500
   AUTH_USER_SERVER_ERROR(


### PR DESCRIPTION
## 🔗 관련 이슈

- close #164 

---

## 📌 주요 변경 사항

- OauthLoginUrlUseCase 에서 redirect uri를 request 파라미터에서 제외하여 provider만 입력해도 바로 url를 응답받을 수 있도록 수정하였습니다. 
- 위의 사항을 반영하여 SocialOauthApiClient들은 모두 redirect url를 받지 않도록 수정하였습니다.
- 

---

## 🛠 상세 구현 내용

- Naver Social Login을 구현하였습니다. 
- NaverOauthApiClient 를 추가하였습니다. 검증 로직 또한 카카오, 구글과 비슷하게 구현하였습니다. 
- Naver, Kakao, Google 모두 response 응답 포맷 형식이 다르기 때문에, NaverUserInfoResponse 추가하였습니다.

---

## ✅ 테스트

### 테스트 방법

- Swagger를 통해 테스트

### 테스트 결과

- LoginUrl, SocialLogin, Refresh Token 재발급 모두 테스트 결과 200으로 통과

### 📸 스크린샷
<img width="817" height="865" alt="image" src="https://github.com/user-attachments/assets/3488bdab-e2d1-4e72-a67f-7d3cf18c3d6c" />
<img width="824" height="724" alt="image" src="https://github.com/user-attachments/assets/f8415715-f756-4acf-86b9-1184eab918e9" />
<img width="822" height="670" alt="image" src="https://github.com/user-attachments/assets/baa0e779-cec5-41fe-9499-f3ea05de9326" />

---

<!--- ## 👀 리뷰 요청 사항

-

---

## ⚠️ 배포 시 주의사항

- 
--->