### PR TITLE
[Feat] #31 공연별 잔여 좌석 수 조회 API 구현

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -1,6 +1,7 @@
 plugins {
 	id 'java'
 	id 'java-library'
+	id 'java-test-fixtures'
 	id 'org.springframework.boot' version '4.0.3'
 	id 'io.spring.dependency-management' version '1.1.7'
 }
@@ -46,6 +47,7 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-security-test'
 	testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	testFixturesImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
 
 	// swagger
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.1'

--- a/common/src/testFixtures/java/com/ticketrush/support/WebMvcSliceTest.java
+++ b/common/src/testFixtures/java/com/ticketrush/support/WebMvcSliceTest.java
@@ -1,0 +1,20 @@
+package com.ticketrush.support;
+
+import com.ticketrush.global.config.JacksonConfig;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.core.annotation.AliasFor;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@WebMvcTest
+@Import(JacksonConfig.class)
+public @interface WebMvcSliceTest {
+
+  @AliasFor(annotation = WebMvcTest.class, attribute = "controllers")
+  Class<?>[] value() default {};
+}

--- a/seat-service/build.gradle
+++ b/seat-service/build.gradle
@@ -44,6 +44,7 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
     testImplementation 'org.springframework.boot:spring-boot-starter-security-test'
     testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
+    testImplementation testFixtures(project(":common"))
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
     // swagger

--- a/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/app/dto/response/SeatAvailabilityResponse.java
+++ b/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/app/dto/response/SeatAvailabilityResponse.java
@@ -1,0 +1,3 @@
+package com.ticketrush.boundedcontext.seat.app.dto.response;
+
+public record SeatAvailabilityResponse(Long availableCount, Long totalCount) {}

--- a/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/app/facade/SeatFacade.java
+++ b/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/app/facade/SeatFacade.java
@@ -1,6 +1,8 @@
 package com.ticketrush.boundedcontext.seat.app.facade;
 
+import com.ticketrush.boundedcontext.seat.app.dto.response.SeatAvailabilityResponse;
 import com.ticketrush.boundedcontext.seat.app.dto.response.SeatLayoutResponse;
+import com.ticketrush.boundedcontext.seat.app.usecase.SeatGetAvailabilityUseCase;
 import com.ticketrush.boundedcontext.seat.app.usecase.SeatGetSeatLayoutsUseCase;
 import com.ticketrush.boundedcontext.seat.app.usecase.SeatHoldUseCase;
 import com.ticketrush.boundedcontext.seat.app.usecase.SeatLockUseCase;
