### PR TITLE
[Feat] #207 사용자 결제 내역 조회 API 구현

### DIFF
--- a/common/src/main/java/com/ticketrush/global/status/ErrorStatus.java
+++ b/common/src/main/java/com/ticketrush/global/status/ErrorStatus.java
@@ -141,6 +141,9 @@ public enum ErrorStatus {
   PAYMENT_AMOUNT_MISMATCH(HttpStatus.BAD_REQUEST, "PAYMENT_400_001", "결제 금액이 일치하지 않습니다."),
   PAYMENT_PROVIDER_NOT_SUPPORTED(HttpStatus.BAD_REQUEST, "PAYMENT_400_002", "지원하지 않는 결제 수단입니다."),
 
+  // Payment 404
+  PAYMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "PAYMENT_404_002", "결제 내역을 찾을 수 없습니다."),
+
   // Payment 409
   PAYMENT_ALREADY_COMPLETED(HttpStatus.CONFLICT, "PAYMENT_409_001", "이미 결제가 완료된 예매입니다."),
 

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/dto/response/PaymentDetailResponse.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/dto/response/PaymentDetailResponse.java
@@ -1,0 +1,34 @@
+package com.ticketrush.boundedcontext.payment.app.dto.response;
+
+import com.ticketrush.boundedcontext.payment.domain.entity.Payment;
+import com.ticketrush.boundedcontext.payment.domain.entity.Refund;
+import com.ticketrush.boundedcontext.payment.domain.types.PaymentProvider;
+import com.ticketrush.boundedcontext.payment.domain.types.PaymentStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+
+@Schema(description = "결제 내역 단건 상세 응답 DTO")
+public record PaymentDetailResponse(
+    @Schema(description = "결제 데이터의 고유 식별자(PK)", example = "1") Long paymentId,
+    @Schema(description = "예매 ID", example = "12") Long bookingId,
+    @Schema(description = "결제 수단", example = "TOSS") PaymentProvider provider,
+    @Schema(description = "결제 금액", example = "55000") Long amount,
+    @Schema(description = "결제 상태", example = "COMPLETED") PaymentStatus status,
+    @Schema(description = "결제 완료 시각") LocalDateTime paidAt,
+    @Schema(description = "PG사 발급 결제 키") String paymentKey,
+    @Schema(description = "PG사 응답 승인 번호") String approvalNumber,
+    @Schema(description = "환불 정보 (환불이 없으면 null)") RefundResponse refund) {
+
+  public static PaymentDetailResponse of(Payment payment, Refund refund) {
+    return new PaymentDetailResponse(
+        payment.getId(),
+        payment.getBookingId(),
+        payment.getProvider(),
+        payment.getAmount(),
+        payment.getStatus(),
+        payment.getPaidAt(),
+        payment.getPaymentKey(),
+        payment.getApprovalNumber(),
+        refund == null ? null : RefundResponse.from(refund));
+  }
+}

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/dto/response/PaymentDetailResponse.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/dto/response/PaymentDetailResponse.java
@@ -17,7 +17,7 @@ public record PaymentDetailResponse(
     @Schema(description = "결제 완료 시각") LocalDateTime paidAt,
     @Schema(description = "PG사 발급 결제 키") String paymentKey,
     @Schema(description = "PG사 응답 승인 번호") String approvalNumber,
-    @Schema(description = "환불 정보 (환불이 없으면 null)") RefundResponse refund) {
+    @Schema(description = "환불 정보 (환불이 있는 경우에만 포함)") RefundResponse refund) {
 
   public static PaymentDetailResponse of(Payment payment, Refund refund) {
     return new PaymentDetailResponse(

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/dto/response/PaymentDetailResponse.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/dto/response/PaymentDetailResponse.java
@@ -15,7 +15,6 @@ public record PaymentDetailResponse(
     @Schema(description = "결제 금액", example = "55000") Long amount,
     @Schema(description = "결제 상태", example = "COMPLETED") PaymentStatus status,
     @Schema(description = "결제 완료 시각") LocalDateTime paidAt,
-    @Schema(description = "PG사 발급 결제 키") String paymentKey,
     @Schema(description = "PG사 응답 승인 번호") String approvalNumber,
     @Schema(description = "환불 정보 (환불이 있는 경우에만 포함)") RefundResponse refund) {
 
@@ -27,7 +26,6 @@ public record PaymentDetailResponse(
         payment.getAmount(),
         payment.getStatus(),
         payment.getPaidAt(),
-        payment.getPaymentKey(),
         payment.getApprovalNumber(),
         refund == null ? null : RefundResponse.from(refund));
   }

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/dto/response/PaymentSummaryResponse.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/dto/response/PaymentSummaryResponse.java
@@ -1,0 +1,27 @@
+package com.ticketrush.boundedcontext.payment.app.dto.response;
+
+import com.ticketrush.boundedcontext.payment.domain.entity.Payment;
+import com.ticketrush.boundedcontext.payment.domain.types.PaymentProvider;
+import com.ticketrush.boundedcontext.payment.domain.types.PaymentStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+
+@Schema(description = "결제 내역 목록 응답 DTO")
+public record PaymentSummaryResponse(
+    @Schema(description = "결제 데이터의 고유 식별자(PK)", example = "1") Long paymentId,
+    @Schema(description = "예매 ID", example = "12") Long bookingId,
+    @Schema(description = "결제 수단", example = "TOSS") PaymentProvider provider,
+    @Schema(description = "결제 금액", example = "55000") Long amount,
+    @Schema(description = "결제 상태", example = "COMPLETED") PaymentStatus status,
+    @Schema(description = "결제 완료 시각") LocalDateTime paidAt) {
+
+  public static PaymentSummaryResponse from(Payment payment) {
+    return new PaymentSummaryResponse(
+        payment.getId(),
+        payment.getBookingId(),
+        payment.getProvider(),
+        payment.getAmount(),
+        payment.getStatus(),
+        payment.getPaidAt());
+  }
+}

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/dto/response/RefundResponse.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/dto/response/RefundResponse.java
@@ -1,0 +1,19 @@
+package com.ticketrush.boundedcontext.payment.app.dto.response;
+
+import com.ticketrush.boundedcontext.payment.domain.entity.Refund;
+import com.ticketrush.boundedcontext.payment.domain.types.RefundStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+
+@Schema(description = "환불 정보 응답 DTO")
+public record RefundResponse(
+    @Schema(description = "환불 데이터의 고유 식별자(PK)", example = "1") Long refundId,
+    @Schema(description = "환불 금액", example = "55000") Long price,
+    @Schema(description = "환불 상태", example = "COMPLETED") RefundStatus status,
+    @Schema(description = "환불 확정 시각") LocalDateTime confirmedAt) {
+
+  public static RefundResponse from(Refund refund) {
+    return new RefundResponse(
+        refund.getId(), refund.getPrice(), refund.getStatus(), refund.getConfirmedAt());
+  }
+}

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/facade/PaymentFacade.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/facade/PaymentFacade.java
@@ -2,8 +2,14 @@ package com.ticketrush.boundedcontext.payment.app.facade;
 
 import com.ticketrush.boundedcontext.payment.app.dto.request.PaymentConfirmRequest;
 import com.ticketrush.boundedcontext.payment.app.dto.response.PaymentConfirmResponse;
+import com.ticketrush.boundedcontext.payment.app.dto.response.PaymentDetailResponse;
+import com.ticketrush.boundedcontext.payment.app.dto.response.PaymentSummaryResponse;
 import com.ticketrush.boundedcontext.payment.app.usecase.PaymentConfirmUseCase;
+import com.ticketrush.boundedcontext.payment.app.usecase.PaymentGetDetailUseCase;
+import com.ticketrush.boundedcontext.payment.app.usecase.PaymentGetListUseCase;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -11,8 +17,18 @@ import org.springframework.stereotype.Service;
 public class PaymentFacade {
 
   private final PaymentConfirmUseCase paymentConfirmUseCase;
+  private final PaymentGetListUseCase paymentGetListUseCase;
+  private final PaymentGetDetailUseCase paymentGetDetailUseCase;
 
   public PaymentConfirmResponse confirm(Long userId, PaymentConfirmRequest request) {
     return paymentConfirmUseCase.execute(userId, request);
+  }
+
+  public Page<PaymentSummaryResponse> getPayments(Long userId, Pageable pageable) {
+    return paymentGetListUseCase.execute(userId, pageable);
+  }
+
+  public PaymentDetailResponse getPayment(Long userId, Long paymentId) {
+    return paymentGetDetailUseCase.execute(userId, paymentId);
   }
 }

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentConfirmUseCase.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentConfirmUseCase.java
@@ -48,6 +48,7 @@ public class PaymentConfirmUseCase {
     Payment payment =
         Payment.builder()
             .bookingId(request.bookingId())
+            .userId(userId)
             .provider(request.provider())
             .amount(approval.approvedAmount())
             .status(PaymentStatus.COMPLETED)

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentGetDetailUseCase.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentGetDetailUseCase.java
@@ -1,0 +1,33 @@
+package com.ticketrush.boundedcontext.payment.app.usecase;
+
+import com.ticketrush.boundedcontext.payment.app.dto.response.PaymentDetailResponse;
+import com.ticketrush.boundedcontext.payment.domain.entity.Payment;
+import com.ticketrush.boundedcontext.payment.domain.entity.Refund;
+import com.ticketrush.boundedcontext.payment.out.repository.PaymentRepository;
+import com.ticketrush.boundedcontext.payment.out.repository.RefundRepository;
+import com.ticketrush.global.exception.BusinessException;
+import com.ticketrush.global.status.ErrorStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class PaymentGetDetailUseCase {
+
+  private final PaymentRepository paymentRepository;
+  private final RefundRepository refundRepository;
+
+  @Transactional(readOnly = true)
+  public PaymentDetailResponse execute(Long userId, Long paymentId) {
+    /* 미존재와 소유권 위반을 동일 응답으로 통일해 다른 사용자 결제 ID 존재 여부 노출을 막는다. */
+    Payment payment =
+        paymentRepository
+            .findByIdAndUserId(paymentId, userId)
+            .orElseThrow(() -> new BusinessException(ErrorStatus.PAYMENT_NOT_FOUND));
+
+    Refund refund = refundRepository.findByBookingId(payment.getBookingId()).orElse(null);
+
+    return PaymentDetailResponse.of(payment, refund);
+  }
+}

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentGetListUseCase.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentGetListUseCase.java
@@ -1,0 +1,24 @@
+package com.ticketrush.boundedcontext.payment.app.usecase;
+
+import com.ticketrush.boundedcontext.payment.app.dto.response.PaymentSummaryResponse;
+import com.ticketrush.boundedcontext.payment.domain.types.PaymentStatus;
+import com.ticketrush.boundedcontext.payment.out.repository.PaymentRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class PaymentGetListUseCase {
+
+  private final PaymentRepository paymentRepository;
+
+  @Transactional(readOnly = true)
+  public Page<PaymentSummaryResponse> execute(Long userId, Pageable pageable) {
+    return paymentRepository
+        .findByUserIdAndStatus(userId, PaymentStatus.COMPLETED, pageable)
+        .map(PaymentSummaryResponse::from);
+  }
+}

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/domain/entity/Payment.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/domain/entity/Payment.java
@@ -25,6 +25,9 @@ public class Payment extends AutoIdBaseEntity {
   @Column(nullable = false)
   private Long bookingId;
 
+  /* userId는 #207 시점 신규 도입. 기존 결제 row 호환을 위해 nullable. backfill 후 NOT NULL 전환 예정. */
+  private Long userId;
+
   @Enumerated(EnumType.STRING)
   @Column(nullable = false)
   private PaymentProvider provider; // 결제 수단 (예: KAKAO, NAVER)
@@ -47,6 +50,7 @@ public class Payment extends AutoIdBaseEntity {
   @Builder
   private Payment(
       Long bookingId,
+      Long userId,
       PaymentProvider provider,
       Long amount,
       PaymentStatus status,
@@ -54,6 +58,7 @@ public class Payment extends AutoIdBaseEntity {
       String approvalNumber,
       LocalDateTime paidAt) {
     this.bookingId = bookingId;
+    this.userId = userId;
     this.provider = provider;
     this.amount = amount;
     this.status = status;

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/in/api/v1/PaymentController.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/in/api/v1/PaymentController.java
@@ -2,23 +2,39 @@ package com.ticketrush.boundedcontext.payment.in.api.v1;
 
 import com.ticketrush.boundedcontext.payment.app.dto.request.PaymentConfirmRequest;
 import com.ticketrush.boundedcontext.payment.app.dto.response.PaymentConfirmResponse;
+import com.ticketrush.boundedcontext.payment.app.dto.response.PaymentDetailResponse;
+import com.ticketrush.boundedcontext.payment.app.dto.response.PaymentSummaryResponse;
 import com.ticketrush.boundedcontext.payment.app.facade.PaymentFacade;
 import com.ticketrush.boundedcontext.payment.in.api.v1.swagger.PaymentConfirmApiResponses;
+import com.ticketrush.boundedcontext.payment.in.api.v1.swagger.PaymentDetailApiResponses;
+import com.ticketrush.boundedcontext.payment.in.api.v1.swagger.PaymentListApiResponses;
 import com.ticketrush.global.dto.response.ApiResponse;
 import com.ticketrush.global.security.CustomUserDetails;
 import com.ticketrush.global.status.SuccessStatus;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Positive;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "Payment", description = "결제 관련 API")
+@Validated
 @RestController
 @RequestMapping("/api/v1/payment")
 @RequiredArgsConstructor
@@ -37,6 +53,31 @@ public class PaymentController {
       @AuthenticationPrincipal CustomUserDetails user,
       @Valid @RequestBody PaymentConfirmRequest request) {
     PaymentConfirmResponse response = paymentFacade.confirm(user.getUserId(), request);
+    return ApiResponse.onSuccess(SuccessStatus.OK, response);
+  }
+
+  @Operation(
+      summary = "결제 내역 목록 조회",
+      description = "로그인 사용자의 결제 내역을 오프셋 페이징으로 조회한다. COMPLETED 상태만 노출된다.")
+  @PaymentListApiResponses
+  @GetMapping
+  public ResponseEntity<ApiResponse<List<PaymentSummaryResponse>>> getPayments(
+      @AuthenticationPrincipal CustomUserDetails user,
+      @ParameterObject @PageableDefault(size = 10, sort = "paidAt", direction = Sort.Direction.DESC)
+          Pageable pageable) {
+    Page<PaymentSummaryResponse> payments = paymentFacade.getPayments(user.getUserId(), pageable);
+    return ApiResponse.onSuccess(SuccessStatus.OK, payments);
+  }
+
+  @Operation(
+      summary = "결제 내역 단건 조회",
+      description = "결제 ID로 본인 결제 단건을 조회한다. 본인 결제가 아니거나 존재하지 않으면 PAYMENT_NOT_FOUND를 반환한다.")
+  @PaymentDetailApiResponses
+  @GetMapping("/{paymentId}")
+  public ResponseEntity<ApiResponse<PaymentDetailResponse>> getPayment(
+      @AuthenticationPrincipal CustomUserDetails user,
+      @Parameter(description = "결제 ID") @Positive @PathVariable Long paymentId) {
+    PaymentDetailResponse response = paymentFacade.getPayment(user.getUserId(), paymentId);
     return ApiResponse.onSuccess(SuccessStatus.OK, response);
   }
 }

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/in/api/v1/swagger/PaymentDetailApiResponses.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/in/api/v1/swagger/PaymentDetailApiResponses.java
@@ -42,8 +42,7 @@ import java.lang.annotation.Target;
                               "status": "COMPLETED",
                               "paid_at": "2025-01-15 10:00:00",
                               "payment_key": "tgen_xxx",
-                              "approval_number": "00000001",
-                              "refund": null
+                              "approval_number": "00000001"
                             }
                           }
                           """))),

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/in/api/v1/swagger/PaymentDetailApiResponses.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/in/api/v1/swagger/PaymentDetailApiResponses.java
@@ -1,0 +1,72 @@
+package com.ticketrush.boundedcontext.payment.in.api.v1.swagger;
+
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@ApiResponses({
+  @ApiResponse(
+      responseCode = "200",
+      description = "결제 내역 단건 조회 성공",
+      content =
+          @Content(
+              mediaType = "application/json",
+              schema =
+                  @Schema(implementation = com.ticketrush.global.dto.response.ApiResponse.class),
+              examples =
+                  @ExampleObject(
+                      name = "Success",
+                      summary = "정상 응답",
+                      value =
+                          """
+                          {
+                            "is_success": true,
+                            "code": "COMMON_200",
+                            "message": "성공입니다.",
+                            "trace_id": "trace-id-example",
+                            "result": {
+                              "payment_id": 1,
+                              "booking_id": 12,
+                              "provider": "TOSS",
+                              "amount": 55000,
+                              "status": "COMPLETED",
+                              "paid_at": "2025-01-15 10:00:00",
+                              "payment_key": "tgen_xxx",
+                              "approval_number": "00000001",
+                              "refund": null
+                            }
+                          }
+                          """))),
+  @ApiResponse(
+      responseCode = "404",
+      description = "결제 내역 없음 또는 본인 결제가 아님",
+      content =
+          @Content(
+              mediaType = "application/json",
+              schema =
+                  @Schema(implementation = com.ticketrush.global.dto.response.ApiResponse.class),
+              examples =
+                  @ExampleObject(
+                      name = "NotFound",
+                      summary = "결제 내역이 없거나 본인 결제가 아닐 때",
+                      value =
+                          """
+                          {
+                            "is_success": false,
+                            "code": "PAYMENT_404_002",
+                            "message": "결제 내역을 찾을 수 없습니다.",
+                            "trace_id": "trace-id-example"
+                          }
+                          """)))
+})
+public @interface PaymentDetailApiResponses {}

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/in/api/v1/swagger/PaymentDetailApiResponses.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/in/api/v1/swagger/PaymentDetailApiResponses.java
@@ -41,7 +41,6 @@ import java.lang.annotation.Target;
                               "amount": 55000,
                               "status": "COMPLETED",
                               "paid_at": "2025-01-15 10:00:00",
-                              "payment_key": "tgen_xxx",
                               "approval_number": "00000001"
                             }
                           }

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/in/api/v1/swagger/PaymentListApiResponses.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/in/api/v1/swagger/PaymentListApiResponses.java
@@ -1,0 +1,57 @@
+package com.ticketrush.boundedcontext.payment.in.api.v1.swagger;
+
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@ApiResponses({
+  @ApiResponse(
+      responseCode = "200",
+      description = "결제 내역 목록 조회 성공",
+      content =
+          @Content(
+              mediaType = "application/json",
+              schema =
+                  @Schema(implementation = com.ticketrush.global.dto.response.ApiResponse.class),
+              examples =
+                  @ExampleObject(
+                      name = "Success",
+                      summary = "정상 응답",
+                      value =
+                          """
+                          {
+                            "is_success": true,
+                            "code": "COMMON_200",
+                            "message": "성공입니다.",
+                            "trace_id": "trace-id-example",
+                            "pagination_info": {
+                              "page_index": 0,
+                              "size": 10,
+                              "has_next": false,
+                              "total_elements": 1,
+                              "total_pages": 1
+                            },
+                            "result": [
+                              {
+                                "payment_id": 1,
+                                "booking_id": 12,
+                                "provider": "TOSS",
+                                "amount": 55000,
+                                "status": "COMPLETED",
+                                "paid_at": "2025-01-15 10:00:00"
+                              }
+                            ]
+                          }
+                          """)))
+})
+public @interface PaymentListApiResponses {}

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/out/repository/PaymentRepository.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/out/repository/PaymentRepository.java
@@ -2,9 +2,16 @@ package com.ticketrush.boundedcontext.payment.out.repository;
 
 import com.ticketrush.boundedcontext.payment.domain.entity.Payment;
 import com.ticketrush.boundedcontext.payment.domain.types.PaymentStatus;
+import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PaymentRepository extends JpaRepository<Payment, Long> {
 
   boolean existsByBookingIdAndStatus(Long bookingId, PaymentStatus status);
+
+  Page<Payment> findByUserIdAndStatus(Long userId, PaymentStatus status, Pageable pageable);
+
+  Optional<Payment> findByIdAndUserId(Long id, Long userId);
 }

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/out/repository/RefundRepository.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/out/repository/RefundRepository.java
@@ -1,0 +1,10 @@
+package com.ticketrush.boundedcontext.payment.out.repository;
+
+import com.ticketrush.boundedcontext.payment.domain.entity.Refund;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RefundRepository extends JpaRepository<Refund, Long> {
+
+  Optional<Refund> findByBookingId(Long bookingId);
+}

--- a/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentConfirmUseCaseTest.java
+++ b/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentConfirmUseCaseTest.java
@@ -88,6 +88,7 @@ class PaymentConfirmUseCaseTest {
     verify(paymentRepository).save(paymentCaptor.capture());
     Payment savedPayment = paymentCaptor.getValue();
     assertThat(savedPayment.getBookingId()).isEqualTo(bookingId);
+    assertThat(savedPayment.getUserId()).isEqualTo(userId);
     assertThat(savedPayment.getProvider()).isEqualTo(PaymentProvider.TOSS);
     assertThat(savedPayment.getAmount()).isEqualTo(amount);
     assertThat(savedPayment.getStatus()).isEqualTo(PaymentStatus.COMPLETED);

--- a/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentGetDetailUseCaseTest.java
+++ b/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentGetDetailUseCaseTest.java
@@ -1,0 +1,128 @@
+package com.ticketrush.boundedcontext.payment.app.usecase;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import com.ticketrush.boundedcontext.payment.app.dto.response.PaymentDetailResponse;
+import com.ticketrush.boundedcontext.payment.domain.entity.Payment;
+import com.ticketrush.boundedcontext.payment.domain.entity.Refund;
+import com.ticketrush.boundedcontext.payment.domain.types.PaymentProvider;
+import com.ticketrush.boundedcontext.payment.domain.types.PaymentStatus;
+import com.ticketrush.boundedcontext.payment.domain.types.RefundStatus;
+import com.ticketrush.boundedcontext.payment.out.repository.PaymentRepository;
+import com.ticketrush.boundedcontext.payment.out.repository.RefundRepository;
+import com.ticketrush.global.exception.BusinessException;
+import com.ticketrush.global.status.ErrorStatus;
+import java.lang.reflect.Field;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class PaymentGetDetailUseCaseTest {
+
+  @Mock private PaymentRepository paymentRepository;
+  @Mock private RefundRepository refundRepository;
+
+  @InjectMocks private PaymentGetDetailUseCase paymentGetDetailUseCase;
+
+  @Test
+  @DisplayName("본인 결제이면 상세를 반환하고 환불이 있으면 함께 포함한다")
+  void execute_returns_detail_with_refund() throws Exception {
+    // given
+    Long userId = 10L;
+    Long paymentId = 1L;
+    Long bookingId = 100L;
+    Payment payment = samplePayment(paymentId, userId, bookingId);
+    Refund refund = sampleRefund(7L, bookingId);
+    given(paymentRepository.findByIdAndUserId(paymentId, userId)).willReturn(Optional.of(payment));
+    given(refundRepository.findByBookingId(bookingId)).willReturn(Optional.of(refund));
+
+    // when
+    PaymentDetailResponse response = paymentGetDetailUseCase.execute(userId, paymentId);
+
+    // then
+    assertThat(response.paymentId()).isEqualTo(paymentId);
+    assertThat(response.bookingId()).isEqualTo(bookingId);
+    assertThat(response.paymentKey()).isEqualTo("pgKey_xyz");
+    assertThat(response.refund()).isNotNull();
+    assertThat(response.refund().refundId()).isEqualTo(7L);
+    assertThat(response.refund().status()).isEqualTo(RefundStatus.COMPLETED);
+  }
+
+  @Test
+  @DisplayName("환불이 없으면 refund 필드는 null이다")
+  void execute_returns_detail_without_refund() throws Exception {
+    // given
+    Long userId = 10L;
+    Long paymentId = 1L;
+    Long bookingId = 100L;
+    Payment payment = samplePayment(paymentId, userId, bookingId);
+    given(paymentRepository.findByIdAndUserId(paymentId, userId)).willReturn(Optional.of(payment));
+    given(refundRepository.findByBookingId(bookingId)).willReturn(Optional.empty());
+
+    // when
+    PaymentDetailResponse response = paymentGetDetailUseCase.execute(userId, paymentId);
+
+    // then
+    assertThat(response.refund()).isNull();
+  }
+
+  @Test
+  @DisplayName("본인 결제가 아니거나 존재하지 않으면 PAYMENT_404_002 예외가 발생한다")
+  void execute_fail_when_not_owned_or_missing() {
+    // given
+    Long userId = 10L;
+    Long paymentId = 999L;
+    given(paymentRepository.findByIdAndUserId(paymentId, userId)).willReturn(Optional.empty());
+
+    // when & then
+    assertThatThrownBy(() -> paymentGetDetailUseCase.execute(userId, paymentId))
+        .isInstanceOf(BusinessException.class)
+        .extracting("errorStatus")
+        .isEqualTo(ErrorStatus.PAYMENT_NOT_FOUND);
+
+    verifyNoInteractions(refundRepository);
+  }
+
+  private Payment samplePayment(Long id, Long userId, Long bookingId) throws Exception {
+    Payment payment =
+        Payment.builder()
+            .bookingId(bookingId)
+            .userId(userId)
+            .provider(PaymentProvider.TOSS)
+            .amount(55_000L)
+            .status(PaymentStatus.COMPLETED)
+            .paymentKey("pgKey_xyz")
+            .approvalNumber("APR-001")
+            .paidAt(LocalDateTime.of(2026, 5, 1, 10, 0))
+            .build();
+    setId(payment, id);
+    return payment;
+  }
+
+  private Refund sampleRefund(Long id, Long bookingId) throws Exception {
+    Refund refund =
+        Refund.builder()
+            .bookingId(bookingId)
+            .price(55_000L)
+            .status(RefundStatus.COMPLETED)
+            .confirmedAt(LocalDateTime.of(2026, 5, 2, 12, 0))
+            .build();
+    setId(refund, id);
+    return refund;
+  }
+
+  private void setId(Object entity, Long id) throws Exception {
+    Field idField = entity.getClass().getSuperclass().getDeclaredField("id");
+    idField.setAccessible(true);
+    idField.set(entity, id);
+  }
+}

--- a/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentGetDetailUseCaseTest.java
+++ b/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentGetDetailUseCaseTest.java
@@ -51,7 +51,7 @@ class PaymentGetDetailUseCaseTest {
     // then
     assertThat(response.paymentId()).isEqualTo(paymentId);
     assertThat(response.bookingId()).isEqualTo(bookingId);
-    assertThat(response.paymentKey()).isEqualTo("pgKey_xyz");
+    assertThat(response.approvalNumber()).isEqualTo("APR-001");
     assertThat(response.refund()).isNotNull();
     assertThat(response.refund().refundId()).isEqualTo(7L);
     assertThat(response.refund().status()).isEqualTo(RefundStatus.COMPLETED);

--- a/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentGetListUseCaseTest.java
+++ b/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentGetListUseCaseTest.java
@@ -1,0 +1,73 @@
+package com.ticketrush.boundedcontext.payment.app.usecase;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+import com.ticketrush.boundedcontext.payment.app.dto.response.PaymentSummaryResponse;
+import com.ticketrush.boundedcontext.payment.domain.entity.Payment;
+import com.ticketrush.boundedcontext.payment.domain.types.PaymentProvider;
+import com.ticketrush.boundedcontext.payment.domain.types.PaymentStatus;
+import com.ticketrush.boundedcontext.payment.out.repository.PaymentRepository;
+import java.lang.reflect.Field;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+
+@ExtendWith(MockitoExtension.class)
+class PaymentGetListUseCaseTest {
+
+  @Mock private PaymentRepository paymentRepository;
+
+  @InjectMocks private PaymentGetListUseCase paymentGetListUseCase;
+
+  @Test
+  @DisplayName("로그인 사용자의 COMPLETED 결제 내역을 페이지로 반환한다")
+  void execute_returns_completed_payments() throws Exception {
+    // given
+    Long userId = 10L;
+    Pageable pageable = PageRequest.of(0, 10, Sort.by(Sort.Direction.DESC, "paidAt"));
+    Payment payment = sample(1L, userId, 100L, 55_000L);
+    Page<Payment> page = new PageImpl<>(List.of(payment), pageable, 1);
+    given(paymentRepository.findByUserIdAndStatus(userId, PaymentStatus.COMPLETED, pageable))
+        .willReturn(page);
+
+    // when
+    Page<PaymentSummaryResponse> result = paymentGetListUseCase.execute(userId, pageable);
+
+    // then
+    assertThat(result.getTotalElements()).isEqualTo(1);
+    PaymentSummaryResponse first = result.getContent().get(0);
+    assertThat(first.paymentId()).isEqualTo(1L);
+    assertThat(first.bookingId()).isEqualTo(100L);
+    assertThat(first.amount()).isEqualTo(55_000L);
+    assertThat(first.status()).isEqualTo(PaymentStatus.COMPLETED);
+  }
+
+  private Payment sample(Long id, Long userId, Long bookingId, Long amount) throws Exception {
+    Payment payment =
+        Payment.builder()
+            .bookingId(bookingId)
+            .userId(userId)
+            .provider(PaymentProvider.TOSS)
+            .amount(amount)
+            .status(PaymentStatus.COMPLETED)
+            .paymentKey("pgKey_xyz")
+            .approvalNumber("APR-001")
+            .paidAt(LocalDateTime.of(2026, 5, 1, 10, 0))
+            .build();
+    Field idField = payment.getClass().getSuperclass().getDeclaredField("id");
+    idField.setAccessible(true);
+    idField.set(payment, id);
+    return payment;
+  }
+}

--- a/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/in/api/v1/PaymentControllerTest.java
+++ b/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/in/api/v1/PaymentControllerTest.java
@@ -5,23 +5,32 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.ticketrush.boundedcontext.payment.app.dto.request.PaymentConfirmRequest;
 import com.ticketrush.boundedcontext.payment.app.dto.response.PaymentConfirmResponse;
+import com.ticketrush.boundedcontext.payment.app.dto.response.PaymentDetailResponse;
+import com.ticketrush.boundedcontext.payment.app.dto.response.PaymentSummaryResponse;
 import com.ticketrush.boundedcontext.payment.app.facade.PaymentFacade;
+import com.ticketrush.boundedcontext.payment.domain.types.PaymentProvider;
+import com.ticketrush.boundedcontext.payment.domain.types.PaymentStatus;
 import com.ticketrush.global.config.SecurityConfig;
 import com.ticketrush.global.exception.BusinessException;
 import com.ticketrush.global.security.GatewayHeaderFilter;
 import com.ticketrush.global.status.ErrorStatus;
 import com.ticketrush.support.WebMvcSliceTest;
 import java.time.LocalDateTime;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
@@ -165,5 +174,90 @@ class PaymentControllerTest {
         .andExpect(jsonPath("$.code").value(ErrorStatus.PAYMENT_AMOUNT_MISMATCH.getCode()));
 
     verify(paymentFacade).confirm(eq(userId), any(PaymentConfirmRequest.class));
+  }
+
+  @Test
+  @DisplayName("결제 내역 목록 조회 성공 시 200 OK와 PageInfo를 반환한다")
+  void getPayments_success() throws Exception {
+    // given
+    Long userId = 10L;
+    PaymentSummaryResponse item =
+        new PaymentSummaryResponse(
+            1L,
+            100L,
+            PaymentProvider.TOSS,
+            55_000L,
+            PaymentStatus.COMPLETED,
+            LocalDateTime.of(2026, 5, 1, 10, 0));
+    Page<PaymentSummaryResponse> page = new PageImpl<>(List.of(item), Pageable.ofSize(10), 1);
+    given(paymentFacade.getPayments(eq(userId), any(Pageable.class))).willReturn(page);
+
+    // when & then
+    mockMvc
+        .perform(
+            get("/api/v1/payment")
+                .header("X-Internal-Token", INTERNAL_TOKEN)
+                .header("X-User-Id", userId)
+                .header("X-User-Role", "USER"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.is_success").value(true))
+        .andExpect(jsonPath("$.pagination_info.total_elements").value(1))
+        .andExpect(jsonPath("$.result[0].payment_id").value(1))
+        .andExpect(jsonPath("$.result[0].booking_id").value(100))
+        .andExpect(jsonPath("$.result[0].status").value("COMPLETED"));
+  }
+
+  @Test
+  @DisplayName("결제 내역 단건 조회 성공 시 200 OK와 상세 정보를 반환한다")
+  void getPayment_success() throws Exception {
+    // given
+    Long userId = 10L;
+    Long paymentId = 1L;
+    PaymentDetailResponse response =
+        new PaymentDetailResponse(
+            paymentId,
+            100L,
+            PaymentProvider.TOSS,
+            55_000L,
+            PaymentStatus.COMPLETED,
+            LocalDateTime.of(2026, 5, 1, 10, 0),
+            "pgKey_xyz",
+            "APR-001",
+            null);
+    given(paymentFacade.getPayment(userId, paymentId)).willReturn(response);
+
+    // when & then
+    mockMvc
+        .perform(
+            get("/api/v1/payment/{paymentId}", paymentId)
+                .header("X-Internal-Token", INTERNAL_TOKEN)
+                .header("X-User-Id", userId)
+                .header("X-User-Role", "USER"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.is_success").value(true))
+        .andExpect(jsonPath("$.result.payment_id").value(1))
+        .andExpect(jsonPath("$.result.payment_key").value("pgKey_xyz"))
+        .andExpect(jsonPath("$.result.refund").doesNotExist());
+  }
+
+  @Test
+  @DisplayName("결제 내역 단건 조회 시 본인 결제가 아니면 PAYMENT_404_002로 실패한다")
+  void getPayment_fails_when_not_found() throws Exception {
+    // given
+    Long userId = 10L;
+    Long paymentId = 999L;
+    given(paymentFacade.getPayment(userId, paymentId))
+        .willThrow(new BusinessException(ErrorStatus.PAYMENT_NOT_FOUND));
+
+    // when & then
+    mockMvc
+        .perform(
+            get("/api/v1/payment/{paymentId}", paymentId)
+                .header("X-Internal-Token", INTERNAL_TOKEN)
+                .header("X-User-Id", userId)
+                .header("X-User-Role", "USER"))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.is_success").value(false))
+        .andExpect(jsonPath("$.code").value(ErrorStatus.PAYMENT_NOT_FOUND.getCode()));
   }
 }

--- a/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/in/api/v1/PaymentControllerTest.java
+++ b/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/in/api/v1/PaymentControllerTest.java
@@ -221,7 +221,6 @@ class PaymentControllerTest {
             55_000L,
             PaymentStatus.COMPLETED,
             LocalDateTime.of(2026, 5, 1, 10, 0),
-            "pgKey_xyz",
             "APR-001",
             null);
     given(paymentFacade.getPayment(userId, paymentId)).willReturn(response);
@@ -236,7 +235,8 @@ class PaymentControllerTest {
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.is_success").value(true))
         .andExpect(jsonPath("$.result.payment_id").value(1))
-        .andExpect(jsonPath("$.result.payment_key").value("pgKey_xyz"))
+        .andExpect(jsonPath("$.result.approval_number").value("APR-001"))
+        .andExpect(jsonPath("$.result.payment_key").doesNotExist())
         .andExpect(jsonPath("$.result.refund").doesNotExist());
   }
 


### PR DESCRIPTION
## 🔗 관련 이슈

- close #207

---

## 📌 주요 변경 사항

- `Payment` 엔티티에 `userId` 컬럼(nullable) 추가 및 `PaymentConfirmUseCase`에서 영속화
- `GET /api/v1/payment` — 본인 결제 내역 목록 조회 (오프셋 페이징, COMPLETED만 노출, paidAt DESC)
- `GET /api/v1/payment/{paymentId}` — 결제 단건 상세 조회 (본인 검증, 환불 정보 포함)
- `ErrorStatus.PAYMENT_NOT_FOUND` (`PAYMENT_404_002`) 신규 추가

---

## 🛠 상세 구현 내용

- **스키마 변경**
  - `Payment.userId` 컬럼 추가 — 기존 row 호환 위해 **nullable**로 도입
  - `PaymentConfirmUseCase`에서 Payment 저장 시 userId 영속화 (#21에서 이벤트로만 흘리던 값을 DB에도 기록)
- **조회 흐름**
  - `PaymentRepository` — `findByUserIdAndStatus(userId, status, pageable)`, `findByIdAndUserId(id, userId)` 추가
  - `PaymentGetListUseCase` — `PaymentStatus.COMPLETED`만 필터링 → PENDING 결제는 마이페이지 미노출 → paidAt nullable 정렬 이슈 자연 해소
  - `PaymentGetDetailUseCase` — `findByIdAndUserId`로 소유권 검증, 미존재/타인 결제 모두 동일한 `PAYMENT_NOT_FOUND` 응답 (다른 사용자의 결제 ID 존재 여부 노출 방지)
  - 환불 정보는 `RefundRepository.findByBookingId`로 조회, 없으면 응답에서 `refund: null`
- **응답 DTO**
  - 목록: `PaymentSummaryResponse` (paymentId, bookingId, provider, amount, status, paidAt)
  - 단건: `PaymentDetailResponse` (위 + paymentKey, approvalNumber, refund)
  - 환불: `RefundResponse` (refundId, price, status, confirmedAt)
- **Swagger** — 컨벤션에 따라 `PaymentListApiResponses` / `PaymentDetailApiResponses` 별도 파일 분리

---

## ✅ 테스트

### 테스트 방법

- `./gradlew :payment-service:test :common:test`

### 테스트 결과

- payment-service 27건, common 모듈 전체 통과
- 신규 테스트
  - `PaymentGetListUseCaseTest` — 목록 조회가 COMPLETED 결제만 페이지로 반환
  - `PaymentGetDetailUseCaseTest` — 단건 조회 정상 / 환불 없음 / 소유권 위반(404) 3케이스
  - `PaymentControllerTest` — `GET /api/v1/payment` 200, `GET /{paymentId}` 200/404 추가
  - `PaymentConfirmUseCaseTest` — 저장 시 userId 영속화 검증 라인 추가
<!---
### 📸 스크린샷

---
-->
## 👀 리뷰 요청 사항

- **`userId` nullable 도입의 적절성** — backfill 후 NOT NULL 전환은 별도 후속 작업으로 분리
- **미존재/타인 결제를 동일 `PAYMENT_NOT_FOUND`(404)로 통일한 정책** — 다른 사용자 결제 ID 존재 여부 노출 방지 의도
- **노출 상태를 `COMPLETED`만으로 한정한 정책** — PENDING은 마이페이지 비노출, `CANCELED`는 #22(환불 API) 머지 후 확장 예정
- **`PAYMENT_404_002` 코드 번호** — #225(`PAYMENT_SESSION_NOT_FOUND`)가 `_404_001` 선점 예정이라 `_002` 사용

---

## ⚠️ 배포 시 주의사항

- **`payment` 테이블에 `user_id` 컬럼 자동 추가** (`ddl-auto=update`, nullable이므로 기존 데이터와 호환)
- **기존 결제 row의 `user_id`는 NULL인 상태로 잔존** → 본 PR로 신규 결제부터 정상 영속화. **backfill 후 NOT NULL 전환은 별도 작업** (이벤트 재발행 불가, booking-service에서 bookingId→userId 매핑 가져와 채워야 함)
- 후속 분리 항목 (#207 본문 참조)
  - 공연/예매 요약 정보(공연명/회차/좌석번호)는 booking-service 신규 엔드포인트 + 본 API 응답 확장 필요 → 별도 이슈
  - 결제 수단 상세(카드사명/마스킹 카드번호)는 PG 응답 추가 영속화 필요 → 별도 이슈
- 환경변수 추가 없음
