### PR TITLE
[Feat] #21 결제 Confirm API 및 PaymentConfirmedEvent 발행 구현

### DIFF
--- a/common/src/main/java/com/ticketrush/global/status/ErrorStatus.java
+++ b/common/src/main/java/com/ticketrush/global/status/ErrorStatus.java
@@ -123,7 +123,17 @@ public enum ErrorStatus {
   USER_EMAIL_REQUIRED(HttpStatus.BAD_REQUEST, "USER_400_004", "이메일은 필수입니다."),
 
   // User 404
-  USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_404_001", "해당 사용자를 찾을 수 없습니다.");
+  USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_404_001", "해당 사용자를 찾을 수 없습니다."),
+
+  // Payment 400
+  PAYMENT_AMOUNT_MISMATCH(HttpStatus.BAD_REQUEST, "PAYMENT_400_001", "결제 금액이 일치하지 않습니다."),
+
+  // Payment 502
+  PAYMENT_APPROVAL_FAILED(HttpStatus.BAD_GATEWAY, "PAYMENT_502_001", "PG사 결제 승인에 실패했습니다."),
+
+  // Payment 503
+  PAYMENT_PG_COMMUNICATION_FAILED(
+      HttpStatus.SERVICE_UNAVAILABLE, "PAYMENT_503_001", "PG사와 통신에 실패했습니다.");
 
   private final HttpStatus httpStatus;
   private final String code;

--- a/common/src/main/java/com/ticketrush/global/status/ErrorStatus.java
+++ b/common/src/main/java/com/ticketrush/global/status/ErrorStatus.java
@@ -128,6 +128,9 @@ public enum ErrorStatus {
   // Payment 400
   PAYMENT_AMOUNT_MISMATCH(HttpStatus.BAD_REQUEST, "PAYMENT_400_001", "결제 금액이 일치하지 않습니다."),
 
+  // Payment 409
+  PAYMENT_ALREADY_COMPLETED(HttpStatus.CONFLICT, "PAYMENT_409_001", "이미 결제가 완료된 예매입니다."),
+
   // Payment 502
   PAYMENT_APPROVAL_FAILED(HttpStatus.BAD_GATEWAY, "PAYMENT_502_001", "PG사 결제 승인에 실패했습니다."),
 

--- a/payment-service/build.gradle
+++ b/payment-service/build.gradle
@@ -50,6 +50,7 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
 	testImplementation 'org.springframework.boot:spring-boot-starter-security-test'
 	testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
+	testImplementation testFixtures(project(":common"))
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
 	// swagger

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/dto/request/PaymentConfirmRequest.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/dto/request/PaymentConfirmRequest.java
@@ -1,0 +1,21 @@
+package com.ticketrush.boundedcontext.payment.app.dto.request;
+
+import com.ticketrush.boundedcontext.payment.domain.types.PaymentProvider;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+
+@Schema(description = "결제 Confirm 요청 DTO")
+public record PaymentConfirmRequest(
+    @Schema(description = "예매 ID", example = "1") @NotNull(message = "예매 ID는 필수입니다.") @Positive
+        Long bookingId,
+    @Schema(description = "좌석 ID", example = "1") @NotNull(message = "좌석 ID는 필수입니다.") @Positive
+        Long seatId,
+    @Schema(description = "결제 수단", example = "KAKAO") @NotNull(message = "결제 수단은 필수입니다.")
+        PaymentProvider provider,
+    @Schema(description = "결제 금액", example = "55000") @NotNull(message = "결제 금액은 필수입니다.") @Positive
+        Long amount,
+    @Schema(description = "PG사가 발급한 결제 키", example = "tossKey_xxxxxxxx")
+        @NotBlank(message = "결제 키는 필수입니다.")
+        String paymentKey) {}

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/dto/response/PaymentConfirmResponse.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/dto/response/PaymentConfirmResponse.java
@@ -1,0 +1,17 @@
+package com.ticketrush.boundedcontext.payment.app.dto.response;
+
+import com.ticketrush.boundedcontext.payment.domain.entity.Payment;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+
+@Schema(description = "결제 Confirm 응답 DTO")
+public record PaymentConfirmResponse(
+    @Schema(description = "결제 데이터의 고유 식별자(PK)", example = "1") Long paymentId,
+    @Schema(description = "결제 상태", example = "COMPLETED") String status,
+    @Schema(description = "결제 완료 시각") LocalDateTime paidAt) {
+
+  public static PaymentConfirmResponse from(Payment payment) {
+    return new PaymentConfirmResponse(
+        payment.getId(), payment.getStatus().name(), payment.getPaidAt());
+  }
+}

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/facade/PaymentFacade.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/facade/PaymentFacade.java
@@ -1,0 +1,18 @@
+package com.ticketrush.boundedcontext.payment.app.facade;
+
+import com.ticketrush.boundedcontext.payment.app.dto.request.PaymentConfirmRequest;
+import com.ticketrush.boundedcontext.payment.app.dto.response.PaymentConfirmResponse;
+import com.ticketrush.boundedcontext.payment.app.usecase.PaymentConfirmUseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PaymentFacade {
+
+  private final PaymentConfirmUseCase paymentConfirmUseCase;
+
+  public PaymentConfirmResponse confirm(Long userId, PaymentConfirmRequest request) {
+    return paymentConfirmUseCase.execute(userId, request);
+  }
+}

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentConfirmUseCase.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentConfirmUseCase.java
@@ -25,6 +25,11 @@ public class PaymentConfirmUseCase {
   private final PaymentEventPublisher paymentEventPublisher;
 
   public PaymentConfirmResponse execute(Long userId, PaymentConfirmRequest request) {
+    if (paymentRepository.existsByBookingIdAndStatus(
+        request.bookingId(), PaymentStatus.COMPLETED)) {
+      throw new BusinessException(ErrorStatus.PAYMENT_ALREADY_COMPLETED);
+    }
+
     PaymentApprovalResponse approval =
         paymentApprovalClient.approve(
             new PaymentApprovalRequest(

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentConfirmUseCase.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentConfirmUseCase.java
@@ -1,0 +1,58 @@
+package com.ticketrush.boundedcontext.payment.app.usecase;
+
+import com.ticketrush.boundedcontext.payment.app.dto.request.PaymentConfirmRequest;
+import com.ticketrush.boundedcontext.payment.app.dto.response.PaymentConfirmResponse;
+import com.ticketrush.boundedcontext.payment.app.support.PaymentEventPublisher;
+import com.ticketrush.boundedcontext.payment.domain.entity.Payment;
+import com.ticketrush.boundedcontext.payment.domain.types.PaymentStatus;
+import com.ticketrush.boundedcontext.payment.out.apiclient.PaymentApprovalClient;
+import com.ticketrush.boundedcontext.payment.out.apiclient.PaymentApprovalRequest;
+import com.ticketrush.boundedcontext.payment.out.apiclient.PaymentApprovalResponse;
+import com.ticketrush.boundedcontext.payment.out.repository.PaymentRepository;
+import com.ticketrush.global.exception.BusinessException;
+import com.ticketrush.global.status.ErrorStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class PaymentConfirmUseCase {
+
+  private final PaymentRepository paymentRepository;
+  private final PaymentApprovalClient paymentApprovalClient;
+  private final PaymentEventPublisher paymentEventPublisher;
+
+  public PaymentConfirmResponse execute(Long userId, PaymentConfirmRequest request) {
+    PaymentApprovalResponse approval =
+        paymentApprovalClient.approve(
+            new PaymentApprovalRequest(
+                request.provider(), request.paymentKey(), request.bookingId(), request.amount()));
+
+    if (!request.amount().equals(approval.approvedAmount())) {
+      throw new BusinessException(ErrorStatus.PAYMENT_AMOUNT_MISMATCH);
+    }
+
+    Payment payment =
+        Payment.builder()
+            .bookingId(request.bookingId())
+            .provider(request.provider())
+            .amount(approval.approvedAmount())
+            .status(PaymentStatus.COMPLETED)
+            .paidAt(approval.approvedAt())
+            .build();
+
+    Payment saved = paymentRepository.save(payment);
+
+    paymentEventPublisher.publishConfirmed(
+        saved.getId(),
+        saved.getBookingId(),
+        request.seatId(),
+        userId,
+        saved.getAmount(),
+        saved.getPaidAt());
+
+    return PaymentConfirmResponse.from(saved);
+  }
+}

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/in/api/v1/PaymentController.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/in/api/v1/PaymentController.java
@@ -1,0 +1,42 @@
+package com.ticketrush.boundedcontext.payment.in.api.v1;
+
+import com.ticketrush.boundedcontext.payment.app.dto.request.PaymentConfirmRequest;
+import com.ticketrush.boundedcontext.payment.app.dto.response.PaymentConfirmResponse;
+import com.ticketrush.boundedcontext.payment.app.facade.PaymentFacade;
+import com.ticketrush.boundedcontext.payment.in.api.v1.swagger.PaymentConfirmApiResponses;
+import com.ticketrush.global.dto.response.ApiResponse;
+import com.ticketrush.global.security.CustomUserDetails;
+import com.ticketrush.global.status.SuccessStatus;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Payment", description = "결제 관련 API")
+@RestController
+@RequestMapping("/api/v1/payment")
+@RequiredArgsConstructor
+public class PaymentController {
+
+  private final PaymentFacade paymentFacade;
+
+  @Operation(
+      summary = "결제 Confirm",
+      description =
+          "PG사 결제 인증 후 넘어온 데이터를 검증하고 결제를 확정한다. "
+              + "성공 시 PaymentConfirmedEvent를 발행하여 후속 도메인이 처리하도록 한다.")
+  @PaymentConfirmApiResponses
+  @PostMapping("/confirm")
+  public ResponseEntity<ApiResponse<PaymentConfirmResponse>> confirm(
+      @AuthenticationPrincipal CustomUserDetails user,
+      @Valid @RequestBody PaymentConfirmRequest request) {
+    PaymentConfirmResponse response = paymentFacade.confirm(user.getUserId(), request);
+    return ApiResponse.onSuccess(SuccessStatus.OK, response);
+  }
+}

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/in/api/v1/swagger/PaymentConfirmApiResponses.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/in/api/v1/swagger/PaymentConfirmApiResponses.java
@@ -37,7 +37,7 @@ import java.lang.annotation.Target;
                             "result": {
                               "payment_id": 1,
                               "status": "COMPLETED",
-                              "paid_at": "2026-05-22T10:00:00"
+                              "paid_at": "2025-01-15 10:00:00"
                             }
                           }
                           """))),

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/in/api/v1/swagger/PaymentConfirmApiResponses.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/in/api/v1/swagger/PaymentConfirmApiResponses.java
@@ -1,0 +1,87 @@
+package com.ticketrush.boundedcontext.payment.in.api.v1.swagger;
+
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@ApiResponses({
+  @ApiResponse(
+      responseCode = "200",
+      description = "결제 확정 성공",
+      content =
+          @Content(
+              mediaType = "application/json",
+              schema =
+                  @Schema(implementation = com.ticketrush.global.dto.response.ApiResponse.class),
+              examples =
+                  @ExampleObject(
+                      name = "Success",
+                      summary = "정상 응답",
+                      value =
+                          """
+                          {
+                            "is_success": true,
+                            "code": "COMMON_200",
+                            "message": "성공입니다.",
+                            "trace_id": "trace-id-example",
+                            "result": {
+                              "payment_id": 1,
+                              "status": "COMPLETED",
+                              "paid_at": "2026-05-22T10:00:00"
+                            }
+                          }
+                          """))),
+  @ApiResponse(
+      responseCode = "400",
+      description = "결제 금액 불일치",
+      content =
+          @Content(
+              mediaType = "application/json",
+              schema =
+                  @Schema(implementation = com.ticketrush.global.dto.response.ApiResponse.class),
+              examples =
+                  @ExampleObject(
+                      name = "AmountMismatch",
+                      summary = "요청 금액과 PG 승인 금액 불일치",
+                      value =
+                          """
+                          {
+                            "is_success": false,
+                            "code": "PAYMENT_400_001",
+                            "message": "결제 금액이 일치하지 않습니다.",
+                            "trace_id": "trace-id-example"
+                          }
+                          """))),
+  @ApiResponse(
+      responseCode = "502",
+      description = "PG사 승인 실패",
+      content =
+          @Content(
+              mediaType = "application/json",
+              schema =
+                  @Schema(implementation = com.ticketrush.global.dto.response.ApiResponse.class),
+              examples =
+                  @ExampleObject(
+                      name = "ApprovalFailed",
+                      summary = "PG사 결제 승인 실패",
+                      value =
+                          """
+                          {
+                            "is_success": false,
+                            "code": "PAYMENT_502_001",
+                            "message": "PG사 결제 승인에 실패했습니다.",
+                            "trace_id": "trace-id-example"
+                          }
+                          """)))
+})
+public @interface PaymentConfirmApiResponses {}

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/out/apiclient/PaymentApprovalClient.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/out/apiclient/PaymentApprovalClient.java
@@ -1,0 +1,11 @@
+package com.ticketrush.boundedcontext.payment.out.apiclient;
+
+/**
+ * PG사 결제 승인 API 호출용 클라이언트.
+ *
+ * <p>본 인터페이스는 #21에서 stub 구현체와 함께 도입되고, #89에서 실제 외부 PG사 연동 구현체로 교체된다.
+ */
+public interface PaymentApprovalClient {
+
+  PaymentApprovalResponse approve(PaymentApprovalRequest request);
+}

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/out/apiclient/PaymentApprovalRequest.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/out/apiclient/PaymentApprovalRequest.java
@@ -1,0 +1,6 @@
+package com.ticketrush.boundedcontext.payment.out.apiclient;
+
+import com.ticketrush.boundedcontext.payment.domain.types.PaymentProvider;
+
+public record PaymentApprovalRequest(
+    PaymentProvider provider, String paymentKey, Long bookingId, Long amount) {}

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/out/apiclient/PaymentApprovalResponse.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/out/apiclient/PaymentApprovalResponse.java
@@ -1,0 +1,6 @@
+package com.ticketrush.boundedcontext.payment.out.apiclient;
+
+import java.time.LocalDateTime;
+
+public record PaymentApprovalResponse(
+    String approvalNumber, Long approvedAmount, LocalDateTime approvedAt) {}

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/out/apiclient/StubPaymentApprovalClient.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/out/apiclient/StubPaymentApprovalClient.java
@@ -1,0 +1,29 @@
+package com.ticketrush.boundedcontext.payment.out.apiclient;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+/**
+ * #21 범위의 stub 구현. 실제 PG 호출 없이 요청 금액을 그대로 승인된 것으로 응답한다.
+ *
+ * <p>#89에서 실제 외부 PG사 연동 구현체로 교체될 예정.
+ */
+@Slf4j
+@Component
+public class StubPaymentApprovalClient implements PaymentApprovalClient {
+
+  @Override
+  public PaymentApprovalResponse approve(PaymentApprovalRequest request) {
+    log.info(
+        "[PG-STUB] provider={}, bookingId={}, amount={}, paymentKey={}",
+        request.provider(),
+        request.bookingId(),
+        request.amount(),
+        request.paymentKey());
+
+    return new PaymentApprovalResponse(
+        UUID.randomUUID().toString(), request.amount(), LocalDateTime.now());
+  }
+}

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/out/repository/PaymentRepository.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/out/repository/PaymentRepository.java
@@ -1,0 +1,6 @@
+package com.ticketrush.boundedcontext.payment.out.repository;
+
+import com.ticketrush.boundedcontext.payment.domain.entity.Payment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PaymentRepository extends JpaRepository<Payment, Long> {}

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/out/repository/PaymentRepository.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/out/repository/PaymentRepository.java
@@ -1,6 +1,10 @@
 package com.ticketrush.boundedcontext.payment.out.repository;
 
 import com.ticketrush.boundedcontext.payment.domain.entity.Payment;
+import com.ticketrush.boundedcontext.payment.domain.types.PaymentStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface PaymentRepository extends JpaRepository<Payment, Long> {}
+public interface PaymentRepository extends JpaRepository<Payment, Long> {
+
+  boolean existsByBookingIdAndStatus(Long bookingId, PaymentStatus status);
+}

--- a/payment-service/src/main/java/com/ticketrush/global/config/SecurityConfig.java
+++ b/payment-service/src/main/java/com/ticketrush/global/config/SecurityConfig.java
@@ -1,14 +1,19 @@
 package com.ticketrush.global.config;
 
+import com.ticketrush.global.security.GatewayHeaderFilter;
+import com.ticketrush.global.status.ErrorStatus;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.security.autoconfigure.SecurityProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
 @EnableWebSecurity
@@ -17,15 +22,37 @@ import org.springframework.security.web.SecurityFilterChain;
 @RequiredArgsConstructor
 public class SecurityConfig {
 
+  private final GatewayHeaderFilter gatewayHeaderFilter;
+
   @Bean
   public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
     http.csrf(csrf -> csrf.disable())
         .cors(cors -> {})
+        .httpBasic(httpBasic -> httpBasic.disable())
+        .formLogin(formLogin -> formLogin.disable())
+        .addFilterBefore(gatewayHeaderFilter, UsernamePasswordAuthenticationFilter.class)
+        .exceptionHandling(
+            exception ->
+                exception.authenticationEntryPoint(
+                    (request, response, authException) -> {
+                      response.setStatus(ErrorStatus.UNAUTHORIZED.getHttpStatus().value());
+                      response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+                      response
+                          .getWriter()
+                          .write(
+                              """
+                              {"is_success":false,"code":"%s","message":"%s"}
+                              """
+                                  .formatted(
+                                      ErrorStatus.UNAUTHORIZED.getCode(),
+                                      ErrorStatus.UNAUTHORIZED.getMessage()));
+                    }))
         .authorizeHttpRequests(
             auth ->
                 auth.requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html")
-                    // TODO: 인증 이후 허용 범위 수정
                     .permitAll()
+                    .requestMatchers(HttpMethod.POST, "/api/v1/payment/confirm")
+                    .authenticated()
                     .anyRequest()
                     .permitAll());
 

--- a/payment-service/src/main/java/com/ticketrush/global/config/SecurityConfig.java
+++ b/payment-service/src/main/java/com/ticketrush/global/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.ticketrush.global.config;
 
+import com.ticketrush.global.dto.response.ApiResponse;
 import com.ticketrush.global.security.GatewayHeaderFilter;
 import com.ticketrush.global.status.ErrorStatus;
 import lombok.RequiredArgsConstructor;
@@ -14,6 +15,7 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import tools.jackson.databind.ObjectMapper;
 
 @Configuration
 @EnableWebSecurity
@@ -23,6 +25,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 public class SecurityConfig {
 
   private final GatewayHeaderFilter gatewayHeaderFilter;
+  private final ObjectMapper objectMapper;
 
   @Bean
   public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -37,15 +40,10 @@ public class SecurityConfig {
                     (request, response, authException) -> {
                       response.setStatus(ErrorStatus.UNAUTHORIZED.getHttpStatus().value());
                       response.setContentType(MediaType.APPLICATION_JSON_VALUE);
-                      response
-                          .getWriter()
-                          .write(
-                              """
-                              {"is_success":false,"code":"%s","message":"%s"}
-                              """
-                                  .formatted(
-                                      ErrorStatus.UNAUTHORIZED.getCode(),
-                                      ErrorStatus.UNAUTHORIZED.getMessage()));
+                      response.setCharacterEncoding("UTF-8");
+                      ApiResponse<?> body =
+                          ApiResponse.onFailure(ErrorStatus.UNAUTHORIZED).getBody();
+                      response.getWriter().write(objectMapper.writeValueAsString(body));
                     }))
         .authorizeHttpRequests(
             auth ->

--- a/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentConfirmUseCaseTest.java
+++ b/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentConfirmUseCaseTest.java
@@ -1,0 +1,103 @@
+package com.ticketrush.boundedcontext.payment.app.usecase;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.ticketrush.boundedcontext.payment.app.dto.request.PaymentConfirmRequest;
+import com.ticketrush.boundedcontext.payment.app.dto.response.PaymentConfirmResponse;
+import com.ticketrush.boundedcontext.payment.app.support.PaymentEventPublisher;
+import com.ticketrush.boundedcontext.payment.domain.entity.Payment;
+import com.ticketrush.boundedcontext.payment.domain.types.PaymentProvider;
+import com.ticketrush.boundedcontext.payment.domain.types.PaymentStatus;
+import com.ticketrush.boundedcontext.payment.out.apiclient.PaymentApprovalClient;
+import com.ticketrush.boundedcontext.payment.out.apiclient.PaymentApprovalResponse;
+import com.ticketrush.boundedcontext.payment.out.repository.PaymentRepository;
+import com.ticketrush.global.exception.BusinessException;
+import com.ticketrush.global.status.ErrorStatus;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class PaymentConfirmUseCaseTest {
+
+  @Mock private PaymentRepository paymentRepository;
+  @Mock private PaymentApprovalClient paymentApprovalClient;
+  @Mock private PaymentEventPublisher paymentEventPublisher;
+
+  @InjectMocks private PaymentConfirmUseCase paymentConfirmUseCase;
+
+  @Test
+  @DisplayName("PG 승인 성공 시 Payment를 COMPLETED 상태로 저장하고 PaymentConfirmedEvent를 발행한다")
+  void execute_success() {
+    // given
+    Long userId = 10L;
+    Long bookingId = 100L;
+    Long seatId = 200L;
+    Long amount = 55_000L;
+    LocalDateTime approvedAt = LocalDateTime.of(2026, 5, 22, 10, 0);
+    PaymentConfirmRequest request =
+        new PaymentConfirmRequest(bookingId, seatId, PaymentProvider.KAKAO, amount, "pgKey_xyz");
+
+    given(paymentApprovalClient.approve(any()))
+        .willReturn(new PaymentApprovalResponse("APR-123", amount, approvedAt));
+
+    Payment savedPayment =
+        Payment.builder()
+            .bookingId(bookingId)
+            .provider(PaymentProvider.KAKAO)
+            .amount(amount)
+            .status(PaymentStatus.COMPLETED)
+            .paidAt(approvedAt)
+            .build();
+    given(paymentRepository.save(any(Payment.class))).willReturn(savedPayment);
+
+    // when
+    PaymentConfirmResponse response = paymentConfirmUseCase.execute(userId, request);
+
+    // then
+    assertThat(response.status()).isEqualTo("COMPLETED");
+    assertThat(response.paidAt()).isEqualTo(approvedAt);
+
+    verify(paymentRepository).save(any(Payment.class));
+    verify(paymentEventPublisher)
+        .publishConfirmed(
+            eq(null), eq(bookingId), eq(seatId), eq(userId), eq(amount), eq(approvedAt));
+  }
+
+  @Test
+  @DisplayName("PG 승인 금액과 요청 금액이 다르면 PAYMENT_400_001 예외가 발생하고 Payment를 저장하지 않는다")
+  void execute_fail_when_amount_mismatch() {
+    // given
+    Long userId = 10L;
+    Long bookingId = 100L;
+    Long seatId = 200L;
+    Long requestAmount = 55_000L;
+    Long approvedAmount = 50_000L;
+    PaymentConfirmRequest request =
+        new PaymentConfirmRequest(
+            bookingId, seatId, PaymentProvider.KAKAO, requestAmount, "pgKey_xyz");
+
+    given(paymentApprovalClient.approve(any()))
+        .willReturn(new PaymentApprovalResponse("APR-123", approvedAmount, LocalDateTime.now()));
+
+    // when & then
+    assertThatThrownBy(() -> paymentConfirmUseCase.execute(userId, request))
+        .isInstanceOf(BusinessException.class)
+        .extracting("errorStatus")
+        .isEqualTo(ErrorStatus.PAYMENT_AMOUNT_MISMATCH);
+
+    verify(paymentRepository, never()).save(any(Payment.class));
+    verify(paymentEventPublisher, never())
+        .publishConfirmed(any(), any(), any(), any(), any(), any());
+  }
+}

--- a/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentConfirmUseCaseTest.java
+++ b/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentConfirmUseCaseTest.java
@@ -48,6 +48,8 @@ class PaymentConfirmUseCaseTest {
     PaymentConfirmRequest request =
         new PaymentConfirmRequest(bookingId, seatId, PaymentProvider.KAKAO, amount, "pgKey_xyz");
 
+    given(paymentRepository.existsByBookingIdAndStatus(bookingId, PaymentStatus.COMPLETED))
+        .willReturn(false);
     given(paymentApprovalClient.approve(any()))
         .willReturn(new PaymentApprovalResponse("APR-123", amount, approvedAt));
 
@@ -87,6 +89,8 @@ class PaymentConfirmUseCaseTest {
         new PaymentConfirmRequest(
             bookingId, seatId, PaymentProvider.KAKAO, requestAmount, "pgKey_xyz");
 
+    given(paymentRepository.existsByBookingIdAndStatus(bookingId, PaymentStatus.COMPLETED))
+        .willReturn(false);
     given(paymentApprovalClient.approve(any()))
         .willReturn(new PaymentApprovalResponse("APR-123", approvedAmount, LocalDateTime.now()));
 
@@ -96,6 +100,30 @@ class PaymentConfirmUseCaseTest {
         .extracting("errorStatus")
         .isEqualTo(ErrorStatus.PAYMENT_AMOUNT_MISMATCH);
 
+    verify(paymentRepository, never()).save(any(Payment.class));
+    verify(paymentEventPublisher, never())
+        .publishConfirmed(any(), any(), any(), any(), any(), any());
+  }
+
+  @Test
+  @DisplayName("동일 bookingId의 COMPLETED 결제가 이미 존재하면 PAYMENT_409_001 예외가 발생한다")
+  void execute_fail_when_already_completed() {
+    // given
+    Long userId = 10L;
+    Long bookingId = 100L;
+    PaymentConfirmRequest request =
+        new PaymentConfirmRequest(bookingId, 200L, PaymentProvider.KAKAO, 55_000L, "pgKey_xyz");
+
+    given(paymentRepository.existsByBookingIdAndStatus(bookingId, PaymentStatus.COMPLETED))
+        .willReturn(true);
+
+    // when & then
+    assertThatThrownBy(() -> paymentConfirmUseCase.execute(userId, request))
+        .isInstanceOf(BusinessException.class)
+        .extracting("errorStatus")
+        .isEqualTo(ErrorStatus.PAYMENT_ALREADY_COMPLETED);
+
+    verify(paymentApprovalClient, never()).approve(any());
     verify(paymentRepository, never()).save(any(Payment.class));
     verify(paymentEventPublisher, never())
         .publishConfirmed(any(), any(), any(), any(), any(), any());

--- a/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentConfirmUseCaseTest.java
+++ b/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentConfirmUseCaseTest.java
@@ -15,14 +15,17 @@ import com.ticketrush.boundedcontext.payment.domain.entity.Payment;
 import com.ticketrush.boundedcontext.payment.domain.types.PaymentProvider;
 import com.ticketrush.boundedcontext.payment.domain.types.PaymentStatus;
 import com.ticketrush.boundedcontext.payment.out.apiclient.PaymentApprovalClient;
+import com.ticketrush.boundedcontext.payment.out.apiclient.PaymentApprovalRequest;
 import com.ticketrush.boundedcontext.payment.out.apiclient.PaymentApprovalResponse;
 import com.ticketrush.boundedcontext.payment.out.repository.PaymentRepository;
 import com.ticketrush.global.exception.BusinessException;
 import com.ticketrush.global.status.ErrorStatus;
+import java.lang.reflect.Field;
 import java.time.LocalDateTime;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -38,42 +41,65 @@ class PaymentConfirmUseCaseTest {
 
   @Test
   @DisplayName("PG 승인 성공 시 Payment를 COMPLETED 상태로 저장하고 PaymentConfirmedEvent를 발행한다")
-  void execute_success() {
+  void execute_success() throws Exception {
     // given
     Long userId = 10L;
     Long bookingId = 100L;
     Long seatId = 200L;
     Long amount = 55_000L;
-    LocalDateTime approvedAt = LocalDateTime.of(2026, 5, 22, 10, 0);
+    String paymentKey = "pgKey_xyz";
+    Long savedPaymentId = 999L;
+    LocalDateTime approvedAt = LocalDateTime.of(2025, 1, 15, 10, 0);
     PaymentConfirmRequest request =
-        new PaymentConfirmRequest(bookingId, seatId, PaymentProvider.KAKAO, amount, "pgKey_xyz");
+        new PaymentConfirmRequest(bookingId, seatId, PaymentProvider.KAKAO, amount, paymentKey);
 
     given(paymentRepository.existsByBookingIdAndStatus(bookingId, PaymentStatus.COMPLETED))
         .willReturn(false);
     given(paymentApprovalClient.approve(any()))
         .willReturn(new PaymentApprovalResponse("APR-123", amount, approvedAt));
-
-    Payment savedPayment =
-        Payment.builder()
-            .bookingId(bookingId)
-            .provider(PaymentProvider.KAKAO)
-            .amount(amount)
-            .status(PaymentStatus.COMPLETED)
-            .paidAt(approvedAt)
-            .build();
-    given(paymentRepository.save(any(Payment.class))).willReturn(savedPayment);
+    given(paymentRepository.save(any(Payment.class)))
+        .willAnswer(
+            invocation -> {
+              Payment p = invocation.getArgument(0);
+              setId(p, savedPaymentId);
+              return p;
+            });
 
     // when
     PaymentConfirmResponse response = paymentConfirmUseCase.execute(userId, request);
 
     // then
+    assertThat(response.paymentId()).isEqualTo(savedPaymentId);
     assertThat(response.status()).isEqualTo("COMPLETED");
     assertThat(response.paidAt()).isEqualTo(approvedAt);
 
-    verify(paymentRepository).save(any(Payment.class));
+    ArgumentCaptor<PaymentApprovalRequest> approvalCaptor =
+        ArgumentCaptor.forClass(PaymentApprovalRequest.class);
+    verify(paymentApprovalClient).approve(approvalCaptor.capture());
+    PaymentApprovalRequest sentApproval = approvalCaptor.getValue();
+    assertThat(sentApproval.provider()).isEqualTo(PaymentProvider.KAKAO);
+    assertThat(sentApproval.paymentKey()).isEqualTo(paymentKey);
+    assertThat(sentApproval.bookingId()).isEqualTo(bookingId);
+    assertThat(sentApproval.amount()).isEqualTo(amount);
+
+    ArgumentCaptor<Payment> paymentCaptor = ArgumentCaptor.forClass(Payment.class);
+    verify(paymentRepository).save(paymentCaptor.capture());
+    Payment savedPayment = paymentCaptor.getValue();
+    assertThat(savedPayment.getBookingId()).isEqualTo(bookingId);
+    assertThat(savedPayment.getProvider()).isEqualTo(PaymentProvider.KAKAO);
+    assertThat(savedPayment.getAmount()).isEqualTo(amount);
+    assertThat(savedPayment.getStatus()).isEqualTo(PaymentStatus.COMPLETED);
+    assertThat(savedPayment.getPaidAt()).isEqualTo(approvedAt);
+
     verify(paymentEventPublisher)
         .publishConfirmed(
-            eq(null), eq(bookingId), eq(seatId), eq(userId), eq(amount), eq(approvedAt));
+            eq(savedPaymentId), eq(bookingId), eq(seatId), eq(userId), eq(amount), eq(approvedAt));
+  }
+
+  private void setId(Payment payment, Long id) throws Exception {
+    Field idField = payment.getClass().getSuperclass().getDeclaredField("id");
+    idField.setAccessible(true);
+    idField.set(payment, id);
   }
 
   @Test

--- a/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/in/api/v1/PaymentControllerTest.java
+++ b/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/in/api/v1/PaymentControllerTest.java
@@ -1,0 +1,166 @@
+package com.ticketrush.boundedcontext.payment.in.api.v1;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.ticketrush.boundedcontext.payment.app.dto.request.PaymentConfirmRequest;
+import com.ticketrush.boundedcontext.payment.app.dto.response.PaymentConfirmResponse;
+import com.ticketrush.boundedcontext.payment.app.facade.PaymentFacade;
+import com.ticketrush.global.config.SecurityConfig;
+import com.ticketrush.global.exception.BusinessException;
+import com.ticketrush.global.security.GatewayHeaderFilter;
+import com.ticketrush.global.status.ErrorStatus;
+import com.ticketrush.support.WebMvcSliceTest;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcSliceTest(PaymentController.class)
+@Import({SecurityConfig.class, GatewayHeaderFilter.class})
+@TestPropertySource(properties = "gateway.internal-token=test-token")
+class PaymentControllerTest {
+
+  private static final String INTERNAL_TOKEN = "test-token";
+
+  @Autowired private MockMvc mockMvc;
+
+  @MockitoBean private PaymentFacade paymentFacade;
+
+  @Test
+  @DisplayName("결제 Confirm 요청을 성공하고 200 OK를 반환한다")
+  void confirm_success() throws Exception {
+    // given
+    Long userId = 10L;
+    LocalDateTime paidAt = LocalDateTime.of(2026, 5, 22, 10, 0);
+    PaymentConfirmResponse response = new PaymentConfirmResponse(1L, "COMPLETED", paidAt);
+    given(paymentFacade.confirm(eq(userId), any(PaymentConfirmRequest.class))).willReturn(response);
+
+    String requestBody =
+        """
+        {
+          "booking_id": 100,
+          "seat_id": 200,
+          "provider": "KAKAO",
+          "amount": 55000,
+          "payment_key": "pgKey_xyz"
+        }
+        """;
+
+    // when & then
+    mockMvc
+        .perform(
+            post("/api/v1/payment/confirm")
+                .header("X-Internal-Token", INTERNAL_TOKEN)
+                .header("X-User-Id", userId)
+                .header("X-User-Role", "USER")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestBody))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.is_success").value(true))
+        .andExpect(jsonPath("$.result.payment_id").value(1))
+        .andExpect(jsonPath("$.result.status").value("COMPLETED"));
+
+    verify(paymentFacade).confirm(eq(userId), any(PaymentConfirmRequest.class));
+  }
+
+  @Test
+  @DisplayName("인증 principal이 없으면 401 Unauthorized를 반환한다")
+  void confirm_fails_when_principal_missing() throws Exception {
+    // given
+    String requestBody =
+        """
+        {
+          "booking_id": 100,
+          "seat_id": 200,
+          "provider": "KAKAO",
+          "amount": 55000,
+          "payment_key": "pgKey_xyz"
+        }
+        """;
+
+    // when & then
+    mockMvc
+        .perform(
+            post("/api/v1/payment/confirm")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestBody))
+        .andExpect(status().isUnauthorized())
+        .andExpect(jsonPath("$.is_success").value(false))
+        .andExpect(jsonPath("$.code").value(ErrorStatus.UNAUTHORIZED.getCode()));
+
+    verifyNoInteractions(paymentFacade);
+  }
+
+  @Test
+  @DisplayName("필수 필드가 누락되면 400 Bad Request를 반환한다")
+  void confirm_fails_when_required_field_missing() throws Exception {
+    // given - bookingId 누락
+    String requestBody =
+        """
+        {
+          "seat_id": 200,
+          "provider": "KAKAO",
+          "amount": 55000,
+          "payment_key": "pgKey_xyz"
+        }
+        """;
+
+    // when & then
+    mockMvc
+        .perform(
+            post("/api/v1/payment/confirm")
+                .header("X-Internal-Token", INTERNAL_TOKEN)
+                .header("X-User-Id", 10L)
+                .header("X-User-Role", "USER")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestBody))
+        .andExpect(status().isBadRequest());
+
+    verifyNoInteractions(paymentFacade);
+  }
+
+  @Test
+  @DisplayName("결제 금액 불일치 시 PAYMENT_400_001로 실패한다")
+  void confirm_fails_when_amount_mismatch() throws Exception {
+    // given
+    Long userId = 10L;
+    given(paymentFacade.confirm(eq(userId), any(PaymentConfirmRequest.class)))
+        .willThrow(new BusinessException(ErrorStatus.PAYMENT_AMOUNT_MISMATCH));
+
+    String requestBody =
+        """
+        {
+          "booking_id": 100,
+          "seat_id": 200,
+          "provider": "KAKAO",
+          "amount": 55000,
+          "payment_key": "pgKey_xyz"
+        }
+        """;
+
+    // when & then
+    mockMvc
+        .perform(
+            post("/api/v1/payment/confirm")
+                .header("X-Internal-Token", INTERNAL_TOKEN)
+                .header("X-User-Id", userId)
+                .header("X-User-Role", "USER")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestBody))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.is_success").value(false))
+        .andExpect(jsonPath("$.code").value(ErrorStatus.PAYMENT_AMOUNT_MISMATCH.getCode()));
+  }
+}

--- a/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/in/api/v1/PaymentControllerTest.java
+++ b/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/in/api/v1/PaymentControllerTest.java
@@ -70,14 +70,15 @@ class PaymentControllerTest {
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.is_success").value(true))
         .andExpect(jsonPath("$.result.payment_id").value(1))
-        .andExpect(jsonPath("$.result.status").value("COMPLETED"));
+        .andExpect(jsonPath("$.result.status").value("COMPLETED"))
+        .andExpect(jsonPath("$.result.paid_at").value("2026-05-22 10:00:00"));
 
     verify(paymentFacade).confirm(eq(userId), any(PaymentConfirmRequest.class));
   }
 
   @Test
-  @DisplayName("인증 principal이 없으면 401 Unauthorized를 반환한다")
-  void confirm_fails_when_principal_missing() throws Exception {
+  @DisplayName("Gateway 인증 헤더가 없으면 401 Unauthorized를 반환한다")
+  void confirm_fails_when_gateway_headers_missing() throws Exception {
     // given
     String requestBody =
         """
@@ -162,5 +163,7 @@ class PaymentControllerTest {
         .andExpect(status().isBadRequest())
         .andExpect(jsonPath("$.is_success").value(false))
         .andExpect(jsonPath("$.code").value(ErrorStatus.PAYMENT_AMOUNT_MISMATCH.getCode()));
+
+    verify(paymentFacade).confirm(eq(userId), any(PaymentConfirmRequest.class));
   }
 }


### PR DESCRIPTION
## 🔗 관련 이슈

- close #21

---

## 📌 주요 변경 사항

- `POST /api/v1/payment/confirm` 엔드포인트 추가 — 결제 무결성 검증 후 결제 확정
- `PaymentConfirmedEvent` Kafka 발행을 통해 후속 도메인(예매·좌석·티켓) 처리 위임
- PG사 승인 API는 `PaymentApprovalClient` 인터페이스 + stub 구현체로 골격만 구성 (실제 외부 연동은 #89에서 진행)
- payment-service `SecurityConfig`에 `GatewayHeaderFilter` 적용, `/api/v1/payment/confirm` 인증 필수화

---

## 🛠 상세 구현 내용

- **결제 무결성 검증**: 클라이언트가 전달한 `amount`와 PG 승인 응답의 `approvedAmount`가 일치하지 않으면 `PAYMENT_400_001` 응답 + 트랜잭션 롤백
- **PaymentConfirmUseCase**: `@Transactional` 적용. PG 승인 호출 → 금액 검증 → `Payment` 레코드 `COMPLETED` 저장 → 이벤트 발행 순서. `KafkaDomainEventPublisher`가 트랜잭션 커밋 후 발행을 보장
- **PaymentApprovalClient (stub)**: 요청 금액을 그대로 승인 응답으로 반환. #89에서 실제 PG사 연동 구현체로 교체 예정
- **이벤트 페이로드**: #208에서 정의된 `PaymentConfirmedEvent(paymentId, bookingId, seatId, userId, amount, paidAt)` 그대로 사용
- **에러 코드 추가**: `PAYMENT_400_001`(금액 불일치), `PAYMENT_502_001`(PG 승인 실패), `PAYMENT_503_001`(PG 통신 실패)
- **Swagger**: `PaymentConfirmApiResponses` 어노테이션으로 성공/실패 응답 예시 분리

---

## ✅ 테스트

### 테스트 방법

- `./gradlew :payment-service:test`
- `PaymentConfirmUseCaseTest`: PG 승인 성공·금액 불일치 케이스
- `PaymentControllerTest`: 정상 응답·인증 없음(401)·필수 필드 누락(400)·금액 불일치(PAYMENT_400_001) 케이스

### 테스트 결과

- 단위 테스트 7건 모두 통과 (UseCase 2 + Controller 4 + 기존 Application 1)
- `spotlessCheck`, `checkstyleMain/Test`, `compileJava/TestJava` 모두 그린
---

## 👀 리뷰 요청 사항

- 결제 confirm 흐름이 **Kafka 비동기 체이닝 방식**(payment → booking → seat/ticket)으로 설계되었습니다. 본 PR은 첫 단계(payment-service)만 포함하며, 후속 컨슈머는 예매/좌석/티켓 도메인 담당자가 별도 이슈로 처리 예정입니다.
- `seatId`는 현재 클라이언트 요청으로 받고 있습니다. payment-service가 booking 정보를 동기 조회하지 않는 컨벤션에 맞춘 결정이며, `bookingNumber-seatId` 연관 검증은 booking 컨슈머(#188)에서 수행됩니다.
- `StubPaymentApprovalClient`는 #89에서 실제 구현체로 교체될 예정입니다. 인터페이스 시그니처가 적절한지 확인 부탁드립니다.

---

## ⚠️ 배포 시 주의사항

- payment-service의 `SecurityConfig`가 변경되어 `/api/v1/payment/confirm`은 인증 필수입니다. Gateway에서 `X-Internal-Token`, `X-User-Id`, `X-User-Role` 헤더가 정상적으로 주입되는지 확인 필요
- DB 마이그레이션 없음 (Payment 엔티티는 #23에서 이미 머지)
- Kafka 토픽 `payment-confirmed-topic`은 #208에서 정의된 상태. 컨슈머 미구현 상태에서 이벤트는 발행되지만 누구도 처리하지 않음 — 후속 도메인 이슈와 함께 묶여 머지되어야 실제 결제 흐름이 동작합니다