@@ -19,6 +21,7 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class SeatFacade {
 
+  private final SeatGetAvailabilityUseCase seatGetAvailabilityUseCase;
   private final SeatGetSeatLayoutsUseCase seatGetSeatLayoutsUseCase;
   private final SeatHoldUseCase seatHoldUseCase;
   private final SeatLockUseCase seatLockUseCase;
@@ -27,6 +30,10 @@ public class SeatFacade {
 
   public List<SeatLayoutResponse> getPerformanceSeatLayouts(Long performanceId) {
     return seatGetSeatLayoutsUseCase.execute(performanceId);
+  }
+
+  public SeatAvailabilityResponse getPerformanceSeatAvailability(Long performanceId) {
+    return seatGetAvailabilityUseCase.execute(performanceId);
   }
 
   public void holdSeat(Long seatId, LocalDateTime holdExpiredAt) {

--- a/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/app/facade/SeatFacade.java
+++ b/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/app/facade/SeatFacade.java
@@ -2,8 +2,8 @@ package com.ticketrush.boundedcontext.seat.app.facade;
 
 import com.ticketrush.boundedcontext.seat.app.dto.response.SeatAvailabilityResponse;
 import com.ticketrush.boundedcontext.seat.app.dto.response.SeatLayoutResponse;
-import com.ticketrush.boundedcontext.seat.app.usecase.SeatGetAvailabilityUseCase;
 import com.ticketrush.boundedcontext.seat.app.usecase.SeatConfirmSoldUseCase;
+import com.ticketrush.boundedcontext.seat.app.usecase.SeatGetAvailabilityUseCase;
 import com.ticketrush.boundedcontext.seat.app.usecase.SeatGetSeatLayoutsUseCase;
 import com.ticketrush.boundedcontext.seat.app.usecase.SeatHoldUseCase;
 import com.ticketrush.boundedcontext.seat.app.usecase.SeatLockUseCase;

--- a/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/app/usecase/SeatGetAvailabilityUseCase.java
+++ b/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/app/usecase/SeatGetAvailabilityUseCase.java
@@ -1,0 +1,24 @@
+package com.ticketrush.boundedcontext.seat.app.usecase;
+
+import com.ticketrush.boundedcontext.seat.app.dto.response.SeatAvailabilityResponse;
+import com.ticketrush.boundedcontext.seat.out.repository.SeatRepository;
+import com.ticketrush.global.types.SeatStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class SeatGetAvailabilityUseCase {
+
+  private final SeatRepository seatRepository;
+
+  public SeatAvailabilityResponse execute(Long performanceId) {
+    Long availableCount =
+        seatRepository.countByPerformanceIdAndSeatStatus(performanceId, SeatStatus.AVAILABLE);
+    Long totalCount = seatRepository.countByPerformanceId(performanceId);
+
+    return new SeatAvailabilityResponse(availableCount, totalCount);
+  }
+}

--- a/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/app/usecase/SeatGetAvailabilityUseCase.java
+++ b/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/app/usecase/SeatGetAvailabilityUseCase.java
@@ -15,10 +15,6 @@ public class SeatGetAvailabilityUseCase {
   private final SeatRepository seatRepository;
 
   public SeatAvailabilityResponse execute(Long performanceId) {
-    Long availableCount =
-        seatRepository.countByPerformanceIdAndSeatStatus(performanceId, SeatStatus.AVAILABLE);
-    Long totalCount = seatRepository.countByPerformanceId(performanceId);
-
-    return new SeatAvailabilityResponse(availableCount, totalCount);
+    return seatRepository.countSeatAvailabilityByPerformanceId(performanceId, SeatStatus.AVAILABLE);
   }
 }

--- a/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/in/api/v1/SeatController.java
+++ b/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/in/api/v1/SeatController.java
@@ -8,6 +8,7 @@ import com.ticketrush.global.dto.response.ApiResponse;
 import com.ticketrush.global.exception.BusinessException;
 import com.ticketrush.global.status.ErrorStatus;
 import com.ticketrush.global.status.SuccessStatus;
+import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -34,6 +35,7 @@ public class SeatController {
   private String internalToken;
 
   @GetMapping("/{performanceId}/seat-layouts")
+  @Operation(summary = "공연별 좌석 배치 조회", description = "공연 ID에 해당하는 좌석 ID, 좌석 배치 ID, 좌석 번호를 조회합니다.")
   public ResponseEntity<ApiResponse<List<SeatLayoutResponse>>> getSeatLayouts(
       @PathVariable Long performanceId) {
     List<SeatLayoutResponse> response = seatFacade.getPerformanceSeatLayouts(performanceId);
@@ -41,6 +43,7 @@ public class SeatController {
   }
 
   @GetMapping("/{performanceId}/seat-counts")
+  @Operation(summary = "공연별 좌석 수 조회", description = "공연 ID에 해당하는 잔여 좌석 수와 전체 좌석 수를 조회합니다.")
   public ResponseEntity<ApiResponse<SeatAvailabilityResponse>> getSeatCounts(
       @PathVariable Long performanceId) {
     SeatAvailabilityResponse response = seatFacade.getPerformanceSeatAvailability(performanceId);
@@ -48,6 +51,7 @@ public class SeatController {
   }
 
   @PostMapping("/internal/sold")
+  @Operation(summary = "좌석 판매 확정", description = "내부 토큰을 검증한 뒤 HOLD 상태 좌석을 SOLD 상태로 확정합니다.")
   public ResponseEntity<ApiResponse<Void>> confirmSold(
       @RequestHeader(value = INTERNAL_TOKEN_HEADER, required = false) String internalTokenHeader,
       @Valid @RequestBody SeatSoldConfirmRequest request) {

--- a/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/in/api/v1/SeatController.java
+++ b/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/in/api/v1/SeatController.java
@@ -1,7 +1,7 @@
 package com.ticketrush.boundedcontext.seat.in.api.v1;
 
-import com.ticketrush.boundedcontext.seat.app.dto.response.SeatAvailabilityResponse;
 import com.ticketrush.boundedcontext.seat.app.dto.request.SeatSoldConfirmRequest;
+import com.ticketrush.boundedcontext.seat.app.dto.response.SeatAvailabilityResponse;
 import com.ticketrush.boundedcontext.seat.app.dto.response.SeatLayoutResponse;
 import com.ticketrush.boundedcontext.seat.app.facade.SeatFacade;
 import com.ticketrush.global.dto.response.ApiResponse;
@@ -45,6 +45,7 @@ public class SeatController {
       @PathVariable Long performanceId) {
     SeatAvailabilityResponse response = seatFacade.getPerformanceSeatAvailability(performanceId);
     return ApiResponse.onSuccess(SuccessStatus.OK, response);
+  }
 
   @PostMapping("/internal/sold")
   public ResponseEntity<ApiResponse<Void>> confirmSold(

--- a/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/in/api/v1/SeatController.java
+++ b/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/in/api/v1/SeatController.java
@@ -1,5 +1,6 @@
 package com.ticketrush.boundedcontext.seat.in.api.v1;
 
+import com.ticketrush.boundedcontext.seat.app.dto.response.SeatAvailabilityResponse;
 import com.ticketrush.boundedcontext.seat.app.dto.response.SeatLayoutResponse;
 import com.ticketrush.boundedcontext.seat.app.facade.SeatFacade;
 import com.ticketrush.global.dto.response.ApiResponse;
@@ -23,6 +24,13 @@ public class SeatController {
   public ResponseEntity<ApiResponse<List<SeatLayoutResponse>>> getSeatLayouts(
       @PathVariable Long performanceId) {
     List<SeatLayoutResponse> response = seatFacade.getPerformanceSeatLayouts(performanceId);
+    return ApiResponse.onSuccess(SuccessStatus.OK, response);
+  }
+
+  @GetMapping("/{performanceId}/seat-counts")
+  public ResponseEntity<ApiResponse<SeatAvailabilityResponse>> getSeatCounts(
+      @PathVariable Long performanceId) {
+    SeatAvailabilityResponse response = seatFacade.getPerformanceSeatAvailability(performanceId);
     return ApiResponse.onSuccess(SuccessStatus.OK, response);
   }
 }

--- a/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/out/repository/SeatRepository.java
+++ b/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/out/repository/SeatRepository.java
@@ -12,6 +12,10 @@ import org.springframework.data.repository.query.Param;
 
 public interface SeatRepository extends JpaRepository<Seat, Long> {
 
+  Long countByPerformanceId(Long performanceId);
+
+  Long countByPerformanceIdAndSeatStatus(Long performanceId, SeatStatus seatStatus);
+
   @Query(
       "SELECT new com.ticketrush.boundedcontext.seat.app.dto.response.SeatLayoutResponse("
           + "s.id, sl.id, s.seatNumber) "

--- a/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/out/repository/SeatRepository.java
+++ b/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/out/repository/SeatRepository.java
@@ -1,5 +1,6 @@
 package com.ticketrush.boundedcontext.seat.out.repository;
 
+import com.ticketrush.boundedcontext.seat.app.dto.response.SeatAvailabilityResponse;
 import com.ticketrush.boundedcontext.seat.app.dto.response.SeatLayoutResponse;
 import com.ticketrush.boundedcontext.seat.domain.entity.Seat;
 import com.ticketrush.global.types.SeatStatus;
@@ -12,9 +13,15 @@ import org.springframework.data.repository.query.Param;
 
 public interface SeatRepository extends JpaRepository<Seat, Long> {
 
-  Long countByPerformanceId(Long performanceId);
-
-  Long countByPerformanceIdAndSeatStatus(Long performanceId, SeatStatus seatStatus);
+  @Query(
+      "SELECT new com.ticketrush.boundedcontext.seat.app.dto.response.SeatAvailabilityResponse("
+          + "COUNT(CASE WHEN s.seatStatus = :availableStatus THEN s.id ELSE null END), "
+          + "COUNT(s)) "
+          + "FROM Seat s "
+          + "WHERE s.performanceId = :performanceId")
+  SeatAvailabilityResponse countSeatAvailabilityByPerformanceId(
+      @Param("performanceId") Long performanceId,
+      @Param("availableStatus") SeatStatus availableStatus);
 
   @Query(
       "SELECT new com.ticketrush.boundedcontext.seat.app.dto.response.SeatLayoutResponse("

--- a/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/app/usecase/SeatGetAvailabilityUseCaseTest.java
+++ b/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/app/usecase/SeatGetAvailabilityUseCaseTest.java
@@ -1,0 +1,39 @@
+package com.ticketrush.boundedcontext.seat.app.usecase;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+import com.ticketrush.boundedcontext.seat.app.dto.response.SeatAvailabilityResponse;
+import com.ticketrush.boundedcontext.seat.out.repository.SeatRepository;
+import com.ticketrush.global.types.SeatStatus;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class SeatGetAvailabilityUseCaseTest {
+
+  @InjectMocks private SeatGetAvailabilityUseCase useCase;
+
+  @Mock private SeatRepository seatRepository;
+
+  @Test
+  @DisplayName("공연 ID에 해당하는 잔여 좌석 수와 전체 좌석 수를 반환한다")
+  void executeReturnsSeatAvailability() {
+    // given
+    Long performanceId = 1L;
+    given(seatRepository.countByPerformanceIdAndSeatStatus(performanceId, SeatStatus.AVAILABLE))
+        .willReturn(8L);
+    given(seatRepository.countByPerformanceId(performanceId)).willReturn(10L);
+
+    // when
+    SeatAvailabilityResponse response = useCase.execute(performanceId);
+
+    // then
+    assertThat(response.availableCount()).isEqualTo(8L);
+    assertThat(response.totalCount()).isEqualTo(10L);
+  }
+}

--- a/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/app/usecase/SeatGetAvailabilityUseCaseTest.java
+++ b/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/app/usecase/SeatGetAvailabilityUseCaseTest.java
@@ -2,6 +2,7 @@ package com.ticketrush.boundedcontext.seat.app.usecase;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
 
 import com.ticketrush.boundedcontext.seat.app.dto.response.SeatAvailabilityResponse;
 import com.ticketrush.boundedcontext.seat.out.repository.SeatRepository;
@@ -25,15 +26,32 @@ class SeatGetAvailabilityUseCaseTest {
   void executeReturnsSeatAvailability() {
     // given
     Long performanceId = 1L;
-    given(seatRepository.countByPerformanceIdAndSeatStatus(performanceId, SeatStatus.AVAILABLE))
-        .willReturn(8L);
-    given(seatRepository.countByPerformanceId(performanceId)).willReturn(10L);
+    given(seatRepository.countSeatAvailabilityByPerformanceId(performanceId, SeatStatus.AVAILABLE))
+        .willReturn(new SeatAvailabilityResponse(8L, 10L));
 
     // when
     SeatAvailabilityResponse response = useCase.execute(performanceId);
 
     // then
     assertThat(response.availableCount()).isEqualTo(8L);
+    assertThat(response.totalCount()).isEqualTo(10L);
+    verify(seatRepository)
+        .countSeatAvailabilityByPerformanceId(performanceId, SeatStatus.AVAILABLE);
+  }
+
+  @Test
+  @DisplayName("잔여 좌석이 없으면 availableCount 0과 전체 좌석 수를 반환한다")
+  void executeReturnsZeroAvailableCount() {
+    // given
+    Long performanceId = 1L;
+    given(seatRepository.countSeatAvailabilityByPerformanceId(performanceId, SeatStatus.AVAILABLE))
+        .willReturn(new SeatAvailabilityResponse(0L, 10L));
+
+    // when
+    SeatAvailabilityResponse response = useCase.execute(performanceId);
+
+    // then
+    assertThat(response.availableCount()).isZero();
     assertThat(response.totalCount()).isEqualTo(10L);
   }
 }

--- a/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/in/api/v1/SeatControllerTest.java
+++ b/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/in/api/v1/SeatControllerTest.java
@@ -1,33 +1,33 @@
 package com.ticketrush.boundedcontext.seat.in.api.v1;
 
-  import static org.mockito.BDDMockito.given;
-  import static org.mockito.Mockito.verify;
-  import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
-  import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-  import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-  import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-  import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-  import com.ticketrush.boundedcontext.seat.app.dto.response.SeatAvailabilityResponse;
-  import com.ticketrush.boundedcontext.seat.app.dto.response.SeatLayoutResponse;
-  import com.ticketrush.boundedcontext.seat.app.facade.SeatFacade;
-  import com.ticketrush.global.config.SecurityConfig;
-  import com.ticketrush.support.WebMvcSliceTest;
-  import java.util.List;
-  import org.junit.jupiter.api.DisplayName;
-  import org.junit.jupiter.api.Test;
-  import org.springframework.beans.factory.annotation.Autowired;
-  import org.springframework.context.annotation.Import;
-  import org.springframework.http.MediaType;
-  import org.springframework.security.test.context.support.WithMockUser;
-  import org.springframework.test.context.TestPropertySource;
-  import org.springframework.test.context.bean.override.mockito.MockitoBean;
-  import org.springframework.test.web.servlet.MockMvc;
+import com.ticketrush.boundedcontext.seat.app.dto.response.SeatAvailabilityResponse;
+import com.ticketrush.boundedcontext.seat.app.dto.response.SeatLayoutResponse;
+import com.ticketrush.boundedcontext.seat.app.facade.SeatFacade;
+import com.ticketrush.global.config.SecurityConfig;
+import com.ticketrush.support.WebMvcSliceTest;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
 
-  @WebMvcSliceTest(SeatController.class)
-  @Import(SecurityConfig.class)
-  @TestPropertySource(properties = "gateway.internal-token=test-token")
-  class SeatControllerTest {
+@WebMvcSliceTest(SeatController.class)
+@Import(SecurityConfig.class)
+@TestPropertySource(properties = "gateway.internal-token=test-token")
+class SeatControllerTest {
 
   private static final String INTERNAL_TOKEN = "test-token";
 
@@ -74,7 +74,10 @@ package com.ticketrush.boundedcontext.seat.in.api.v1;
         .andExpect(jsonPath("$.is_success").value(true))
         .andExpect(jsonPath("$.result.available_count").value(8))
         .andExpect(jsonPath("$.result.total_count").value(10));
+  }
 
+  @Test
+  @WithMockUser
   @DisplayName("좌석 판매 확정 요청을 성공하고 200 OK를 반환한다")
   void confirmSold() throws Exception {
     // given

--- a/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/in/api/v1/SeatControllerTest.java
+++ b/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/in/api/v1/SeatControllerTest.java
@@ -8,16 +8,16 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.ticketrush.boundedcontext.seat.app.dto.response.SeatAvailabilityResponse;
 import com.ticketrush.boundedcontext.seat.app.dto.response.SeatLayoutResponse;
 import com.ticketrush.boundedcontext.seat.app.facade.SeatFacade;
+import com.ticketrush.support.WebMvcSliceTest;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
-@WebMvcTest(SeatController.class)
+@WebMvcSliceTest(SeatController.class)
 class SeatControllerTest {
 
   @Autowired private MockMvc mockMvc;
@@ -38,13 +38,13 @@ class SeatControllerTest {
     mockMvc
         .perform(get("/api/v1/seat/{performanceId}/seat-layouts", performanceId))
         .andExpect(status().isOk())
-        .andExpect(jsonPath("$.isSuccess").value(true))
+        .andExpect(jsonPath("$.is_success").value(true))
         .andExpect(jsonPath("$.result.length()").value(2))
-        .andExpect(jsonPath("$.result[0].seatId").value(1))
-        .andExpect(jsonPath("$.result[0].seatLayoutId").value(101))
-        .andExpect(jsonPath("$.result[0].seatNumber").value("A-1"))
-        .andExpect(jsonPath("$.result[1].seatId").value(2))
-        .andExpect(jsonPath("$.result[1].seatNumber").value("A-2"));
+        .andExpect(jsonPath("$.result[0].seat_id").value(1))
+        .andExpect(jsonPath("$.result[0].seat_layout_id").value(101))
+        .andExpect(jsonPath("$.result[0].seat_number").value("A-1"))
+        .andExpect(jsonPath("$.result[1].seat_id").value(2))
+        .andExpect(jsonPath("$.result[1].seat_number").value("A-2"));
   }
 
   @Test
@@ -60,8 +60,8 @@ class SeatControllerTest {
     mockMvc
         .perform(get("/api/v1/seat/{performanceId}/seat-counts", performanceId))
         .andExpect(status().isOk())
-        .andExpect(jsonPath("$.isSuccess").value(true))
-        .andExpect(jsonPath("$.result.availableCount").value(8))
-        .andExpect(jsonPath("$.result.totalCount").value(10));
+        .andExpect(jsonPath("$.is_success").value(true))
+        .andExpect(jsonPath("$.result.available_count").value(8))
+        .andExpect(jsonPath("$.result.total_count").value(10));
   }
 }

--- a/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/in/api/v1/SeatControllerTest.java
+++ b/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/in/api/v1/SeatControllerTest.java
@@ -5,6 +5,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.ticketrush.boundedcontext.seat.app.dto.response.SeatAvailabilityResponse;
 import com.ticketrush.boundedcontext.seat.app.dto.response.SeatLayoutResponse;
 import com.ticketrush.boundedcontext.seat.app.facade.SeatFacade;
 import java.util.List;
@@ -44,5 +45,23 @@ class SeatControllerTest {
         .andExpect(jsonPath("$.result[0].seatNumber").value("A-1"))
         .andExpect(jsonPath("$.result[1].seatId").value(2))
         .andExpect(jsonPath("$.result[1].seatNumber").value("A-2"));
+  }
+
+  @Test
+  @WithMockUser
+  @DisplayName("공연 ID로 잔여 좌석 수와 전체 좌석 수를 조회하고 200 OK를 반환한다")
+  void getSeatCounts() throws Exception {
+    // given
+    Long performanceId = 1L;
+    SeatAvailabilityResponse response = new SeatAvailabilityResponse(8L, 10L);
+    given(seatFacade.getPerformanceSeatAvailability(performanceId)).willReturn(response);
+
+    // when & then
+    mockMvc
+        .perform(get("/api/v1/seat/{performanceId}/seat-counts", performanceId))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.isSuccess").value(true))
+        .andExpect(jsonPath("$.result.availableCount").value(8))
+        .andExpect(jsonPath("$.result.totalCount").value(10));
   }
 }

--- a/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/out/repository/SeatRepositoryTest.java
+++ b/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/out/repository/SeatRepositoryTest.java
@@ -203,7 +203,9 @@ class SeatRepositoryTest {
     // then
     assertThat(availableCount).isEqualTo(2L);
     assertThat(totalCount).isEqualTo(4L);
+  }
 
+  @Test
   @DisplayName("HOLD 상태인 좌석을 SOLD 상태로 변경하고 선점 만료 시간을 초기화한다")
   void confirmSoldById_ChangesHoldSeatToSold() {
     // given

--- a/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/out/repository/SeatRepositoryTest.java
+++ b/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/out/repository/SeatRepositoryTest.java
@@ -151,7 +151,7 @@ class SeatRepositoryTest {
 
   @Test
   @DisplayName("공연 ID로 전체 좌석 수와 AVAILABLE 상태 좌석 수를 계산한다")
-  void countByPerformanceIdAndSeatStatus() {
+  void countSeatAvailabilityByPerformanceId_ReturnsAvailableAndTotalCounts() {
     // given
     Long targetPerformanceId = 1L;
     Long otherPerformanceId = 99L;
@@ -196,13 +196,24 @@ class SeatRepositoryTest {
         List.of(availableSeat1, availableSeat2, holdSeat, soldSeat, otherPerformanceSeat));
 
     // when
-    Long availableCount =
-        seatRepository.countByPerformanceIdAndSeatStatus(targetPerformanceId, SeatStatus.AVAILABLE);
-    Long totalCount = seatRepository.countByPerformanceId(targetPerformanceId);
+    var response =
+        seatRepository.countSeatAvailabilityByPerformanceId(
+            targetPerformanceId, SeatStatus.AVAILABLE);
 
     // then
-    assertThat(availableCount).isEqualTo(2L);
-    assertThat(totalCount).isEqualTo(4L);
+    assertThat(response.availableCount()).isEqualTo(2L);
+    assertThat(response.totalCount()).isEqualTo(4L);
+  }
+
+  @Test
+  @DisplayName("공연 ID에 해당하는 좌석이 없으면 0을 반환한다")
+  void countSeatAvailabilityByPerformanceId_ReturnsZeroWhenNoSeatsExist() {
+    // when
+    var response = seatRepository.countSeatAvailabilityByPerformanceId(1L, SeatStatus.AVAILABLE);
+
+    // then
+    assertThat(response.availableCount()).isZero();
+    assertThat(response.totalCount()).isZero();
   }
 
   @Test

--- a/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/out/repository/SeatRepositoryTest.java
+++ b/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/out/repository/SeatRepositoryTest.java
@@ -148,4 +148,60 @@ class SeatRepositoryTest {
     assertThat(validSeat.getSeatStatus()).isEqualTo(SeatStatus.HOLD); // 변경되지 않음
     assertThat(updatedSoldSeat.getSeatStatus()).isEqualTo(SeatStatus.SOLD); // 변경되지 않음
   }
+
+  @Test
+  @DisplayName("공연 ID로 전체 좌석 수와 AVAILABLE 상태 좌석 수를 계산한다")
+  void countByPerformanceIdAndSeatStatus() {
+    // given
+    Long targetPerformanceId = 1L;
+    Long otherPerformanceId = 99L;
+
+    Seat availableSeat1 =
+        Seat.builder()
+            .seatLayoutId(1L)
+            .performanceId(targetPerformanceId)
+            .seatNumber("A1")
+            .seatStatus(SeatStatus.AVAILABLE)
+            .build();
+    Seat availableSeat2 =
+        Seat.builder()
+            .seatLayoutId(1L)
+            .performanceId(targetPerformanceId)
+            .seatNumber("A2")
+            .seatStatus(SeatStatus.AVAILABLE)
+            .build();
+    Seat holdSeat =
+        Seat.builder()
+            .seatLayoutId(1L)
+            .performanceId(targetPerformanceId)
+            .seatNumber("A3")
+            .seatStatus(SeatStatus.HOLD)
+            .build();
+    Seat soldSeat =
+        Seat.builder()
+            .seatLayoutId(1L)
+            .performanceId(targetPerformanceId)
+            .seatNumber("A4")
+            .seatStatus(SeatStatus.SOLD)
+            .build();
+    Seat otherPerformanceSeat =
+        Seat.builder()
+            .seatLayoutId(2L)
+            .performanceId(otherPerformanceId)
+            .seatNumber("A1")
+            .seatStatus(SeatStatus.AVAILABLE)
+            .build();
+
+    seatRepository.saveAll(
+        List.of(availableSeat1, availableSeat2, holdSeat, soldSeat, otherPerformanceSeat));
+
+    // when
+    Long availableCount =
+        seatRepository.countByPerformanceIdAndSeatStatus(targetPerformanceId, SeatStatus.AVAILABLE);
+    Long totalCount = seatRepository.countByPerformanceId(targetPerformanceId);
+
+    // then
+    assertThat(availableCount).isEqualTo(2L);
+    assertThat(totalCount).isEqualTo(4L);
+  }
 }


### PR DESCRIPTION
## 🔗 관련 이슈

- close #31

---

## 📌 주요 변경 사항

- 공연 ID 기준 잔여 좌석 수와 전체 좌석 수를 반환하는 API 추가
- `AVAILABLE` 상태 좌석만 잔여 좌석으로 집계
- 컨트롤러, 유스케이스, 리포지토리 테스트 추가

---

## 🛠 상세 구현 내용

- `GET /api/v1/seat/{performanceId}/seat-counts` 추가
- `SeatAvailabilityResponse` 추가
  - `availableCount`: 예약 가능한 좌석 수
  - `totalCount`: 공연의 전체 좌석 수
- `SeatGetAvailabilityUseCase` 추가
  - 공연 ID로 전체 좌석 수와 `AVAILABLE` 좌석 수 조회
- `SeatRepository` count 파생 쿼리 추가
  - `countByPerformanceId`
  - `countByPerformanceIdAndSeatStatus`
- `SeatFacade#getPerformanceSeatAvailability` 추가

---

## ✅ 테스트

### 테스트 방법

- `./gradlew.bat :seat-service:test`
- `./gradlew.bat :seat-service:check`
- `git diff --check`

### 테스트 결과

- 모두 통과

<!--
### 📸 스크린샷


---

## 👀 리뷰 요청 사항

-

---

## ⚠️ 배포 시 주의사항

-
-->