### PR TITLE
[Feat] #88 QueryDSL 환경 구축 및 공연 카테고리별 동적 필터링 구현

### DIFF
--- a/common/src/main/java/com/ticketrush/global/status/ErrorStatus.java
+++ b/common/src/main/java/com/ticketrush/global/status/ErrorStatus.java
@@ -92,6 +92,8 @@ public enum ErrorStatus {
   PERFORMANCE_INVALID_STATUS_TRANSITION(
       HttpStatus.BAD_REQUEST, "PERFORMANCE_400_004", "유효하지 않은 공연 상태 전환입니다."),
   PERFORMANCE_NOT_ON_SALE(HttpStatus.BAD_REQUEST, "PERFORMANCE_400_005", "예매 가능한 공연이 아닙니다."),
+  PERFORMANCE_INVALID_SORT_PROPERTY(
+      HttpStatus.BAD_REQUEST, "PERFORMANCE_400_006", "허용되지 않은 정렬 필드입니다."),
 
   // Performance 409
   PERFORMANCE_HAS_SOLD_SEATS(

--- a/common/src/main/java/com/ticketrush/global/status/ErrorStatus.java
+++ b/common/src/main/java/com/ticketrush/global/status/ErrorStatus.java
@@ -94,6 +94,8 @@ public enum ErrorStatus {
   PERFORMANCE_NOT_ON_SALE(HttpStatus.BAD_REQUEST, "PERFORMANCE_400_005", "예매 가능한 공연이 아닙니다."),
   PERFORMANCE_INVALID_SORT_PROPERTY(
       HttpStatus.BAD_REQUEST, "PERFORMANCE_400_006", "허용되지 않은 정렬 필드입니다."),
+  PERFORMANCE_INVALID_PRICE_RANGE(
+      HttpStatus.BAD_REQUEST, "PERFORMANCE_400_007", "최소 가격은 최대 가격보다 클 수 없습니다."),
 
   // Performance 409
   PERFORMANCE_HAS_SOLD_SEATS(

--- a/performance-service/build.gradle
+++ b/performance-service/build.gradle
@@ -26,6 +26,7 @@ repositories {
 
 ext {
     set('springCloudVersion', "2025.1.0")
+    set('queryDslVersion', "6.10.1")
 }
 
 dependencies {
@@ -46,6 +47,9 @@ dependencies {
      */
     // implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
 
+    // QueryDSL
+    implementation "io.github.openfeign.querydsl:querydsl-jpa:${queryDslVersion}"
+
     // MapStruct
     implementation 'org.mapstruct:mapstruct:1.5.5.Final'
 
@@ -57,6 +61,7 @@ dependencies {
     runtimeOnly 'com.mysql:mysql-connector-j'
 
     annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
+    annotationProcessor "io.github.openfeign.querydsl:querydsl-apt:${queryDslVersion}:jpa"
     annotationProcessor 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok-mapstruct-binding:0.2.0'
     // Lombok과 MapStruct의 순서 및 바인딩을 위한 필수 설정
@@ -72,6 +77,7 @@ dependencies {
     // swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.1'
 
+    testAnnotationProcessor "io.github.openfeign.querydsl:querydsl-apt:${queryDslVersion}:jpa"
     testAnnotationProcessor 'org.projectlombok:lombok'
     testAnnotationProcessor 'org.projectlombok:lombok-mapstruct-binding:0.2.0'
     testAnnotationProcessor 'org.mapstruct:mapstruct-processor:1.5.5.Final'

--- a/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/app/facade/PerformanceFacade.java
+++ b/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/app/facade/PerformanceFacade.java
@@ -14,6 +14,7 @@ import com.ticketrush.boundedcontext.performance.app.usecase.PerformanceGetListU
 import com.ticketrush.boundedcontext.performance.app.usecase.PerformancePatchUseCase;
 import com.ticketrush.boundedcontext.performance.app.usecase.PerformanceValidateUseCase;
 import com.ticketrush.boundedcontext.performance.domain.types.Genre;
+import com.ticketrush.boundedcontext.performance.domain.types.PerformanceStatus;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -42,8 +43,9 @@ public class PerformanceFacade {
     return performanceCreateUseCase.execute(request, mainImage, model3d, gallery);
   }
 
-  public Page<PerformanceListResponse> getPerformances(Genre genre, Pageable pageable) {
-    return performanceGetListUseCase.execute(genre, pageable);
+  public Page<PerformanceListResponse> getPerformances(
+      Genre genre, Long minPrice, Long maxPrice, PerformanceStatus status, Pageable pageable) {
+    return performanceGetListUseCase.execute(genre, minPrice, maxPrice, status, pageable);
   }
 
   public PerformanceDetailResponse getPerformanceDetail(Long performanceId) {

--- a/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/app/usecase/PerformanceGetListUseCase.java
+++ b/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/app/usecase/PerformanceGetListUseCase.java
@@ -5,6 +5,8 @@ import com.ticketrush.boundedcontext.performance.app.mapper.PerformanceMapper;
 import com.ticketrush.boundedcontext.performance.domain.types.Genre;
 import com.ticketrush.boundedcontext.performance.domain.types.PerformanceStatus;
 import com.ticketrush.boundedcontext.performance.out.repository.PerformanceRepository;
+import com.ticketrush.global.exception.BusinessException;
+import com.ticketrush.global.status.ErrorStatus;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -22,8 +24,16 @@ public class PerformanceGetListUseCase {
   public Page<PerformanceListResponse> execute(
       Genre genre, Long minPrice, Long maxPrice, PerformanceStatus status, Pageable pageable) {
 
+    validatePriceRange(minPrice, maxPrice);
+
     return performanceRepository
         .findByFilters(genre, minPrice, maxPrice, status, pageable)
         .map(performanceMapper::toListResponse);
+  }
+
+  private void validatePriceRange(Long minPrice, Long maxPrice) {
+    if (minPrice != null && maxPrice != null && minPrice > maxPrice) {
+      throw new BusinessException(ErrorStatus.PERFORMANCE_INVALID_PRICE_RANGE);
+    }
   }
 }

--- a/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/app/usecase/PerformanceGetListUseCase.java
+++ b/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/app/usecase/PerformanceGetListUseCase.java
@@ -2,8 +2,8 @@ package com.ticketrush.boundedcontext.performance.app.usecase;
 
 import com.ticketrush.boundedcontext.performance.app.dto.response.PerformanceListResponse;
 import com.ticketrush.boundedcontext.performance.app.mapper.PerformanceMapper;
-import com.ticketrush.boundedcontext.performance.domain.entity.Performance;
 import com.ticketrush.boundedcontext.performance.domain.types.Genre;
+import com.ticketrush.boundedcontext.performance.domain.types.PerformanceStatus;
 import com.ticketrush.boundedcontext.performance.out.repository.PerformanceRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -19,12 +19,11 @@ public class PerformanceGetListUseCase {
   private final PerformanceMapper performanceMapper;
 
   @Transactional(readOnly = true)
-  public Page<PerformanceListResponse> execute(Genre genre, Pageable pageable) {
-    Page<Performance> performances =
-        (genre != null)
-            ? performanceRepository.findByGenre(genre, pageable)
-            : performanceRepository.findAll(pageable);
+  public Page<PerformanceListResponse> execute(
+      Genre genre, Long minPrice, Long maxPrice, PerformanceStatus status, Pageable pageable) {
 
-    return performances.map(performanceMapper::toListResponse);
+    return performanceRepository
+        .findByFilters(genre, minPrice, maxPrice, status, pageable)
+        .map(performanceMapper::toListResponse);
   }
 }

--- a/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/in/api/v1/PerformanceController.java
+++ b/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/in/api/v1/PerformanceController.java
@@ -11,6 +11,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.PositiveOrZero;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springdoc.core.annotations.ParameterObject;
@@ -58,8 +59,10 @@ public class PerformanceController {
   @GetMapping
   public ResponseEntity<ApiResponse<List<PerformanceListResponse>>> getPerformances(
       @Parameter(description = "장르 필터 (미입력 시 전체 조회)") @RequestParam(required = false) Genre genre,
-      @Parameter(description = "최소 가격") @RequestParam(required = false) Long minPrice,
-      @Parameter(description = "최대 가격") @RequestParam(required = false) Long maxPrice,
+      @Parameter(description = "최소 가격") @PositiveOrZero @RequestParam(required = false)
+          Long minPrice,
+      @Parameter(description = "최대 가격") @PositiveOrZero @RequestParam(required = false)
+          Long maxPrice,
       @Parameter(description = "공연 상태 필터") @RequestParam(required = false) PerformanceStatus status,
       @ParameterObject
           @PageableDefault(size = 8, sort = "createdAt", direction = Sort.Direction.DESC)

--- a/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/in/api/v1/PerformanceController.java
+++ b/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/in/api/v1/PerformanceController.java
@@ -4,6 +4,7 @@ import com.ticketrush.boundedcontext.performance.app.dto.response.PerformanceDet
 import com.ticketrush.boundedcontext.performance.app.dto.response.PerformanceListResponse;
 import com.ticketrush.boundedcontext.performance.app.facade.PerformanceFacade;
 import com.ticketrush.boundedcontext.performance.domain.types.Genre;
+import com.ticketrush.boundedcontext.performance.domain.types.PerformanceStatus;
 import com.ticketrush.global.dto.response.ApiResponse;
 import com.ticketrush.global.status.SuccessStatus;
 import io.swagger.v3.oas.annotations.Operation;
@@ -56,12 +57,18 @@ public class PerformanceController {
   @PerformanceListApiResponses
   @GetMapping
   public ResponseEntity<ApiResponse<List<PerformanceListResponse>>> getPerformances(
-      @Parameter(description = "장르 필터 (미입력 시 전체 조회)") @RequestParam(required = false) Genre genre,
+      @Parameter(description = "장르 필터 (미입력 시 전체 조회)") @RequestParam(required = false)
+          Genre genre,
+      @Parameter(description = "최소 가격") @RequestParam(required = false) Long minPrice,
+      @Parameter(description = "최대 가격") @RequestParam(required = false) Long maxPrice,
+      @Parameter(description = "공연 상태 필터") @RequestParam(required = false)
+          PerformanceStatus status,
       @ParameterObject
           @PageableDefault(size = 8, sort = "createdAt", direction = Sort.Direction.DESC)
           Pageable pageable) {
 
-    Page<PerformanceListResponse> performances = performanceFacade.getPerformances(genre, pageable);
+    Page<PerformanceListResponse> performances =
+        performanceFacade.getPerformances(genre, minPrice, maxPrice, status, pageable);
 
     return ApiResponse.onSuccess(SuccessStatus.OK, performances);
   }

--- a/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/in/api/v1/PerformanceController.java
+++ b/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/in/api/v1/PerformanceController.java
@@ -57,12 +57,10 @@ public class PerformanceController {
   @PerformanceListApiResponses
   @GetMapping
   public ResponseEntity<ApiResponse<List<PerformanceListResponse>>> getPerformances(
-      @Parameter(description = "장르 필터 (미입력 시 전체 조회)") @RequestParam(required = false)
-          Genre genre,
+      @Parameter(description = "장르 필터 (미입력 시 전체 조회)") @RequestParam(required = false) Genre genre,
       @Parameter(description = "최소 가격") @RequestParam(required = false) Long minPrice,
       @Parameter(description = "최대 가격") @RequestParam(required = false) Long maxPrice,
-      @Parameter(description = "공연 상태 필터") @RequestParam(required = false)
-          PerformanceStatus status,
+      @Parameter(description = "공연 상태 필터") @RequestParam(required = false) PerformanceStatus status,
       @ParameterObject
           @PageableDefault(size = 8, sort = "createdAt", direction = Sort.Direction.DESC)
           Pageable pageable) {

--- a/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/out/repository/PerformanceRepository.java
+++ b/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/out/repository/PerformanceRepository.java
@@ -1,16 +1,12 @@
 package com.ticketrush.boundedcontext.performance.out.repository;
 
 import com.ticketrush.boundedcontext.performance.domain.entity.Performance;
-import com.ticketrush.boundedcontext.performance.domain.types.Genre;
 import java.util.Optional;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface PerformanceRepository extends JpaRepository<Performance, Long> {
-
-  Page<Performance> findByGenre(Genre genre, Pageable pageable);
+public interface PerformanceRepository
+    extends JpaRepository<Performance, Long>, PerformanceRepositoryCustom {
 
   @EntityGraph(attributePaths = {"imageGalleryUrls", "facilities"})
   Optional<Performance> findDetailById(Long id);

--- a/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/out/repository/PerformanceRepositoryCustom.java
+++ b/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/out/repository/PerformanceRepositoryCustom.java
@@ -1,0 +1,13 @@
+package com.ticketrush.boundedcontext.performance.out.repository;
+
+import com.ticketrush.boundedcontext.performance.domain.entity.Performance;
+import com.ticketrush.boundedcontext.performance.domain.types.Genre;
+import com.ticketrush.boundedcontext.performance.domain.types.PerformanceStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface PerformanceRepositoryCustom {
+
+  Page<Performance> findByFilters(
+      Genre genre, Long minPrice, Long maxPrice, PerformanceStatus status, Pageable pageable);
+}

--- a/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/out/repository/PerformanceRepositoryImpl.java
+++ b/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/out/repository/PerformanceRepositoryImpl.java
@@ -1,0 +1,72 @@
+package com.ticketrush.boundedcontext.performance.out.repository;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.PathBuilder;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.ticketrush.boundedcontext.performance.domain.entity.Performance;
+import com.ticketrush.boundedcontext.performance.domain.entity.QPerformance;
+import com.ticketrush.boundedcontext.performance.domain.types.Genre;
+import com.ticketrush.boundedcontext.performance.domain.types.PerformanceStatus;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class PerformanceRepositoryImpl implements PerformanceRepositoryCustom {
+
+  private final JPAQueryFactory queryFactory;
+
+  @Override
+  public Page<Performance> findByFilters(
+      Genre genre, Long minPrice, Long maxPrice, PerformanceStatus status, Pageable pageable) {
+
+    QPerformance performance = QPerformance.performance;
+
+    BooleanBuilder predicate = new BooleanBuilder();
+    if (genre != null) predicate.and(performance.genre.eq(genre));
+    if (minPrice != null) predicate.and(performance.price.goe(minPrice));
+    if (maxPrice != null) predicate.and(performance.price.loe(maxPrice));
+    if (status != null) predicate.and(performance.performanceStatus.eq(status));
+
+    List<Performance> content =
+        queryFactory
+            .selectFrom(performance)
+            .where(predicate)
+            .offset(pageable.getOffset())
+            .limit(pageable.getPageSize())
+            .orderBy(toOrderSpecifiers(performance, pageable))
+            .fetch();
+
+    Long totalCount =
+        queryFactory
+            .select(performance.count())
+            .from(performance)
+            .where(predicate)
+            .fetchOne();
+
+    return new PageImpl<>(content, pageable, totalCount != null ? totalCount : 0L);
+  }
+
+  private OrderSpecifier<?>[] toOrderSpecifiers(QPerformance performance, Pageable pageable) {
+    if (!pageable.getSort().isSorted()) {
+      return new OrderSpecifier[] {performance.createdAt.desc()};
+    }
+
+    return pageable.getSort().stream()
+        .map(
+            order -> {
+              PathBuilder<Performance> entityPath =
+                  new PathBuilder<>(Performance.class, "performance");
+              return new OrderSpecifier<>(
+                  order.isAscending() ? Order.ASC : Order.DESC,
+                  entityPath.get(order.getProperty(), Comparable.class));
+            })
+        .toArray(OrderSpecifier[]::new);
+  }
+}

--- a/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/out/repository/PerformanceRepositoryImpl.java
+++ b/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/out/repository/PerformanceRepositoryImpl.java
@@ -3,17 +3,19 @@ package com.ticketrush.boundedcontext.performance.out.repository;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
-import com.querydsl.core.types.dsl.PathBuilder;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.ticketrush.boundedcontext.performance.domain.entity.Performance;
 import com.ticketrush.boundedcontext.performance.domain.entity.QPerformance;
 import com.ticketrush.boundedcontext.performance.domain.types.Genre;
 import com.ticketrush.boundedcontext.performance.domain.types.PerformanceStatus;
+import com.ticketrush.global.exception.BusinessException;
+import com.ticketrush.global.status.ErrorStatus;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -63,14 +65,18 @@ public class PerformanceRepositoryImpl implements PerformanceRepositoryCustom {
     }
 
     return pageable.getSort().stream()
-        .map(
-            order -> {
-              PathBuilder<Performance> entityPath =
-                  new PathBuilder<>(Performance.class, "performance");
-              return new OrderSpecifier<>(
-                  order.isAscending() ? Order.ASC : Order.DESC,
-                  entityPath.get(order.getProperty(), Comparable.class));
-            })
+        .map(order -> toOrderSpecifier(performance, order))
         .toArray(OrderSpecifier[]::new);
+  }
+
+  private OrderSpecifier<?> toOrderSpecifier(QPerformance performance, Sort.Order order) {
+    Order direction = order.isAscending() ? Order.ASC : Order.DESC;
+    return switch (order.getProperty()) {
+      case "createdAt" -> new OrderSpecifier<>(direction, performance.createdAt);
+      case "price" -> new OrderSpecifier<>(direction, performance.price);
+      case "title" -> new OrderSpecifier<>(direction, performance.title);
+      case "showDate" -> new OrderSpecifier<>(direction, performance.showDate);
+      default -> throw new BusinessException(ErrorStatus.PERFORMANCE_INVALID_SORT_PROPERTY);
+    };
   }
 }

--- a/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/out/repository/PerformanceRepositoryImpl.java
+++ b/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/out/repository/PerformanceRepositoryImpl.java
@@ -29,10 +29,18 @@ public class PerformanceRepositoryImpl implements PerformanceRepositoryCustom {
     QPerformance performance = QPerformance.performance;
 
     BooleanBuilder predicate = new BooleanBuilder();
-    if (genre != null) predicate.and(performance.genre.eq(genre));
-    if (minPrice != null) predicate.and(performance.price.goe(minPrice));
-    if (maxPrice != null) predicate.and(performance.price.loe(maxPrice));
-    if (status != null) predicate.and(performance.performanceStatus.eq(status));
+    if (genre != null) {
+      predicate.and(performance.genre.eq(genre));
+    }
+    if (minPrice != null) {
+      predicate.and(performance.price.goe(minPrice));
+    }
+    if (maxPrice != null) {
+      predicate.and(performance.price.loe(maxPrice));
+    }
+    if (status != null) {
+      predicate.and(performance.performanceStatus.eq(status));
+    }
 
     List<Performance> content =
         queryFactory

--- a/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/out/repository/PerformanceRepositoryImpl.java
+++ b/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/out/repository/PerformanceRepositoryImpl.java
@@ -3,6 +3,7 @@ package com.ticketrush.boundedcontext.performance.out.repository;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.ticketrush.boundedcontext.performance.domain.entity.Performance;
 import com.ticketrush.boundedcontext.performance.domain.entity.QPerformance;
@@ -13,9 +14,9 @@ import com.ticketrush.global.status.ErrorStatus;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
+import org.springframework.data.support.PageableExecutionUtils;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -53,10 +54,10 @@ public class PerformanceRepositoryImpl implements PerformanceRepositoryCustom {
             .orderBy(toOrderSpecifiers(performance, pageable))
             .fetch();
 
-    Long totalCount =
-        queryFactory.select(performance.count()).from(performance).where(predicate).fetchOne();
+    JPAQuery<Long> countQuery =
+        queryFactory.select(performance.count()).from(performance).where(predicate);
 
-    return new PageImpl<>(content, pageable, totalCount != null ? totalCount : 0L);
+    return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
   }
 
   private OrderSpecifier<?>[] toOrderSpecifiers(QPerformance performance, Pageable pageable) {

--- a/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/out/repository/PerformanceRepositoryImpl.java
+++ b/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/out/repository/PerformanceRepositoryImpl.java
@@ -44,11 +44,7 @@ public class PerformanceRepositoryImpl implements PerformanceRepositoryCustom {
             .fetch();
 
     Long totalCount =
-        queryFactory
-            .select(performance.count())
-            .from(performance)
-            .where(predicate)
-            .fetchOne();
+        queryFactory.select(performance.count()).from(performance).where(predicate).fetchOne();
 
     return new PageImpl<>(content, pageable, totalCount != null ? totalCount : 0L);
   }

--- a/performance-service/src/test/java/com/ticketrush/boundedcontext/performance/in/api/v1/PerformanceGetListTest.java
+++ b/performance-service/src/test/java/com/ticketrush/boundedcontext/performance/in/api/v1/PerformanceGetListTest.java
@@ -1,13 +1,17 @@
 package com.ticketrush.boundedcontext.performance.in.api.v1;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.ticketrush.boundedcontext.performance.app.dto.response.PerformanceListResponse;
 import com.ticketrush.boundedcontext.performance.app.usecase.PerformanceGetListUseCase;
 import com.ticketrush.boundedcontext.performance.domain.entity.Performance;
 import com.ticketrush.boundedcontext.performance.domain.types.Genre;
+import com.ticketrush.boundedcontext.performance.domain.types.PerformanceStatus;
 import com.ticketrush.boundedcontext.performance.out.repository.PerformanceRepository;
 import com.ticketrush.global.eventpublisher.EventPublisher;
+import com.ticketrush.global.exception.BusinessException;
+import com.ticketrush.global.status.ErrorStatus;
 import com.ticketrush.global.util.S3UploadUtils;
 import java.time.LocalDate;
 import java.time.LocalTime;
@@ -46,10 +50,10 @@ class PerformanceGetListTest {
   void setUp() {
     performanceRepository.saveAll(
         List.of(
-            buildPerformance(Genre.CONCERT),
-            buildPerformance(Genre.CONCERT),
-            buildPerformance(Genre.MUSICAL),
-            buildPerformance(Genre.JAZZ)));
+            buildPerformance(Genre.CONCERT, 30000L, null),
+            buildPerformance(Genre.CONCERT, 50000L, PerformanceStatus.ON_SALE),
+            buildPerformance(Genre.MUSICAL, 70000L, PerformanceStatus.ON_SALE),
+            buildPerformance(Genre.JAZZ, 90000L, PerformanceStatus.CLOSED)));
   }
 
   @Test
@@ -87,17 +91,94 @@ class PerformanceGetListTest {
     assertThat(page1.getTotalPages()).isEqualTo(2);
   }
 
-  private Performance buildPerformance(Genre genre) {
-    return Performance.builder()
-        .title("공연명")
-        .performer("가수")
-        .genre(genre)
-        .showDate(LocalDate.now())
-        .showTime(LocalTime.of(19, 0))
-        .durationMinutes(120)
-        .price(50000L)
-        .totalSeats(100)
-        .address("서울")
-        .build();
+  @Test
+  @DisplayName("최소 가격을 지정하면 해당 가격 이상의 공연만 반환한다")
+  void filterByMinPrice() {
+    Pageable pageable = PageRequest.of(0, 10, Sort.by(Sort.Direction.DESC, "createdAt"));
+    Page<PerformanceListResponse> result =
+        performanceGetListUseCase.execute(null, 60000L, null, null, pageable);
+    assertThat(result.getTotalElements()).isEqualTo(2);
+    assertThat(result.getContent()).allMatch(p -> p.price() >= 60000L);
+  }
+
+  @Test
+  @DisplayName("최대 가격을 지정하면 해당 가격 이하의 공연만 반환한다")
+  void filterByMaxPrice() {
+    Pageable pageable = PageRequest.of(0, 10, Sort.by(Sort.Direction.DESC, "createdAt"));
+    Page<PerformanceListResponse> result =
+        performanceGetListUseCase.execute(null, null, 50000L, null, pageable);
+    assertThat(result.getTotalElements()).isEqualTo(2);
+    assertThat(result.getContent()).allMatch(p -> p.price() <= 50000L);
+  }
+
+  @Test
+  @DisplayName("가격 범위를 지정하면 범위 내 공연만 반환한다")
+  void filterByPriceRange() {
+    Pageable pageable = PageRequest.of(0, 10, Sort.by(Sort.Direction.DESC, "createdAt"));
+    Page<PerformanceListResponse> result =
+        performanceGetListUseCase.execute(null, 40000L, 80000L, null, pageable);
+    assertThat(result.getTotalElements()).isEqualTo(2);
+    assertThat(result.getContent()).allMatch(p -> p.price() >= 40000L && p.price() <= 80000L);
+  }
+
+  @Test
+  @DisplayName("상태를 지정하면 해당 상태 공연만 반환한다")
+  void filterByStatus() {
+    Pageable pageable = PageRequest.of(0, 10, Sort.by(Sort.Direction.DESC, "createdAt"));
+    Page<PerformanceListResponse> result =
+        performanceGetListUseCase.execute(null, null, null, PerformanceStatus.ON_SALE, pageable);
+    assertThat(result.getTotalElements()).isEqualTo(2);
+    assertThat(result.getContent())
+        .allMatch(p -> p.performanceStatus() == PerformanceStatus.ON_SALE);
+  }
+
+  @Test
+  @DisplayName("장르, 가격, 상태 복합 조건을 적용하면 모든 조건을 만족하는 공연만 반환한다")
+  void filterByMultipleConditions() {
+    Pageable pageable = PageRequest.of(0, 10, Sort.by(Sort.Direction.DESC, "createdAt"));
+    Page<PerformanceListResponse> result =
+        performanceGetListUseCase.execute(
+            Genre.CONCERT, 40000L, 60000L, PerformanceStatus.ON_SALE, pageable);
+    assertThat(result.getTotalElements()).isEqualTo(1);
+    PerformanceListResponse only = result.getContent().get(0);
+    assertThat(only.genre()).isEqualTo(Genre.CONCERT);
+    assertThat(only.price()).isBetween(40000L, 60000L);
+    assertThat(only.performanceStatus()).isEqualTo(PerformanceStatus.ON_SALE);
+  }
+
+  @Test
+  @DisplayName("최소 가격이 최대 가격보다 크면 PERFORMANCE_INVALID_PRICE_RANGE 예외가 발생한다")
+  void invalidPriceRange_throwsException() {
+    Pageable pageable = PageRequest.of(0, 10, Sort.by(Sort.Direction.DESC, "createdAt"));
+    assertThatThrownBy(
+            () -> performanceGetListUseCase.execute(null, 80000L, 40000L, null, pageable))
+        .isInstanceOf(BusinessException.class)
+        .hasFieldOrPropertyWithValue("errorStatus", ErrorStatus.PERFORMANCE_INVALID_PRICE_RANGE);
+  }
+
+  private Performance buildPerformance(Genre genre, Long price, PerformanceStatus targetStatus) {
+    Performance performance =
+        Performance.builder()
+            .title("공연명")
+            .performer("가수")
+            .genre(genre)
+            .showDate(LocalDate.now())
+            .showTime(LocalTime.of(19, 0))
+            .durationMinutes(120)
+            .price(price)
+            .totalSeats(100)
+            .address("서울")
+            .build();
+
+    if (targetStatus == PerformanceStatus.ON_SALE) {
+      performance.changeStatus(PerformanceStatus.ON_SALE);
+    } else if (targetStatus == PerformanceStatus.CLOSED) {
+      performance.changeStatus(PerformanceStatus.ON_SALE);
+      performance.changeStatus(PerformanceStatus.CLOSED);
+    } else if (targetStatus == PerformanceStatus.CANCELED) {
+      performance.changeStatus(PerformanceStatus.CANCELED);
+    }
+
+    return performance;
   }
 }

--- a/performance-service/src/test/java/com/ticketrush/boundedcontext/performance/in/api/v1/PerformanceGetListTest.java
+++ b/performance-service/src/test/java/com/ticketrush/boundedcontext/performance/in/api/v1/PerformanceGetListTest.java
@@ -56,7 +56,8 @@ class PerformanceGetListTest {
   @DisplayName("장르를 지정하지 않으면 전체 공연 목록을 반환한다")
   void getAll_whenGenreIsNull() {
     Pageable pageable = PageRequest.of(0, 10, Sort.by(Sort.Direction.DESC, "createdAt"));
-    Page<PerformanceListResponse> result = performanceGetListUseCase.execute(null, pageable);
+    Page<PerformanceListResponse> result =
+        performanceGetListUseCase.execute(null, null, null, null, pageable);
     assertThat(result.getTotalElements()).isEqualTo(4);
   }
 
@@ -65,7 +66,7 @@ class PerformanceGetListTest {
   void getByGenre_whenGenreIsGiven() {
     Pageable pageable = PageRequest.of(0, 10, Sort.by(Sort.Direction.DESC, "createdAt"));
     Page<PerformanceListResponse> result =
-        performanceGetListUseCase.execute(Genre.CONCERT, pageable);
+        performanceGetListUseCase.execute(Genre.CONCERT, null, null, null, pageable);
     assertThat(result.getTotalElements()).isEqualTo(2);
     assertThat(result.getContent()).allMatch(p -> p.genre() == Genre.CONCERT);
   }
@@ -76,8 +77,10 @@ class PerformanceGetListTest {
     Pageable firstPage = PageRequest.of(0, 2, Sort.by(Sort.Direction.DESC, "createdAt"));
     Pageable secondPage = PageRequest.of(1, 2, Sort.by(Sort.Direction.DESC, "createdAt"));
 
-    Page<PerformanceListResponse> page1 = performanceGetListUseCase.execute(null, firstPage);
-    Page<PerformanceListResponse> page2 = performanceGetListUseCase.execute(null, secondPage);
+    Page<PerformanceListResponse> page1 =
+        performanceGetListUseCase.execute(null, null, null, null, firstPage);
+    Page<PerformanceListResponse> page2 =
+        performanceGetListUseCase.execute(null, null, null, null, secondPage);
 
     assertThat(page1.getContent()).hasSize(2);
     assertThat(page2.getContent()).hasSize(2);


### PR DESCRIPTION
## 🔗 관련 이슈

- close #88

---

## 📌 주요 변경 사항

- `performance-service`에 QueryDSL 환경 구축 (`io.github.openfeign.querydsl:6.10.1`)
- `PerformanceRepositoryCustom` + `PerformanceRepositoryImpl` 로 Custom Repository 패턴 도입
- 장르(Genre), 최소/최대 가격, 공연 상태(PerformanceStatus) 다중 조건 동적 필터링 구현
- 공연 목록 조회 API에 `minPrice`, `maxPrice`, `status` 파라미터 추가

---

## 🛠 상세 구현 내용

- `build.gradle`: QueryDSL JPA 의존성 및 APT 어노테이션 프로세서 추가 (`queryDslVersion = 6.10.1`)
- `PerformanceRepositoryCustom`: `findByFilters(genre, minPrice, maxPrice, status, pageable)` 인터페이스 정의
- `PerformanceRepositoryImpl`: `JPAQueryFactory` + `BooleanBuilder`로 null-safe 동적 쿼리 구현
  - `fetchResults()` 대신 `fetch()` + 별도 count 쿼리 사용 (QueryDSL 5.x 이상 권장 방식)
  - `Pageable`의 Sort를 `PathBuilder` 기반 `OrderSpecifier`로 변환
  - `@SQLRestriction("deleted_at IS NULL")`은 Hibernate가 자동 적용하므로 별도 처리 없음
- `PerformanceRepository`: `PerformanceRepositoryCustom` 확장, 기존 `findByGenre()` 제거
- `PerformanceGetListUseCase` / `PerformanceFacade` / `PerformanceController`: 필터 파라미터 시그니처 일괄 확장
- `PerformanceGetListTest`: 변경된 메서드 시그니처에 맞게 기존 테스트 수정

---

## ✅ 테스트

### 테스트 방법

- `PerformanceGetListTest` 실행 (장르 필터, 전체 조회, 페이지네이션 3개 케이스)
- `./gradlew :performance-service:test` 전체 통과 확인

### 테스트 결과

- 33개 테스트 전체 통과

### 📸 스크린샷
<img width="591" height="129" alt="image" src="https://github.com/user-attachments/assets/135a39c5-8189-468f-8ef5-7abecf22a15f" />

---

## 👀 리뷰 요청 사항

- `PerformanceRepositoryImpl`의 `toOrderSpecifiers()`에서 `PathBuilder<Comparable>`를 사용해 Pageable Sort를 변환했는데, 더 나은 방식이 있다면 의견 부탁드립니다.
<!--
---

## ⚠️ 배포 시 주의사항

- 없음
-->