### PR TITLE
[Refactor] #193 소셜 로그인 회원 생성 시 이메일 저장 로직 추가

### DIFF
--- a/auth-service/src/main/java/com/ticketrush/boundedcontext/auth/app/dto/request/UserServiceSocialLoginRequest.java
+++ b/auth-service/src/main/java/com/ticketrush/boundedcontext/auth/app/dto/request/UserServiceSocialLoginRequest.java
@@ -1,4 +1,5 @@
 package com.ticketrush.boundedcontext.auth.app.dto.request;
 
 // auth → user-service 요청 DTO
-public record UserServiceSocialLoginRequest(String socialId, String socialProvider, String name) {}
+public record UserServiceSocialLoginRequest(
+    String socialId, String socialProvider, String name, String email) {}

--- a/auth-service/src/main/java/com/ticketrush/boundedcontext/auth/app/dto/response/GoogleUserInfoResponse.java
+++ b/auth-service/src/main/java/com/ticketrush/boundedcontext/auth/app/dto/response/GoogleUserInfoResponse.java
@@ -1,3 +1,3 @@
 package com.ticketrush.boundedcontext.auth.app.dto.response;
 
-public record GoogleUserInfoResponse(String id, String name) {}
+public record GoogleUserInfoResponse(String id, String name, String email) {}

--- a/auth-service/src/main/java/com/ticketrush/boundedcontext/auth/app/dto/response/NaverUserInfoResponse.java
+++ b/auth-service/src/main/java/com/ticketrush/boundedcontext/auth/app/dto/response/NaverUserInfoResponse.java
@@ -2,5 +2,5 @@ package com.ticketrush.boundedcontext.auth.app.dto.response;
 
 public record NaverUserInfoResponse(String resultcode, String message, Response response) {
 
-  public record Response(String id, String name) {}
+  public record Response(String id, String name, String email) {}
 }

--- a/auth-service/src/main/java/com/ticketrush/boundedcontext/auth/app/dto/response/UserServiceSocialLoginResponse.java
+++ b/auth-service/src/main/java/com/ticketrush/boundedcontext/auth/app/dto/response/UserServiceSocialLoginResponse.java
@@ -4,9 +4,9 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 // user-service → auth-service 응답 DTO
 public record UserServiceSocialLoginResponse(
-  @JsonProperty(value = "user_id") Long userId,
-  String name,
-  @JsonProperty(value = "is_new_user") boolean isNewUser) {
+    @JsonProperty(value = "user_id") Long userId,
+    String name,
+    @JsonProperty(value = "is_new_user") boolean isNewUser) {
 
   private String maskValue(String value) {
     if (value == null || value.isEmpty()) {
@@ -23,13 +23,13 @@ public record UserServiceSocialLoginResponse(
   @Override
   public String toString() {
     return "UserServiceSocialLoginResponse{"
-      + "userId="
-      + userId
-      + ", name='"
-      + maskValue(name)
-      + '\''
-      + ", isNewUser="
-      + isNewUser
-      + '}';
+        + "userId="
+        + userId
+        + ", name='"
+        + maskValue(name)
+        + '\''
+        + ", isNewUser="
+        + isNewUser
+        + '}';
   }
 }

--- a/auth-service/src/main/java/com/ticketrush/boundedcontext/auth/app/dto/response/UserServiceSocialLoginResponse.java
+++ b/auth-service/src/main/java/com/ticketrush/boundedcontext/auth/app/dto/response/UserServiceSocialLoginResponse.java
@@ -4,6 +4,32 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 // user-service → auth-service 응답 DTO
 public record UserServiceSocialLoginResponse(
-    @JsonProperty(value = "user_id") Long userId,
-    String name,
-    @JsonProperty(value = "is_new_user") boolean isNewUser) {}
+  @JsonProperty(value = "user_id") Long userId,
+  String name,
+  @JsonProperty(value = "is_new_user") boolean isNewUser) {
+
+  private String maskValue(String value) {
+    if (value == null || value.isEmpty()) {
+      return value;
+    }
+
+    if (value.length() <= 2) {
+      return value.charAt(0) + "***";
+    }
+
+    return value.substring(0, 2) + "***";
+  }
+
+  @Override
+  public String toString() {
+    return "UserServiceSocialLoginResponse{"
+      + "userId="
+      + userId
+      + ", name='"
+      + maskValue(name)
+      + '\''
+      + ", isNewUser="
+      + isNewUser
+      + '}';
+  }
+}

--- a/auth-service/src/main/java/com/ticketrush/boundedcontext/auth/app/usecase/SocialOauthLoginUseCase.java
+++ b/auth-service/src/main/java/com/ticketrush/boundedcontext/auth/app/usecase/SocialOauthLoginUseCase.java
@@ -43,7 +43,8 @@ public class SocialOauthLoginUseCase {
             new UserServiceSocialLoginRequest(
                 socialUserInfo.socialId(),
                 socialUserInfo.socialProvider().name(),
-                socialUserInfo.name()));
+                socialUserInfo.name(),
+                socialUserInfo.email()));
 
     Long userId = userResponse.userId();
 

