### PR TITLE
[Feat] #37 마이페이지 회원 예매 내역 조회 API

### DIFF
--- a/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/app/dto/response/BookingCountResponse.java
+++ b/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/app/dto/response/BookingCountResponse.java
@@ -1,0 +1,9 @@
+package com.ticketrush.boundedcontext.booking.app.dto.response;
+
+import com.ticketrush.boundedcontext.booking.domain.types.BookingStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "회원 예매 수 응답 DTO")
+public record BookingCountResponse(
+    @Schema(description = "집계 대상 예매 상태", example = "CONFIRMED") BookingStatus bookingStatus,
+    @Schema(description = "예매 수", example = "3") long count) {}

--- a/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/app/dto/response/BookingSummaryResponse.java
+++ b/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/app/dto/response/BookingSummaryResponse.java
@@ -1,0 +1,26 @@
+package com.ticketrush.boundedcontext.booking.app.dto.response;
+
+import com.ticketrush.boundedcontext.booking.domain.entity.Booking;
+import com.ticketrush.boundedcontext.booking.domain.types.BookingStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+
+@Schema(description = "회원 예매 요약 응답 DTO")
+public record BookingSummaryResponse(
+    @Schema(description = "예매 ID", example = "1") Long bookingId,
+    @Schema(description = "클라이언트에게 노출되는 주문/예약 번호", example = "X7B29-KLPW1") String bookingNumber,
+    @Schema(description = "공연 ID", example = "10") Long performanceId,
+    @Schema(description = "좌석 ID", example = "100") Long seatId,
+    @Schema(description = "예매 상태", example = "CONFIRMED") BookingStatus bookingStatus,
+    @Schema(description = "예매 확정일", example = "2026-05-22 10:30:00") LocalDateTime confirmedAt) {
+
+  public static BookingSummaryResponse from(Booking booking) {
+    return new BookingSummaryResponse(
+        booking.getId(),
+        booking.getBookingNumber(),
+        booking.getPerformanceId(),
+        booking.getSeatId(),
+        booking.getBookingStatus(),
+        booking.getConfirmedAt());
+  }
+}

--- a/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/app/facade/BookingFacade.java
+++ b/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/app/facade/BookingFacade.java
@@ -1,12 +1,18 @@
 package com.ticketrush.boundedcontext.booking.app.facade;
 
 import com.ticketrush.boundedcontext.booking.app.dto.request.BookingCreateRequest;
+import com.ticketrush.boundedcontext.booking.app.dto.response.BookingCountResponse;
 import com.ticketrush.boundedcontext.booking.app.dto.response.BookingPendingResponse;
+import com.ticketrush.boundedcontext.booking.app.dto.response.BookingSummaryResponse;
+import com.ticketrush.boundedcontext.booking.app.usecase.BookingCountUseCase;
 import com.ticketrush.boundedcontext.booking.app.usecase.BookingCreateUseCase;
+import com.ticketrush.boundedcontext.booking.app.usecase.BookingGetMyBookingsUseCase;
 import com.ticketrush.boundedcontext.booking.app.usecase.BookingIssueNumberUseCase;
 import com.ticketrush.boundedcontext.booking.app.usecase.BookingValidateReferencesUseCase;
 import com.ticketrush.boundedcontext.booking.app.usecase.BookingValidateSeatAvailableUseCase;
 import com.ticketrush.boundedcontext.booking.domain.entity.Booking;
+import com.ticketrush.boundedcontext.booking.domain.types.BookingStatus;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -18,6 +24,8 @@ public class BookingFacade {
 
   private final BookingIssueNumberUseCase bookingIssueNumberUseCase;
   private final BookingCreateUseCase bookingCreateUseCase;
+  private final BookingGetMyBookingsUseCase bookingGetMyBookingsUseCase;
+  private final BookingCountUseCase bookingCountUseCase;
   private final BookingValidateReferencesUseCase bookingValidateReferencesUseCase;
   private final BookingValidateSeatAvailableUseCase bookingValidateSeatAvailableUseCase;
 
@@ -36,5 +44,13 @@ public class BookingFacade {
     Booking booking = bookingCreateUseCase.execute(request);
 
     return BookingPendingResponse.from(booking);
+  }
+
+  public List<BookingSummaryResponse> getMyBookings(Long userId, BookingStatus bookingStatus) {
+    return bookingGetMyBookingsUseCase.execute(userId, bookingStatus);
+  }
+
+  public BookingCountResponse countMyBookings(Long userId, BookingStatus bookingStatus) {
+    return bookingCountUseCase.execute(userId, bookingStatus);
   }
 }

--- a/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/app/facade/BookingFacade.java
+++ b/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/app/facade/BookingFacade.java
@@ -12,9 +12,10 @@ import com.ticketrush.boundedcontext.booking.app.usecase.BookingValidateReferenc
 import com.ticketrush.boundedcontext.booking.app.usecase.BookingValidateSeatAvailableUseCase;
 import com.ticketrush.boundedcontext.booking.domain.entity.Booking;
 import com.ticketrush.boundedcontext.booking.domain.types.BookingStatus;
-import java.util.List;
+import com.ticketrush.global.dto.request.OffsetPageRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
 
 @Slf4j
@@ -46,8 +47,9 @@ public class BookingFacade {
     return BookingPendingResponse.from(booking);
   }
 
