### PR TITLE
[Feat] #89 외부 PG사(Toss) 결제 승인 API 연동

### DIFF
--- a/common/src/main/java/com/ticketrush/global/status/ErrorStatus.java
+++ b/common/src/main/java/com/ticketrush/global/status/ErrorStatus.java
@@ -139,6 +139,7 @@ public enum ErrorStatus {
 
   // Payment 400
   PAYMENT_AMOUNT_MISMATCH(HttpStatus.BAD_REQUEST, "PAYMENT_400_001", "결제 금액이 일치하지 않습니다."),
+  PAYMENT_PROVIDER_NOT_SUPPORTED(HttpStatus.BAD_REQUEST, "PAYMENT_400_002", "지원하지 않는 결제 수단입니다."),
 
   // Payment 409
   PAYMENT_ALREADY_COMPLETED(HttpStatus.CONFLICT, "PAYMENT_409_001", "이미 결제가 완료된 예매입니다."),

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentConfirmUseCase.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentConfirmUseCase.java
@@ -69,7 +69,7 @@ public class PaymentConfirmUseCase {
     return PaymentConfirmResponse.from(saved);
   }
 
-  /* Toss orderId 규격(6~64자, 영문/숫자/_/-)을 만족하기 위해 zero-padding 한다. */
+  /* PG 공통 orderId 규격(6~64자, 영문/숫자/_/-, 현재 Toss 기준)을 만족하기 위해 zero-padding 한다. */
   private String generateOrderId(Long bookingId) {
     return "BKG-%07d".formatted(bookingId);
   }

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentConfirmUseCase.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentConfirmUseCase.java
@@ -5,7 +5,7 @@ import com.ticketrush.boundedcontext.payment.app.dto.response.PaymentConfirmResp
 import com.ticketrush.boundedcontext.payment.app.support.PaymentEventPublisher;
 import com.ticketrush.boundedcontext.payment.domain.entity.Payment;
 import com.ticketrush.boundedcontext.payment.domain.types.PaymentStatus;
-import com.ticketrush.boundedcontext.payment.out.apiclient.PaymentApprovalClient;
+import com.ticketrush.boundedcontext.payment.out.apiclient.PaymentApprovalClientRouter;
 import com.ticketrush.boundedcontext.payment.out.apiclient.PaymentApprovalRequest;
 import com.ticketrush.boundedcontext.payment.out.apiclient.PaymentApprovalResponse;
 import com.ticketrush.boundedcontext.payment.out.repository.PaymentRepository;
@@ -21,7 +21,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class PaymentConfirmUseCase {
 
   private final PaymentRepository paymentRepository;
-  private final PaymentApprovalClient paymentApprovalClient;
+  private final PaymentApprovalClientRouter paymentApprovalClientRouter;
   private final PaymentEventPublisher paymentEventPublisher;
 
   public PaymentConfirmResponse execute(Long userId, PaymentConfirmRequest request) {
@@ -30,10 +30,16 @@ public class PaymentConfirmUseCase {
       throw new BusinessException(ErrorStatus.PAYMENT_ALREADY_COMPLETED);
     }
 
+    String orderId = generateOrderId(request.bookingId());
+
     PaymentApprovalResponse approval =
-        paymentApprovalClient.approve(
+        paymentApprovalClientRouter.approve(
             new PaymentApprovalRequest(
-                request.provider(), request.paymentKey(), request.bookingId(), request.amount()));
+                request.provider(),
+                request.paymentKey(),
+                orderId,
+                request.bookingId(),
+                request.amount()));
 
     if (!request.amount().equals(approval.approvedAmount())) {
       throw new BusinessException(ErrorStatus.PAYMENT_AMOUNT_MISMATCH);
@@ -45,6 +51,8 @@ public class PaymentConfirmUseCase {
             .provider(request.provider())
             .amount(approval.approvedAmount())
             .status(PaymentStatus.COMPLETED)
+            .paymentKey(request.paymentKey())
+            .approvalNumber(approval.approvalNumber())
             .paidAt(approval.approvedAt())
             .build();
 
@@ -59,5 +67,10 @@ public class PaymentConfirmUseCase {
         saved.getPaidAt());
 
     return PaymentConfirmResponse.from(saved);
+  }
+
+  /* Toss orderId 규격(6~64자, 영문/숫자/_/-)을 만족하기 위해 zero-padding 한다. */
+  private String generateOrderId(Long bookingId) {
+    return "BKG-%07d".formatted(bookingId);
   }
 }

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/domain/entity/Payment.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/domain/entity/Payment.java
@@ -36,6 +36,12 @@ public class Payment extends AutoIdBaseEntity {
   @Column(nullable = false)
   private PaymentStatus status; // 결제 상태 (PENDING, COMPLETED 등)
 
+  @Column(length = 200)
+  private String paymentKey; // PG사 발급 결제 키
+
+  @Column(length = 100)
+  private String approvalNumber; // PG사 응답 승인 번호 / 거래 식별자
+
   private LocalDateTime paidAt; // 결제 완료 시점
 
   @Builder
@@ -44,11 +50,15 @@ public class Payment extends AutoIdBaseEntity {
       PaymentProvider provider,
       Long amount,
       PaymentStatus status,
+      String paymentKey,
+      String approvalNumber,
       LocalDateTime paidAt) {
     this.bookingId = bookingId;
     this.provider = provider;
     this.amount = amount;
     this.status = status;
+    this.paymentKey = paymentKey;
+    this.approvalNumber = approvalNumber;
     this.paidAt = paidAt;
   }
 }

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/out/apiclient/PaymentApprovalClient.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/out/apiclient/PaymentApprovalClient.java
@@ -1,11 +1,16 @@
 package com.ticketrush.boundedcontext.payment.out.apiclient;
 
+import com.ticketrush.boundedcontext.payment.domain.types.PaymentProvider;
+
 /**
  * PG사 결제 승인 API 호출용 클라이언트.
  *
- * <p>본 인터페이스는 #21에서 stub 구현체와 함께 도입되고, #89에서 실제 외부 PG사 연동 구현체로 교체된다.
+ * <p>구현체는 {@link #supports(PaymentProvider)}로 자신이 처리 가능한 PG를 알리고, {@link
+ * PaymentApprovalClientRouter}가 요청 provider에 맞는 클라이언트를 선택해 호출한다.
  */
 public interface PaymentApprovalClient {
+
+  boolean supports(PaymentProvider provider);
 
   PaymentApprovalResponse approve(PaymentApprovalRequest request);
 }

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/out/apiclient/PaymentApprovalClientRouter.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/out/apiclient/PaymentApprovalClientRouter.java
@@ -1,0 +1,32 @@
+package com.ticketrush.boundedcontext.payment.out.apiclient;
+
+import com.ticketrush.boundedcontext.payment.domain.types.PaymentProvider;
+import com.ticketrush.global.exception.BusinessException;
+import com.ticketrush.global.status.ErrorStatus;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+/**
+ * 등록된 {@link PaymentApprovalClient} 중 요청 provider를 지원하는 첫 번째 구현체로 결제 승인을 위임한다.
+ *
+ * <p>Stub은 {@link org.springframework.core.annotation.Order} 가장 낮은 우선순위로 등록되어 실제 provider 구현체가 우선
+ * 선택되도록 한다.
+ */
+@Component
+@RequiredArgsConstructor
+public class PaymentApprovalClientRouter {
+
+  private final List<PaymentApprovalClient> clients;
+
+  public PaymentApprovalResponse approve(PaymentApprovalRequest request) {
+    return resolve(request.provider()).approve(request);
+  }
+
+  private PaymentApprovalClient resolve(PaymentProvider provider) {
+    return clients.stream()
+        .filter(client -> client.supports(provider))
+        .findFirst()
+        .orElseThrow(() -> new BusinessException(ErrorStatus.PAYMENT_PROVIDER_NOT_SUPPORTED));
+  }
+}

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/out/apiclient/PaymentApprovalRequest.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/out/apiclient/PaymentApprovalRequest.java
@@ -3,4 +3,4 @@ package com.ticketrush.boundedcontext.payment.out.apiclient;
 import com.ticketrush.boundedcontext.payment.domain.types.PaymentProvider;
 
 public record PaymentApprovalRequest(
-    PaymentProvider provider, String paymentKey, Long bookingId, Long amount) {}
+    PaymentProvider provider, String paymentKey, String orderId, Long bookingId, Long amount) {}

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/out/apiclient/StubPaymentApprovalClient.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/out/apiclient/StubPaymentApprovalClient.java
@@ -1,29 +1,52 @@
 package com.ticketrush.boundedcontext.payment.out.apiclient;
 
+import com.ticketrush.boundedcontext.payment.domain.types.PaymentProvider;
 import java.time.LocalDateTime;
 import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 
 /**
- * #21 범위의 stub 구현. 실제 PG 호출 없이 요청 금액을 그대로 승인된 것으로 응답한다.
+ * 실 PG 호출 없이 요청 금액을 그대로 승인된 것으로 응답하는 stub 구현.
  *
- * <p>#89에서 실제 외부 PG사 연동 구현체로 교체될 예정.
+ * <p>{@code payment.pg.stub.enabled=true} 일 때만 활성화된다. {@link PaymentApprovalClientRouter}에서 실제
+ * provider별 구현체가 우선 선택되도록 {@link Order} 우선순위는 가장 낮게 둔다.
  */
 @Slf4j
 @Component
+@Order(Integer.MAX_VALUE)
+@ConditionalOnProperty(
+    prefix = "payment.pg.stub",
+    name = "enabled",
+    havingValue = "true",
+    matchIfMissing = false)
 public class StubPaymentApprovalClient implements PaymentApprovalClient {
+
+  @Override
+  public boolean supports(PaymentProvider provider) {
+    return true;
+  }
 
   @Override
   public PaymentApprovalResponse approve(PaymentApprovalRequest request) {
     log.info(
-        "[PG-STUB] provider={}, bookingId={}, amount={}, paymentKey={}",
+        "[PG-STUB] provider={}, orderId={}, bookingId={}, amount={}, paymentKey={}",
         request.provider(),
+        request.orderId(),
         request.bookingId(),
         request.amount(),
-        request.paymentKey());
+        mask(request.paymentKey()));
 
     return new PaymentApprovalResponse(
         UUID.randomUUID().toString(), request.amount(), LocalDateTime.now());
+  }
+
+  private String mask(String value) {
+    if (value == null || value.length() <= 4) {
+      return "****";
+    }
+    return value.substring(0, 4) + "****";
   }
 }

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/out/apiclient/StubPaymentApprovalClient.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/out/apiclient/StubPaymentApprovalClient.java
@@ -5,6 +5,7 @@ import java.time.LocalDateTime;
 import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Profile;
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 
@@ -13,9 +14,12 @@ import org.springframework.stereotype.Component;
  *
  * <p>{@code payment.pg.stub.enabled=true} 일 때만 활성화된다. {@link PaymentApprovalClientRouter}에서 실제
  * provider별 구현체가 우선 선택되도록 {@link Order} 우선순위는 가장 낮게 둔다.
