### PR TITLE
[Feat] #87 공연 정보 수정(Patch) 및 논리 삭제(Soft Delete) 구현

### DIFF
--- a/common/src/main/java/com/ticketrush/global/status/ErrorStatus.java
+++ b/common/src/main/java/com/ticketrush/global/status/ErrorStatus.java
@@ -83,6 +83,10 @@ public enum ErrorStatus {
       HttpStatus.BAD_REQUEST, "PERFORMANCE_400_004", "유효하지 않은 공연 상태 전환입니다."),
   PERFORMANCE_NOT_ON_SALE(HttpStatus.BAD_REQUEST, "PERFORMANCE_400_005", "예매 가능한 공연이 아닙니다."),
 
+  // Performance 409
+  PERFORMANCE_HAS_SOLD_SEATS(
+      HttpStatus.CONFLICT, "PERFORMANCE_409_001", "예매 완료된 좌석이 있어 삭제할 수 없습니다."),
+
   // Performance 404
   PERFORMANCE_NOT_FOUND(HttpStatus.NOT_FOUND, "PERFORMANCE_404_001", "공연이 존재하지 않습니다."),
 

--- a/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/app/dto/request/PerformancePatchRequest.java
+++ b/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/app/dto/request/PerformancePatchRequest.java
@@ -1,6 +1,7 @@
 package com.ticketrush.boundedcontext.performance.app.dto.request;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.ticketrush.boundedcontext.performance.app.support.NullOrNotBlank;
 import com.ticketrush.boundedcontext.performance.domain.types.Genre;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Positive;