-  public List<BookingSummaryResponse> getMyBookings(Long userId, BookingStatus bookingStatus) {
-    return bookingGetMyBookingsUseCase.execute(userId, bookingStatus);
+  public Page<BookingSummaryResponse> getMyBookings(
+      Long userId, BookingStatus bookingStatus, OffsetPageRequest pageRequest) {
+    return bookingGetMyBookingsUseCase.execute(userId, bookingStatus, pageRequest);
   }
 
   public BookingCountResponse countMyBookings(Long userId, BookingStatus bookingStatus) {

--- a/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/app/usecase/BookingConfirmUseCase.java
+++ b/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/app/usecase/BookingConfirmUseCase.java
@@ -1,0 +1,27 @@
+package com.ticketrush.boundedcontext.booking.app.usecase;
+
+import com.ticketrush.boundedcontext.booking.domain.entity.Booking;
+import com.ticketrush.boundedcontext.booking.out.repository.BookingRepository;
+import com.ticketrush.global.exception.BusinessException;
+import com.ticketrush.global.status.ErrorStatus;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class BookingConfirmUseCase {
+
+  private final BookingRepository bookingRepository;
+
+  public void execute(Long bookingId, LocalDateTime confirmedAt) {
+    Booking booking =
+        bookingRepository
+            .findById(bookingId)
+            .orElseThrow(() -> new BusinessException(ErrorStatus.BOOKING_NOT_FOUND));
+
+    booking.confirm(confirmedAt);
+  }
+}

--- a/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/app/usecase/BookingCountUseCase.java
+++ b/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/app/usecase/BookingCountUseCase.java
@@ -1,0 +1,21 @@
+package com.ticketrush.boundedcontext.booking.app.usecase;
+
+import com.ticketrush.boundedcontext.booking.app.dto.response.BookingCountResponse;
+import com.ticketrush.boundedcontext.booking.domain.types.BookingStatus;
+import com.ticketrush.boundedcontext.booking.out.repository.BookingRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class BookingCountUseCase {
+
+  private final BookingRepository bookingRepository;
+
+  public BookingCountResponse execute(Long userId, BookingStatus bookingStatus) {
+    long count = bookingRepository.countByUserIdAndBookingStatus(userId, bookingStatus);
+    return new BookingCountResponse(bookingStatus, count);
+  }
+}

--- a/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/app/usecase/BookingGetMyBookingsUseCase.java
+++ b/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/app/usecase/BookingGetMyBookingsUseCase.java
@@ -1,0 +1,25 @@
+package com.ticketrush.boundedcontext.booking.app.usecase;
+
+import com.ticketrush.boundedcontext.booking.app.dto.response.BookingSummaryResponse;
+import com.ticketrush.boundedcontext.booking.domain.types.BookingStatus;
+import com.ticketrush.boundedcontext.booking.out.repository.BookingRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class BookingGetMyBookingsUseCase {
+
+  private final BookingRepository bookingRepository;
+
+  public List<BookingSummaryResponse> execute(Long userId, BookingStatus bookingStatus) {
+    return bookingRepository
+        .findByUserIdAndBookingStatusOrderByConfirmedAtDescCreatedAtDesc(userId, bookingStatus)
+        .stream()
+        .map(BookingSummaryResponse::from)
+        .toList();
+  }
+}

--- a/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/app/usecase/BookingGetMyBookingsUseCase.java
+++ b/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/app/usecase/BookingGetMyBookingsUseCase.java
@@ -3,8 +3,11 @@ package com.ticketrush.boundedcontext.booking.app.usecase;
 import com.ticketrush.boundedcontext.booking.app.dto.response.BookingSummaryResponse;
 import com.ticketrush.boundedcontext.booking.domain.types.BookingStatus;
 import com.ticketrush.boundedcontext.booking.out.repository.BookingRepository;
-import java.util.List;
+import com.ticketrush.global.dto.request.OffsetPageRequest;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -15,11 +18,21 @@ public class BookingGetMyBookingsUseCase {
 
   private final BookingRepository bookingRepository;
 
-  public List<BookingSummaryResponse> execute(Long userId, BookingStatus bookingStatus) {
+  public Page<BookingSummaryResponse> execute(
+      Long userId, BookingStatus bookingStatus, OffsetPageRequest pageRequest) {
     return bookingRepository
-        .findByUserIdAndBookingStatusOrderByConfirmedAtDescCreatedAtDesc(userId, bookingStatus)
-        .stream()
-        .map(BookingSummaryResponse::from)
-        .toList();
+        .findByUserIdAndBookingStatus(
+            userId,
+            bookingStatus,
+            PageRequest.of(pageRequest.page(), pageRequest.size(), sortByStatus(bookingStatus)))
+        .map(BookingSummaryResponse::from);
+  }
+
+  private Sort sortByStatus(BookingStatus bookingStatus) {
+    if (bookingStatus == BookingStatus.CONFIRMED) {
+      return Sort.by(Sort.Order.desc("confirmedAt"), Sort.Order.desc("createdAt"));
+    }
+
+    return Sort.by(Sort.Order.desc("createdAt"));
   }
 }

--- a/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/domain/entity/Booking.java
+++ b/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/domain/entity/Booking.java
@@ -66,6 +66,7 @@ public class Booking extends AutoIdBaseEntity {
   public void confirm(LocalDateTime confirmedAt) {
     if (this.bookingStatus == BookingStatus.CONFIRMED) {
       if (this.confirmedAt == null) {
+        // 결제 확정 이벤트 재처리 시 과거 확정 데이터의 누락된 확정 시각을 보정한다.
         this.confirmedAt = confirmedAt;
       }
       return;

--- a/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/domain/entity/Booking.java
+++ b/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/domain/entity/Booking.java
@@ -10,6 +10,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.Table;
+import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -38,6 +39,9 @@ public class Booking extends AutoIdBaseEntity {
   @Column(name = "booking_status", length = 20, nullable = false)
   private BookingStatus bookingStatus;
 
+  @Column(name = "confirmed_at")
+  private LocalDateTime confirmedAt;
+
   @Builder
   public Booking(
       String bookingNumber,
@@ -57,5 +61,18 @@ public class Booking extends AutoIdBaseEntity {
       throw new BusinessException(ErrorStatus.BOOKING_CANCEL_NOT_ALLOWED);
     }
     this.bookingStatus = BookingStatus.CANCELED;
+  }
+
+  public void confirm(LocalDateTime confirmedAt) {
+    if (this.bookingStatus == BookingStatus.CONFIRMED) {
+      return;
+    }
+
+    if (this.bookingStatus != BookingStatus.PENDING) {
+      throw new BusinessException(ErrorStatus.BOOKING_CONFIRM_NOT_ALLOWED);
+    }
+
+    this.bookingStatus = BookingStatus.CONFIRMED;
+    this.confirmedAt = confirmedAt;
   }
 }

--- a/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/domain/entity/Booking.java
+++ b/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/domain/entity/Booking.java
@@ -65,6 +65,9 @@ public class Booking extends AutoIdBaseEntity {
 
   public void confirm(LocalDateTime confirmedAt) {
     if (this.bookingStatus == BookingStatus.CONFIRMED) {
+      if (this.confirmedAt == null) {
+        this.confirmedAt = confirmedAt;
+      }
       return;
     }
 

--- a/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/in/api/v1/BookingController.java
+++ b/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/in/api/v1/BookingController.java
@@ -1,20 +1,26 @@
 package com.ticketrush.boundedcontext.booking.in.api.v1;
 
 import com.ticketrush.boundedcontext.booking.app.dto.request.BookingPendingRequest;
+import com.ticketrush.boundedcontext.booking.app.dto.response.BookingCountResponse;
 import com.ticketrush.boundedcontext.booking.app.dto.response.BookingPendingResponse;
+import com.ticketrush.boundedcontext.booking.app.dto.response.BookingSummaryResponse;
 import com.ticketrush.boundedcontext.booking.app.facade.BookingFacade;
+import com.ticketrush.boundedcontext.booking.domain.types.BookingStatus;
 import com.ticketrush.global.dto.response.ApiResponse;
 import com.ticketrush.global.security.CustomUserDetails;
 import com.ticketrush.global.status.SuccessStatus;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "Booking", description = "예약 관련 API")
@@ -36,5 +42,27 @@ public class BookingController {
         bookingFacade.createBooking(user.getUserId(), request.performanceId(), request.seatId());
 
     return ApiResponse.onSuccess(SuccessStatus.CREATED, response);
+  }
+
+  @Operation(
+      summary = "내 예매 내역 조회",
+      description = "로그인한 사용자의 예매 내역을 조회합니다. 좌석 번호와 공연 상세 정보는 각 모듈 API에서 조회합니다.")
+  @GetMapping("/me")
+  public ResponseEntity<ApiResponse<List<BookingSummaryResponse>>> getMyBookings(
+      @AuthenticationPrincipal CustomUserDetails user,
+      @RequestParam(defaultValue = "CONFIRMED") BookingStatus status) {
+    List<BookingSummaryResponse> response = bookingFacade.getMyBookings(user.getUserId(), status);
+
+    return ApiResponse.onSuccess(SuccessStatus.OK, response);
+  }
+
+  @Operation(summary = "내 예매 수 조회", description = "로그인한 사용자의 상태별 예매 수를 조회합니다.")
+  @GetMapping("/me/count")
+  public ResponseEntity<ApiResponse<BookingCountResponse>> countMyBookings(
+      @AuthenticationPrincipal CustomUserDetails user,
+      @RequestParam(defaultValue = "CONFIRMED") BookingStatus status) {
+    BookingCountResponse response = bookingFacade.countMyBookings(user.getUserId(), status);
+
+    return ApiResponse.onSuccess(SuccessStatus.OK, response);
   }
 }

--- a/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/in/api/v1/BookingController.java
+++ b/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/in/api/v1/BookingController.java
@@ -6,6 +6,7 @@ import com.ticketrush.boundedcontext.booking.app.dto.response.BookingPendingResp
 import com.ticketrush.boundedcontext.booking.app.dto.response.BookingSummaryResponse;
 import com.ticketrush.boundedcontext.booking.app.facade.BookingFacade;
 import com.ticketrush.boundedcontext.booking.domain.types.BookingStatus;
+import com.ticketrush.global.dto.request.OffsetPageRequest;
 import com.ticketrush.global.dto.response.ApiResponse;
 import com.ticketrush.global.security.CustomUserDetails;
 import com.ticketrush.global.status.SuccessStatus;
@@ -14,9 +15,12 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -24,6 +28,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "Booking", description = "예약 관련 API")
+@Validated
 @RestController
 @RequestMapping("/api/v1/booking")
 @RequiredArgsConstructor
@@ -50,8 +55,10 @@ public class BookingController {
   @GetMapping("/me")
   public ResponseEntity<ApiResponse<List<BookingSummaryResponse>>> getMyBookings(
       @AuthenticationPrincipal CustomUserDetails user,
-      @RequestParam(defaultValue = "CONFIRMED") BookingStatus status) {
-    List<BookingSummaryResponse> response = bookingFacade.getMyBookings(user.getUserId(), status);
+      @RequestParam(defaultValue = "CONFIRMED") BookingStatus status,
+      @ModelAttribute OffsetPageRequest pageRequest) {
+    Page<BookingSummaryResponse> response =
+        bookingFacade.getMyBookings(user.getUserId(), status, pageRequest);
 
     return ApiResponse.onSuccess(SuccessStatus.OK, response);
   }

--- a/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/out/repository/BookingRepository.java
+++ b/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/out/repository/BookingRepository.java
@@ -1,6 +1,14 @@
 package com.ticketrush.boundedcontext.booking.out.repository;
 
 import com.ticketrush.boundedcontext.booking.domain.entity.Booking;
+import com.ticketrush.boundedcontext.booking.domain.types.BookingStatus;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface BookingRepository extends JpaRepository<Booking, Long> {}
+public interface BookingRepository extends JpaRepository<Booking, Long> {
+
+  List<Booking> findByUserIdAndBookingStatusOrderByConfirmedAtDescCreatedAtDesc(
+      Long userId, BookingStatus bookingStatus);
+
+  long countByUserIdAndBookingStatus(Long userId, BookingStatus bookingStatus);
+}

--- a/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/out/repository/BookingRepository.java
+++ b/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/out/repository/BookingRepository.java
@@ -2,13 +2,14 @@ package com.ticketrush.boundedcontext.booking.out.repository;
 
 import com.ticketrush.boundedcontext.booking.domain.entity.Booking;
 import com.ticketrush.boundedcontext.booking.domain.types.BookingStatus;
-import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface BookingRepository extends JpaRepository<Booking, Long> {
 
-  List<Booking> findByUserIdAndBookingStatusOrderByConfirmedAtDescCreatedAtDesc(
-      Long userId, BookingStatus bookingStatus);
+  Page<Booking> findByUserIdAndBookingStatus(
+      Long userId, BookingStatus bookingStatus, Pageable pageable);
 
   long countByUserIdAndBookingStatus(Long userId, BookingStatus bookingStatus);
 }

--- a/booking-service/src/test/java/com/ticketrush/boundedcontext/booking/app/facade/BookingFacadeTest.java
+++ b/booking-service/src/test/java/com/ticketrush/boundedcontext/booking/app/facade/BookingFacadeTest.java
@@ -21,6 +21,7 @@ import com.ticketrush.boundedcontext.booking.app.usecase.BookingValidateReferenc
 import com.ticketrush.boundedcontext.booking.app.usecase.BookingValidateSeatAvailableUseCase;
 import com.ticketrush.boundedcontext.booking.domain.entity.Booking;
 import com.ticketrush.boundedcontext.booking.domain.types.BookingStatus;
+import com.ticketrush.global.dto.request.OffsetPageRequest;
 import com.ticketrush.global.exception.BusinessException;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -30,6 +31,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 
 @ExtendWith(MockitoExtension.class)
 class BookingFacadeTest {
@@ -135,16 +138,19 @@ class BookingFacadeTest {
             BookingStatus.CONFIRMED,
             LocalDateTime.of(2026, 5, 22, 10, 30));
 
-    given(bookingGetMyBookingsUseCase.execute(userId, BookingStatus.CONFIRMED))
-        .willReturn(List.of(response));
+    given(
+            bookingGetMyBookingsUseCase.execute(
+                userId, BookingStatus.CONFIRMED, new OffsetPageRequest(0, 10)))
+        .willReturn(new PageImpl<>(List.of(response)));
 
     // when
-    List<BookingSummaryResponse> result =
-        bookingFacade.getMyBookings(userId, BookingStatus.CONFIRMED);
+    Page<BookingSummaryResponse> result =
+        bookingFacade.getMyBookings(userId, BookingStatus.CONFIRMED, new OffsetPageRequest(0, 10));
 
     // then
-    assertThat(result).containsExactly(response);
-    verify(bookingGetMyBookingsUseCase).execute(userId, BookingStatus.CONFIRMED);
+    assertThat(result.getContent()).containsExactly(response);
+    verify(bookingGetMyBookingsUseCase)
+        .execute(userId, BookingStatus.CONFIRMED, new OffsetPageRequest(0, 10));
   }
 
   @Test

--- a/booking-service/src/test/java/com/ticketrush/boundedcontext/booking/app/facade/BookingFacadeTest.java
+++ b/booking-service/src/test/java/com/ticketrush/boundedcontext/booking/app/facade/BookingFacadeTest.java
@@ -10,14 +10,20 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 
 import com.ticketrush.boundedcontext.booking.app.dto.request.BookingCreateRequest;
+import com.ticketrush.boundedcontext.booking.app.dto.response.BookingCountResponse;
 import com.ticketrush.boundedcontext.booking.app.dto.response.BookingPendingResponse;
+import com.ticketrush.boundedcontext.booking.app.dto.response.BookingSummaryResponse;
+import com.ticketrush.boundedcontext.booking.app.usecase.BookingCountUseCase;
 import com.ticketrush.boundedcontext.booking.app.usecase.BookingCreateUseCase;
+import com.ticketrush.boundedcontext.booking.app.usecase.BookingGetMyBookingsUseCase;
 import com.ticketrush.boundedcontext.booking.app.usecase.BookingIssueNumberUseCase;
 import com.ticketrush.boundedcontext.booking.app.usecase.BookingValidateReferencesUseCase;
 import com.ticketrush.boundedcontext.booking.app.usecase.BookingValidateSeatAvailableUseCase;
 import com.ticketrush.boundedcontext.booking.domain.entity.Booking;
 import com.ticketrush.boundedcontext.booking.domain.types.BookingStatus;
 import com.ticketrush.global.exception.BusinessException;
+import java.time.LocalDateTime;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -32,6 +38,8 @@ class BookingFacadeTest {
 
   @Mock private BookingIssueNumberUseCase bookingIssueNumberUseCase;
   @Mock private BookingCreateUseCase bookingCreateUseCase;
+  @Mock private BookingGetMyBookingsUseCase bookingGetMyBookingsUseCase;
+  @Mock private BookingCountUseCase bookingCountUseCase;
   @Mock private BookingValidateReferencesUseCase bookingValidateReferencesUseCase;
   @Mock private BookingValidateSeatAvailableUseCase bookingValidateSeatAvailableUseCase;
 
@@ -111,5 +119,47 @@ class BookingFacadeTest {
     verify(bookingValidateReferencesUseCase).execute(userId, performanceId, seatId);
     verify(bookingValidateSeatAvailableUseCase).execute(seatId, performanceId);
     verifyNoInteractions(bookingIssueNumberUseCase, bookingCreateUseCase);
+  }
+
+  @Test
+  @DisplayName("성공: 회원 예매 내역 조회를 위임한다")
+  void getMyBookings_success() {
+    // given
+    Long userId = 1L;
+    BookingSummaryResponse response =
+        new BookingSummaryResponse(
+            100L,
+            "BOOK-1234",
+            2L,
+            3L,
+            BookingStatus.CONFIRMED,
+            LocalDateTime.of(2026, 5, 22, 10, 30));
+
+    given(bookingGetMyBookingsUseCase.execute(userId, BookingStatus.CONFIRMED))
+        .willReturn(List.of(response));
+
+    // when
+    List<BookingSummaryResponse> result =
+        bookingFacade.getMyBookings(userId, BookingStatus.CONFIRMED);
+
+    // then
+    assertThat(result).containsExactly(response);
+    verify(bookingGetMyBookingsUseCase).execute(userId, BookingStatus.CONFIRMED);
+  }
+
+  @Test
+  @DisplayName("성공: 회원 예매 수 조회를 위임한다")
+  void countMyBookings_success() {
+    // given
+    Long userId = 1L;
+    BookingCountResponse response = new BookingCountResponse(BookingStatus.CONFIRMED, 3L);
+    given(bookingCountUseCase.execute(userId, BookingStatus.CONFIRMED)).willReturn(response);
+
+    // when
+    BookingCountResponse result = bookingFacade.countMyBookings(userId, BookingStatus.CONFIRMED);
+
+    // then
+    assertThat(result).isEqualTo(response);
+    verify(bookingCountUseCase).execute(userId, BookingStatus.CONFIRMED);
   }
 }

--- a/booking-service/src/test/java/com/ticketrush/boundedcontext/booking/app/usecase/BookingConfirmUseCaseTest.java
+++ b/booking-service/src/test/java/com/ticketrush/boundedcontext/booking/app/usecase/BookingConfirmUseCaseTest.java
@@ -1,0 +1,65 @@
+package com.ticketrush.boundedcontext.booking.app.usecase;
+
+import static com.ticketrush.global.status.ErrorStatus.BOOKING_NOT_FOUND;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+import com.ticketrush.boundedcontext.booking.domain.entity.Booking;
+import com.ticketrush.boundedcontext.booking.domain.types.BookingStatus;
+import com.ticketrush.boundedcontext.booking.out.repository.BookingRepository;
+import com.ticketrush.global.exception.BusinessException;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class BookingConfirmUseCaseTest {
+
+  @InjectMocks private BookingConfirmUseCase bookingConfirmUseCase;
+
+  @Mock private BookingRepository bookingRepository;
+
+  @Test
+  @DisplayName("성공: 예매를 확정하고 확정 시각을 기록한다")
+  void execute_success() {
+    // given
+    Long bookingId = 1L;
+    LocalDateTime confirmedAt = LocalDateTime.of(2026, 5, 22, 10, 30);
+    Booking booking =
+        Booking.builder()
+            .userId(1L)
+            .performanceId(2L)
+            .seatId(3L)
+            .bookingNumber("BOOK-1234")
+            .bookingStatus(BookingStatus.PENDING)
+            .build();
+    given(bookingRepository.findById(bookingId)).willReturn(Optional.of(booking));
+
+    // when
+    bookingConfirmUseCase.execute(bookingId, confirmedAt);
+
+    // then
+    assertThat(booking.getBookingStatus()).isEqualTo(BookingStatus.CONFIRMED);
+    assertThat(booking.getConfirmedAt()).isEqualTo(confirmedAt);
+  }
+
+  @Test
+  @DisplayName("실패: 예매가 없으면 예외를 던진다")
+  void execute_fail_when_booking_not_found() {
+    // given
+    Long bookingId = 1L;
+    given(bookingRepository.findById(bookingId)).willReturn(Optional.empty());
+
+    // when & then
+    assertThatThrownBy(() -> bookingConfirmUseCase.execute(bookingId, LocalDateTime.now()))
+        .isInstanceOf(BusinessException.class)
+        .extracting(ex -> ((BusinessException) ex).getErrorStatus())
+        .isEqualTo(BOOKING_NOT_FOUND);
+  }
+}

--- a/booking-service/src/test/java/com/ticketrush/boundedcontext/booking/app/usecase/BookingConfirmUseCaseTest.java
+++ b/booking-service/src/test/java/com/ticketrush/boundedcontext/booking/app/usecase/BookingConfirmUseCaseTest.java
@@ -50,6 +50,30 @@ class BookingConfirmUseCaseTest {
   }
 
   @Test
+  @DisplayName("성공: 이미 확정된 예매의 확정 시각이 비어 있으면 보정한다")
+  void execute_fills_confirmed_at_when_already_confirmed_without_timestamp() {
+    // given
+    Long bookingId = 1L;
+    LocalDateTime confirmedAt = LocalDateTime.of(2026, 5, 22, 10, 30);
+    Booking booking =
+        Booking.builder()
+            .userId(1L)
+            .performanceId(2L)
+            .seatId(3L)
+            .bookingNumber("BOOK-1234")
+            .bookingStatus(BookingStatus.CONFIRMED)
+            .build();
+    given(bookingRepository.findById(bookingId)).willReturn(Optional.of(booking));
+
+    // when
+    bookingConfirmUseCase.execute(bookingId, confirmedAt);
+
+    // then
+    assertThat(booking.getBookingStatus()).isEqualTo(BookingStatus.CONFIRMED);
+    assertThat(booking.getConfirmedAt()).isEqualTo(confirmedAt);
+  }
+
+  @Test
   @DisplayName("실패: 예매가 없으면 예외를 던진다")
   void execute_fail_when_booking_not_found() {
     // given

--- a/booking-service/src/test/java/com/ticketrush/boundedcontext/booking/app/usecase/BookingCountUseCaseTest.java
+++ b/booking-service/src/test/java/com/ticketrush/boundedcontext/booking/app/usecase/BookingCountUseCaseTest.java
@@ -1,0 +1,40 @@
+package com.ticketrush.boundedcontext.booking.app.usecase;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import com.ticketrush.boundedcontext.booking.app.dto.response.BookingCountResponse;
+import com.ticketrush.boundedcontext.booking.domain.types.BookingStatus;
+import com.ticketrush.boundedcontext.booking.out.repository.BookingRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class BookingCountUseCaseTest {
+
+  @InjectMocks private BookingCountUseCase bookingCountUseCase;
+
+  @Mock private BookingRepository bookingRepository;
+
+  @Test
+  @DisplayName("성공: 회원 ID와 상태로 예매 수를 조회한다")
+  void execute_success() {
+    // given
+    Long userId = 1L;
+    given(bookingRepository.countByUserIdAndBookingStatus(userId, BookingStatus.CONFIRMED))
+        .willReturn(3L);
+
+    // when
+    BookingCountResponse result = bookingCountUseCase.execute(userId, BookingStatus.CONFIRMED);
+
+    // then
+    assertThat(result.bookingStatus()).isEqualTo(BookingStatus.CONFIRMED);
+    assertThat(result.count()).isEqualTo(3L);
+    verify(bookingRepository).countByUserIdAndBookingStatus(userId, BookingStatus.CONFIRMED);
+  }
+}

--- a/booking-service/src/test/java/com/ticketrush/boundedcontext/booking/app/usecase/BookingGetMyBookingsUseCaseTest.java
+++ b/booking-service/src/test/java/com/ticketrush/boundedcontext/booking/app/usecase/BookingGetMyBookingsUseCaseTest.java
@@ -8,6 +8,7 @@ import com.ticketrush.boundedcontext.booking.app.dto.response.BookingSummaryResp
 import com.ticketrush.boundedcontext.booking.domain.entity.Booking;
 import com.ticketrush.boundedcontext.booking.domain.types.BookingStatus;
 import com.ticketrush.boundedcontext.booking.out.repository.BookingRepository;
+import com.ticketrush.global.dto.request.OffsetPageRequest;
 import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
@@ -16,6 +17,10 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
@@ -43,23 +48,30 @@ class BookingGetMyBookingsUseCaseTest {
     booking.confirm(confirmedAt);
 
     given(
-            bookingRepository.findByUserIdAndBookingStatusOrderByConfirmedAtDescCreatedAtDesc(
-                userId, BookingStatus.CONFIRMED))
-        .willReturn(List.of(booking));
+            bookingRepository.findByUserIdAndBookingStatus(
+                userId,
+                BookingStatus.CONFIRMED,
+                PageRequest.of(
+                    0, 10, Sort.by(Sort.Order.desc("confirmedAt"), Sort.Order.desc("createdAt")))))
+        .willReturn(new PageImpl<>(List.of(booking), PageRequest.of(0, 10), 1));
 
     // when
-    List<BookingSummaryResponse> result =
-        bookingGetMyBookingsUseCase.execute(userId, BookingStatus.CONFIRMED);
+    Page<BookingSummaryResponse> result =
+        bookingGetMyBookingsUseCase.execute(
+            userId, BookingStatus.CONFIRMED, new OffsetPageRequest(0, 10));
 
     // then
     assertThat(result).hasSize(1);
-    assertThat(result.getFirst().bookingId()).isEqualTo(100L);
-    assertThat(result.getFirst().bookingNumber()).isEqualTo("BOOK-1234");
-    assertThat(result.getFirst().performanceId()).isEqualTo(2L);
-    assertThat(result.getFirst().seatId()).isEqualTo(3L);
-    assertThat(result.getFirst().confirmedAt()).isEqualTo(confirmedAt);
+    assertThat(result.getContent().getFirst().bookingId()).isEqualTo(100L);
+    assertThat(result.getContent().getFirst().bookingNumber()).isEqualTo("BOOK-1234");
+    assertThat(result.getContent().getFirst().performanceId()).isEqualTo(2L);
+    assertThat(result.getContent().getFirst().seatId()).isEqualTo(3L);
+    assertThat(result.getContent().getFirst().confirmedAt()).isEqualTo(confirmedAt);
     verify(bookingRepository)
-        .findByUserIdAndBookingStatusOrderByConfirmedAtDescCreatedAtDesc(
-            userId, BookingStatus.CONFIRMED);
+        .findByUserIdAndBookingStatus(
+            userId,
+            BookingStatus.CONFIRMED,
+            PageRequest.of(
+                0, 10, Sort.by(Sort.Order.desc("confirmedAt"), Sort.Order.desc("createdAt"))));
   }
 }

--- a/booking-service/src/test/java/com/ticketrush/boundedcontext/booking/app/usecase/BookingGetMyBookingsUseCaseTest.java
+++ b/booking-service/src/test/java/com/ticketrush/boundedcontext/booking/app/usecase/BookingGetMyBookingsUseCaseTest.java
@@ -1,0 +1,65 @@
+package com.ticketrush.boundedcontext.booking.app.usecase;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import com.ticketrush.boundedcontext.booking.app.dto.response.BookingSummaryResponse;
+import com.ticketrush.boundedcontext.booking.domain.entity.Booking;
+import com.ticketrush.boundedcontext.booking.domain.types.BookingStatus;
+import com.ticketrush.boundedcontext.booking.out.repository.BookingRepository;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class BookingGetMyBookingsUseCaseTest {
+
+  @InjectMocks private BookingGetMyBookingsUseCase bookingGetMyBookingsUseCase;
+
+  @Mock private BookingRepository bookingRepository;
+
+  @Test
+  @DisplayName("성공: 회원 ID와 상태로 예매 요약 목록을 조회한다")
+  void execute_success() {
+    // given
+    Long userId = 1L;
+    LocalDateTime confirmedAt = LocalDateTime.of(2026, 5, 22, 10, 30);
+    Booking booking =
+        Booking.builder()
+            .userId(userId)
+            .performanceId(2L)
+            .seatId(3L)
+            .bookingNumber("BOOK-1234")
+            .bookingStatus(BookingStatus.PENDING)
+            .build();
+    ReflectionTestUtils.setField(booking, "id", 100L);
+    booking.confirm(confirmedAt);
+
+    given(
+            bookingRepository.findByUserIdAndBookingStatusOrderByConfirmedAtDescCreatedAtDesc(
+                userId, BookingStatus.CONFIRMED))
+        .willReturn(List.of(booking));
+
+    // when
+    List<BookingSummaryResponse> result =
+        bookingGetMyBookingsUseCase.execute(userId, BookingStatus.CONFIRMED);
+
+    // then
+    assertThat(result).hasSize(1);
+    assertThat(result.getFirst().bookingId()).isEqualTo(100L);
+    assertThat(result.getFirst().bookingNumber()).isEqualTo("BOOK-1234");
+    assertThat(result.getFirst().performanceId()).isEqualTo(2L);
+    assertThat(result.getFirst().seatId()).isEqualTo(3L);
+    assertThat(result.getFirst().confirmedAt()).isEqualTo(confirmedAt);
+    verify(bookingRepository)
+        .findByUserIdAndBookingStatusOrderByConfirmedAtDescCreatedAtDesc(
+            userId, BookingStatus.CONFIRMED);
+  }
+}

--- a/booking-service/src/test/java/com/ticketrush/boundedcontext/booking/in/api/v1/BookingControllerTest.java
+++ b/booking-service/src/test/java/com/ticketrush/boundedcontext/booking/in/api/v1/BookingControllerTest.java
@@ -16,6 +16,7 @@ import com.ticketrush.boundedcontext.booking.app.facade.BookingFacade;
 import com.ticketrush.boundedcontext.booking.domain.types.BookingStatus;
 import com.ticketrush.global.config.JacksonConfig;
 import com.ticketrush.global.config.SecurityConfig;
+import com.ticketrush.global.dto.request.OffsetPageRequest;
 import com.ticketrush.global.security.GatewayHeaderFilter;
 import com.ticketrush.global.status.ErrorStatus;
 import java.time.LocalDateTime;
@@ -25,6 +26,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
@@ -90,8 +93,10 @@ class BookingControllerTest {
             BookingStatus.CONFIRMED,
             LocalDateTime.of(2026, 5, 22, 10, 30));
 
-    given(bookingFacade.getMyBookings(userId, BookingStatus.CONFIRMED))
-        .willReturn(List.of(response));
+    given(
+            bookingFacade.getMyBookings(
+                userId, BookingStatus.CONFIRMED, new OffsetPageRequest(0, 10)))
+        .willReturn(new PageImpl<>(List.of(response), PageRequest.of(0, 10), 1));
 
     // when & then
     mockMvc
@@ -107,9 +112,14 @@ class BookingControllerTest {
         .andExpect(jsonPath("$.result[0].performance_id").value(2))
         .andExpect(jsonPath("$.result[0].seat_id").value(3))
         .andExpect(jsonPath("$.result[0].booking_status").value("CONFIRMED"))
-        .andExpect(jsonPath("$.result[0].confirmed_at").value("2026-05-22 10:30:00"));
+        .andExpect(jsonPath("$.result[0].confirmed_at").value("2026-05-22 10:30:00"))
+        .andExpect(jsonPath("$.pagination_info.page_index").value(0))
+        .andExpect(jsonPath("$.pagination_info.size").value(10))
+        .andExpect(jsonPath("$.pagination_info.total_elements").value(1))
+        .andExpect(jsonPath("$.pagination_info.total_pages").value(1));
 
-    verify(bookingFacade).getMyBookings(eq(userId), eq(BookingStatus.CONFIRMED));
+    verify(bookingFacade)
+        .getMyBookings(eq(userId), eq(BookingStatus.CONFIRMED), eq(new OffsetPageRequest(0, 10)));
   }
 
   @Test

--- a/booking-service/src/test/java/com/ticketrush/boundedcontext/booking/in/api/v1/BookingControllerTest.java
+++ b/booking-service/src/test/java/com/ticketrush/boundedcontext/booking/in/api/v1/BookingControllerTest.java
@@ -4,16 +4,22 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.ticketrush.boundedcontext.booking.app.dto.response.BookingCountResponse;
 import com.ticketrush.boundedcontext.booking.app.dto.response.BookingPendingResponse;
+import com.ticketrush.boundedcontext.booking.app.dto.response.BookingSummaryResponse;
 import com.ticketrush.boundedcontext.booking.app.facade.BookingFacade;
+import com.ticketrush.boundedcontext.booking.domain.types.BookingStatus;
 import com.ticketrush.global.config.JacksonConfig;
 import com.ticketrush.global.config.SecurityConfig;
 import com.ticketrush.global.security.GatewayHeaderFilter;
 import com.ticketrush.global.status.ErrorStatus;
+import java.time.LocalDateTime;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -68,6 +74,66 @@ class BookingControllerTest {
         .andExpect(jsonPath("$.result.booking_number").value("BOOK-1234"));
 
     verify(bookingFacade).createBooking(eq(userId), eq(performanceId), eq(seatId));
+  }
+
+  @Test
+  @DisplayName("인증 principal의 userId로 내 예매 내역을 조회한다")
+  void getMyBookings_uses_authenticated_user_id() throws Exception {
+    // given
+    Long userId = 1L;
+    BookingSummaryResponse response =
+        new BookingSummaryResponse(
+            100L,
+            "BOOK-1234",
+            2L,
+            3L,
+            BookingStatus.CONFIRMED,
+            LocalDateTime.of(2026, 5, 22, 10, 30));
+
+    given(bookingFacade.getMyBookings(userId, BookingStatus.CONFIRMED))
+        .willReturn(List.of(response));
+
+    // when & then
+    mockMvc
+        .perform(
+            get("/api/v1/booking/me")
+                .param("status", "CONFIRMED")
+                .header("X-Internal-Token", INTERNAL_TOKEN)
+                .header("X-User-Id", userId)
+                .header("X-User-Role", "USER"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.is_success").value(true))
+        .andExpect(jsonPath("$.result[0].booking_number").value("BOOK-1234"))
+        .andExpect(jsonPath("$.result[0].performance_id").value(2))
+        .andExpect(jsonPath("$.result[0].seat_id").value(3))
+        .andExpect(jsonPath("$.result[0].booking_status").value("CONFIRMED"))
+        .andExpect(jsonPath("$.result[0].confirmed_at").value("2026-05-22 10:30:00"));
+
+    verify(bookingFacade).getMyBookings(eq(userId), eq(BookingStatus.CONFIRMED));
+  }
+
+  @Test
+  @DisplayName("인증 principal의 userId로 내 예매 수를 조회한다")
+  void countMyBookings_uses_authenticated_user_id() throws Exception {
+    // given
+    Long userId = 1L;
+    BookingCountResponse response = new BookingCountResponse(BookingStatus.CONFIRMED, 3L);
+    given(bookingFacade.countMyBookings(userId, BookingStatus.CONFIRMED)).willReturn(response);
+
+    // when & then
+    mockMvc
+        .perform(
+            get("/api/v1/booking/me/count")
+                .param("status", "CONFIRMED")
+                .header("X-Internal-Token", INTERNAL_TOKEN)
+                .header("X-User-Id", userId)
+                .header("X-User-Role", "USER"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.is_success").value(true))
+        .andExpect(jsonPath("$.result.booking_status").value("CONFIRMED"))
+        .andExpect(jsonPath("$.result.count").value(3));
+
+    verify(bookingFacade).countMyBookings(eq(userId), eq(BookingStatus.CONFIRMED));
   }
 
   @Test

--- a/common/src/main/java/com/ticketrush/global/constants/PaginationConstants.java
+++ b/common/src/main/java/com/ticketrush/global/constants/PaginationConstants.java
@@ -2,4 +2,5 @@ package com.ticketrush.global.constants;
 
 public class PaginationConstants {
   public static final int DEFAULT_PAGE_SIZE = 10;
+  public static final int MAX_PAGE_SIZE = 50;
 }

--- a/common/src/main/java/com/ticketrush/global/dto/request/OffsetPageRequest.java
+++ b/common/src/main/java/com/ticketrush/global/dto/request/OffsetPageRequest.java
@@ -1,6 +1,7 @@
 package com.ticketrush.global.dto.request;
 
 import static com.ticketrush.global.constants.PaginationConstants.DEFAULT_PAGE_SIZE;
+import static com.ticketrush.global.constants.PaginationConstants.MAX_PAGE_SIZE;
 
 public record OffsetPageRequest(Integer page, Integer size) implements PaginationRequest {
 
@@ -10,6 +11,9 @@ public record OffsetPageRequest(Integer page, Integer size) implements Paginatio
     }
     if (size == null || size < 1) {
       size = DEFAULT_PAGE_SIZE;
+    }
+    if (size > MAX_PAGE_SIZE) {
+      size = MAX_PAGE_SIZE;
     }
   }
 }

--- a/common/src/main/java/com/ticketrush/global/status/ErrorStatus.java
+++ b/common/src/main/java/com/ticketrush/global/status/ErrorStatus.java
@@ -75,6 +75,7 @@ public enum ErrorStatus {
 
   // Booking 409
   BOOKING_CANCEL_NOT_ALLOWED(HttpStatus.CONFLICT, "BOOKING_409_001", "취소할 수 없는 예매 상태입니다."),
+  BOOKING_CONFIRM_NOT_ALLOWED(HttpStatus.CONFLICT, "BOOKING_409_002", "확정할 수 없는 예매 상태입니다."),
 
   // Booking 500
   BOOKING_NUMBER_RETRY_EXCEEDED(

--- a/common/src/test/java/com/ticketrush/global/dto/request/OffsetPageRequestTest.java
+++ b/common/src/test/java/com/ticketrush/global/dto/request/OffsetPageRequestTest.java
@@ -1,0 +1,28 @@
+package com.ticketrush.global.dto.request;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.ticketrush.global.constants.PaginationConstants;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class OffsetPageRequestTest {
+
+  @Test
+  @DisplayName("page와 size가 비어있거나 범위를 벗어나면 공통 기본값으로 보정한다")
+  void offset_page_request_normalizes_invalid_values() {
+    OffsetPageRequest request = new OffsetPageRequest(-1, 0);
+
+    assertThat(request.page()).isZero();
+    assertThat(request.size()).isEqualTo(PaginationConstants.DEFAULT_PAGE_SIZE);
+  }
+
+  @Test
+  @DisplayName("size가 공통 최대 크기를 초과하면 최대 크기로 보정한다")
+  void offset_page_request_caps_size() {
+    OffsetPageRequest request = new OffsetPageRequest(1, 1000);
+
+    assertThat(request.page()).isEqualTo(1);
+    assertThat(request.size()).isEqualTo(PaginationConstants.MAX_PAGE_SIZE);
+  }
+}

--- a/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/app/dto/response/SeatNumberResponse.java
+++ b/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/app/dto/response/SeatNumberResponse.java
@@ -1,0 +1,8 @@
+package com.ticketrush.boundedcontext.seat.app.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "좌석 번호 응답 DTO")
+public record SeatNumberResponse(
+    @Schema(description = "좌석 ID", example = "1") Long seatId,
+    @Schema(description = "좌석 번호", example = "A-1") String seatNumber) {}

--- a/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/app/facade/SeatFacade.java
+++ b/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/app/facade/SeatFacade.java
@@ -1,10 +1,12 @@
 package com.ticketrush.boundedcontext.seat.app.facade;
 
 import com.ticketrush.boundedcontext.seat.app.dto.response.SeatLayoutResponse;
+import com.ticketrush.boundedcontext.seat.app.dto.response.SeatNumberResponse;
 import com.ticketrush.boundedcontext.seat.app.dto.response.SeatStatusCountsResponse;
 import com.ticketrush.boundedcontext.seat.app.support.SeatStatusStreamSubscriber;
 import com.ticketrush.boundedcontext.seat.app.usecase.SeatConfirmSoldUseCase;
 import com.ticketrush.boundedcontext.seat.app.usecase.SeatCreateDefaultLayoutUseCase;
+import com.ticketrush.boundedcontext.seat.app.usecase.SeatGetNumbersUseCase;
 import com.ticketrush.boundedcontext.seat.app.usecase.SeatGetSeatLayoutsUseCase;
 import com.ticketrush.boundedcontext.seat.app.usecase.SeatGetStatusCountsUseCase;
 import com.ticketrush.boundedcontext.seat.app.usecase.SeatHoldUseCase;
@@ -29,6 +31,7 @@ public class SeatFacade {
 
   private final SeatGetStatusCountsUseCase seatGetStatusCountsUseCase;
   private final SeatGetSeatLayoutsUseCase seatGetSeatLayoutsUseCase;
+  private final SeatGetNumbersUseCase seatGetNumbersUseCase;
   private final SeatCreateDefaultLayoutUseCase seatCreateDefaultLayoutUseCase;
   private final SeatConfirmSoldUseCase seatConfirmSoldUseCase;
   private final SeatHoldUseCase seatHoldUseCase;
@@ -40,6 +43,10 @@ public class SeatFacade {
 
   public List<SeatLayoutResponse> getPerformanceSeatLayouts(Long performanceId) {
     return seatGetSeatLayoutsUseCase.execute(performanceId);
+  }
+
+  public List<SeatNumberResponse> getSeatNumbers(List<Long> seatIds) {
+    return seatGetNumbersUseCase.execute(seatIds);
   }
 
   public SeatStatusCountsResponse getPerformanceSeatStatusCounts(Long performanceId) {

--- a/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/app/usecase/SeatGetNumbersUseCase.java
+++ b/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/app/usecase/SeatGetNumbersUseCase.java
@@ -2,9 +2,12 @@ package com.ticketrush.boundedcontext.seat.app.usecase;
 
 import com.ticketrush.boundedcontext.seat.app.dto.response.SeatNumberResponse;
 import com.ticketrush.boundedcontext.seat.out.repository.SeatRepository;
+import com.ticketrush.global.exception.BusinessException;
+import com.ticketrush.global.status.ErrorStatus;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -27,6 +30,12 @@ public class SeatGetNumbersUseCase {
         seatRepository.findSeatNumbersByIdIn(seatIds).stream()
             .collect(Collectors.toMap(SeatNumberResponse::seatId, Function.identity()));
 
-    return seatIds.stream().map(seatNumbersById::get).filter(Objects::nonNull).toList();
+    Set<Long> missingSeatIds = new LinkedHashSet<>(seatIds);
+    missingSeatIds.removeAll(seatNumbersById.keySet());
+    if (!missingSeatIds.isEmpty()) {
+      throw new BusinessException(ErrorStatus.SEAT_NOT_FOUND, missingSeatIds);
+    }
+
+    return seatIds.stream().map(seatNumbersById::get).toList();
   }
 }

--- a/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/app/usecase/SeatGetNumbersUseCase.java
+++ b/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/app/usecase/SeatGetNumbersUseCase.java
@@ -3,6 +3,10 @@ package com.ticketrush.boundedcontext.seat.app.usecase;
 import com.ticketrush.boundedcontext.seat.app.dto.response.SeatNumberResponse;
 import com.ticketrush.boundedcontext.seat.out.repository.SeatRepository;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -19,6 +23,10 @@ public class SeatGetNumbersUseCase {
       return List.of();
     }
 
-    return seatRepository.findSeatNumbersByIdIn(seatIds);
+    Map<Long, SeatNumberResponse> seatNumbersById =
+        seatRepository.findSeatNumbersByIdIn(seatIds).stream()
+            .collect(Collectors.toMap(SeatNumberResponse::seatId, Function.identity()));
+
+    return seatIds.stream().map(seatNumbersById::get).filter(Objects::nonNull).toList();
   }
 }

--- a/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/app/usecase/SeatGetNumbersUseCase.java
+++ b/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/app/usecase/SeatGetNumbersUseCase.java
@@ -1,0 +1,24 @@
+package com.ticketrush.boundedcontext.seat.app.usecase;
+
+import com.ticketrush.boundedcontext.seat.app.dto.response.SeatNumberResponse;
+import com.ticketrush.boundedcontext.seat.out.repository.SeatRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class SeatGetNumbersUseCase {
+
+  private final SeatRepository seatRepository;
+
+  public List<SeatNumberResponse> execute(List<Long> seatIds) {
+    if (seatIds.isEmpty()) {
+      return List.of();
+    }
+
+    return seatRepository.findSeatNumbersByIdIn(seatIds);
+  }
+}

--- a/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/in/api/v1/SeatController.java
+++ b/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/in/api/v1/SeatController.java
@@ -2,6 +2,7 @@ package com.ticketrush.boundedcontext.seat.in.api.v1;
 
 import com.ticketrush.boundedcontext.seat.app.dto.request.SeatSoldConfirmRequest;
 import com.ticketrush.boundedcontext.seat.app.dto.response.SeatLayoutResponse;
+import com.ticketrush.boundedcontext.seat.app.dto.response.SeatNumberResponse;
 import com.ticketrush.boundedcontext.seat.app.dto.response.SeatStatusCountsResponse;
 import com.ticketrush.boundedcontext.seat.app.facade.SeatFacade;
 import com.ticketrush.global.dto.response.ApiResponse;
@@ -22,6 +23,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
@@ -42,6 +44,14 @@ public class SeatController {
   public ResponseEntity<ApiResponse<List<SeatLayoutResponse>>> getSeatLayouts(
       @PathVariable Long performanceId) {
     List<SeatLayoutResponse> response = seatFacade.getPerformanceSeatLayouts(performanceId);
+    return ApiResponse.onSuccess(SuccessStatus.OK, response);
+  }
+
+  @GetMapping("/numbers")
+  @Operation(summary = "좌석 번호 목록 조회", description = "좌석 ID 목록에 해당하는 좌석 번호를 조회합니다.")
+  public ResponseEntity<ApiResponse<List<SeatNumberResponse>>> getSeatNumbers(
+      @RequestParam List<Long> seatIds) {
+    List<SeatNumberResponse> response = seatFacade.getSeatNumbers(seatIds);
     return ApiResponse.onSuccess(SuccessStatus.OK, response);
   }
 

--- a/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/in/api/v1/SeatController.java
+++ b/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/in/api/v1/SeatController.java
@@ -12,11 +12,13 @@ import com.ticketrush.global.status.SuccessStatus;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Size;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -27,6 +29,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
+@Validated
 @RestController
 @RequestMapping("/api/v1/seat")
 @RequiredArgsConstructor
@@ -50,7 +53,7 @@ public class SeatController {
   @GetMapping("/numbers")
   @Operation(summary = "좌석 번호 목록 조회", description = "좌석 ID 목록에 해당하는 좌석 번호를 조회합니다.")
   public ResponseEntity<ApiResponse<List<SeatNumberResponse>>> getSeatNumbers(
-      @RequestParam List<Long> seatIds) {
+      @RequestParam @Size(min = 1, max = 120) List<Long> seatIds) {
     List<SeatNumberResponse> response = seatFacade.getSeatNumbers(seatIds);
     return ApiResponse.onSuccess(SuccessStatus.OK, response);
   }

--- a/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/out/repository/SeatRepository.java
+++ b/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/out/repository/SeatRepository.java
@@ -1,6 +1,7 @@
 package com.ticketrush.boundedcontext.seat.out.repository;
 
 import com.ticketrush.boundedcontext.seat.app.dto.response.SeatLayoutResponse;
+import com.ticketrush.boundedcontext.seat.app.dto.response.SeatNumberResponse;
 import com.ticketrush.boundedcontext.seat.app.dto.response.SeatStatusCountsResponse;
 import com.ticketrush.boundedcontext.seat.domain.entity.Seat;
 import com.ticketrush.global.types.SeatStatus;
@@ -47,6 +48,13 @@ public interface SeatRepository extends JpaRepository<Seat, Long> {
           + "WHERE s.performanceId = :performanceId")
   List<SeatLayoutResponse> findSeatLayoutsByPerformanceId(
       @Param("performanceId") Long performanceId);
+
+  @Query(
+      "SELECT new com.ticketrush.boundedcontext.seat.app.dto.response.SeatNumberResponse("
+          + "s.id, s.seatNumber) "
+          + "FROM Seat s "
+          + "WHERE s.id IN :seatIds")
+  List<SeatNumberResponse> findSeatNumbersByIdIn(@Param("seatIds") List<Long> seatIds);
 
   @Query("SELECT s FROM Seat s " + "WHERE s.seatStatus = :holdStatus AND s.holdExpiredAt <= :now")
   List<Seat> findExpiredHoldSeats(

--- a/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/app/usecase/SeatGetNumbersUseCaseTest.java
+++ b/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/app/usecase/SeatGetNumbersUseCaseTest.java
@@ -1,11 +1,14 @@
 package com.ticketrush.boundedcontext.seat.app.usecase;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
 import com.ticketrush.boundedcontext.seat.app.dto.response.SeatNumberResponse;
 import com.ticketrush.boundedcontext.seat.out.repository.SeatRepository;
+import com.ticketrush.global.exception.BusinessException;
+import com.ticketrush.global.status.ErrorStatus;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -46,5 +49,20 @@ class SeatGetNumbersUseCaseTest {
 
     // then
     assertThat(result).isEmpty();
+  }
+
+  @Test
+  @DisplayName("실패: 요청한 좌석 ID 중 존재하지 않는 ID가 있으면 예외를 던진다")
+  void execute_fails_when_any_seat_id_missing() {
+    // given
+    List<Long> seatIds = List.of(1L, 999L);
+    given(seatRepository.findSeatNumbersByIdIn(seatIds))
+        .willReturn(List.of(new SeatNumberResponse(1L, "A-1")));
+
+    // when & then
+    assertThatThrownBy(() -> seatGetNumbersUseCase.execute(seatIds))
+        .isInstanceOf(BusinessException.class)
+        .extracting(ex -> ((BusinessException) ex).getErrorStatus())
+        .isEqualTo(ErrorStatus.SEAT_NOT_FOUND);
   }
 }

--- a/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/app/usecase/SeatGetNumbersUseCaseTest.java
+++ b/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/app/usecase/SeatGetNumbersUseCaseTest.java
@@ -1,0 +1,50 @@
+package com.ticketrush.boundedcontext.seat.app.usecase;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import com.ticketrush.boundedcontext.seat.app.dto.response.SeatNumberResponse;
+import com.ticketrush.boundedcontext.seat.out.repository.SeatRepository;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class SeatGetNumbersUseCaseTest {
+
+  @InjectMocks private SeatGetNumbersUseCase seatGetNumbersUseCase;
+
+  @Mock private SeatRepository seatRepository;
+
+  @Test
+  @DisplayName("성공: 좌석 ID 목록 순서대로 좌석 번호를 반환한다")
+  void execute_returns_in_requested_order() {
+    // given
+    List<Long> seatIds = List.of(2L, 1L);
+    given(seatRepository.findSeatNumbersByIdIn(seatIds))
+        .willReturn(List.of(new SeatNumberResponse(1L, "A-1"), new SeatNumberResponse(2L, "A-2")));
+
+    // when
+    List<SeatNumberResponse> result = seatGetNumbersUseCase.execute(seatIds);
+
+    // then
+    assertThat(result)
+        .containsExactly(new SeatNumberResponse(2L, "A-2"), new SeatNumberResponse(1L, "A-1"));
+    verify(seatRepository).findSeatNumbersByIdIn(seatIds);
+  }
+
+  @Test
+  @DisplayName("성공: 빈 좌석 ID 목록이면 빈 목록을 반환한다")
+  void execute_returns_empty_when_seat_ids_empty() {
+    // when
+    List<SeatNumberResponse> result = seatGetNumbersUseCase.execute(List.of());
+
+    // then
+    assertThat(result).isEmpty();
+  }
+}

--- a/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/in/api/v1/SeatControllerTest.java
+++ b/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/in/api/v1/SeatControllerTest.java
@@ -9,6 +9,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.ticketrush.boundedcontext.seat.app.dto.response.SeatLayoutResponse;
+import com.ticketrush.boundedcontext.seat.app.dto.response.SeatNumberResponse;
 import com.ticketrush.boundedcontext.seat.app.dto.response.SeatStatusCountsResponse;
 import com.ticketrush.boundedcontext.seat.app.facade.SeatFacade;
 import com.ticketrush.global.config.SecurityConfig;
@@ -62,6 +63,29 @@ class SeatControllerTest {
         .andExpect(jsonPath("$.result[1].seat_id").value(2))
         .andExpect(jsonPath("$.result[1].seat_number").value("A-2"))
         .andExpect(jsonPath("$.result[1].seat_status").value("HOLD"));
+  }
+
+  @Test
+  @WithMockUser
+  @DisplayName("좌석 ID 목록으로 좌석 번호 목록을 조회한다")
+  void getSeatNumbers() throws Exception {
+    // given
+    List<Long> seatIds = List.of(1L, 2L);
+    List<SeatNumberResponse> response =
+        List.of(new SeatNumberResponse(1L, "A-1"), new SeatNumberResponse(2L, "A-2"));
+    given(seatFacade.getSeatNumbers(seatIds)).willReturn(response);
+
+    // when & then
+    mockMvc
+        .perform(get("/api/v1/seat/numbers").param("seatIds", "1", "2"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.is_success").value(true))
+        .andExpect(jsonPath("$.result[0].seat_id").value(1))
+        .andExpect(jsonPath("$.result[0].seat_number").value("A-1"))
+        .andExpect(jsonPath("$.result[1].seat_id").value(2))
+        .andExpect(jsonPath("$.result[1].seat_number").value("A-2"));
+
+    verify(seatFacade).getSeatNumbers(seatIds);
   }
 
   @Test


### PR DESCRIPTION
## 🔗 관련 이슈

- close #37

---

## 📌 주요 변경 사항

- 내 예매 목록 및 예매 수 조회 API를 추가했습니다.
- Booking 확정 시각 저장을 위한 `confirmedAt`, `confirm()`, `BookingConfirmUseCase`를 추가했습니다.
- 좌석 ID 목록으로 좌석 번호를 조회하는 Seat API를 추가했습니다.

---

## 🛠 상세 구현 내용

- `GET /api/v1/booking/me?status=CONFIRMED`로 로그인 사용자의 예매 요약 목록을 조회합니다.
- `GET /api/v1/booking/me/count?status=CONFIRMED`로 로그인 사용자의 상태별 예매 수를 조회합니다.
- Booking 응답은 `bookingId`, `bookingNumber`, `performanceId`, `seatId`, `bookingStatus`, `confirmedAt`만 포함해 모듈 경계를 유지합니다.
- `GET /api/v1/seat/numbers?seatIds=1&seatIds=2`로 좌석 번호를 배치 조회합니다.
- 결제 완료 이벤트 리스너 연결은 후속 이슈 #213에서 처리하도록 분리했습니다.

---

## ✅ 테스트

### 테스트 방법

- `./gradlew.bat :booking-service:test :seat-service:test`
- `./gradlew.bat :booking-service:check :seat-service:check`

### 테스트 결과

- 두 명령 모두 통과했습니다.

### 📸 스크린샷

---

## 👀 리뷰 요청 사항

- Booking 모듈 응답을 식별자 중심으로 유지하고, 좌석/공연 상세 정보는 각 모듈 API와 프론트 조합으로 처리하는 방향이 적절한지 확인 부탁드립니다.
- `confirmedAt` 저장 흐름은 #213에서 결제 완료 이벤트와 연결할 예정입니다.

---

## ⚠️ 배포 시 주의사항

- `booking` 테이블에 `confirmed_at` 컬럼이 추가됩니다.