### PR TITLE
[Infra] #201 SSE 연결 유지를 위한 gateway timeout 설정 추가

### DIFF
--- a/gateway-service/src/main/resources/application.yml
+++ b/gateway-service/src/main/resources/application.yml
@@ -53,6 +53,14 @@ spring:
               filters:
                 - RewritePath=/v3/api-docs/payment,/v3/api-docs
 
+            - id: seat-sse-service
+              uri: http://${services.seat.host}:8086
+              predicates:
+                - Path=/api/v1/seat/*/seat-status/stream
+              metadata:
+                response-timeout: 2100000
+                connect-timeout: 5000
+
             - id: seat-service
               uri: http://${services.seat.host}:8086
               predicates:

--- a/gateway-service/src/main/resources/application.yml
+++ b/gateway-service/src/main/resources/application.yml
@@ -58,7 +58,7 @@ spring:
               predicates:
                 - Path=/api/v1/seat/*/seat-status/stream
               metadata:
-                response-timeout: 2100000
+                response-timeout: -1
                 connect-timeout: 5000
 
             - id: seat-service


### PR DESCRIPTION
## 🔗 관련 이슈

- close #201 

---

## 📌 주요 변경 사항

- Gateway-service에서 seat-sse-service timeout 설정 추가
---

## 🛠 상세 구현 내용

- seat-service 위에 seat-sse-service 따로 추가
- 정해놓은 Path일 때만 timeout 설정될 수 있도록 구현

---

<!--- ## ✅ 테스트

### 테스트 방법

-

### 테스트 결과

-

### 📸 스크린샷

---

## 👀 리뷰 요청 사항

-

---

## ⚠️ 배포 시 주의사항

- 
--->