+ *
+ * <p>운영(prod) 프로파일에서는 환경변수 설정과 무관하게 절대 활성화되지 않는다.
  */
 @Slf4j
 @Component
+@Profile("!prod")
 @Order(Integer.MAX_VALUE)
 @ConditionalOnProperty(
     prefix = "payment.pg.stub",

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/out/apiclient/toss/TossConfirmRequest.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/out/apiclient/toss/TossConfirmRequest.java
@@ -1,0 +1,8 @@
+package com.ticketrush.boundedcontext.payment.out.apiclient.toss;
+
+/**
+ * Toss Payments 결제 승인 API 요청 페이로드.
+ *
+ * <p>참고: https://docs.tosspayments.com/reference#결제-승인
+ */
+public record TossConfirmRequest(String paymentKey, String orderId, Long amount) {}

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/out/apiclient/toss/TossConfirmResponse.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/out/apiclient/toss/TossConfirmResponse.java
@@ -1,0 +1,18 @@
+package com.ticketrush.boundedcontext.payment.out.apiclient.toss;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.time.OffsetDateTime;
+
+/**
+ * Toss Payments 결제 승인 응답 (필요 필드만 매핑).
+ *
+ * <p>전체 응답 명세: https://docs.tosspayments.com/reference#payment-객체
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record TossConfirmResponse(
+    String paymentKey,
+    String orderId,
+    String transactionKey,
+    Long totalAmount,
+    String status,
+    OffsetDateTime approvedAt) {}

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/out/apiclient/toss/TossPaymentApprovalClient.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/out/apiclient/toss/TossPaymentApprovalClient.java
@@ -1,0 +1,117 @@
+package com.ticketrush.boundedcontext.payment.out.apiclient.toss;
+
+import com.ticketrush.boundedcontext.payment.domain.types.PaymentProvider;
+import com.ticketrush.boundedcontext.payment.out.apiclient.PaymentApprovalClient;
+import com.ticketrush.boundedcontext.payment.out.apiclient.PaymentApprovalRequest;
+import com.ticketrush.boundedcontext.payment.out.apiclient.PaymentApprovalResponse;
+import com.ticketrush.global.exception.BusinessException;
+import com.ticketrush.global.status.ErrorStatus;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.ResourceAccessException;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
+
+/**
+ * Toss Payments 결제 승인 API 연동 구현체.
+ *
+ * <p>{@code payment.pg.toss.secret-key} 가 비어있지 않을 때만 활성화된다.
+ */
+@Slf4j
+@Component
+@Order(0)
+@ConditionalOnProperty(prefix = "payment.pg.toss", name = "secret-key")
+public class TossPaymentApprovalClient implements PaymentApprovalClient {
+
+  private static final String CONFIRM_PATH = "/v1/payments/confirm";
+
+  private final RestClient restClient;
+
+  public TossPaymentApprovalClient(@Qualifier("tossPaymentRestClient") RestClient restClient) {
+    this.restClient = restClient;
+  }
+
+  @Override
+  public boolean supports(PaymentProvider provider) {
+    return provider == PaymentProvider.TOSS;
+  }
+
+  @Override
+  public PaymentApprovalResponse approve(PaymentApprovalRequest request) {
+    TossConfirmRequest body =
+        new TossConfirmRequest(request.paymentKey(), request.orderId(), request.amount());
+
+    try {
+      TossConfirmResponse response =
+          restClient
+              .post()
+              .uri(CONFIRM_PATH)
+              .contentType(MediaType.APPLICATION_JSON)
+              .body(body)
+              .retrieve()
+              .onStatus(
+                  HttpStatusCode::is4xxClientError,
+                  (req, res) -> {
+                    log.warn(
+                        "[PG-TOSS] 결제 승인 거절. status={}, orderId={}, bookingId={}",
+                        res.getStatusCode(),
+                        request.orderId(),
+                        request.bookingId());
+                    throw new BusinessException(ErrorStatus.PAYMENT_APPROVAL_FAILED);
+                  })
+              .onStatus(
+                  HttpStatusCode::is5xxServerError,
+                  (req, res) -> {
+                    log.error(
+                        "[PG-TOSS] PG 서버 오류. status={}, orderId={}, bookingId={}",
+                        res.getStatusCode(),
+                        request.orderId(),
+                        request.bookingId());
+                    throw new BusinessException(ErrorStatus.PAYMENT_PG_COMMUNICATION_FAILED);
+                  })
+              .body(TossConfirmResponse.class);
+
+      if (response == null) {
+        log.error(
+            "[PG-TOSS] 응답이 비어있습니다. orderId={}, bookingId={}",
+            request.orderId(),
+            request.bookingId());
+        throw new BusinessException(ErrorStatus.PAYMENT_PG_COMMUNICATION_FAILED);
+      }
+
+      LocalDateTime approvedAt =
+          response.approvedAt() == null
+              ? LocalDateTime.now()
+              : response.approvedAt().atZoneSameInstant(ZoneId.systemDefault()).toLocalDateTime();
+
+      String approvalNumber =
+          response.transactionKey() != null ? response.transactionKey() : response.paymentKey();
+
+      return new PaymentApprovalResponse(approvalNumber, response.totalAmount(), approvedAt);
+
+    } catch (BusinessException e) {
+      throw e;
+    } catch (ResourceAccessException e) {
+      log.error(
+          "[PG-TOSS] PG 통신 실패(timeout 등). orderId={}, bookingId={}, message={}",
+          request.orderId(),
+          request.bookingId(),
+          e.getMessage());
+      throw new BusinessException(ErrorStatus.PAYMENT_PG_COMMUNICATION_FAILED);
+    } catch (RestClientException e) {
+      log.error(
+          "[PG-TOSS] PG 호출 중 예외 발생. orderId={}, bookingId={}, message={}",
+          request.orderId(),
+          request.bookingId(),
+          e.getMessage());
+      throw new BusinessException(ErrorStatus.PAYMENT_PG_COMMUNICATION_FAILED);
+    }
+  }
+}

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/out/apiclient/toss/TossPaymentApprovalClient.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/out/apiclient/toss/TossPaymentApprovalClient.java
@@ -87,13 +87,26 @@ public class TossPaymentApprovalClient implements PaymentApprovalClient {
         throw new BusinessException(ErrorStatus.PAYMENT_PG_COMMUNICATION_FAILED);
       }
 
-      LocalDateTime approvedAt =
-          response.approvedAt() == null
-              ? LocalDateTime.now()
-              : response.approvedAt().atZoneSameInstant(ZoneId.systemDefault()).toLocalDateTime();
+      if (response.approvedAt() == null) {
+        log.error(
+            "[PG-TOSS] 응답에 approvedAt 누락. orderId={}, bookingId={}",
+            request.orderId(),
+            request.bookingId());
+        throw new BusinessException(ErrorStatus.PAYMENT_PG_COMMUNICATION_FAILED);
+      }
 
       String approvalNumber =
           response.transactionKey() != null ? response.transactionKey() : response.paymentKey();
+      if (approvalNumber == null) {
+        log.error(
+            "[PG-TOSS] 응답에 transactionKey, paymentKey 모두 누락. orderId={}, bookingId={}",
+            request.orderId(),
+            request.bookingId());
+        throw new BusinessException(ErrorStatus.PAYMENT_PG_COMMUNICATION_FAILED);
+      }
+
+      LocalDateTime approvedAt =
+          response.approvedAt().atZoneSameInstant(ZoneId.systemDefault()).toLocalDateTime();
 
       return new PaymentApprovalResponse(approvalNumber, response.totalAmount(), approvedAt);
 

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/out/apiclient/toss/TossPaymentApprovalClient.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/out/apiclient/toss/TossPaymentApprovalClient.java
@@ -22,12 +22,13 @@ import org.springframework.web.client.RestClientException;
 /**
  * Toss Payments 결제 승인 API 연동 구현체.
  *
- * <p>{@code payment.pg.toss.secret-key} 가 비어있지 않을 때만 활성화된다.
+ * <p>{@code payment.pg.toss.enabled=true} 일 때만 활성화된다. secret-key 미설정 시 {@link
+ * com.ticketrush.global.config.RestClientConfig#tossPaymentRestClient}에서 startup 단계에 실패시킨다.
  */
 @Slf4j
 @Component
 @Order(0)
-@ConditionalOnProperty(prefix = "payment.pg.toss", name = "secret-key")
+@ConditionalOnProperty(prefix = "payment.pg.toss", name = "enabled", havingValue = "true")
 public class TossPaymentApprovalClient implements PaymentApprovalClient {
 
   private static final String CONFIRM_PATH = "/v1/payments/confirm";

--- a/payment-service/src/main/java/com/ticketrush/global/config/RestClientConfig.java
+++ b/payment-service/src/main/java/com/ticketrush/global/config/RestClientConfig.java
@@ -19,11 +19,16 @@ public class RestClientConfig {
   @Bean
   @ConditionalOnProperty(prefix = "payment.pg.toss", name = "enabled", havingValue = "true")
   public RestClient tossPaymentRestClient(
-      @Value("${payment.pg.toss.base-url}") String baseUrl,
+      @Value("${payment.pg.toss.base-url:}") String baseUrl,
       @Value("${payment.pg.toss.secret-key:}") String secretKey,
       @Value("${payment.pg.toss.connect-timeout-ms:3000}") long connectTimeoutMs,
       @Value("${payment.pg.toss.read-timeout-ms:10000}") long readTimeoutMs) {
 
+    if (!StringUtils.hasText(baseUrl)) {
+      throw new IllegalStateException(
+          "payment.pg.toss.enabled=true 인데 payment.pg.toss.base-url 가 비어있습니다. "
+              + "TOSS_PAYMENTS_BASE_URL 환경변수를 설정하세요.");
+    }
     if (!StringUtils.hasText(secretKey)) {
       throw new IllegalStateException(
           "payment.pg.toss.enabled=true 인데 payment.pg.toss.secret-key 가 비어있습니다. "

--- a/payment-service/src/main/java/com/ticketrush/global/config/RestClientConfig.java
+++ b/payment-service/src/main/java/com/ticketrush/global/config/RestClientConfig.java
@@ -1,0 +1,42 @@
+package com.ticketrush.global.config;
+
+import java.net.http.HttpClient;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Base64;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.client.JdkClientHttpRequestFactory;
+import org.springframework.web.client.RestClient;
+
+@Configuration
+public class RestClientConfig {
+
+  @Bean
+  @ConditionalOnProperty(prefix = "payment.pg.toss", name = "secret-key")
+  public RestClient tossPaymentRestClient(
+      @Value("${payment.pg.toss.base-url}") String baseUrl,
+      @Value("${payment.pg.toss.secret-key}") String secretKey,
+      @Value("${payment.pg.toss.connect-timeout-ms:3000}") long connectTimeoutMs,
+      @Value("${payment.pg.toss.read-timeout-ms:10000}") long readTimeoutMs) {
+
+    HttpClient httpClient =
+        HttpClient.newBuilder().connectTimeout(Duration.ofMillis(connectTimeoutMs)).build();
+    JdkClientHttpRequestFactory factory = new JdkClientHttpRequestFactory(httpClient);
+    factory.setReadTimeout(Duration.ofMillis(readTimeoutMs));
+
+    String basicAuth =
+        "Basic "
+            + Base64.getEncoder()
+                .encodeToString((secretKey + ":").getBytes(StandardCharsets.UTF_8));
+
+    return RestClient.builder()
+        .baseUrl(baseUrl)
+        .requestFactory(factory)
+        .defaultHeader(HttpHeaders.AUTHORIZATION, basicAuth)
+        .build();
+  }
+}

--- a/payment-service/src/main/java/com/ticketrush/global/config/RestClientConfig.java
+++ b/payment-service/src/main/java/com/ticketrush/global/config/RestClientConfig.java
@@ -10,18 +10,25 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.client.JdkClientHttpRequestFactory;
+import org.springframework.util.StringUtils;
 import org.springframework.web.client.RestClient;
 
 @Configuration
 public class RestClientConfig {
 
   @Bean
-  @ConditionalOnProperty(prefix = "payment.pg.toss", name = "secret-key")
+  @ConditionalOnProperty(prefix = "payment.pg.toss", name = "enabled", havingValue = "true")
   public RestClient tossPaymentRestClient(
       @Value("${payment.pg.toss.base-url}") String baseUrl,
-      @Value("${payment.pg.toss.secret-key}") String secretKey,
+      @Value("${payment.pg.toss.secret-key:}") String secretKey,
       @Value("${payment.pg.toss.connect-timeout-ms:3000}") long connectTimeoutMs,
       @Value("${payment.pg.toss.read-timeout-ms:10000}") long readTimeoutMs) {
+
+    if (!StringUtils.hasText(secretKey)) {
+      throw new IllegalStateException(
+          "payment.pg.toss.enabled=true 인데 payment.pg.toss.secret-key 가 비어있습니다. "
+              + "TOSS_PAYMENTS_SECRET_KEY 환경변수를 설정하세요.");
+    }
 
     HttpClient httpClient =
         HttpClient.newBuilder().connectTimeout(Duration.ofMillis(connectTimeoutMs)).build();

--- a/payment-service/src/main/resources/application-test.yml
+++ b/payment-service/src/main/resources/application-test.yml
@@ -1,3 +1,8 @@
 app:
   event-publisher:
     type: kafka
+
+payment:
+  pg:
+    stub:
+      enabled: true

--- a/payment-service/src/main/resources/application.yml
+++ b/payment-service/src/main/resources/application.yml
@@ -28,6 +28,7 @@ payment:
     stub:
       enabled: ${PAYMENT_PG_STUB_ENABLED:false}
     toss:
+      enabled: ${TOSS_PAYMENTS_ENABLED:false}
       base-url: ${TOSS_PAYMENTS_BASE_URL:https://api.tosspayments.com}
       secret-key: ${TOSS_PAYMENTS_SECRET_KEY:}
       connect-timeout-ms: ${TOSS_PAYMENTS_CONNECT_TIMEOUT_MS:3000}

--- a/payment-service/src/main/resources/application.yml
+++ b/payment-service/src/main/resources/application.yml
@@ -22,3 +22,13 @@ springdoc:
 
 gateway:
   internal-token: ${GATEWAY_INTERNAL_TOKEN:test-token}
+
+payment:
+  pg:
+    stub:
+      enabled: ${PAYMENT_PG_STUB_ENABLED:false}
+    toss:
+      base-url: ${TOSS_PAYMENTS_BASE_URL:https://api.tosspayments.com}
+      secret-key: ${TOSS_PAYMENTS_SECRET_KEY:}
+      connect-timeout-ms: ${TOSS_PAYMENTS_CONNECT_TIMEOUT_MS:3000}
+      read-timeout-ms: ${TOSS_PAYMENTS_READ_TIMEOUT_MS:10000}

--- a/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentConfirmUseCaseTest.java
+++ b/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentConfirmUseCaseTest.java
@@ -14,7 +14,7 @@ import com.ticketrush.boundedcontext.payment.app.support.PaymentEventPublisher;
 import com.ticketrush.boundedcontext.payment.domain.entity.Payment;
 import com.ticketrush.boundedcontext.payment.domain.types.PaymentProvider;
 import com.ticketrush.boundedcontext.payment.domain.types.PaymentStatus;
-import com.ticketrush.boundedcontext.payment.out.apiclient.PaymentApprovalClient;
+import com.ticketrush.boundedcontext.payment.out.apiclient.PaymentApprovalClientRouter;
 import com.ticketrush.boundedcontext.payment.out.apiclient.PaymentApprovalRequest;
 import com.ticketrush.boundedcontext.payment.out.apiclient.PaymentApprovalResponse;
 import com.ticketrush.boundedcontext.payment.out.repository.PaymentRepository;
@@ -34,7 +34,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class PaymentConfirmUseCaseTest {
 
   @Mock private PaymentRepository paymentRepository;
-  @Mock private PaymentApprovalClient paymentApprovalClient;
+  @Mock private PaymentApprovalClientRouter paymentApprovalClientRouter;
   @Mock private PaymentEventPublisher paymentEventPublisher;
 
   @InjectMocks private PaymentConfirmUseCase paymentConfirmUseCase;
@@ -48,15 +48,16 @@ class PaymentConfirmUseCaseTest {
     Long seatId = 200L;
     Long amount = 55_000L;
     String paymentKey = "pgKey_xyz";
+    String approvalNumber = "APR-123";
     Long savedPaymentId = 999L;
     LocalDateTime approvedAt = LocalDateTime.of(2025, 1, 15, 10, 0);
     PaymentConfirmRequest request =
-        new PaymentConfirmRequest(bookingId, seatId, PaymentProvider.KAKAO, amount, paymentKey);
+        new PaymentConfirmRequest(bookingId, seatId, PaymentProvider.TOSS, amount, paymentKey);
 
     given(paymentRepository.existsByBookingIdAndStatus(bookingId, PaymentStatus.COMPLETED))
         .willReturn(false);
-    given(paymentApprovalClient.approve(any()))
-        .willReturn(new PaymentApprovalResponse("APR-123", amount, approvedAt));
+    given(paymentApprovalClientRouter.approve(any()))
+        .willReturn(new PaymentApprovalResponse(approvalNumber, amount, approvedAt));
     given(paymentRepository.save(any(Payment.class)))
         .willAnswer(
             invocation -> {
@@ -75,10 +76,11 @@ class PaymentConfirmUseCaseTest {
 
     ArgumentCaptor<PaymentApprovalRequest> approvalCaptor =
         ArgumentCaptor.forClass(PaymentApprovalRequest.class);
-    verify(paymentApprovalClient).approve(approvalCaptor.capture());
+    verify(paymentApprovalClientRouter).approve(approvalCaptor.capture());
     PaymentApprovalRequest sentApproval = approvalCaptor.getValue();
-    assertThat(sentApproval.provider()).isEqualTo(PaymentProvider.KAKAO);
+    assertThat(sentApproval.provider()).isEqualTo(PaymentProvider.TOSS);
     assertThat(sentApproval.paymentKey()).isEqualTo(paymentKey);
+    assertThat(sentApproval.orderId()).isEqualTo("BKG-0000100");
     assertThat(sentApproval.bookingId()).isEqualTo(bookingId);
     assertThat(sentApproval.amount()).isEqualTo(amount);
 
@@ -86,9 +88,11 @@ class PaymentConfirmUseCaseTest {
     verify(paymentRepository).save(paymentCaptor.capture());
     Payment savedPayment = paymentCaptor.getValue();
     assertThat(savedPayment.getBookingId()).isEqualTo(bookingId);
-    assertThat(savedPayment.getProvider()).isEqualTo(PaymentProvider.KAKAO);
+    assertThat(savedPayment.getProvider()).isEqualTo(PaymentProvider.TOSS);
     assertThat(savedPayment.getAmount()).isEqualTo(amount);
     assertThat(savedPayment.getStatus()).isEqualTo(PaymentStatus.COMPLETED);
+    assertThat(savedPayment.getPaymentKey()).isEqualTo(paymentKey);
+    assertThat(savedPayment.getApprovalNumber()).isEqualTo(approvalNumber);
     assertThat(savedPayment.getPaidAt()).isEqualTo(approvedAt);
 
     verify(paymentEventPublisher)
@@ -117,7 +121,7 @@ class PaymentConfirmUseCaseTest {
 
     given(paymentRepository.existsByBookingIdAndStatus(bookingId, PaymentStatus.COMPLETED))
         .willReturn(false);
-    given(paymentApprovalClient.approve(any()))
+    given(paymentApprovalClientRouter.approve(any()))
         .willReturn(new PaymentApprovalResponse("APR-123", approvedAmount, LocalDateTime.now()));
 
     // when & then
@@ -149,7 +153,7 @@ class PaymentConfirmUseCaseTest {
         .extracting("errorStatus")
         .isEqualTo(ErrorStatus.PAYMENT_ALREADY_COMPLETED);
 
-    verify(paymentApprovalClient, never()).approve(any());
+    verify(paymentApprovalClientRouter, never()).approve(any());
     verify(paymentRepository, never()).save(any(Payment.class));
     verify(paymentEventPublisher, never())
         .publishConfirmed(any(), any(), any(), any(), any(), any());

--- a/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/out/apiclient/PaymentApprovalClientRouterTest.java
+++ b/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/out/apiclient/PaymentApprovalClientRouterTest.java
@@ -1,0 +1,73 @@
+package com.ticketrush.boundedcontext.payment.out.apiclient;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+import com.ticketrush.boundedcontext.payment.domain.types.PaymentProvider;
+import com.ticketrush.global.exception.BusinessException;
+import com.ticketrush.global.status.ErrorStatus;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class PaymentApprovalClientRouterTest {
+
+  @Mock private PaymentApprovalClient tossClient;
+  @Mock private PaymentApprovalClient stubClient;
+
+  @Test
+  @DisplayName("provider를 지원하는 첫 번째 클라이언트로 위임한다")
+  void approve_delegates_to_supporting_client() {
+    given(tossClient.supports(PaymentProvider.TOSS)).willReturn(true);
+    PaymentApprovalResponse response =
+        new PaymentApprovalResponse("APR-1", 1_000L, LocalDateTime.now());
+    given(tossClient.approve(any())).willReturn(response);
+
+    PaymentApprovalClientRouter router = new PaymentApprovalClientRouter(List.of(tossClient));
+
+    PaymentApprovalResponse actual =
+        router.approve(
+            new PaymentApprovalRequest(PaymentProvider.TOSS, "key", "BKG-0000001", 1L, 1_000L));
+
+    assertThat(actual).isEqualTo(response);
+  }
+
+  @Test
+  @DisplayName("등록 순서가 빠른 클라이언트가 우선 매칭된다 (Stub은 fallback)")
+  void approve_picks_first_supporting_client() {
+    given(tossClient.supports(PaymentProvider.TOSS)).willReturn(true);
+    PaymentApprovalResponse response =
+        new PaymentApprovalResponse("APR-1", 1_000L, LocalDateTime.now());
+    given(tossClient.approve(any())).willReturn(response);
+
+    PaymentApprovalClientRouter router =
+        new PaymentApprovalClientRouter(List.of(tossClient, stubClient));
+
+    router.approve(
+        new PaymentApprovalRequest(PaymentProvider.TOSS, "key", "BKG-0000001", 1L, 1_000L));
+  }
+
+  @Test
+  @DisplayName("지원하는 클라이언트가 없으면 PAYMENT_400_002 예외가 발생한다")
+  void approve_throws_when_no_client_supports_provider() {
+    given(tossClient.supports(PaymentProvider.KAKAO)).willReturn(false);
+
+    PaymentApprovalClientRouter router = new PaymentApprovalClientRouter(List.of(tossClient));
+
+    assertThatThrownBy(
+            () ->
+                router.approve(
+                    new PaymentApprovalRequest(
+                        PaymentProvider.KAKAO, "key", "BKG-0000001", 1L, 1_000L)))
+        .isInstanceOf(BusinessException.class)
+        .extracting("errorStatus")
+        .isEqualTo(ErrorStatus.PAYMENT_PROVIDER_NOT_SUPPORTED);
+  }
+}

--- a/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/out/apiclient/StubPaymentApprovalClientTest.java
+++ b/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/out/apiclient/StubPaymentApprovalClientTest.java
@@ -1,0 +1,33 @@
+package com.ticketrush.boundedcontext.payment.out.apiclient;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.ticketrush.boundedcontext.payment.domain.types.PaymentProvider;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class StubPaymentApprovalClientTest {
+
+  private final StubPaymentApprovalClient client = new StubPaymentApprovalClient();
+
+  @Test
+  @DisplayName("모든 provider를 지원한다 (fallback 클라이언트)")
+  void supports_all_providers() {
+    assertThat(client.supports(PaymentProvider.TOSS)).isTrue();
+    assertThat(client.supports(PaymentProvider.KAKAO)).isTrue();
+    assertThat(client.supports(PaymentProvider.NAVER)).isTrue();
+  }
+
+  @Test
+  @DisplayName("요청 금액 그대로 승인 응답을 만든다")
+  void approve_returns_response_with_request_amount() {
+    PaymentApprovalResponse response =
+        client.approve(
+            new PaymentApprovalRequest(
+                PaymentProvider.TOSS, "pgKey_xyz", "BKG-0000001", 1L, 1_000L));
+
+    assertThat(response.approvedAmount()).isEqualTo(1_000L);
+    assertThat(response.approvalNumber()).isNotBlank();
+    assertThat(response.approvedAt()).isNotNull();
+  }
+}

--- a/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/out/apiclient/toss/TossPaymentApprovalClientTest.java
+++ b/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/out/apiclient/toss/TossPaymentApprovalClientTest.java
@@ -132,6 +132,65 @@ class TossPaymentApprovalClientTest {
   }
 
   @Test
+  @DisplayName("응답에 approvedAt이 없으면 통신 실패로 처리한다")
+  void approve_fails_when_approved_at_is_missing() {
+    String responseBody =
+        """
+        {
+          "paymentKey": "pgKey_xyz",
+          "orderId": "BKG-0000100",
+          "transactionKey": "TX-ABC123",
+          "totalAmount": 55000,
+          "status": "DONE"
+        }
+        """;
+
+    mockServer
+        .expect(requestTo(CONFIRM_URL))
+        .andRespond(withSuccess(responseBody, MediaType.APPLICATION_JSON));
+
+    assertThatThrownBy(
+            () ->
+                client.approve(
+                    new PaymentApprovalRequest(
+                        PaymentProvider.TOSS, "pgKey_xyz", "BKG-0000100", 100L, 55_000L)))
+        .isInstanceOf(BusinessException.class)
+        .extracting("errorStatus")
+        .isEqualTo(ErrorStatus.PAYMENT_PG_COMMUNICATION_FAILED);
+
+    mockServer.verify();
+  }
+
+  @Test
+  @DisplayName("응답에 transactionKey와 paymentKey가 모두 없으면 통신 실패로 처리한다")
+  void approve_fails_when_both_identifiers_are_missing() {
+    String responseBody =
+        """
+        {
+          "orderId": "BKG-0000100",
+          "totalAmount": 55000,
+          "status": "DONE",
+          "approvedAt": "2026-05-22T10:00:00+09:00"
+        }
+        """;
+
+    mockServer
+        .expect(requestTo(CONFIRM_URL))
+        .andRespond(withSuccess(responseBody, MediaType.APPLICATION_JSON));
+
+    assertThatThrownBy(
+            () ->
+                client.approve(
+                    new PaymentApprovalRequest(
+                        PaymentProvider.TOSS, "pgKey_xyz", "BKG-0000100", 100L, 55_000L)))
+        .isInstanceOf(BusinessException.class)
+        .extracting("errorStatus")
+        .isEqualTo(ErrorStatus.PAYMENT_PG_COMMUNICATION_FAILED);
+
+    mockServer.verify();
+  }
+
+  @Test
   @DisplayName("TOSS provider만 지원한다")
   void supports_toss_only() {
     assertThat(client.supports(PaymentProvider.TOSS)).isTrue();

--- a/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/out/apiclient/toss/TossPaymentApprovalClientTest.java
+++ b/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/out/apiclient/toss/TossPaymentApprovalClientTest.java
@@ -1,0 +1,141 @@
+package com.ticketrush.boundedcontext.payment.out.apiclient.toss;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.jsonPath;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withRawStatus;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withServerError;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withStatus;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+import com.ticketrush.boundedcontext.payment.domain.types.PaymentProvider;
+import com.ticketrush.boundedcontext.payment.out.apiclient.PaymentApprovalRequest;
+import com.ticketrush.boundedcontext.payment.out.apiclient.PaymentApprovalResponse;
+import com.ticketrush.global.exception.BusinessException;
+import com.ticketrush.global.status.ErrorStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestClient;
+
+class TossPaymentApprovalClientTest {
+
+  private static final String BASE_URL = "https://api.tosspayments.com";
+  private static final String CONFIRM_URL = BASE_URL + "/v1/payments/confirm";
+
+  private MockRestServiceServer mockServer;
+  private TossPaymentApprovalClient client;
+
+  @BeforeEach
+  void setUp() {
+    RestClient.Builder builder = RestClient.builder().baseUrl(BASE_URL);
+    mockServer = MockRestServiceServer.bindTo(builder).build();
+    client = new TossPaymentApprovalClient(builder.build());
+  }
+
+  @Test
+  @DisplayName("Toss 결제 승인 성공 시 transactionKey를 approvalNumber로 매핑한다")
+  void approve_success() {
+    String responseBody =
+        """
+        {
+          "paymentKey": "pgKey_xyz",
+          "orderId": "BKG-0000100",
+          "transactionKey": "TX-ABC123",
+          "totalAmount": 55000,
+          "status": "DONE",
+          "approvedAt": "2026-05-22T10:00:00+09:00"
+        }
+        """;
+
+    mockServer
+        .expect(requestTo(CONFIRM_URL))
+        .andExpect(method(HttpMethod.POST))
+        .andExpect(jsonPath("$.paymentKey").value("pgKey_xyz"))
+        .andExpect(jsonPath("$.orderId").value("BKG-0000100"))
+        .andExpect(jsonPath("$.amount").value(55000))
+        .andRespond(withSuccess(responseBody, MediaType.APPLICATION_JSON));
+
+    PaymentApprovalResponse response =
+        client.approve(
+            new PaymentApprovalRequest(
+                PaymentProvider.TOSS, "pgKey_xyz", "BKG-0000100", 100L, 55_000L));
+
+    assertThat(response.approvalNumber()).isEqualTo("TX-ABC123");
+    assertThat(response.approvedAmount()).isEqualTo(55_000L);
+    assertThat(response.approvedAt()).isNotNull();
+
+    mockServer.verify();
+  }
+
+  @Test
+  @DisplayName("Toss가 4xx를 반환하면 PAYMENT_502_001 예외가 발생한다")
+  void approve_fails_when_pg_returns_4xx() {
+    mockServer
+        .expect(requestTo(CONFIRM_URL))
+        .andRespond(
+            withStatus(org.springframework.http.HttpStatus.BAD_REQUEST)
+                .contentType(MediaType.APPLICATION_JSON)
+                .body("{\"code\":\"ALREADY_PROCESSED_PAYMENT\"}"));
+
+    assertThatThrownBy(
+            () ->
+                client.approve(
+                    new PaymentApprovalRequest(
+                        PaymentProvider.TOSS, "pgKey_xyz", "BKG-0000100", 100L, 55_000L)))
+        .isInstanceOf(BusinessException.class)
+        .extracting("errorStatus")
+        .isEqualTo(ErrorStatus.PAYMENT_APPROVAL_FAILED);
+
+    mockServer.verify();
+  }
+
+  @Test
+  @DisplayName("Toss가 5xx를 반환하면 PAYMENT_503_001 예외가 발생한다")
+  void approve_fails_when_pg_returns_5xx() {
+    mockServer.expect(requestTo(CONFIRM_URL)).andRespond(withServerError());
+
+    assertThatThrownBy(
+            () ->
+                client.approve(
+                    new PaymentApprovalRequest(
+                        PaymentProvider.TOSS, "pgKey_xyz", "BKG-0000100", 100L, 55_000L)))
+        .isInstanceOf(BusinessException.class)
+        .extracting("errorStatus")
+        .isEqualTo(ErrorStatus.PAYMENT_PG_COMMUNICATION_FAILED);
+
+    mockServer.verify();
+  }
+
+  @Test
+  @DisplayName("응답 본문이 비어있어도 통신 실패로 처리한다")
+  void approve_fails_when_response_body_is_empty() {
+    mockServer
+        .expect(requestTo(CONFIRM_URL))
+        .andRespond(withRawStatus(200).contentType(MediaType.APPLICATION_JSON).body(""));
+
+    assertThatThrownBy(
+            () ->
+                client.approve(
+                    new PaymentApprovalRequest(
+                        PaymentProvider.TOSS, "pgKey_xyz", "BKG-0000100", 100L, 55_000L)))
+        .isInstanceOf(BusinessException.class)
+        .extracting("errorStatus")
+        .isEqualTo(ErrorStatus.PAYMENT_PG_COMMUNICATION_FAILED);
+
+    mockServer.verify();
+  }
+
+  @Test
+  @DisplayName("TOSS provider만 지원한다")
+  void supports_toss_only() {
+    assertThat(client.supports(PaymentProvider.TOSS)).isTrue();
+    assertThat(client.supports(PaymentProvider.KAKAO)).isFalse();
+    assertThat(client.supports(PaymentProvider.NAVER)).isFalse();
+  }
+}


### PR DESCRIPTION
## 🔗 관련 이슈

- close #89

---

## 📌 주요 변경 사항

- Toss Payments 결제 승인 API 실제 연동 (기존 stub을 대체)
- 다중 PG provider 라우팅 도입 (`PaymentApprovalClientRouter`)
- PG 거래 식별자(`paymentKey`, `approvalNumber`) 영속화

---

## 🛠 상세 구현 내용

- **Provider 라우팅 인프라**
  - `PaymentApprovalClient` 인터페이스에 `PaymentProvider provider()` 추가
  - `PaymentApprovalClientRouter`가 요청의 `PaymentProvider`에 맞는 구현체로 위임
  - Stub 활성화는 `payment.pg.stub.enabled` 토글 (기본 `false`, 로컬은 환경변수로 on/off)
- **Toss 클라이언트**
  - `TossPaymentApprovalClient` + `TossConfirmRequest/Response` 신규
  - Basic Auth (`secretKey:` Base64) + connect/read 타임아웃 적용
  - `RestClientConfig`로 `RestClient.Builder` 빈 등록
  - 시크릿 키/타임아웃은 `application.yml` 환경변수 주입 (`TOSS_PAYMENTS_*`)
- **Payment 엔티티**
  - `paymentKey`, `approvalNumber` 컬럼 추가, confirm 성공 시 영속화
  - `PaymentApprovalRequest`에 `bookingId` 포함 (로깅용)
- **예외 매핑**
  - PG 4xx → `PAYMENT_APPROVAL_FAILED` (502) — 본 PR 범위는 단일 매핑
  - PG 5xx/타임아웃/통신 실패 → `PAYMENT_PG_COMMUNICATION_FAILED` (503)
  - 거절 코드 세분화는 후속 이슈 #222로 분리
- **Stub 정리**
  - `paymentKey` 평문 로깅 마스킹 적용

---

## ✅ 테스트

### 테스트 방법

- `./gradlew :payment-service:test`
- Toss 인증 검증 (실호출): 시크릿 키 주입 후 dummy paymentKey로 Toss confirm 호출 → 401이 아닌 404 `NOT_FOUND_PAYMENT_SESSION` 응답 확인 (인증 헤더 정상)

### 테스트 결과

- 단위 테스트 **18/18 통과**
  - `PaymentConfirmUseCaseTest` 3
  - `PaymentApprovalClientRouterTest` 3
  - `StubPaymentApprovalClientTest` 2
  - `TossPaymentApprovalClientTest` 5
  - `PaymentControllerTest` 4
  - `PaymentServiceApplicationTests` 1
- spotless / checkstyle 위반 없음

### 📸 스크린샷
<img width="1816" height="494" alt="image" src="https://github.com/user-attachments/assets/513a3fd7-620a-4779-87ef-7d962a62a787" />

---

## 👀 리뷰 요청 사항

- Provider 라우팅 인터페이스 확장 방향이 적절한지 (`provider()` 메서드 + Router에 `List<PaymentApprovalClient>` 주입)
- 4xx 단일 매핑으로 우선 머지하고 거절 코드 세분화는 #222로 분리한 결정에 대한 의견
- `RestClient` 타임아웃 기본값(connect 3s / read 10s)이 결제 도메인에 적절한지

---

## ⚠️ 배포 시 주의사항

- **환경변수 추가 필요:**
  - `TOSS_PAYMENTS_SECRET_KEY` — **필수**, 미설정 시 Toss 호출 401
  - `TOSS_PAYMENTS_BASE_URL` — 선택, 기본 `https://api.tosspayments.com`
  - `TOSS_PAYMENTS_CONNECT_TIMEOUT_MS` / `TOSS_PAYMENTS_READ_TIMEOUT_MS` — 선택
  - `PAYMENT_PG_STUB_ENABLED` — 선택, 기본 `false`; 로컬에서 stub 사용 시 `true`
- `Payment` 엔티티에 `paymentKey`, `approvalNumber` 컬럼 추가 → DDL 자동 반영 (`ddl-auto=update`)