### PR TITLE
[Feat] #208 결제 도메인 이벤트 정의 및 Kafka 발행 골격 구축

### DIFF
--- a/common/src/main/java/com/ticketrush/shared/payment/event/PaymentCanceledEvent.java
+++ b/common/src/main/java/com/ticketrush/shared/payment/event/PaymentCanceledEvent.java
@@ -1,0 +1,39 @@
+package com.ticketrush.shared.payment.event;
+
+import com.ticketrush.global.event.DomainEvent;
+import com.ticketrush.global.event.EventUtils;
+import java.time.LocalDateTime;
+
+public record PaymentCanceledEvent(
+    Long paymentId,
+    Long bookingId,
+    Long seatId,
+    Long refundId,
+    Long refundedAmount,
+    String reason,
+    LocalDateTime canceledAt)
+    implements DomainEvent {
+
+  public static final String TOPIC = "payment-canceled-topic";
+  public static final String EVENT_NAME = "PaymentCanceled";
+
+  @Override
+  public String topic() {
+    return TOPIC;
+  }
+
+  @Override
+  public String key() {
+    return String.valueOf(bookingId);
+  }
+
+  @Override
+  public String eventName() {
+    return EVENT_NAME;
+  }
+
+  @Override
+  public String traceId() {
+    return EventUtils.extractTraceId();
+  }
+}

--- a/common/src/main/java/com/ticketrush/shared/payment/event/PaymentConfirmedEvent.java
+++ b/common/src/main/java/com/ticketrush/shared/payment/event/PaymentConfirmedEvent.java
@@ -1,0 +1,33 @@
+package com.ticketrush.shared.payment.event;
+
+import com.ticketrush.global.event.DomainEvent;
+import com.ticketrush.global.event.EventUtils;
+import java.time.LocalDateTime;
+
+public record PaymentConfirmedEvent(
+    Long paymentId, Long bookingId, Long seatId, Long userId, Long amount, LocalDateTime paidAt)
+    implements DomainEvent {
+
+  public static final String TOPIC = "payment-confirmed-topic";
+  public static final String EVENT_NAME = "PaymentConfirmed";
+
+  @Override
+  public String topic() {
+    return TOPIC;
+  }
+
+  @Override
+  public String key() {
+    return String.valueOf(bookingId);
+  }
+
+  @Override
+  public String eventName() {
+    return EVENT_NAME;
+  }
+
+  @Override
+  public String traceId() {
+    return EventUtils.extractTraceId();
+  }
+}

