### PR TITLE
[Feat] #117 공연 관리 API 권한 검증 적용

### DIFF
--- a/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/in/api/v1/PerformanceAdminController.java
+++ b/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/in/api/v1/PerformanceAdminController.java
@@ -20,6 +20,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -35,6 +36,7 @@ import org.springframework.web.multipart.MultipartFile;
 @RestController
 @RequestMapping("/api/v1/performance")
 @RequiredArgsConstructor
+@PreAuthorize("hasRole('ADMIN')")
 public class PerformanceAdminController {
 
   private final PerformanceFacade performanceFacade;

--- a/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/in/api/v1/PerformanceAdminController.java
+++ b/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/in/api/v1/PerformanceAdminController.java
@@ -34,7 +34,7 @@ import org.springframework.web.multipart.MultipartFile;
 @Tag(name = "Performance Admin", description = "공연 관리자 API")
 @Validated
 @RestController
-@RequestMapping("/api/v1/performance")
+@RequestMapping("/api/v1/performance/admin")
 @RequiredArgsConstructor
 @PreAuthorize("hasRole('ADMIN')")
 public class PerformanceAdminController {

--- a/performance-service/src/main/java/com/ticketrush/global/config/SecurityConfig.java
+++ b/performance-service/src/main/java/com/ticketrush/global/config/SecurityConfig.java
@@ -30,6 +30,8 @@ public class SecurityConfig {
             auth ->
                 auth.requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html")
                     .permitAll()
+                    .requestMatchers("/api/v1/performance/admin/**")
+                    .hasRole("ADMIN")
                     .anyRequest()
                     .permitAll());
 

--- a/performance-service/src/main/java/com/ticketrush/global/config/SecurityConfig.java
+++ b/performance-service/src/main/java/com/ticketrush/global/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.ticketrush.global.config;
 
+import com.ticketrush.global.security.GatewayHeaderFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.security.autoconfigure.SecurityProperties;
@@ -9,6 +10,7 @@ import org.springframework.security.config.annotation.method.configuration.Enabl
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
 @EnableWebSecurity
@@ -17,14 +19,16 @@ import org.springframework.security.web.SecurityFilterChain;
 @RequiredArgsConstructor
 public class SecurityConfig {
 
+  private final GatewayHeaderFilter gatewayHeaderFilter;
+
   @Bean
   public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
     http.csrf(csrf -> csrf.disable())
         .cors(cors -> {})
+        .addFilterBefore(gatewayHeaderFilter, UsernamePasswordAuthenticationFilter.class)
         .authorizeHttpRequests(
             auth ->
                 auth.requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html")
-                    // TODO: 인증 이후 허용 범위 수정
                     .permitAll()
                     .anyRequest()
                     .permitAll());

--- a/performance-service/src/test/java/com/ticketrush/boundedcontext/performance/in/api/v1/PerformanceAdminControllerTest.java
+++ b/performance-service/src/test/java/com/ticketrush/boundedcontext/performance/in/api/v1/PerformanceAdminControllerTest.java
@@ -1,0 +1,60 @@
+package com.ticketrush.boundedcontext.performance.in.api.v1;
+
+import static org.mockito.Mockito.doNothing;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.ticketrush.boundedcontext.performance.app.facade.PerformanceFacade;
+import com.ticketrush.global.config.JacksonConfig;
+import com.ticketrush.global.config.SecurityConfig;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(PerformanceAdminController.class)
+@Import({JacksonConfig.class, SecurityConfig.class})
+class PerformanceAdminControllerTest {
+
+  @Autowired private MockMvc mockMvc;
+
+  @MockitoBean private PerformanceFacade performanceFacade;
+
+  private static final String BASE_URL = "/api/v1/performance";
+  private static final String INTERNAL_TOKEN = "test-token";
+
+  @Test
+  @DisplayName("관리자 권한으로 공연 삭제 요청 시 200을 반환한다")
+  void deletePerformance_admin_success() throws Exception {
+    doNothing().when(performanceFacade).deletePerformance(1L);
+
+    mockMvc
+        .perform(
+            delete(BASE_URL + "/1")
+                .header("X-Internal-Token", INTERNAL_TOKEN)
+                .header("X-User-Id", "1")
+                .header("X-User-Role", "ADMIN"))
+        .andExpect(status().isOk());
+  }
+
+  @Test
+  @DisplayName("일반 사용자 권한으로 공연 삭제 요청 시 403을 반환한다")
+  void deletePerformance_userRole_forbidden() throws Exception {
+    mockMvc
+        .perform(
+            delete(BASE_URL + "/1")
+                .header("X-Internal-Token", INTERNAL_TOKEN)
+                .header("X-User-Id", "1")
+                .header("X-User-Role", "USER"))
+        .andExpect(status().isForbidden());
+  }
+
+  @Test
+  @DisplayName("인증 없이 공연 삭제 요청 시 403을 반환한다")
+  void deletePerformance_noAuth_forbidden() throws Exception {
+    mockMvc.perform(delete(BASE_URL + "/1")).andExpect(status().isForbidden());
+  }
+}

--- a/performance-service/src/test/java/com/ticketrush/boundedcontext/performance/in/api/v1/PerformanceAdminControllerTest.java
+++ b/performance-service/src/test/java/com/ticketrush/boundedcontext/performance/in/api/v1/PerformanceAdminControllerTest.java
@@ -25,7 +25,7 @@ class PerformanceAdminControllerTest {
 
   @MockitoBean private PerformanceFacade performanceFacade;
 
-  private static final String BASE_URL = "/api/v1/performance";
+  private static final String BASE_URL = "/api/v1/performance/admin";
   private static final String INTERNAL_TOKEN = "test-token";
 
   @Test

--- a/performance-service/src/test/java/com/ticketrush/boundedcontext/performance/in/api/v1/PerformanceAdminControllerTest.java
+++ b/performance-service/src/test/java/com/ticketrush/boundedcontext/performance/in/api/v1/PerformanceAdminControllerTest.java
@@ -59,4 +59,24 @@ class PerformanceAdminControllerTest {
   void deletePerformance_noAuth_forbidden() throws Exception {
     mockMvc.perform(delete(BASE_URL + "/1")).andExpect(status().isForbidden());
   }
+
+  @Test
+  @DisplayName("내부 토큰 없이 관리자 권한으로 공연 삭제 요청 시 403을 반환한다")
+  void deletePerformance_missingInternalToken_forbidden() throws Exception {
+    mockMvc
+        .perform(delete(BASE_URL + "/1").header("X-User-Id", "1").header("X-User-Role", "ADMIN"))
+        .andExpect(status().isForbidden());
+  }
+
+  @Test
+  @DisplayName("잘못된 내부 토큰과 관리자 권한으로 공연 삭제 요청 시 403을 반환한다")
+  void deletePerformance_invalidInternalToken_forbidden() throws Exception {
+    mockMvc
+        .perform(
+            delete(BASE_URL + "/1")
+                .header("X-Internal-Token", "invalid-token")
+                .header("X-User-Id", "1")
+                .header("X-User-Role", "ADMIN"))
+        .andExpect(status().isForbidden());
+  }
 }

--- a/performance-service/src/test/java/com/ticketrush/boundedcontext/performance/in/api/v1/PerformanceAdminControllerTest.java
+++ b/performance-service/src/test/java/com/ticketrush/boundedcontext/performance/in/api/v1/PerformanceAdminControllerTest.java
@@ -12,11 +12,13 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(PerformanceAdminController.class)
 @Import({JacksonConfig.class, SecurityConfig.class})
+@TestPropertySource(properties = "gateway.internal-token=test-token")
 class PerformanceAdminControllerTest {
 
   @Autowired private MockMvc mockMvc;

--- a/performance-service/src/test/java/com/ticketrush/boundedcontext/performance/in/api/v1/PerformanceValidationTest.java
+++ b/performance-service/src/test/java/com/ticketrush/boundedcontext/performance/in/api/v1/PerformanceValidationTest.java
@@ -36,7 +36,7 @@ class PerformanceValidationTest {
 
   @MockitoBean private PerformanceFacade performanceFacade;
 
-  final String baseUrl = "/api/v1/performance";
+  final String baseUrl = "/api/v1/performance/admin";
 
   private PerformanceCreateRequest.PerformanceCreateRequestBuilder createBaseRequest() {
     return PerformanceCreateRequest.builder()


### PR DESCRIPTION
## 🔗 관련 이슈

- close #117

---

## 📌 주요 변경 사항

- `SecurityConfig`에 `@EnableMethodSecurity` 활성화 및 `GatewayHeaderFilter` 필터 체인 등록
- `PerformanceAdminController` 클래스 레벨에 `@PreAuthorize("hasRole('ADMIN')")` 적용
- 관리자 권한 검증 슬라이스 테스트 추가

---

## 🛠 상세 구현 내용

- `SecurityConfig`: `@EnableMethodSecurity` 추가로 메서드 레벨 보안 활성화, `GatewayHeaderFilter`를 `UsernamePasswordAuthenticationFilter` 앞에 등록
- `PerformanceAdminController`: 공연 등록/수정/삭제/상태변경 API 전체에 `ADMIN` 권한 체크 일괄 적용 (클래스 레벨 `@PreAuthorize`)
- `PerformanceAdminControllerTest`: DELETE 엔드포인트 기준으로 3가지 케이스 검증
  - 관리자(`X-User-Role: ADMIN`) → 200
  - 일반 사용자(`X-User-Role: USER`) → 403
  - 비인증(헤더 없음) → 403

---

## ✅ 테스트

### 테스트 방법

- `PerformanceAdminControllerTest` 실행

### 테스트 결과

- 3개 테스트 모두 통과

### 📸 스크린샷
<img width="1345" height="414" alt="image" src="https://github.com/user-attachments/assets/ab9ac354-1f26-42a8-8e3c-a0ed046e71be" />


---

## 👀 리뷰 요청 사항

- `@PreAuthorize`가 클래스 레벨에 적용되어 있어 POST/PATCH/DELETE 모두 동일하게 동작합니다. 테스트는 DELETE 엔드포인트로 대표 검증했는데 방향이 맞는지 확인 부탁드립니다.
<!--
---

## ⚠️ 배포 시 주의사항

- 없음
-->