--- a/auth-service/src/main/java/com/ticketrush/boundedcontext/auth/app/usecase/SocialOauthLoginUseCase.java
+++ b/auth-service/src/main/java/com/ticketrush/boundedcontext/auth/app/usecase/SocialOauthLoginUseCase.java
@@ -48,8 +48,6 @@ public class SocialOauthLoginUseCase {
 
     Long userId = userResponse.userId();
 
-    log.info("🔥 user-service 응답 = {}", userResponse);
-
     // 3. JWT 생성
     String accessToken = jwtTokenProvider.createAccessToken(userId, "USER");
 

--- a/auth-service/src/main/java/com/ticketrush/boundedcontext/auth/domain/types/SocialUserInfo.java
+++ b/auth-service/src/main/java/com/ticketrush/boundedcontext/auth/domain/types/SocialUserInfo.java
@@ -1,4 +1,5 @@
 package com.ticketrush.boundedcontext.auth.domain.types;
 
 // 카카오,네이버,구글에서 받아온 "원본 유저 정보"
-public record SocialUserInfo(String socialId, SocialProvider socialProvider, String name) {}
+public record SocialUserInfo(
+    String socialId, SocialProvider socialProvider, String name, String email) {}

--- a/auth-service/src/main/java/com/ticketrush/boundedcontext/auth/out/apiclient/GoogleOauthApiClient.java
+++ b/auth-service/src/main/java/com/ticketrush/boundedcontext/auth/out/apiclient/GoogleOauthApiClient.java
@@ -12,6 +12,8 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestClient;
 import org.springframework.web.util.UriComponentsBuilder;
 
@@ -98,22 +100,20 @@ public class GoogleOauthApiClient implements SocialOauthApiClient {
 
   private OauthTokenResponse requestToken(String code, String redirectUri) {
 
+    MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+    params.add("code", code);
+    params.add("client_id", clientId);
+    params.add("client_secret", clientSecret);
+    params.add("redirect_uri", redirectUri);
+    params.add("grant_type", "authorization_code");
+
     return restClient
-        .post()
-        .uri(tokenUri)
-        .contentType(MediaType.APPLICATION_FORM_URLENCODED)
-        .body(
-            "code="
-                + code
-                + "&client_id="
-                + clientId
-                + "&client_secret="
-                + clientSecret
-                + "&redirect_uri="
-                + redirectUri
-                + "&grant_type=authorization_code")
-        .retrieve()
-        .body(OauthTokenResponse.class);
+      .post()
+      .uri(tokenUri)
+      .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+      .body(params)
+      .retrieve()
+      .body(OauthTokenResponse.class);
   }
 
   private GoogleUserInfoResponse requestUserInfo(String accessToken) {

--- a/auth-service/src/main/java/com/ticketrush/boundedcontext/auth/out/apiclient/GoogleOauthApiClient.java
+++ b/auth-service/src/main/java/com/ticketrush/boundedcontext/auth/out/apiclient/GoogleOauthApiClient.java
@@ -69,7 +69,7 @@ public class GoogleOauthApiClient implements SocialOauthApiClient {
 
       // 3. 공통 객체로 변환
       return new SocialUserInfo(
-        userInfoResponse.id(), getProvider(), userInfoResponse.name(), userInfoResponse.email());
+          userInfoResponse.id(), getProvider(), userInfoResponse.name(), userInfoResponse.email());
 
     } catch (BusinessException e) {
       throw e;
@@ -84,13 +84,13 @@ public class GoogleOauthApiClient implements SocialOauthApiClient {
   public String generateOAuthUrl() {
 
     return UriComponentsBuilder.fromUriString(authUri)
-      .queryParam("client_id", clientId)
-      .queryParam("redirect_uri", defaultRedirectUri)
-      .queryParam("response_type", "code")
-      .queryParam("scope", "profile email")
-      .build()
-      .encode()
-      .toUriString();
+        .queryParam("client_id", clientId)
+        .queryParam("redirect_uri", defaultRedirectUri)
+        .queryParam("response_type", "code")
+        .queryParam("scope", "profile email")
+        .build()
+        .encode()
+        .toUriString();
   }
 
   @Override
@@ -109,45 +109,45 @@ public class GoogleOauthApiClient implements SocialOauthApiClient {
     form.add("grant_type", "authorization_code");
 
     return restClient
-      .post()
-      .uri(tokenUri)
-      .contentType(MediaType.APPLICATION_FORM_URLENCODED)
-      .body(form)
-      .retrieve()
-      .onStatus(
-        HttpStatusCode::is4xxClientError,
-        (request, response) -> {
-          log.warn("Google OAuth 토큰 발급 요청 실패 - 클라이언트 오류. status={}", response.getStatusCode());
-          throw new BusinessException(ErrorStatus.AUTH_GOOGLE_TOKEN_FAILED);
-        })
-      .onStatus(
-        HttpStatusCode::is5xxServerError,
-        (request, response) -> {
-          log.error("Google OAuth 토큰 발급 요청 실패 - 서버 오류. status={}", response.getStatusCode());
-          throw new BusinessException(ErrorStatus.AUTH_GOOGLE_TOKEN_FAILED);
-        })
-      .body(OauthTokenResponse.class);
+        .post()
+        .uri(tokenUri)
+        .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+        .body(form)
+        .retrieve()
+        .onStatus(
+            HttpStatusCode::is4xxClientError,
+            (request, response) -> {
+              log.warn("Google OAuth 토큰 발급 요청 실패 - 클라이언트 오류. status={}", response.getStatusCode());
+              throw new BusinessException(ErrorStatus.AUTH_GOOGLE_TOKEN_FAILED);
+            })
+        .onStatus(
+            HttpStatusCode::is5xxServerError,
+            (request, response) -> {
+              log.error("Google OAuth 토큰 발급 요청 실패 - 서버 오류. status={}", response.getStatusCode());
+              throw new BusinessException(ErrorStatus.AUTH_GOOGLE_TOKEN_FAILED);
+            })
+        .body(OauthTokenResponse.class);
   }
 
   private GoogleUserInfoResponse requestUserInfo(String accessToken) {
 
     return restClient
-      .get()
-      .uri(userInfoUri)
-      .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
-      .retrieve()
-      .onStatus(
-        HttpStatusCode::is4xxClientError,
-        (request, response) -> {
-          log.warn("Google OAuth 사용자 정보 조회 실패 - 클라이언트 오류. status={}", response.getStatusCode());
-          throw new BusinessException(ErrorStatus.AUTH_GOOGLE_INFO_FAILED);
-        })
-      .onStatus(
-        HttpStatusCode::is5xxServerError,
-        (request, response) -> {
-          log.error("Google OAuth 사용자 정보 조회 실패 - 서버 오류. status={}", response.getStatusCode());
-          throw new BusinessException(ErrorStatus.AUTH_GOOGLE_INFO_FAILED);
-        })
-      .body(GoogleUserInfoResponse.class);
+        .get()
+        .uri(userInfoUri)
+        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+        .retrieve()
+        .onStatus(
+            HttpStatusCode::is4xxClientError,
+            (request, response) -> {
+              log.warn("Google OAuth 사용자 정보 조회 실패 - 클라이언트 오류. status={}", response.getStatusCode());
+              throw new BusinessException(ErrorStatus.AUTH_GOOGLE_INFO_FAILED);
+            })
+        .onStatus(
+            HttpStatusCode::is5xxServerError,
+            (request, response) -> {
+              log.error("Google OAuth 사용자 정보 조회 실패 - 서버 오류. status={}", response.getStatusCode());
+              throw new BusinessException(ErrorStatus.AUTH_GOOGLE_INFO_FAILED);
+            })
+        .body(GoogleUserInfoResponse.class);
   }
 }

--- a/auth-service/src/main/java/com/ticketrush/boundedcontext/auth/out/apiclient/GoogleOauthApiClient.java
+++ b/auth-service/src/main/java/com/ticketrush/boundedcontext/auth/out/apiclient/GoogleOauthApiClient.java
@@ -65,7 +65,8 @@ public class GoogleOauthApiClient implements SocialOauthApiClient {
       }
 
       // 3. 공통 객체로 변환
-      return new SocialUserInfo(userInfoResponse.id(), getProvider(), userInfoResponse.name());
+      return new SocialUserInfo(
+          userInfoResponse.id(), getProvider(), userInfoResponse.name(), userInfoResponse.email());
 
     } catch (BusinessException e) {
 
@@ -85,7 +86,7 @@ public class GoogleOauthApiClient implements SocialOauthApiClient {
         .queryParam("client_id", clientId)
         .queryParam("redirect_uri", defaultRedirectUri)
         .queryParam("response_type", "code")
-        .queryParam("scope", "profile")
+        .queryParam("scope", "profile email")
         .build()
         .toUriString();
   }

--- a/auth-service/src/main/java/com/ticketrush/boundedcontext/auth/out/apiclient/GoogleOauthApiClient.java
+++ b/auth-service/src/main/java/com/ticketrush/boundedcontext/auth/out/apiclient/GoogleOauthApiClient.java
@@ -10,6 +10,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.util.LinkedMultiValueMap;
@@ -68,15 +69,13 @@ public class GoogleOauthApiClient implements SocialOauthApiClient {
 
       // 3. 공통 객체로 변환
       return new SocialUserInfo(
-          userInfoResponse.id(), getProvider(), userInfoResponse.name(), userInfoResponse.email());
+        userInfoResponse.id(), getProvider(), userInfoResponse.name(), userInfoResponse.email());
 
     } catch (BusinessException e) {
-
       throw e;
 
     } catch (Exception e) {
-
-      log.error("Google OAuth 처리 중 에러 발생", e);
+      log.error("Google OAuth 처리 중 예상하지 못한 에러 발생", e);
       throw new BusinessException(ErrorStatus.AUTH_GOOGLE_INFO_FAILED);
     }
   }
@@ -85,12 +84,13 @@ public class GoogleOauthApiClient implements SocialOauthApiClient {
   public String generateOAuthUrl() {
 
     return UriComponentsBuilder.fromUriString(authUri)
-        .queryParam("client_id", clientId)
-        .queryParam("redirect_uri", defaultRedirectUri)
-        .queryParam("response_type", "code")
-        .queryParam("scope", "profile email")
-        .build()
-        .toUriString();
+      .queryParam("client_id", clientId)
+      .queryParam("redirect_uri", defaultRedirectUri)
+      .queryParam("response_type", "code")
+      .queryParam("scope", "profile email")
+      .build()
+      .encode()
+      .toUriString();
   }
 
   @Override
@@ -100,29 +100,54 @@ public class GoogleOauthApiClient implements SocialOauthApiClient {
 
   private OauthTokenResponse requestToken(String code, String redirectUri) {
 
-    MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
-    params.add("code", code);
-    params.add("client_id", clientId);
-    params.add("client_secret", clientSecret);
-    params.add("redirect_uri", redirectUri);
-    params.add("grant_type", "authorization_code");
+    MultiValueMap<String, String> form = new LinkedMultiValueMap<>();
+
+    form.add("code", code);
+    form.add("client_id", clientId);
+    form.add("client_secret", clientSecret);
+    form.add("redirect_uri", redirectUri);
+    form.add("grant_type", "authorization_code");
 
     return restClient
       .post()
       .uri(tokenUri)
       .contentType(MediaType.APPLICATION_FORM_URLENCODED)
-      .body(params)
+      .body(form)
       .retrieve()
+      .onStatus(
+        HttpStatusCode::is4xxClientError,
+        (request, response) -> {
+          log.warn("Google OAuth 토큰 발급 요청 실패 - 클라이언트 오류. status={}", response.getStatusCode());
+          throw new BusinessException(ErrorStatus.AUTH_GOOGLE_TOKEN_FAILED);
+        })
+      .onStatus(
+        HttpStatusCode::is5xxServerError,
+        (request, response) -> {
+          log.error("Google OAuth 토큰 발급 요청 실패 - 서버 오류. status={}", response.getStatusCode());
+          throw new BusinessException(ErrorStatus.AUTH_GOOGLE_TOKEN_FAILED);
+        })
       .body(OauthTokenResponse.class);
   }
 
   private GoogleUserInfoResponse requestUserInfo(String accessToken) {
 
     return restClient
-        .get()
-        .uri(userInfoUri)
-        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
-        .retrieve()
-        .body(GoogleUserInfoResponse.class);
+      .get()
+      .uri(userInfoUri)
+      .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+      .retrieve()
+      .onStatus(
+        HttpStatusCode::is4xxClientError,
+        (request, response) -> {
+          log.warn("Google OAuth 사용자 정보 조회 실패 - 클라이언트 오류. status={}", response.getStatusCode());
+          throw new BusinessException(ErrorStatus.AUTH_GOOGLE_INFO_FAILED);
+        })
+      .onStatus(
+        HttpStatusCode::is5xxServerError,
+        (request, response) -> {
+          log.error("Google OAuth 사용자 정보 조회 실패 - 서버 오류. status={}", response.getStatusCode());
+          throw new BusinessException(ErrorStatus.AUTH_GOOGLE_INFO_FAILED);
+        })
+      .body(GoogleUserInfoResponse.class);
   }
 }

--- a/auth-service/src/main/java/com/ticketrush/boundedcontext/auth/out/apiclient/KakaoOauthApiClient.java
+++ b/auth-service/src/main/java/com/ticketrush/boundedcontext/auth/out/apiclient/KakaoOauthApiClient.java
@@ -65,7 +65,7 @@ public class KakaoOauthApiClient implements SocialOauthApiClient {
 
       String socialId = String.valueOf(userInfoResponse.id());
       String nickname =
-        userInfoResponse.properties() != null ? userInfoResponse.properties().nickname() : null;
+          userInfoResponse.properties() != null ? userInfoResponse.properties().nickname() : null;
 
       return new SocialUserInfo(socialId, getProvider(), nickname, null);
 
@@ -82,12 +82,12 @@ public class KakaoOauthApiClient implements SocialOauthApiClient {
   public String generateOAuthUrl() {
 
     return UriComponentsBuilder.fromUriString(authUri)
-      .queryParam("client_id", clientId)
-      .queryParam("redirect_uri", redirectUri)
-      .queryParam("response_type", "code")
-      .build()
-      .encode()
-      .toUriString();
+        .queryParam("client_id", clientId)
+        .queryParam("redirect_uri", redirectUri)
+        .queryParam("response_type", "code")
+        .build()
+        .encode()
+        .toUriString();
   }
 
   private OauthTokenResponse getToken(String code) {
@@ -100,46 +100,46 @@ public class KakaoOauthApiClient implements SocialOauthApiClient {
     form.add("code", code);
 
     return restClient
-      .post()
-      .uri(tokenUri)
-      .contentType(MediaType.APPLICATION_FORM_URLENCODED)
-      .body(form)
-      .retrieve()
-      .onStatus(
-        HttpStatusCode::is4xxClientError,
-        (request, response) -> {
-          log.warn("Kakao OAuth 토큰 발급 요청 실패 - 클라이언트 오류. status={}", response.getStatusCode());
-          throw new BusinessException(ErrorStatus.AUTH_KAKAO_TOKEN_FAILED);
-        })
-      .onStatus(
-        HttpStatusCode::is5xxServerError,
-        (request, response) -> {
-          log.error("Kakao OAuth 토큰 발급 요청 실패 - 서버 오류. status={}", response.getStatusCode());
-          throw new BusinessException(ErrorStatus.AUTH_KAKAO_TOKEN_FAILED);
-        })
-      .body(OauthTokenResponse.class);
+        .post()
+        .uri(tokenUri)
+        .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+        .body(form)
+        .retrieve()
+        .onStatus(
+            HttpStatusCode::is4xxClientError,
+            (request, response) -> {
+              log.warn("Kakao OAuth 토큰 발급 요청 실패 - 클라이언트 오류. status={}", response.getStatusCode());
+              throw new BusinessException(ErrorStatus.AUTH_KAKAO_TOKEN_FAILED);
+            })
+        .onStatus(
+            HttpStatusCode::is5xxServerError,
+            (request, response) -> {
+              log.error("Kakao OAuth 토큰 발급 요청 실패 - 서버 오류. status={}", response.getStatusCode());
+              throw new BusinessException(ErrorStatus.AUTH_KAKAO_TOKEN_FAILED);
+            })
+        .body(OauthTokenResponse.class);
   }
 
   private KakaoUserInfoResponse getProfile(String accessToken) {
 
     return restClient
-      .get()
-      .uri(userInfoUri)
-      .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
-      .retrieve()
-      .onStatus(
-        HttpStatusCode::is4xxClientError,
-        (request, response) -> {
-          log.warn("Kakao OAuth 사용자 정보 조회 실패 - 클라이언트 오류. status={}", response.getStatusCode());
-          throw new BusinessException(ErrorStatus.AUTH_KAKAO_INFO_FAILED);
-        })
-      .onStatus(
-        HttpStatusCode::is5xxServerError,
-        (request, response) -> {
-          log.error("Kakao OAuth 사용자 정보 조회 실패 - 서버 오류. status={}", response.getStatusCode());
-          throw new BusinessException(ErrorStatus.AUTH_KAKAO_INFO_FAILED);
-        })
-      .body(KakaoUserInfoResponse.class);
+        .get()
+        .uri(userInfoUri)
+        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+        .retrieve()
+        .onStatus(
+            HttpStatusCode::is4xxClientError,
+            (request, response) -> {
+              log.warn("Kakao OAuth 사용자 정보 조회 실패 - 클라이언트 오류. status={}", response.getStatusCode());
+              throw new BusinessException(ErrorStatus.AUTH_KAKAO_INFO_FAILED);
+            })
+        .onStatus(
+            HttpStatusCode::is5xxServerError,
+            (request, response) -> {
+              log.error("Kakao OAuth 사용자 정보 조회 실패 - 서버 오류. status={}", response.getStatusCode());
+              throw new BusinessException(ErrorStatus.AUTH_KAKAO_INFO_FAILED);
+            })
+        .body(KakaoUserInfoResponse.class);
   }
 
   @Override

--- a/auth-service/src/main/java/com/ticketrush/boundedcontext/auth/out/apiclient/KakaoOauthApiClient.java
+++ b/auth-service/src/main/java/com/ticketrush/boundedcontext/auth/out/apiclient/KakaoOauthApiClient.java
@@ -65,7 +65,7 @@ public class KakaoOauthApiClient implements SocialOauthApiClient {
       String nickname =
           userInfoResponse.properties() != null ? userInfoResponse.properties().nickname() : null;
 
-      return new SocialUserInfo(socialId, getProvider(), nickname);
+      return new SocialUserInfo(socialId, getProvider(), nickname, null);
 
     } catch (BusinessException e) {
 

--- a/auth-service/src/main/java/com/ticketrush/boundedcontext/auth/out/apiclient/KakaoOauthApiClient.java
+++ b/auth-service/src/main/java/com/ticketrush/boundedcontext/auth/out/apiclient/KakaoOauthApiClient.java
@@ -9,6 +9,8 @@ import com.ticketrush.global.status.ErrorStatus;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.util.LinkedMultiValueMap;
@@ -63,15 +65,15 @@ public class KakaoOauthApiClient implements SocialOauthApiClient {
 
       String socialId = String.valueOf(userInfoResponse.id());
       String nickname =
-          userInfoResponse.properties() != null ? userInfoResponse.properties().nickname() : null;
+        userInfoResponse.properties() != null ? userInfoResponse.properties().nickname() : null;
 
       return new SocialUserInfo(socialId, getProvider(), nickname, null);
 
     } catch (BusinessException e) {
-
       throw e;
+
     } catch (Exception e) {
-      log.error("Kakao OAuth 처리 중 에러 발생", e);
+      log.error("Kakao OAuth 처리 중 예상하지 못한 에러 발생", e);
       throw new BusinessException(ErrorStatus.AUTH_KAKAO_INFO_FAILED);
     }
   }
@@ -80,18 +82,15 @@ public class KakaoOauthApiClient implements SocialOauthApiClient {
   public String generateOAuthUrl() {
 
     return UriComponentsBuilder.fromUriString(authUri)
-        .queryParam("client_id", clientId)
-        .queryParam("redirect_uri", redirectUri)
-        .queryParam("response_type", "code")
-        .build()
-        .toUriString();
+      .queryParam("client_id", clientId)
+      .queryParam("redirect_uri", redirectUri)
+      .queryParam("response_type", "code")
+      .build()
+      .encode()
+      .toUriString();
   }
 
   private OauthTokenResponse getToken(String code) {
-
-    log.info("clientId = {}", clientId);
-    log.info("clientSecret = {}", clientSecret);
-    log.info("redirectUri = {}", redirectUri);
 
     MultiValueMap<String, String> form = new LinkedMultiValueMap<>();
     form.add("grant_type", "authorization_code");
@@ -101,21 +100,46 @@ public class KakaoOauthApiClient implements SocialOauthApiClient {
     form.add("code", code);
 
     return restClient
-        .post()
-        .uri(tokenUri)
-        .contentType(MediaType.APPLICATION_FORM_URLENCODED)
-        .body(form)
-        .retrieve()
-        .body(OauthTokenResponse.class);
+      .post()
+      .uri(tokenUri)
+      .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+      .body(form)
+      .retrieve()
+      .onStatus(
+        HttpStatusCode::is4xxClientError,
+        (request, response) -> {
+          log.warn("Kakao OAuth 토큰 발급 요청 실패 - 클라이언트 오류. status={}", response.getStatusCode());
+          throw new BusinessException(ErrorStatus.AUTH_KAKAO_TOKEN_FAILED);
+        })
+      .onStatus(
+        HttpStatusCode::is5xxServerError,
+        (request, response) -> {
+          log.error("Kakao OAuth 토큰 발급 요청 실패 - 서버 오류. status={}", response.getStatusCode());
+          throw new BusinessException(ErrorStatus.AUTH_KAKAO_TOKEN_FAILED);
+        })
+      .body(OauthTokenResponse.class);
   }
 
   private KakaoUserInfoResponse getProfile(String accessToken) {
+
     return restClient
-        .get()
-        .uri(userInfoUri)
-        .header("Authorization", "Bearer " + accessToken)
-        .retrieve()
-        .body(KakaoUserInfoResponse.class);
+      .get()
+      .uri(userInfoUri)
+      .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+      .retrieve()
+      .onStatus(
+        HttpStatusCode::is4xxClientError,
+        (request, response) -> {
+          log.warn("Kakao OAuth 사용자 정보 조회 실패 - 클라이언트 오류. status={}", response.getStatusCode());
+          throw new BusinessException(ErrorStatus.AUTH_KAKAO_INFO_FAILED);
+        })
+      .onStatus(
+        HttpStatusCode::is5xxServerError,
+        (request, response) -> {
+          log.error("Kakao OAuth 사용자 정보 조회 실패 - 서버 오류. status={}", response.getStatusCode());
+          throw new BusinessException(ErrorStatus.AUTH_KAKAO_INFO_FAILED);
+        })
+      .body(KakaoUserInfoResponse.class);
   }
 
   @Override

--- a/auth-service/src/main/java/com/ticketrush/boundedcontext/auth/out/apiclient/NaverOauthApiClient.java
+++ b/auth-service/src/main/java/com/ticketrush/boundedcontext/auth/out/apiclient/NaverOauthApiClient.java
@@ -68,8 +68,9 @@ public class NaverOauthApiClient implements SocialOauthApiClient {
 
       String socialId = userInfoResponse.response().id();
       String nickname = userInfoResponse.response().name();
+      String email = userInfoResponse.response().email();
 
-      return new SocialUserInfo(socialId, getProvider(), nickname);
+      return new SocialUserInfo(socialId, getProvider(), nickname, email);
 
     } catch (BusinessException e) {
       throw e;

--- a/user-service/src/main/java/com/ticketrush/boundedcontext/user/app/dto/request/SocialLoginRequest.java
+++ b/user-service/src/main/java/com/ticketrush/boundedcontext/user/app/dto/request/SocialLoginRequest.java
@@ -60,18 +60,18 @@ public class SocialLoginRequest {
   @Override
   public String toString() {
     return "SocialLoginRequest{"
-      + "socialId='"
-      + maskValue(socialId)
-      + '\''
-      + ", socialProvider='"
-      + socialProvider
-      + '\''
-      + ", name='"
-      + maskValue(name)
-      + '\''
-      + ", email='"
-      + maskEmail(email)
-      + '\''
-      + '}';
+        + "socialId='"
+        + maskValue(socialId)
+        + '\''
+        + ", socialProvider='"
+        + socialProvider
+        + '\''
+        + ", name='"
+        + maskValue(name)
+        + '\''
+        + ", email='"
+        + maskEmail(email)
+        + '\''
+        + '}';
   }
 }

--- a/user-service/src/main/java/com/ticketrush/boundedcontext/user/app/dto/request/SocialLoginRequest.java
+++ b/user-service/src/main/java/com/ticketrush/boundedcontext/user/app/dto/request/SocialLoginRequest.java
@@ -28,24 +28,50 @@ public class SocialLoginRequest {
     if (value == null || value.isEmpty()) {
       return value;
     }
-    return "***";
+
+    if (value.length() <= 2) {
+      return value.charAt(0) + "***";
+    }
+
+    return value.substring(0, 2) + "***";
+  }
+
+  private String maskEmail(String email) {
+    if (email == null || email.isEmpty()) {
+      return email;
+    }
+
+    int atIndex = email.indexOf("@");
+
+    if (atIndex <= 0) {
+      return maskValue(email);
+    }
+
+    String localPart = email.substring(0, atIndex);
+    String domain = email.substring(atIndex);
+
+    if (localPart.length() <= 2) {
+      return localPart.charAt(0) + "***" + domain;
+    }
+
+    return localPart.substring(0, 2) + "***" + domain;
   }
 
   @Override
   public String toString() {
     return "SocialLoginRequest{"
-        + "socialId='"
-        + maskValue(socialId)
-        + '\''
-        + ", socialProvider='"
-        + socialProvider
-        + '\''
-        + ", name='"
-        + maskValue(name)
-        + '\''
-        + ", email='"
-        + maskValue(email)
-        + '\''
-        + '}';
+      + "socialId='"
+      + maskValue(socialId)
+      + '\''
+      + ", socialProvider='"
+      + socialProvider
+      + '\''
+      + ", name='"
+      + maskValue(name)
+      + '\''
+      + ", email='"
+      + maskEmail(email)
+      + '\''
+      + '}';
   }
 }

--- a/user-service/src/main/java/com/ticketrush/boundedcontext/user/app/dto/request/SocialLoginRequest.java
+++ b/user-service/src/main/java/com/ticketrush/boundedcontext/user/app/dto/request/SocialLoginRequest.java
@@ -21,6 +21,9 @@ public class SocialLoginRequest {
   @JsonProperty("name")
   private String name;
 
+  @JsonProperty("email")
+  private String email;
+
   private String maskValue(String value) {
     if (value == null || value.isEmpty()) {
       return value;
@@ -39,6 +42,9 @@ public class SocialLoginRequest {
         + '\''
         + ", name='"
         + maskValue(name)
+        + '\''
+        + ", email='"
+        + maskValue(email)
         + '\''
         + '}';
   }

--- a/user-service/src/main/java/com/ticketrush/boundedcontext/user/domain/entity/User.java
+++ b/user-service/src/main/java/com/ticketrush/boundedcontext/user/domain/entity/User.java
@@ -29,7 +29,7 @@ public class User extends AutoIdBaseEntity {
   private UserRole userRole;
 
   @Builder
-  public User(String name, String email, String phone, UserRole userRole) {
+  public User(String name, String email, UserRole userRole) {
     this.name = name;
     this.email = email;
     this.userRole = userRole;


### PR DESCRIPTION
## 🔗 관련 이슈

- close #193 

---

## 📌 주요 변경 사항

- SocialLoginRequest, SocialUserInfo, GoogleUserInfoResponse, NaverUserInfoResponse에 email 로직 추가
- GoogleOauthApiClient의 generateOAuthUrl 로직 중에 email 로직 추가
- SocialOauthLoginUseCase에서도 socialUserInfo.email() 로직 추가

---

## 🛠 상세 구현 내용

- 자체 회원가입 과정 중 이메일 중복 검증을 하기 위해서 소셜로그인의 이메일 정보도 DB에 저장되어야 합니다. Kakao는 기본적으로 email 정보를 제공하지 않기 때문에 제외하고 naver, google만 email 정보를 받아오도록 다시 코드 설계하였습니다. 
---

## ✅ 테스트

### 테스트 방법

- MySQL에서 원래 로그인 정보를 모두 삭제하고 다시 소셜로그인을 했을 때, naver, google 이메일이 DB에 저장되는지 확인. 

### 테스트 결과

- 본 테스터의 naver, google 이메일이 각각 DB에 저장되었다. 

### 📸 스크린샷
<img width="829" height="199" alt="Pasted Graphic" src="https://github.com/user-attachments/assets/3217e90b-3382-40a5-8036-4c4e5c612fe6" />

---

<!---## 👀 리뷰 요청 사항

-

---

## ⚠️ 배포 시 주의사항

- 
--->