--- a/payment-service/build.gradle
+++ b/payment-service/build.gradle
@@ -40,6 +40,11 @@ dependencies {
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
 	annotationProcessor 'org.projectlombok:lombok'
+
+	// Kafka
+	implementation 'org.springframework.boot:spring-boot-starter-kafka'
+	testImplementation 'org.springframework.boot:spring-boot-starter-kafka-test'
+
 	testImplementation 'com.h2database:h2'
 	testImplementation 'org.springframework.boot:spring-boot-starter-actuator-test'
 	testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/support/PaymentEventPublisher.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/support/PaymentEventPublisher.java
@@ -1,0 +1,34 @@
+package com.ticketrush.boundedcontext.payment.app.support;
+
+import com.ticketrush.global.eventpublisher.EventPublisher;
+import com.ticketrush.shared.payment.event.PaymentCanceledEvent;
+import com.ticketrush.shared.payment.event.PaymentConfirmedEvent;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class PaymentEventPublisher {
+
+  private final EventPublisher eventPublisher;
+
+  public void publishConfirmed(
+      Long paymentId, Long bookingId, Long seatId, Long userId, Long amount, LocalDateTime paidAt) {
+    eventPublisher.publish(
+        new PaymentConfirmedEvent(paymentId, bookingId, seatId, userId, amount, paidAt));
+  }
+
+  public void publishCanceled(
+      Long paymentId,
+      Long bookingId,
+      Long seatId,
+      Long refundId,
+      Long refundedAmount,
+      String reason,
+      LocalDateTime canceledAt) {
+    eventPublisher.publish(
+        new PaymentCanceledEvent(
+            paymentId, bookingId, seatId, refundId, refundedAmount, reason, canceledAt));
+  }
+}


### PR DESCRIPTION
## 🔗 관련 이슈

- close #208

---

## 📌 주요 변경 사항

- payment-service Kafka 의존성 추가 및 결제 도메인 이벤트(`PaymentConfirmedEvent`, `PaymentCanceledEvent`) 정의
- 결제 이벤트 발행 wrapper `PaymentEventPublisher` 추가 — `KafkaDomainEventPublisher` 활용
- 토픽 네이밍 컨벤션 통일: 이벤트 record 내 `public static final String TOPIC` 상수 노출 (`PerformanceCreatedEvent` 패턴)

---

## 🛠 상세 구현 내용

- `payment-service/build.gradle`
  - `spring-boot-starter-kafka` (+ test) 의존성 추가
  - `application-local.yml` 의 `app.event-publisher.type=kafka`, `spring.kafka.bootstrap-servers` 설정은 이미 존재해 그대로 활용
- `common/src/main/java/com/ticketrush/shared/payment/event/PaymentConfirmedEvent`
  - 결제 승인 시 발행. topic: `payment-confirmed-topic`, key: `bookingId`
  - 필드: `paymentId`, `bookingId`, `seatId`, `userId`, `amount`, `paidAt`
- `common/src/main/java/com/ticketrush/shared/payment/event/PaymentCanceledEvent`
  - 결제 취소/환불 확정 시 발행. topic: `payment-canceled-topic`, key: `bookingId`
  - 필드: `paymentId`, `bookingId`, `seatId`, `refundId`, `refundedAmount`, `reason`, `canceledAt`
- `payment-service/.../boundedcontext/payment/app/support/PaymentEventPublisher`
  - `publishConfirmed(...)`, `publishCanceled(...)` 메서드 제공
  - 내부적으로 `EventPublisher.publish(event)` 호출 → `KafkaDomainEventPublisher`가 트랜잭션 `afterCommit` 후 비동기 발행 처리

---

## ✅ 테스트

### 테스트 방법

- 본 PR은 **컨트랙트/인프라 골격 도입**이라 실제 발행 호출은 후속 이슈(#21 confirm, #22 cancel)에서 검증
- 빌드 정적 검증:
  - `./gradlew :common:spotlessApply :payment-service:spotlessApply`
  - `./gradlew :common:checkstyleMain :payment-service:checkstyleMain`

### 테스트 결과

- spotless / checkstyle / compileJava 모두 BUILD SUCCESSFUL
<!--

### 📸 스크린샷

(해당 없음 — 백엔드 골격 변경)

---
-->

## 👀 리뷰 요청 사항

- **이벤트 필드 구성**이 booking-service / seat-service 양쪽 컨슈머에 충분한지 검토 부탁드립니다.
  - `PaymentConfirmedEvent`: `paymentId`, `bookingId`, `seatId`, `userId`, `amount`, `paidAt`
  - `PaymentCanceledEvent`: `paymentId`, `bookingId`, `seatId`, `refundId`, `refundedAmount`, `reason`, `canceledAt`
- **토픽명**(`payment-confirmed-topic`, `payment-canceled-topic`) 이 기존 컨벤션과 일관성 있는지 확인 부탁드립니다.

---

## ⚠️ 배포 시 주의사항

- payment-service 에 Kafka 의존성이 새로 추가되므로, 배포 환경에 `spring.kafka.bootstrap-servers` 설정이 준비되어 있어야 합니다.
- 본 PR 단독으로는 실제 이벤트가 발행되지 않습니다 (실제 호출은 #21/#22 에서 추가 예정).