@@ -11,9 +12,11 @@ import java.time.LocalTime;
 @Schema(description = "공연 정보 수정 요청 (null 필드는 수정하지 않음)")
 public record PerformancePatchRequest(
     @Schema(description = "공연명", example = "BTS World Tour 2025")
+        @NullOrNotBlank
         @Size(max = 200, message = "공연명은 200자를 초과할 수 없습니다.")
         String title,
     @Schema(description = "출연진", example = "BTS")
+        @NullOrNotBlank
         @Size(max = 200, message = "출연진은 200자를 초과할 수 없습니다.")
         String performer,
     @Schema(
@@ -34,5 +37,6 @@ public record PerformancePatchRequest(
     @Schema(description = "총 좌석 수", example = "500") @Positive(message = "총 좌석 수는 1개 이상이어야 합니다.")
         Integer totalSeats,
     @Schema(description = "공연장 주소", example = "서울특별시 송파구 올림픽로 25 잠실종합운동장")
+        @NullOrNotBlank
         @Size(max = 255, message = "주소는 255자를 초과할 수 없습니다.")
         String address) {}

--- a/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/app/dto/request/PerformancePatchRequest.java
+++ b/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/app/dto/request/PerformancePatchRequest.java
@@ -1,0 +1,38 @@
+package com.ticketrush.boundedcontext.performance.app.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.ticketrush.boundedcontext.performance.domain.types.Genre;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.Size;
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+@Schema(description = "공연 정보 수정 요청 (null 필드는 수정하지 않음)")
+public record PerformancePatchRequest(
+    @Schema(description = "공연명", example = "BTS World Tour 2025")
+        @Size(max = 200, message = "공연명은 200자를 초과할 수 없습니다.")
+        String title,
+    @Schema(description = "출연진", example = "BTS")
+        @Size(max = 200, message = "출연진은 200자를 초과할 수 없습니다.")
+        String performer,
+    @Schema(
+            description = "장르 (MUSICAL/CONCERT/CLASSIC/JAZZ/FESTIVAL/BALLET/FANMEETING)",
+            example = "CONCERT")
+        Genre genre,
+    @Schema(description = "공연 설명", example = "공연 설명입니다.", nullable = true) String description,
+    @Schema(description = "공연 날짜 (yyyy-MM-dd)", example = "2025-08-15")
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+        LocalDate showDate,
+    @Schema(description = "공연 시작 시간 (HH:mm:ss)", example = "19:00:00")
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm:ss")
+        LocalTime showTime,
+    @Schema(description = "공연 시간 (분)", example = "120") @Positive(message = "공연 시간은 0보다 커야 합니다.")
+        Integer durationMinutes,
+    @Schema(description = "티켓 가격 (원)", example = "150000") @Positive(message = "가격은 0보다 커야 합니다.")
+        Long price,
+    @Schema(description = "총 좌석 수", example = "500") @Positive(message = "총 좌석 수는 1개 이상이어야 합니다.")
+        Integer totalSeats,
+    @Schema(description = "공연장 주소", example = "서울특별시 송파구 올림픽로 25 잠실종합운동장")
+        @Size(max = 255, message = "주소는 255자를 초과할 수 없습니다.")
+        String address) {}

--- a/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/app/facade/PerformanceFacade.java
+++ b/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/app/facade/PerformanceFacade.java
@@ -2,13 +2,16 @@ package com.ticketrush.boundedcontext.performance.app.facade;
 
 import com.ticketrush.boundedcontext.performance.app.dto.request.PerformanceChangeStatusRequest;
 import com.ticketrush.boundedcontext.performance.app.dto.request.PerformanceCreateRequest;
+import com.ticketrush.boundedcontext.performance.app.dto.request.PerformancePatchRequest;
 import com.ticketrush.boundedcontext.performance.app.dto.response.PerformanceCreateResponse;
 import com.ticketrush.boundedcontext.performance.app.dto.response.PerformanceDetailResponse;
 import com.ticketrush.boundedcontext.performance.app.dto.response.PerformanceListResponse;
 import com.ticketrush.boundedcontext.performance.app.usecase.PerformanceChangeStatusUseCase;
 import com.ticketrush.boundedcontext.performance.app.usecase.PerformanceCreateUseCase;
+import com.ticketrush.boundedcontext.performance.app.usecase.PerformanceDeleteUseCase;
 import com.ticketrush.boundedcontext.performance.app.usecase.PerformanceGetDetailUseCase;
 import com.ticketrush.boundedcontext.performance.app.usecase.PerformanceGetListUseCase;
+import com.ticketrush.boundedcontext.performance.app.usecase.PerformancePatchUseCase;
 import com.ticketrush.boundedcontext.performance.app.usecase.PerformanceValidateUseCase;
 import com.ticketrush.boundedcontext.performance.domain.types.Genre;
 import java.util.List;
@@ -26,6 +29,8 @@ public class PerformanceFacade {
   private final PerformanceGetListUseCase performanceGetListUseCase;
   private final PerformanceGetDetailUseCase performanceGetDetailUseCase;
   private final PerformanceChangeStatusUseCase performanceChangeStatusUseCase;
+  private final PerformancePatchUseCase performancePatchUseCase;
+  private final PerformanceDeleteUseCase performanceDeleteUseCase;
   private final PerformanceValidateUseCase performanceValidateUseCase;
 
   public PerformanceCreateResponse createPerformance(
@@ -47,6 +52,14 @@ public class PerformanceFacade {
 
   public void changePerformanceStatus(Long performanceId, PerformanceChangeStatusRequest request) {
     performanceChangeStatusUseCase.execute(performanceId, request);
+  }
+
+  public void patchPerformance(Long performanceId, PerformancePatchRequest request) {
+    performancePatchUseCase.execute(performanceId, request);
+  }
+
+  public void deletePerformance(Long performanceId) {
+    performanceDeleteUseCase.execute(performanceId);
   }
 
   public void validatePerformance(Long performanceId) {

--- a/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/app/support/NullOrNotBlank.java
+++ b/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/app/support/NullOrNotBlank.java
@@ -1,0 +1,23 @@
+package com.ticketrush.boundedcontext.performance.app.support;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/** null은 허용하되, 값이 존재하는 경우 빈 문자열·공백 문자열을 거부하는 검증 어노테이션. */
+@Target({ElementType.FIELD, ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Constraint(validatedBy = NullOrNotBlankValidator.class)
+public @interface NullOrNotBlank {
+
+  String message() default "공백 문자열은 입력할 수 없습니다.";
+
+  Class<?>[] groups() default {};
+
+  Class<? extends Payload>[] payload() default {};
+}

--- a/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/app/support/NullOrNotBlankValidator.java
+++ b/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/app/support/NullOrNotBlankValidator.java
@@ -1,0 +1,12 @@
+package com.ticketrush.boundedcontext.performance.app.support;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+public class NullOrNotBlankValidator implements ConstraintValidator<NullOrNotBlank, String> {
+
+  @Override
+  public boolean isValid(String value, ConstraintValidatorContext context) {
+    return value == null || !value.trim().isEmpty();
+  }
+}

--- a/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/app/usecase/PerformanceDeleteUseCase.java
+++ b/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/app/usecase/PerformanceDeleteUseCase.java
@@ -1,0 +1,27 @@
+package com.ticketrush.boundedcontext.performance.app.usecase;
+
+import com.ticketrush.boundedcontext.performance.domain.entity.Performance;
+import com.ticketrush.boundedcontext.performance.out.repository.PerformanceRepository;
+import com.ticketrush.global.exception.BusinessException;
+import com.ticketrush.global.status.ErrorStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class PerformanceDeleteUseCase {
+
+  private final PerformanceRepository performanceRepository;
+
+  @Transactional
+  public void execute(Long performanceId) {
+    Performance performance =
+        performanceRepository
+            .findById(performanceId)
+            .orElseThrow(() -> new BusinessException(ErrorStatus.PERFORMANCE_NOT_FOUND));
+
+    // TODO: #87 seat-service 연동 후 SOLD 좌석 존재 시 PERFORMANCE_HAS_SOLD_SEATS 예외 발생 필요
+    performance.softDelete();
+  }
+}

--- a/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/app/usecase/PerformancePatchUseCase.java
+++ b/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/app/usecase/PerformancePatchUseCase.java
@@ -1,0 +1,37 @@
+package com.ticketrush.boundedcontext.performance.app.usecase;
+
+import com.ticketrush.boundedcontext.performance.app.dto.request.PerformancePatchRequest;
+import com.ticketrush.boundedcontext.performance.domain.entity.Performance;
+import com.ticketrush.boundedcontext.performance.out.repository.PerformanceRepository;
+import com.ticketrush.global.exception.BusinessException;
+import com.ticketrush.global.status.ErrorStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class PerformancePatchUseCase {
+
+  private final PerformanceRepository performanceRepository;
+
+  @Transactional
+  public void execute(Long performanceId, PerformancePatchRequest request) {
+    Performance performance =
+        performanceRepository
+            .findById(performanceId)
+            .orElseThrow(() -> new BusinessException(ErrorStatus.PERFORMANCE_NOT_FOUND));
+
+    performance.update(
+        request.title(),
+        request.performer(),
+        request.genre(),
+        request.description(),
+        request.showDate(),
+        request.showTime(),
+        request.durationMinutes(),
+        request.price(),
+        request.totalSeats(),
+        request.address());
+  }
+}

--- a/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/domain/entity/Performance.java
+++ b/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/domain/entity/Performance.java
@@ -16,6 +16,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OrderColumn;
 import jakarta.persistence.Table;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -23,9 +24,11 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
 
 @Entity
 @Table(name = "performance")
+@SQLRestriction("deleted_at IS NULL")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AttributeOverride(name = "id", column = @Column(name = "performance_id"))
@@ -84,6 +87,9 @@ public class Performance extends AutoIdBaseEntity {
   @OrderColumn(name = "facility_order")
   private List<String> facilities = new ArrayList<>();
 
+  @Column(name = "deleted_at")
+  private LocalDateTime deletedAt;
+
   @Builder
   public Performance(
       String title,
@@ -123,6 +129,53 @@ public class Performance extends AutoIdBaseEntity {
     this.imageMainUrl = mainImageUrl;
     this.image3dUrl = model3dUrl;
     this.imageGalleryUrls = galleryUrls != null ? galleryUrls : new ArrayList<>();
+  }
+
+  public void update(
+      String title,
+      String performer,
+      Genre genre,
+      String description,
+      LocalDate showDate,
+      LocalTime showTime,
+      Integer durationMinutes,
+      Long price,
+      Integer totalSeats,
+      String address) {
+    if (title != null) {
+      this.title = title;
+    }
+    if (performer != null) {
+      this.performer = performer;
+    }
+    if (genre != null) {
+      this.genre = genre;
+    }
+    if (description != null) {
+      this.description = description;
+    }
+    if (showDate != null) {
+      this.showDate = showDate;
+    }
+    if (showTime != null) {
+      this.showTime = showTime;
+    }
+    if (durationMinutes != null) {
+      this.durationMinutes = durationMinutes;
+    }
+    if (price != null) {
+      this.price = price;
+    }
+    if (totalSeats != null) {
+      this.totalSeats = totalSeats;
+    }
+    if (address != null) {
+      this.address = address;
+    }
+  }
+
+  public void softDelete() {
+    this.deletedAt = LocalDateTime.now();
   }
 
   public boolean canTransitionTo(PerformanceStatus target) {

--- a/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/in/api/v1/PerformanceAdminController.java
+++ b/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/in/api/v1/PerformanceAdminController.java
@@ -96,7 +96,7 @@ public class PerformanceAdminController {
     return ApiResponse.onSuccess(SuccessStatus.OK);
   }
 
-  @Operation(summary = "공연 정보 수정", description = "공연의 텍스트 정보를 부분 수정합니다. null 필드는 수정하지 않습니다.")
+  @Operation(summary = "공연 정보 수정", description = "공연 정보를 부분 수정합니다. null 필드는 수정하지 않습니다.")
   @PerformancePatchApiResponses
   @PatchMapping("/{id}")
   public ResponseEntity<ApiResponse<Void>> patchPerformance(

--- a/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/in/api/v1/PerformanceAdminController.java
+++ b/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/in/api/v1/PerformanceAdminController.java
@@ -2,21 +2,26 @@ package com.ticketrush.boundedcontext.performance.in.api.v1;
 
 import com.ticketrush.boundedcontext.performance.app.dto.request.PerformanceChangeStatusRequest;
 import com.ticketrush.boundedcontext.performance.app.dto.request.PerformanceCreateRequest;
+import com.ticketrush.boundedcontext.performance.app.dto.request.PerformancePatchRequest;
 import com.ticketrush.boundedcontext.performance.app.dto.response.PerformanceCreateResponse;
 import com.ticketrush.boundedcontext.performance.app.facade.PerformanceFacade;
 import com.ticketrush.global.dto.response.ApiResponse;
 import com.ticketrush.global.status.SuccessStatus;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Encoding;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Positive;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -26,6 +31,7 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
 @Tag(name = "Performance Admin", description = "공연 관리자 API")
+@Validated
 @RestController
 @RequestMapping("/api/v1/performance")
 @RequiredArgsConstructor
@@ -86,6 +92,29 @@ public class PerformanceAdminController {
           PerformanceChangeStatusRequest request) {
 
     performanceFacade.changePerformanceStatus(id, request);
+
+    return ApiResponse.onSuccess(SuccessStatus.OK);
+  }
+
+  @Operation(summary = "공연 정보 수정", description = "공연의 텍스트 정보를 부분 수정합니다. null 필드는 수정하지 않습니다.")
+  @PerformancePatchApiResponses
+  @PatchMapping("/{id}")
+  public ResponseEntity<ApiResponse<Void>> patchPerformance(
+      @Parameter(description = "공연 ID") @Positive @PathVariable Long id,
+      @org.springframework.web.bind.annotation.RequestBody @Valid PerformancePatchRequest request) {
+
+    performanceFacade.patchPerformance(id, request);
+
+    return ApiResponse.onSuccess(SuccessStatus.OK);
+  }
+
+  @Operation(summary = "공연 삭제", description = "공연을 논리 삭제합니다. 삭제된 공연은 모든 조회에서 제외됩니다.")
+  @PerformanceDeleteApiResponses
+  @DeleteMapping("/{id}")
+  public ResponseEntity<ApiResponse<Void>> deletePerformance(
+      @Parameter(description = "공연 ID") @Positive @PathVariable Long id) {
+
+    performanceFacade.deletePerformance(id);
 
     return ApiResponse.onSuccess(SuccessStatus.OK);
   }

--- a/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/in/api/v1/PerformanceDeleteApiResponses.java
+++ b/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/in/api/v1/PerformanceDeleteApiResponses.java
@@ -1,0 +1,61 @@
+package com.ticketrush.boundedcontext.performance.in.api.v1;
+
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@ApiResponses({
+  @ApiResponse(
+      responseCode = "404",
+      description = "공연 없음",
+      content =
+          @Content(
+              mediaType = "application/json",
+              schema =
+                  @Schema(implementation = com.ticketrush.global.dto.response.ApiResponse.class),
+              examples =
+                  @ExampleObject(
+                      name = "PerformanceNotFound",
+                      summary = "공연이 존재하지 않음",
+                      value =
+                          """
+                          {
+                            "is_success": false,
+                            "code": "PERFORMANCE_404_001",
+                            "message": "공연이 존재하지 않습니다.",
+                            "trace_id": "trace-id-example"
+                          }
+                          """))),
+  @ApiResponse(
+      responseCode = "500",
+      description = "서버 오류",
+      content =
+          @Content(
+              mediaType = "application/json",
+              schema =
+                  @Schema(implementation = com.ticketrush.global.dto.response.ApiResponse.class),
+              examples =
+                  @ExampleObject(
+                      name = "InternalServerError",
+                      summary = "서버 내부 오류",
+                      value =
+                          """
+                          {
+                            "is_success": false,
+                            "code": "COMMON_500",
+                            "message": "서버 에러, 관리자에게 문의 바랍니다.",
+                            "trace_id": "trace-id-example"
+                          }
+                          """)))
+})
+public @interface PerformanceDeleteApiResponses {}

--- a/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/in/api/v1/PerformanceDeleteApiResponses.java
+++ b/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/in/api/v1/PerformanceDeleteApiResponses.java
@@ -16,6 +16,27 @@ import java.lang.annotation.Target;
 @Documented
 @ApiResponses({
   @ApiResponse(
+      responseCode = "400",
+      description = "잘못된 요청",
+      content =
+          @Content(
+              mediaType = "application/json",
+              schema =
+                  @Schema(implementation = com.ticketrush.global.dto.response.ApiResponse.class),
+              examples =
+                  @ExampleObject(
+                      name = "ValidationError",
+                      summary = "유효하지 않은 공연 ID",
+                      value =
+                          """
+                          {
+                            "is_success": false,
+                            "code": "VALID_400_001",
+                            "message": "입력값이 올바르지 않습니다.",
+                            "trace_id": "trace-id-example"
+                          }
+                          """))),
+  @ApiResponse(
       responseCode = "404",
       description = "공연 없음",
       content =

--- a/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/in/api/v1/PerformancePatchApiResponses.java
+++ b/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/in/api/v1/PerformancePatchApiResponses.java
@@ -1,0 +1,82 @@
+package com.ticketrush.boundedcontext.performance.in.api.v1;
+
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@ApiResponses({
+  @ApiResponse(
+      responseCode = "400",
+      description = "잘못된 요청",
+      content =
+          @Content(
+              mediaType = "application/json",
+              schema =
+                  @Schema(implementation = com.ticketrush.global.dto.response.ApiResponse.class),
+              examples =
+                  @ExampleObject(
+                      name = "ValidationError",
+                      summary = "입력값 오류",
+                      value =
+                          """
+                          {
+                            "is_success": false,
+                            "code": "VALID_400_001",
+                            "message": "가격은 0보다 커야 합니다.",
+                            "trace_id": "trace-id-example"
+                          }
+                          """))),
+  @ApiResponse(
+      responseCode = "404",
+      description = "공연 없음",
+      content =
+          @Content(
+              mediaType = "application/json",
+              schema =
+                  @Schema(implementation = com.ticketrush.global.dto.response.ApiResponse.class),
+              examples =
+                  @ExampleObject(
+                      name = "PerformanceNotFound",
+                      summary = "공연이 존재하지 않음",
+                      value =
+                          """
+                          {
+                            "is_success": false,
+                            "code": "PERFORMANCE_404_001",
+                            "message": "공연이 존재하지 않습니다.",
+                            "trace_id": "trace-id-example"
+                          }
+                          """))),
+  @ApiResponse(
+      responseCode = "500",
+      description = "서버 오류",
+      content =
+          @Content(
+              mediaType = "application/json",
+              schema =
+                  @Schema(implementation = com.ticketrush.global.dto.response.ApiResponse.class),
+              examples =
+                  @ExampleObject(
+                      name = "InternalServerError",
+                      summary = "서버 내부 오류",
+                      value =
+                          """
+                          {
+                            "is_success": false,
+                            "code": "COMMON_500",
+                            "message": "서버 에러, 관리자에게 문의 바랍니다.",
+                            "trace_id": "trace-id-example"
+                          }
+                          """)))
+})
+public @interface PerformancePatchApiResponses {}

--- a/performance-service/src/test/java/com/ticketrush/boundedcontext/performance/in/api/v1/PerformanceDeleteTest.java
+++ b/performance-service/src/test/java/com/ticketrush/boundedcontext/performance/in/api/v1/PerformanceDeleteTest.java
@@ -1,0 +1,97 @@
+package com.ticketrush.boundedcontext.performance.in.api.v1;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.ticketrush.boundedcontext.performance.app.usecase.PerformanceDeleteUseCase;
+import com.ticketrush.boundedcontext.performance.domain.entity.Performance;
+import com.ticketrush.boundedcontext.performance.domain.types.Genre;
+import com.ticketrush.boundedcontext.performance.out.repository.PerformanceRepository;
+import com.ticketrush.global.eventpublisher.EventPublisher;
+import com.ticketrush.global.exception.BusinessException;
+import com.ticketrush.global.status.ErrorStatus;
+import com.ticketrush.global.util.S3UploadUtils;
+import jakarta.persistence.EntityManager;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@EnableAutoConfiguration(
+    exclude = {
+      io.awspring.cloud.autoconfigure.s3.S3AutoConfiguration.class,
+      io.awspring.cloud.autoconfigure.core.AwsAutoConfiguration.class
+    })
+@Transactional
+class PerformanceDeleteTest {
+
+  @MockitoBean private S3UploadUtils s3UploadUtils;
+  @MockitoBean private EventPublisher eventPublisher;
+
+  @Autowired private PerformanceDeleteUseCase performanceDeleteUseCase;
+  @Autowired private PerformanceRepository performanceRepository;
+  @Autowired private EntityManager em;
+
+  private Performance savePerformance() {
+    return performanceRepository.save(
+        Performance.builder()
+            .title("테스트 공연")
+            .performer("테스터")
+            .genre(Genre.CONCERT)
+            .description("설명")
+            .showDate(LocalDate.now().plusDays(30))
+            .showTime(LocalTime.of(19, 0))
+            .durationMinutes(120)
+            .price(50000L)
+            .totalSeats(100)
+            .address("서울")
+            .build());
+  }
+
+  @Test
+  @DisplayName("공연 삭제 시 deleted_at이 설정되고 이후 조회에서 제외된다")
+  void softDelete_success() {
+    Performance performance = savePerformance();
+    Long id = performance.getId();
+
+    performanceDeleteUseCase.execute(id);
+
+    // L1 캐시를 비워 @SQLRestriction 필터가 적용된 실제 쿼리로 검증
+    em.flush();
+    em.clear();
+
+    assertThat(performanceRepository.findById(id)).isEmpty();
+  }
+
+  @Test
+  @DisplayName("존재하지 않는 공연 ID로 삭제 요청 시 예외 발생")
+  void deletePerformance_notFound() {
+    assertThatThrownBy(() -> performanceDeleteUseCase.execute(999L))
+        .isInstanceOf(BusinessException.class)
+        .hasMessage(ErrorStatus.PERFORMANCE_NOT_FOUND.getMessage());
+  }
+
+  @Test
+  @DisplayName("이미 삭제된 공연을 다시 삭제하면 예외 발생")
+  void deleteAlreadyDeletedPerformance_notFound() {
+    Performance performance = savePerformance();
+    Long id = performance.getId();
+
+    performanceDeleteUseCase.execute(id);
+
+    em.flush();
+    em.clear();
+
+    assertThatThrownBy(() -> performanceDeleteUseCase.execute(id))
+        .isInstanceOf(BusinessException.class)
+        .hasMessage(ErrorStatus.PERFORMANCE_NOT_FOUND.getMessage());
+  }
+}

--- a/performance-service/src/test/java/com/ticketrush/boundedcontext/performance/in/api/v1/PerformancePatchTest.java
+++ b/performance-service/src/test/java/com/ticketrush/boundedcontext/performance/in/api/v1/PerformancePatchTest.java
@@ -12,6 +12,7 @@ import com.ticketrush.global.eventpublisher.EventPublisher;
 import com.ticketrush.global.exception.BusinessException;
 import com.ticketrush.global.status.ErrorStatus;
 import com.ticketrush.global.util.S3UploadUtils;
+import jakarta.persistence.EntityManager;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import org.junit.jupiter.api.DisplayName;
@@ -38,6 +39,7 @@ class PerformancePatchTest {
 
   @Autowired private PerformancePatchUseCase performancePatchUseCase;
   @Autowired private PerformanceRepository performanceRepository;
+  @Autowired private EntityManager em;
 
   private Performance savePerformance() {
     return performanceRepository.save(
@@ -56,9 +58,11 @@ class PerformancePatchTest {
   }
 
   @Test
-  @DisplayName("전체 텍스트 필드를 수정하면 DB에 반영된다")
+  @DisplayName("전체 필드를 수정하면 DB에 반영된다")
   void patchAllFields_success() {
     Performance performance = savePerformance();
+    LocalDate newShowDate = LocalDate.now().plusDays(60);
+    LocalTime newShowTime = LocalTime.of(20, 0);
 
     performancePatchUseCase.execute(
         performance.getId(),
@@ -67,18 +71,23 @@ class PerformancePatchTest {
             "새로운 출연진",
             Genre.MUSICAL,
             "새로운 설명",
-            LocalDate.now().plusDays(60),
-            LocalTime.of(20, 0),
+            newShowDate,
+            newShowTime,
             150,
             80000L,
             200,
             "부산"));
+
+    em.flush();
+    em.clear();
 
     Performance updated = performanceRepository.findById(performance.getId()).orElseThrow();
     assertThat(updated.getTitle()).isEqualTo("새로운 공연명");
     assertThat(updated.getPerformer()).isEqualTo("새로운 출연진");
     assertThat(updated.getGenre()).isEqualTo(Genre.MUSICAL);
     assertThat(updated.getDescription()).isEqualTo("새로운 설명");
+    assertThat(updated.getShowDate()).isEqualTo(newShowDate);
+    assertThat(updated.getShowTime()).isEqualTo(newShowTime);
     assertThat(updated.getDurationMinutes()).isEqualTo(150);
     assertThat(updated.getPrice()).isEqualTo(80000L);
     assertThat(updated.getTotalSeats()).isEqualTo(200);
@@ -94,6 +103,9 @@ class PerformancePatchTest {
         performance.getId(),
         new PerformancePatchRequest(
             "새로운 공연명", null, null, null, null, null, null, null, null, null));
+
+    em.flush();
+    em.clear();
 
     Performance updated = performanceRepository.findById(performance.getId()).orElseThrow();
     assertThat(updated.getTitle()).isEqualTo("새로운 공연명");

--- a/performance-service/src/test/java/com/ticketrush/boundedcontext/performance/in/api/v1/PerformancePatchTest.java
+++ b/performance-service/src/test/java/com/ticketrush/boundedcontext/performance/in/api/v1/PerformancePatchTest.java
@@ -1,0 +1,116 @@
+package com.ticketrush.boundedcontext.performance.in.api.v1;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.ticketrush.boundedcontext.performance.app.dto.request.PerformancePatchRequest;
+import com.ticketrush.boundedcontext.performance.app.usecase.PerformancePatchUseCase;
+import com.ticketrush.boundedcontext.performance.domain.entity.Performance;
+import com.ticketrush.boundedcontext.performance.domain.types.Genre;
+import com.ticketrush.boundedcontext.performance.out.repository.PerformanceRepository;
+import com.ticketrush.global.eventpublisher.EventPublisher;
+import com.ticketrush.global.exception.BusinessException;
+import com.ticketrush.global.status.ErrorStatus;
+import com.ticketrush.global.util.S3UploadUtils;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@EnableAutoConfiguration(
+    exclude = {
+      io.awspring.cloud.autoconfigure.s3.S3AutoConfiguration.class,
+      io.awspring.cloud.autoconfigure.core.AwsAutoConfiguration.class
+    })
+@Transactional
+class PerformancePatchTest {
+
+  @MockitoBean private S3UploadUtils s3UploadUtils;
+  @MockitoBean private EventPublisher eventPublisher;
+
+  @Autowired private PerformancePatchUseCase performancePatchUseCase;
+  @Autowired private PerformanceRepository performanceRepository;
+
+  private Performance savePerformance() {
+    return performanceRepository.save(
+        Performance.builder()
+            .title("원래 공연명")
+            .performer("원래 출연진")
+            .genre(Genre.CONCERT)
+            .description("원래 설명")
+            .showDate(LocalDate.now().plusDays(30))
+            .showTime(LocalTime.of(19, 0))
+            .durationMinutes(120)
+            .price(50000L)
+            .totalSeats(100)
+            .address("서울")
+            .build());
+  }
+
+  @Test
+  @DisplayName("전체 텍스트 필드를 수정하면 DB에 반영된다")
+  void patchAllFields_success() {
+    Performance performance = savePerformance();
+
+    performancePatchUseCase.execute(
+        performance.getId(),
+        new PerformancePatchRequest(
+            "새로운 공연명",
+            "새로운 출연진",
+            Genre.MUSICAL,
+            "새로운 설명",
+            LocalDate.now().plusDays(60),
+            LocalTime.of(20, 0),
+            150,
+            80000L,
+            200,
+            "부산"));
+
+    Performance updated = performanceRepository.findById(performance.getId()).orElseThrow();
+    assertThat(updated.getTitle()).isEqualTo("새로운 공연명");
+    assertThat(updated.getPerformer()).isEqualTo("새로운 출연진");
+    assertThat(updated.getGenre()).isEqualTo(Genre.MUSICAL);
+    assertThat(updated.getDescription()).isEqualTo("새로운 설명");
+    assertThat(updated.getDurationMinutes()).isEqualTo(150);
+    assertThat(updated.getPrice()).isEqualTo(80000L);
+    assertThat(updated.getTotalSeats()).isEqualTo(200);
+    assertThat(updated.getAddress()).isEqualTo("부산");
+  }
+
+  @Test
+  @DisplayName("null 필드는 수정하지 않고 기존 값을 유지한다")
+  void patchPartialFields_nullFieldsUnchanged() {
+    Performance performance = savePerformance();
+
+    performancePatchUseCase.execute(
+        performance.getId(),
+        new PerformancePatchRequest(
+            "새로운 공연명", null, null, null, null, null, null, null, null, null));
+
+    Performance updated = performanceRepository.findById(performance.getId()).orElseThrow();
+    assertThat(updated.getTitle()).isEqualTo("새로운 공연명");
+    assertThat(updated.getPerformer()).isEqualTo("원래 출연진");
+    assertThat(updated.getGenre()).isEqualTo(Genre.CONCERT);
+    assertThat(updated.getDescription()).isEqualTo("원래 설명");
+    assertThat(updated.getPrice()).isEqualTo(50000L);
+  }
+
+  @Test
+  @DisplayName("존재하지 않는 공연 ID로 수정 요청 시 예외 발생")
+  void patchPerformance_notFound() {
+    PerformancePatchRequest request =
+        new PerformancePatchRequest("새 제목", null, null, null, null, null, null, null, null, null);
+
+    assertThatThrownBy(() -> performancePatchUseCase.execute(999L, request))
+        .isInstanceOf(BusinessException.class)
+        .hasMessage(ErrorStatus.PERFORMANCE_NOT_FOUND.getMessage());
+  }
+}


### PR DESCRIPTION
  ## 🔗 관련 이슈

  - close #87

  ---

  ## 📌 주요 변경 사항

  - `PATCH /api/v1/performance/{id}` — 텍스트 필드 부분 수정 API 구현 (null 필드는 수정 안 함)
  - `DELETE /api/v1/performance/{id}` — Soft Delete 구현 (`deleted_at` 기반 논리 삭제)
  - `@SQLRestriction("deleted_at IS NULL")` 적용으로 삭제된 공연은 전체 조회에서 자동 제외
  - SOLD 좌석 존재 시 삭제 제한 로직은 seat-service 연동 후 추가 예정 (TODO 마킹)

  ---

  ## 🛠 상세 구현 내용

  - `Performance` 엔티티에 `deletedAt` 필드 추가, `update()` / `softDelete()` 도메인 메서드 추가
  - `@SQLRestriction` 적용 — Hibernate 7 환경에서 `@Where` 대신 사용 (Spring Boot 4.0.1 호환)
  - `PerformancePatchRequest` — 전체 필드 optional, 제공된 필드만 선택적으로 업데이트
  - `PerformancePatchUseCase` / `PerformanceDeleteUseCase` 신규 생성
  - `ErrorStatus.PERFORMANCE_HAS_SOLD_SEATS` (409) 추가 — 향후 seat-service 연동 시 사용

  ---

  ## ✅ 테스트

  ### 테스트 방법

  - `PerformancePatchTest` / `PerformanceDeleteTest` — `@SpringBootTest` 통합 테스트 실행

  ### 테스트 결과
  
  - 전체 필드 수정 → DB 반영 확인
  - null 필드 수정 → 기존 값 유지 확인
  - 존재하지 않는 ID → `PERFORMANCE_NOT_FOUND` 예외 발생 확인
  - Soft Delete 후 `findById` → `@SQLRestriction` 필터로 조회 결과 없음 확인
  - 이미 삭제된 공연 재삭제 → `PERFORMANCE_NOT_FOUND` 예외 발생 확인

  ---

  ## 👀 리뷰 요청 사항

  - SOLD 좌석 체크 로직은 seat-service에 조회용 internal API가 없어 이번 PR에서는 TODO로 남겼습니다. seat-service 담당자와 협의 후 별도 이슈로 처리할 예정입니다.

  ---
  
  ## ⚠️ 배포 시 주의사항

  - `performance` 테이블에 `deleted_at` 컬럼이 추가되므로 DDL 반영 필요