### PR TITLE
[Feat] #39 사용자 예매 취소 및 좌석 반환 처리

### DIFF
--- a/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/app/facade/BookingFacade.java
+++ b/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/app/facade/BookingFacade.java
@@ -4,6 +4,7 @@ import com.ticketrush.boundedcontext.booking.app.dto.request.BookingCreateReques
 import com.ticketrush.boundedcontext.booking.app.dto.response.BookingCountResponse;
 import com.ticketrush.boundedcontext.booking.app.dto.response.BookingPendingResponse;
 import com.ticketrush.boundedcontext.booking.app.dto.response.BookingSummaryResponse;
+import com.ticketrush.boundedcontext.booking.app.usecase.BookingCancelMyBookingUseCase;
 import com.ticketrush.boundedcontext.booking.app.usecase.BookingCountUseCase;
 import com.ticketrush.boundedcontext.booking.app.usecase.BookingCreateUseCase;
 import com.ticketrush.boundedcontext.booking.app.usecase.BookingGetMyBookingsUseCase;
@@ -27,6 +28,7 @@ public class BookingFacade {
   private final BookingCreateUseCase bookingCreateUseCase;
   private final BookingGetMyBookingsUseCase bookingGetMyBookingsUseCase;
   private final BookingCountUseCase bookingCountUseCase;
+  private final BookingCancelMyBookingUseCase bookingCancelMyBookingUseCase;
   private final BookingValidateReferencesUseCase bookingValidateReferencesUseCase;
   private final BookingValidateSeatAvailableUseCase bookingValidateSeatAvailableUseCase;
 
@@ -54,5 +56,9 @@ public class BookingFacade {
 
   public BookingCountResponse countMyBookings(Long userId, BookingStatus bookingStatus) {
     return bookingCountUseCase.execute(userId, bookingStatus);
+  }
+
+  public void cancelMyBooking(Long userId, String bookingNumber) {
+    bookingCancelMyBookingUseCase.execute(userId, bookingNumber);
   }
 }

--- a/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/app/usecase/BookingCancelMyBookingUseCase.java
+++ b/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/app/usecase/BookingCancelMyBookingUseCase.java
@@ -25,7 +25,7 @@ public class BookingCancelMyBookingUseCase {
             .findByBookingNumberAndUserId(bookingNumber, userId)
             .orElseThrow(() -> new BusinessException(ErrorStatus.BOOKING_NOT_FOUND));
 
-    booking.cancelConfirmed();
+    booking.cancelConfirmedByUser();
 
     eventPublisher.publish(
         new BookingCanceledEvent(

--- a/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/app/usecase/BookingCancelMyBookingUseCase.java
+++ b/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/app/usecase/BookingCancelMyBookingUseCase.java
@@ -1,0 +1,38 @@
+package com.ticketrush.boundedcontext.booking.app.usecase;
+
+import com.ticketrush.boundedcontext.booking.domain.entity.Booking;
+import com.ticketrush.boundedcontext.booking.out.repository.BookingRepository;
+import com.ticketrush.global.eventpublisher.EventPublisher;
+import com.ticketrush.global.exception.BusinessException;
+import com.ticketrush.global.status.ErrorStatus;
+import com.ticketrush.shared.booking.event.BookingCanceledEvent;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class BookingCancelMyBookingUseCase {
+
+  private final BookingRepository bookingRepository;
+  private final EventPublisher eventPublisher;
+
+  public void execute(Long userId, String bookingNumber) {
+    Booking booking =
+        bookingRepository
+            .findByBookingNumberAndUserId(bookingNumber, userId)
+            .orElseThrow(() -> new BusinessException(ErrorStatus.BOOKING_NOT_FOUND));
+
+    booking.cancelConfirmed();
+
+    eventPublisher.publish(
+        new BookingCanceledEvent(
+            booking.getId(),
+            booking.getBookingNumber(),
+            booking.getSeatId(),
+            booking.getUserId(),
+            LocalDateTime.now()));
+  }
+}

--- a/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/app/usecase/BookingCancelUseCase.java
+++ b/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/app/usecase/BookingCancelUseCase.java
@@ -23,7 +23,7 @@ public class BookingCancelUseCase {
       return;
     }
 
-    booking.cancel();
+    booking.cancelPendingPayment();
 
     log.debug("보상 트랜잭션 정상 처리 : 예매가 취소(CANCELED) 되었습니다. bookingId: {}", bookingId);
   }

--- a/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/app/usecase/BookingCreateUseCase.java
+++ b/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/app/usecase/BookingCreateUseCase.java
@@ -27,7 +27,11 @@ public class BookingCreateUseCase {
 
     BookingCreatedEvent event =
         new BookingCreatedEvent(
-            savedBooking.getId(), request.seatId(), request.performanceId(), request.userId());
+            savedBooking.getId(),
+            request.bookingNumber(),
+            request.seatId(),
+            request.performanceId(),
+            request.userId());
 
     applicationEventPublisher.publishEvent(event);
 

--- a/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/domain/entity/Booking.java
+++ b/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/domain/entity/Booking.java
@@ -63,6 +63,13 @@ public class Booking extends AutoIdBaseEntity {
     this.bookingStatus = BookingStatus.CANCELED;
   }
 
+  public void cancelConfirmed() {
+    if (this.bookingStatus != BookingStatus.CONFIRMED) {
+      throw new BusinessException(ErrorStatus.BOOKING_CANCEL_NOT_ALLOWED);
+    }
+    this.bookingStatus = BookingStatus.CANCELED;
+  }
+
   public void confirm(LocalDateTime confirmedAt) {
     if (this.bookingStatus == BookingStatus.CONFIRMED) {
       if (this.confirmedAt == null) {

--- a/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/domain/entity/Booking.java
+++ b/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/domain/entity/Booking.java
@@ -56,15 +56,16 @@ public class Booking extends AutoIdBaseEntity {
     this.bookingStatus = bookingStatus;
   }
 
-  public void cancel() {
-    if (this.bookingStatus != BookingStatus.PENDING) {
-      throw new BusinessException(ErrorStatus.BOOKING_CANCEL_NOT_ALLOWED);
-    }
-    this.bookingStatus = BookingStatus.CANCELED;
+  public void cancelPendingPayment() {
+    cancelIfStatus(BookingStatus.PENDING);
   }
 
-  public void cancelConfirmed() {
-    if (this.bookingStatus != BookingStatus.CONFIRMED) {
+  public void cancelConfirmedByUser() {
+    cancelIfStatus(BookingStatus.CONFIRMED);
+  }
+
+  private void cancelIfStatus(BookingStatus allowedStatus) {
+    if (this.bookingStatus != allowedStatus) {
       throw new BusinessException(ErrorStatus.BOOKING_CANCEL_NOT_ALLOWED);
     }
     this.bookingStatus = BookingStatus.CANCELED;

--- a/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/in/api/v1/BookingController.java
+++ b/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/in/api/v1/BookingController.java
@@ -19,8 +19,10 @@ import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -71,5 +73,14 @@ public class BookingController {
     BookingCountResponse response = bookingFacade.countMyBookings(user.getUserId(), status);
 
     return ApiResponse.onSuccess(SuccessStatus.OK, response);
+  }
+
+  @Operation(summary = "내 예매 취소", description = "로그인한 사용자의 확정 예매를 취소하고 좌석 반환 이벤트를 발행합니다.")
+  @DeleteMapping("/{bookingNumber}")
+  public ResponseEntity<ApiResponse<Void>> cancelMyBooking(
+      @AuthenticationPrincipal CustomUserDetails user, @PathVariable String bookingNumber) {
+    bookingFacade.cancelMyBooking(user.getUserId(), bookingNumber);
+
+    return ApiResponse.onSuccess(SuccessStatus.NO_CONTENT);
   }
 }

--- a/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/in/api/v1/BookingController.java
+++ b/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/in/api/v1/BookingController.java
@@ -81,6 +81,6 @@ public class BookingController {
       @AuthenticationPrincipal CustomUserDetails user, @PathVariable String bookingNumber) {
     bookingFacade.cancelMyBooking(user.getUserId(), bookingNumber);
 
-    return ApiResponse.onSuccess(SuccessStatus.NO_CONTENT);
+    return ApiResponse.onSuccess(SuccessStatus.OK);
   }
 }

--- a/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/out/repository/BookingRepository.java
+++ b/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/out/repository/BookingRepository.java
@@ -2,6 +2,7 @@ package com.ticketrush.boundedcontext.booking.out.repository;
 
 import com.ticketrush.boundedcontext.booking.domain.entity.Booking;
 import com.ticketrush.boundedcontext.booking.domain.types.BookingStatus;
+import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -12,4 +13,6 @@ public interface BookingRepository extends JpaRepository<Booking, Long> {
       Long userId, BookingStatus bookingStatus, Pageable pageable);
 
   long countByUserIdAndBookingStatus(Long userId, BookingStatus bookingStatus);
+
+  Optional<Booking> findByBookingNumberAndUserId(String bookingNumber, Long userId);
 }

--- a/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/out/repository/BookingRepository.java
+++ b/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/out/repository/BookingRepository.java
@@ -2,9 +2,9 @@ package com.ticketrush.boundedcontext.booking.out.repository;
 
 import com.ticketrush.boundedcontext.booking.domain.entity.Booking;
 import com.ticketrush.boundedcontext.booking.domain.types.BookingStatus;
-import java.util.Optional;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -20,6 +20,7 @@ public interface BookingRepository extends JpaRepository<Booking, Long> {
   long countByUserIdAndBookingStatus(Long userId, BookingStatus bookingStatus);
 
   Optional<Booking> findByBookingNumberAndUserId(String bookingNumber, Long userId);
+
   @Query(
       "SELECT b.id FROM Booking b "
           + "WHERE b.bookingStatus = :bookingStatus AND b.createdAt <= :cutoff "

--- a/booking-service/src/test/java/com/ticketrush/boundedcontext/booking/app/facade/BookingFacadeTest.java
+++ b/booking-service/src/test/java/com/ticketrush/boundedcontext/booking/app/facade/BookingFacadeTest.java
@@ -13,6 +13,7 @@ import com.ticketrush.boundedcontext.booking.app.dto.request.BookingCreateReques
 import com.ticketrush.boundedcontext.booking.app.dto.response.BookingCountResponse;
 import com.ticketrush.boundedcontext.booking.app.dto.response.BookingPendingResponse;
 import com.ticketrush.boundedcontext.booking.app.dto.response.BookingSummaryResponse;
+import com.ticketrush.boundedcontext.booking.app.usecase.BookingCancelMyBookingUseCase;
 import com.ticketrush.boundedcontext.booking.app.usecase.BookingCountUseCase;
 import com.ticketrush.boundedcontext.booking.app.usecase.BookingCreateUseCase;
 import com.ticketrush.boundedcontext.booking.app.usecase.BookingGetMyBookingsUseCase;
@@ -43,6 +44,7 @@ class BookingFacadeTest {
   @Mock private BookingCreateUseCase bookingCreateUseCase;
   @Mock private BookingGetMyBookingsUseCase bookingGetMyBookingsUseCase;
   @Mock private BookingCountUseCase bookingCountUseCase;
+  @Mock private BookingCancelMyBookingUseCase bookingCancelMyBookingUseCase;
   @Mock private BookingValidateReferencesUseCase bookingValidateReferencesUseCase;
   @Mock private BookingValidateSeatAvailableUseCase bookingValidateSeatAvailableUseCase;
 
@@ -167,5 +169,19 @@ class BookingFacadeTest {
     // then
     assertThat(result).isEqualTo(response);
     verify(bookingCountUseCase).execute(userId, BookingStatus.CONFIRMED);
+  }
+
+  @Test
+  @DisplayName("성공: 회원 예매 취소를 위임한다")
+  void cancelMyBooking_success() {
+    // given
+    Long userId = 1L;
+    String bookingNumber = "BOOK-1234";
+
+    // when
+    bookingFacade.cancelMyBooking(userId, bookingNumber);
+
+    // then
+    verify(bookingCancelMyBookingUseCase).execute(userId, bookingNumber);
   }
 }

--- a/booking-service/src/test/java/com/ticketrush/boundedcontext/booking/app/usecase/BookingCancelMyBookingUseCaseTest.java
+++ b/booking-service/src/test/java/com/ticketrush/boundedcontext/booking/app/usecase/BookingCancelMyBookingUseCaseTest.java
@@ -1,0 +1,112 @@
+package com.ticketrush.boundedcontext.booking.app.usecase;
+
+import static com.ticketrush.global.status.ErrorStatus.BOOKING_CANCEL_NOT_ALLOWED;
+import static com.ticketrush.global.status.ErrorStatus.BOOKING_NOT_FOUND;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import com.ticketrush.boundedcontext.booking.domain.entity.Booking;
+import com.ticketrush.boundedcontext.booking.domain.types.BookingStatus;
+import com.ticketrush.boundedcontext.booking.out.repository.BookingRepository;
+import com.ticketrush.global.eventpublisher.EventPublisher;
+import com.ticketrush.global.exception.BusinessException;
+import com.ticketrush.shared.booking.event.BookingCanceledEvent;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class BookingCancelMyBookingUseCaseTest {
+
+  @InjectMocks private BookingCancelMyBookingUseCase bookingCancelMyBookingUseCase;
+
+  @Mock private BookingRepository bookingRepository;
+  @Mock private EventPublisher eventPublisher;
+
+  @Test
+  @DisplayName("성공: 본인의 확정 예매를 취소하고 BookingCanceledEvent를 발행한다")
+  void execute_success() {
+    // given
+    Long userId = 1L;
+    String bookingNumber = "BOOK-1234";
+    Booking booking =
+        Booking.builder()
+            .userId(userId)
+            .performanceId(2L)
+            .seatId(3L)
+            .bookingNumber(bookingNumber)
+            .bookingStatus(BookingStatus.CONFIRMED)
+            .build();
+
+    given(bookingRepository.findByBookingNumberAndUserId(bookingNumber, userId))
+        .willReturn(Optional.of(booking));
+
+    // when
+    bookingCancelMyBookingUseCase.execute(userId, bookingNumber);
+
+    // then
+    assertThat(booking.getBookingStatus()).isEqualTo(BookingStatus.CANCELED);
+    verify(eventPublisher)
+        .publish(
+            argThat(
+                event ->
+                    event instanceof BookingCanceledEvent canceledEvent
+                        && canceledEvent.bookingNumber().equals(bookingNumber)
+                        && canceledEvent.seatId().equals(3L)
+                        && canceledEvent.userId().equals(userId)
+                        && canceledEvent.canceledAt() != null));
+  }
+
+  @Test
+  @DisplayName("실패: 본인의 예매가 아니거나 예매가 없으면 BOOKING_NOT_FOUND를 던진다")
+  void execute_fail_when_booking_not_found_or_not_owned() {
+    // given
+    Long userId = 1L;
+    String bookingNumber = "BOOK-1234";
+    given(bookingRepository.findByBookingNumberAndUserId(bookingNumber, userId))
+        .willReturn(Optional.empty());
+
+    // when & then
+    assertThatThrownBy(() -> bookingCancelMyBookingUseCase.execute(userId, bookingNumber))
+        .isInstanceOf(BusinessException.class)
+        .extracting(ex -> ((BusinessException) ex).getErrorStatus())
+        .isEqualTo(BOOKING_NOT_FOUND);
+
+    verifyNoInteractions(eventPublisher);
+  }
+
+  @Test
+  @DisplayName("실패: 확정 상태가 아닌 예매는 취소할 수 없다")
+  void execute_fail_when_booking_status_is_not_confirmed() {
+    // given
+    Long userId = 1L;
+    String bookingNumber = "BOOK-1234";
+    Booking booking =
+        Booking.builder()
+            .userId(userId)
+            .performanceId(2L)
+            .seatId(3L)
+            .bookingNumber(bookingNumber)
+            .bookingStatus(BookingStatus.PENDING)
+            .build();
+
+    given(bookingRepository.findByBookingNumberAndUserId(bookingNumber, userId))
+        .willReturn(Optional.of(booking));
+
+    // when & then
+    assertThatThrownBy(() -> bookingCancelMyBookingUseCase.execute(userId, bookingNumber))
+        .isInstanceOf(BusinessException.class)
+        .extracting(ex -> ((BusinessException) ex).getErrorStatus())
+        .isEqualTo(BOOKING_CANCEL_NOT_ALLOWED);
+
+    verifyNoInteractions(eventPublisher);
+  }
+}

--- a/booking-service/src/test/java/com/ticketrush/boundedcontext/booking/app/usecase/BookingCancelUseCaseTest.java
+++ b/booking-service/src/test/java/com/ticketrush/boundedcontext/booking/app/usecase/BookingCancelUseCaseTest.java
@@ -34,7 +34,7 @@ class BookingCancelUseCaseTest {
     bookingCancelUseCase.execute(bookingId);
 
     // then
-    verify(mockBooking).cancel();
+    verify(mockBooking).cancelPendingPayment();
   }
 
   @Test

--- a/booking-service/src/test/java/com/ticketrush/boundedcontext/booking/in/api/v1/BookingControllerTest.java
+++ b/booking-service/src/test/java/com/ticketrush/boundedcontext/booking/in/api/v1/BookingControllerTest.java
@@ -4,6 +4,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -144,6 +145,25 @@ class BookingControllerTest {
         .andExpect(jsonPath("$.result.count").value(3));
 
     verify(bookingFacade).countMyBookings(eq(userId), eq(BookingStatus.CONFIRMED));
+  }
+
+  @Test
+  @DisplayName("인증 principal의 userId로 내 예매 취소를 요청한다")
+  void cancelMyBooking_uses_authenticated_user_id() throws Exception {
+    // given
+    Long userId = 1L;
+    String bookingNumber = "BOOK-1234";
+
+    // when & then
+    mockMvc
+        .perform(
+            delete("/api/v1/booking/{bookingNumber}", bookingNumber)
+                .header("X-Internal-Token", INTERNAL_TOKEN)
+                .header("X-User-Id", userId)
+                .header("X-User-Role", "USER"))
+        .andExpect(status().isNoContent());
+
+    verify(bookingFacade).cancelMyBooking(eq(userId), eq(bookingNumber));
   }
 
   @Test

--- a/booking-service/src/test/java/com/ticketrush/boundedcontext/booking/in/api/v1/BookingControllerTest.java
+++ b/booking-service/src/test/java/com/ticketrush/boundedcontext/booking/in/api/v1/BookingControllerTest.java
@@ -161,7 +161,8 @@ class BookingControllerTest {
                 .header("X-Internal-Token", INTERNAL_TOKEN)
                 .header("X-User-Id", userId)
                 .header("X-User-Role", "USER"))
-        .andExpect(status().isNoContent());
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.is_success").value(true));
 
     verify(bookingFacade).cancelMyBooking(eq(userId), eq(bookingNumber));
   }

--- a/common/src/main/java/com/ticketrush/global/status/ErrorStatus.java
+++ b/common/src/main/java/com/ticketrush/global/status/ErrorStatus.java
@@ -87,6 +87,7 @@ public enum ErrorStatus {
 
   // Seat 400
   SEAT_HOLD_TIME_INVALID(HttpStatus.BAD_REQUEST, "SEAT_400_001", "선점 만료 시간은 현재 시간 이후여야 합니다."),
+  SEAT_BOOKING_NUMBER_REQUIRED(HttpStatus.BAD_REQUEST, "SEAT_400_002", "좌석 선점에는 예매 번호가 필요합니다."),
 
   // Seat 404
   SEAT_NOT_FOUND(HttpStatus.NOT_FOUND, "SEAT_404_001", "해당 좌석을 찾을 수 없습니다."),

--- a/common/src/main/java/com/ticketrush/shared/booking/event/BookingCanceledEvent.java
+++ b/common/src/main/java/com/ticketrush/shared/booking/event/BookingCanceledEvent.java
@@ -1,0 +1,33 @@
+package com.ticketrush.shared.booking.event;
+
+import com.ticketrush.global.event.DomainEvent;
+import com.ticketrush.global.event.EventUtils;
+import java.time.LocalDateTime;
+
+public record BookingCanceledEvent(
+    Long bookingId, String bookingNumber, Long seatId, Long userId, LocalDateTime canceledAt)
+    implements DomainEvent {
+
+  public static final String TOPIC = "booking-canceled-topic";
+  public static final String EVENT_NAME = "BookingCanceledEvent";
+
+  @Override
+  public String topic() {
+    return TOPIC;
+  }
+
+  @Override
+  public String key() {
+    return String.valueOf(bookingId);
+  }
+
+  @Override
+  public String eventName() {
+    return EVENT_NAME;
+  }
+
+  @Override
+  public String traceId() {
+    return EventUtils.extractTraceId();
+  }
+}

--- a/common/src/main/java/com/ticketrush/shared/booking/event/BookingCreatedEvent.java
+++ b/common/src/main/java/com/ticketrush/shared/booking/event/BookingCreatedEvent.java
@@ -3,7 +3,8 @@ package com.ticketrush.shared.booking.event;
 import com.ticketrush.global.event.DomainEvent;
 import com.ticketrush.global.event.EventUtils;
 
-public record BookingCreatedEvent(Long bookingId, Long seatId, Long performanceId, Long userId)
+public record BookingCreatedEvent(
+    Long bookingId, String bookingNumber, Long seatId, Long performanceId, Long userId)
     implements DomainEvent {
 
   @Override

--- a/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/app/facade/SeatFacade.java
+++ b/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/app/facade/SeatFacade.java
@@ -11,6 +11,7 @@ import com.ticketrush.boundedcontext.seat.app.usecase.SeatGetSeatLayoutsUseCase;
 import com.ticketrush.boundedcontext.seat.app.usecase.SeatGetStatusCountsUseCase;
 import com.ticketrush.boundedcontext.seat.app.usecase.SeatHoldUseCase;
 import com.ticketrush.boundedcontext.seat.app.usecase.SeatLockUseCase;
+import com.ticketrush.boundedcontext.seat.app.usecase.SeatReleaseReservationUseCase;
 import com.ticketrush.boundedcontext.seat.app.usecase.SeatUnlockUseCase;
 import com.ticketrush.boundedcontext.seat.out.repository.SeatLayoutRepository;
 import com.ticketrush.global.eventpublisher.EventPublisher;
@@ -36,6 +37,7 @@ public class SeatFacade {
   private final SeatConfirmSoldUseCase seatConfirmSoldUseCase;
   private final SeatHoldUseCase seatHoldUseCase;
   private final SeatLockUseCase seatLockUseCase;
+  private final SeatReleaseReservationUseCase seatReleaseReservationUseCase;
   private final SeatUnlockUseCase seatUnlockUseCase;
   private final SeatStatusStreamSubscriber seatStatusStreamSubscriber;
   private final SeatLayoutRepository seatLayoutRepository;
@@ -78,14 +80,18 @@ public class SeatFacade {
     seatConfirmSoldUseCase.execute(bookingNumber, seatId);
   }
 
-  public void tryLockSeat(Long bookingId, Long seatId, Long userId) {
+  public void releaseReservation(Long seatId, String bookingNumber) {
+    seatReleaseReservationUseCase.execute(seatId, bookingNumber);
+  }
+
+  public void tryLockSeat(Long bookingId, String bookingNumber, Long seatId, Long userId) {
     // 1. Redis 락 시도
     Optional<LocalDateTime> holdExpiredAtOpt = seatLockUseCase.execute(seatId, userId);
 
     if (holdExpiredAtOpt.isPresent()) {
       try {
         // 2-A. 성공: Seat DB 상태를 HOLD로 업데이트
-        seatHoldUseCase.execute(seatId, holdExpiredAtOpt.get());
+        seatHoldUseCase.execute(seatId, holdExpiredAtOpt.get(), bookingNumber);
 
       } catch (Exception e) {
         log.error("좌석 DB 업데이트 중 오류 발생. Redis 락 해제 및 보상 이벤트 발행. seatId: {}", seatId, e);

--- a/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/app/facade/SeatFacade.java
+++ b/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/app/facade/SeatFacade.java
@@ -11,7 +11,7 @@ import com.ticketrush.boundedcontext.seat.app.usecase.SeatGetSeatLayoutsUseCase;
 import com.ticketrush.boundedcontext.seat.app.usecase.SeatGetStatusCountsUseCase;
 import com.ticketrush.boundedcontext.seat.app.usecase.SeatHoldUseCase;
 import com.ticketrush.boundedcontext.seat.app.usecase.SeatLockUseCase;
-import com.ticketrush.boundedcontext.seat.app.usecase.SeatReleaseReservationUseCase;
+import com.ticketrush.boundedcontext.seat.app.usecase.SeatReleaseBookedSeatUseCase;
 import com.ticketrush.boundedcontext.seat.app.usecase.SeatUnlockUseCase;
 import com.ticketrush.boundedcontext.seat.out.repository.SeatLayoutRepository;
 import com.ticketrush.global.eventpublisher.EventPublisher;
@@ -37,7 +37,7 @@ public class SeatFacade {
   private final SeatConfirmSoldUseCase seatConfirmSoldUseCase;
   private final SeatHoldUseCase seatHoldUseCase;
   private final SeatLockUseCase seatLockUseCase;
-  private final SeatReleaseReservationUseCase seatReleaseReservationUseCase;
+  private final SeatReleaseBookedSeatUseCase seatReleaseBookedSeatUseCase;
   private final SeatUnlockUseCase seatUnlockUseCase;
   private final SeatStatusStreamSubscriber seatStatusStreamSubscriber;
   private final SeatLayoutRepository seatLayoutRepository;
@@ -72,16 +72,12 @@ public class SeatFacade {
     }
   }
 
-  public void holdSeat(Long seatId, LocalDateTime holdExpiredAt) {
-    seatHoldUseCase.execute(seatId, holdExpiredAt);
-  }
-
   public void confirmSold(String bookingNumber, Long seatId) {
     seatConfirmSoldUseCase.execute(bookingNumber, seatId);
   }
 
-  public void releaseReservation(Long seatId, String bookingNumber) {
-    seatReleaseReservationUseCase.execute(seatId, bookingNumber);
+  public void releaseBookedSeat(Long seatId, String bookingNumber) {
+    seatReleaseBookedSeatUseCase.execute(seatId, bookingNumber);
   }
 
   public void tryLockSeat(Long bookingId, String bookingNumber, Long seatId, Long userId) {

--- a/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/app/usecase/SeatConfirmSoldUseCase.java
+++ b/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/app/usecase/SeatConfirmSoldUseCase.java
@@ -24,7 +24,8 @@ public class SeatConfirmSoldUseCase {
 
   @Transactional
   public void execute(String bookingNumber, Long seatId) {
-    int updatedCount = seatRepository.confirmSoldById(seatId, SeatStatus.HOLD, SeatStatus.SOLD);
+    int updatedCount =
+        seatRepository.confirmSoldById(seatId, bookingNumber, SeatStatus.HOLD, SeatStatus.SOLD);
 
     if (updatedCount == 1) {
       Seat seat =

--- a/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/app/usecase/SeatHoldUseCase.java
+++ b/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/app/usecase/SeatHoldUseCase.java
@@ -19,12 +19,16 @@ public class SeatHoldUseCase {
   private final SeatStatusEventPublisher seatStatusEventPublisher;
 
   public void execute(Long seatId, LocalDateTime holdExpiredAt) {
+    execute(seatId, holdExpiredAt, null);
+  }
+
+  public void execute(Long seatId, LocalDateTime holdExpiredAt, String bookingNumber) {
     Seat seat =
         seatRepository
             .findById(seatId)
             .orElseThrow(() -> new BusinessException(ErrorStatus.SEAT_NOT_FOUND));
 
-    seat.hold(holdExpiredAt);
+    seat.hold(holdExpiredAt, bookingNumber);
     seatStatusEventPublisher.publishAfterCommit(seat);
   }
 }

--- a/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/app/usecase/SeatHoldUseCase.java
+++ b/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/app/usecase/SeatHoldUseCase.java
@@ -18,10 +18,6 @@ public class SeatHoldUseCase {
   private final SeatRepository seatRepository;
   private final SeatStatusEventPublisher seatStatusEventPublisher;
 
-  public void execute(Long seatId, LocalDateTime holdExpiredAt) {
-    execute(seatId, holdExpiredAt, null);
-  }
-
   public void execute(Long seatId, LocalDateTime holdExpiredAt, String bookingNumber) {
     Seat seat =
         seatRepository

--- a/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/app/usecase/SeatReleaseBookedSeatUseCase.java
+++ b/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/app/usecase/SeatReleaseBookedSeatUseCase.java
@@ -14,13 +14,18 @@ import org.springframework.transaction.annotation.Transactional;
 @Slf4j
 @Service
 @RequiredArgsConstructor
-public class SeatReleaseReservationUseCase {
+public class SeatReleaseBookedSeatUseCase {
 
   private final SeatRepository seatRepository;
   private final SeatStatusEventPublisher seatStatusEventPublisher;
 
   @Transactional
   public void execute(Long seatId, String bookingNumber) {
+    if (bookingNumber == null || bookingNumber.isBlank()) {
+      log.warn("예매 취소 좌석 반환 스킵: 이벤트 예매 번호가 없습니다. seatId: {}", seatId);
+      return;
+    }
+
     var seat =
         seatRepository
             .findById(seatId)
@@ -31,8 +36,12 @@ public class SeatReleaseReservationUseCase {
       return;
     }
 
-    if (seat.getBookingNumber() != null
-        && !Objects.equals(seat.getBookingNumber(), bookingNumber)) {
+    if (seat.getBookingNumber() == null) {
+      log.warn("예매 취소 좌석 반환 스킵: 좌석의 예매 번호가 없어 이벤트 예매 번호를 검증할 수 없습니다. seatId: {}", seatId);
+      return;
+    }
+
+    if (!Objects.equals(seat.getBookingNumber(), bookingNumber)) {
       log.warn(
           "예매 취소 좌석 반환 스킵: 좌석의 예매 번호가 이벤트와 다릅니다. seatId: {}, eventBookingNumber: {}",
           seatId,
@@ -40,12 +49,7 @@ public class SeatReleaseReservationUseCase {
       return;
     }
 
-    if (seat.getBookingNumber() == null) {
-      log.warn("예매 취소 좌석 반환 스킵: 좌석의 예매 번호가 없어 이벤트 예매 번호를 검증할 수 없습니다. seatId: {}", seatId);
-      return;
-    }
-
-    seat.releaseReservation();
+    seat.releaseBooking();
     seatStatusEventPublisher.publishAfterCommit(seat);
     log.info("예매 취소 좌석 반환 완료. seatId: {}", seatId);
   }

--- a/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/app/usecase/SeatReleaseReservationUseCase.java
+++ b/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/app/usecase/SeatReleaseReservationUseCase.java
@@ -1,0 +1,46 @@
+package com.ticketrush.boundedcontext.seat.app.usecase;
+
+import com.ticketrush.boundedcontext.seat.app.support.SeatStatusEventPublisher;
+import com.ticketrush.boundedcontext.seat.out.repository.SeatRepository;
+import com.ticketrush.global.exception.BusinessException;
+import com.ticketrush.global.status.ErrorStatus;
+import com.ticketrush.global.types.SeatStatus;
+import java.util.Objects;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class SeatReleaseReservationUseCase {
+
+  private final SeatRepository seatRepository;
+  private final SeatStatusEventPublisher seatStatusEventPublisher;
+
+  @Transactional
+  public void execute(Long seatId, String bookingNumber) {
+    var seat =
+        seatRepository
+            .findById(seatId)
+            .orElseThrow(() -> new BusinessException(ErrorStatus.SEAT_NOT_FOUND));
+
+    if (seat.getSeatStatus() == SeatStatus.AVAILABLE) {
+      log.info("예매 취소 좌석 반환 스킵: 이미 AVAILABLE 상태입니다. seatId: {}", seatId);
+      return;
+    }
+
+    if (!Objects.equals(seat.getBookingNumber(), bookingNumber)) {
+      log.warn(
+          "예매 취소 좌석 반환 스킵: 좌석의 예매 번호가 이벤트와 다릅니다. seatId: {}, eventBookingNumber: {}",
+          seatId,
+          bookingNumber);
+      return;
+    }
+
+    seat.releaseReservation();
+    seatStatusEventPublisher.publishAfterCommit(seat);
+    log.info("예매 취소 좌석 반환 완료. seatId: {}", seatId);
+  }
+}

--- a/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/app/usecase/SeatReleaseReservationUseCase.java
+++ b/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/app/usecase/SeatReleaseReservationUseCase.java
@@ -31,12 +31,17 @@ public class SeatReleaseReservationUseCase {
       return;
     }
 
-    if (!Objects.equals(seat.getBookingNumber(), bookingNumber)) {
+    if (seat.getBookingNumber() != null
+        && !Objects.equals(seat.getBookingNumber(), bookingNumber)) {
       log.warn(
           "예매 취소 좌석 반환 스킵: 좌석의 예매 번호가 이벤트와 다릅니다. seatId: {}, eventBookingNumber: {}",
           seatId,
           bookingNumber);
       return;
+    }
+
+    if (seat.getBookingNumber() == null) {
+      log.warn("예매 취소 좌석 반환: 좌석의 예매 번호가 없어 이벤트 예매 번호 검증을 생략합니다. seatId: {}", seatId);
     }
 
     seat.releaseReservation();

--- a/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/app/usecase/SeatReleaseReservationUseCase.java
+++ b/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/app/usecase/SeatReleaseReservationUseCase.java
@@ -41,7 +41,8 @@ public class SeatReleaseReservationUseCase {
     }
 
     if (seat.getBookingNumber() == null) {
-      log.warn("예매 취소 좌석 반환: 좌석의 예매 번호가 없어 이벤트 예매 번호 검증을 생략합니다. seatId: {}", seatId);
+      log.warn("예매 취소 좌석 반환 스킵: 좌석의 예매 번호가 없어 이벤트 예매 번호를 검증할 수 없습니다. seatId: {}", seatId);
+      return;
     }
 
     seat.releaseReservation();

--- a/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/domain/entity/Seat.java
+++ b/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/domain/entity/Seat.java
@@ -39,21 +39,30 @@ public class Seat extends AutoIdBaseEntity {
   @Column(name = "hold_expired_at")
   private LocalDateTime holdExpiredAt;
 
+  @Column(name = "booking_number", length = 50)
+  private String bookingNumber;
+
   @Builder
   public Seat(
       Long seatLayoutId,
       Long performanceId,
       String seatNumber,
       SeatStatus seatStatus,
-      LocalDateTime holdExpiredAt) {
+      LocalDateTime holdExpiredAt,
+      String bookingNumber) {
     this.seatLayoutId = seatLayoutId;
     this.performanceId = performanceId;
     this.seatNumber = seatNumber;
     this.seatStatus = seatStatus;
     this.holdExpiredAt = holdExpiredAt;
+    this.bookingNumber = bookingNumber;
   }
 
   public void hold(LocalDateTime expiredAt) {
+    hold(expiredAt, null);
+  }
+
+  public void hold(LocalDateTime expiredAt, String bookingNumber) {
     // 1. 상태 검증
     if (this.seatStatus != SeatStatus.AVAILABLE) {
       throw new BusinessException(ErrorStatus.SEAT_NOT_AVAILABLE);
@@ -67,12 +76,22 @@ public class Seat extends AutoIdBaseEntity {
     // 3. 상태 업데이트
     this.seatStatus = SeatStatus.HOLD;
     this.holdExpiredAt = expiredAt;
+    this.bookingNumber = bookingNumber;
   }
 
   public void releaseHold() {
     if (this.seatStatus == SeatStatus.HOLD) {
       this.seatStatus = SeatStatus.AVAILABLE;
       this.holdExpiredAt = null;
+      this.bookingNumber = null;
+    }
+  }
+
+  public void releaseReservation() {
+    if (this.seatStatus == SeatStatus.HOLD || this.seatStatus == SeatStatus.SOLD) {
+      this.seatStatus = SeatStatus.AVAILABLE;
+      this.holdExpiredAt = null;
+      this.bookingNumber = null;
     }
   }
 }

--- a/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/domain/entity/Seat.java
+++ b/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/domain/entity/Seat.java
@@ -58,22 +58,23 @@ public class Seat extends AutoIdBaseEntity {
     this.bookingNumber = bookingNumber;
   }
 
-  public void hold(LocalDateTime expiredAt) {
-    hold(expiredAt, null);
-  }
-
   public void hold(LocalDateTime expiredAt, String bookingNumber) {
     // 1. 상태 검증
     if (this.seatStatus != SeatStatus.AVAILABLE) {
       throw new BusinessException(ErrorStatus.SEAT_NOT_AVAILABLE);
     }
 
-    // 2. 시간 유효성 검증
+    // 2. 예매 번호 유효성 검증
+    if (bookingNumber == null || bookingNumber.isBlank()) {
+      throw new BusinessException(ErrorStatus.SEAT_BOOKING_NUMBER_REQUIRED);
+    }
+
+    // 3. 시간 유효성 검증
     if (expiredAt == null || expiredAt.isBefore(LocalDateTime.now())) {
       throw new BusinessException(ErrorStatus.SEAT_HOLD_TIME_INVALID);
     }
 
-    // 3. 상태 업데이트
+    // 4. 상태 업데이트
     this.seatStatus = SeatStatus.HOLD;
     this.holdExpiredAt = expiredAt;
     this.bookingNumber = bookingNumber;
@@ -87,7 +88,7 @@ public class Seat extends AutoIdBaseEntity {
     }
   }
 
-  public void releaseReservation() {
+  public void releaseBooking() {
     if (this.seatStatus == SeatStatus.HOLD || this.seatStatus == SeatStatus.SOLD) {
       this.seatStatus = SeatStatus.AVAILABLE;
       this.holdExpiredAt = null;

--- a/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/in/eventlistener/BookingCanceledEventListener.java
+++ b/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/in/eventlistener/BookingCanceledEventListener.java
@@ -1,0 +1,37 @@
+package com.ticketrush.boundedcontext.seat.in.eventlistener;
+
+import com.ticketrush.boundedcontext.seat.app.facade.SeatFacade;
+import com.ticketrush.global.event.DomainEventEnvelope;
+import com.ticketrush.global.json.JsonConverter;
+import com.ticketrush.shared.booking.event.BookingCanceledEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class BookingCanceledEventListener {
+
+  private final SeatFacade seatFacade;
+  private final JsonConverter jsonConverter;
+
+  @KafkaListener(topics = BookingCanceledEvent.TOPIC, groupId = "seat-group")
+  public void handleBookingCanceled(@Payload DomainEventEnvelope envelope, Acknowledgment ack) {
+    BookingCanceledEvent event = null;
+
+    try {
+      event = jsonConverter.deserialize(envelope.payload(), BookingCanceledEvent.class);
+      seatFacade.releaseReservation(event.seatId(), event.bookingNumber());
+    } catch (Exception e) {
+      Long bookingId = event != null ? event.bookingId() : null;
+      log.error("예매 취소 좌석 반환 이벤트 처리 실패. bookingId: {}", bookingId, e);
+      throw e;
+    }
+
+    ack.acknowledge();
+  }
+}

--- a/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/in/eventlistener/BookingCanceledEventListener.java
+++ b/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/in/eventlistener/BookingCanceledEventListener.java
@@ -25,7 +25,7 @@ public class BookingCanceledEventListener {
 
     try {
       event = jsonConverter.deserialize(envelope.payload(), BookingCanceledEvent.class);
-      seatFacade.releaseReservation(event.seatId(), event.bookingNumber());
+      seatFacade.releaseBookedSeat(event.seatId(), event.bookingNumber());
     } catch (Exception e) {
       Long bookingId = event != null ? event.bookingId() : null;
       log.error("예매 취소 좌석 반환 이벤트 처리 실패. bookingId: {}", bookingId, e);

--- a/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/in/eventlistener/BookingCreatedEventListener.java
+++ b/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/in/eventlistener/BookingCreatedEventListener.java
@@ -50,7 +50,8 @@ public class BookingCreatedEventListener {
       BookingCreatedEvent event =
           jsonConverter.deserialize(envelope.payload(), BookingCreatedEvent.class);
 
-      seatFacade.tryLockSeat(event.bookingId(), event.seatId(), event.userId());
+      seatFacade.tryLockSeat(
+          event.bookingId(), event.bookingNumber(), event.seatId(), event.userId());
 
     } catch (Exception e) {
       log.error("이벤트 처리 중 에러 발생. 재시도를 위해 멱등성 키를 롤백합니다. eventId: {}", eventId, e);

--- a/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/out/repository/SeatRepository.java
+++ b/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/out/repository/SeatRepository.java
@@ -72,9 +72,12 @@ public interface SeatRepository extends JpaRepository<Seat, Long> {
   @Modifying(clearAutomatically = true)
   @Query(
       "UPDATE Seat s SET s.seatStatus = :soldStatus, s.holdExpiredAt = null "
-          + "WHERE s.id = :seatId AND s.seatStatus = :holdStatus")
+          + "WHERE s.id = :seatId "
+          + "AND s.bookingNumber = :bookingNumber "
+          + "AND s.seatStatus = :holdStatus")
   int confirmSoldById(
       @Param("seatId") Long seatId,
+      @Param("bookingNumber") String bookingNumber,
       @Param("holdStatus") SeatStatus holdStatus,
       @Param("soldStatus") SeatStatus soldStatus);
 }

--- a/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/app/usecase/SeatConfirmSoldUseCaseTest.java
+++ b/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/app/usecase/SeatConfirmSoldUseCaseTest.java
@@ -37,14 +37,15 @@ class SeatConfirmSoldUseCaseTest {
     Seat seat =
         Seat.builder().performanceId(1L).seatNumber("A-1").seatStatus(SeatStatus.SOLD).build();
 
-    given(seatRepository.confirmSoldById(seatId, SeatStatus.HOLD, SeatStatus.SOLD)).willReturn(1);
+    given(seatRepository.confirmSoldById(seatId, bookingNumber, SeatStatus.HOLD, SeatStatus.SOLD))
+        .willReturn(1);
     given(seatRepository.findById(seatId)).willReturn(Optional.of(seat));
 
     // when
     seatConfirmSoldUseCase.execute(bookingNumber, seatId);
 
     // then
-    verify(seatRepository).confirmSoldById(seatId, SeatStatus.HOLD, SeatStatus.SOLD);
+    verify(seatRepository).confirmSoldById(seatId, bookingNumber, SeatStatus.HOLD, SeatStatus.SOLD);
     verify(seatRepository).findById(seatId);
     verify(seatStatusEventPublisher).publishAfterCommit(seat);
     verify(seatUnlockUseCase).forceRelease(seatId);
@@ -55,17 +56,19 @@ class SeatConfirmSoldUseCaseTest {
   void execute_fail_seat_not_found() {
     // given
     Long seatId = 1L;
+    String bookingNumber = "X7B29-KLPW1";
 
-    given(seatRepository.confirmSoldById(seatId, SeatStatus.HOLD, SeatStatus.SOLD)).willReturn(0);
+    given(seatRepository.confirmSoldById(seatId, bookingNumber, SeatStatus.HOLD, SeatStatus.SOLD))
+        .willReturn(0);
     given(seatRepository.existsById(seatId)).willReturn(false);
 
     // when & then
-    assertThatThrownBy(() -> seatConfirmSoldUseCase.execute("X7B29-KLPW1", seatId))
+    assertThatThrownBy(() -> seatConfirmSoldUseCase.execute(bookingNumber, seatId))
         .isInstanceOf(BusinessException.class)
         .extracting("errorStatus")
         .isEqualTo(ErrorStatus.SEAT_NOT_FOUND);
 
-    verify(seatRepository).confirmSoldById(seatId, SeatStatus.HOLD, SeatStatus.SOLD);
+    verify(seatRepository).confirmSoldById(seatId, bookingNumber, SeatStatus.HOLD, SeatStatus.SOLD);
     verify(seatRepository).existsById(seatId);
     verifyNoMoreInteractions(seatRepository, seatUnlockUseCase);
   }
@@ -75,17 +78,19 @@ class SeatConfirmSoldUseCaseTest {
   void execute_fail_seat_not_hold() {
     // given
     Long seatId = 1L;
+    String bookingNumber = "X7B29-KLPW1";
 
-    given(seatRepository.confirmSoldById(seatId, SeatStatus.HOLD, SeatStatus.SOLD)).willReturn(0);
+    given(seatRepository.confirmSoldById(seatId, bookingNumber, SeatStatus.HOLD, SeatStatus.SOLD))
+        .willReturn(0);
     given(seatRepository.existsById(seatId)).willReturn(true);
 
     // when & then
-    assertThatThrownBy(() -> seatConfirmSoldUseCase.execute("X7B29-KLPW1", seatId))
+    assertThatThrownBy(() -> seatConfirmSoldUseCase.execute(bookingNumber, seatId))
         .isInstanceOf(BusinessException.class)
         .extracting("errorStatus")
         .isEqualTo(ErrorStatus.SEAT_NOT_AVAILABLE);
 
-    verify(seatRepository).confirmSoldById(seatId, SeatStatus.HOLD, SeatStatus.SOLD);
+    verify(seatRepository).confirmSoldById(seatId, bookingNumber, SeatStatus.HOLD, SeatStatus.SOLD);
     verify(seatRepository).existsById(seatId);
     verifyNoMoreInteractions(seatRepository, seatUnlockUseCase);
   }

--- a/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/app/usecase/SeatHoldUseCaseTest.java
+++ b/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/app/usecase/SeatHoldUseCaseTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 
 import com.ticketrush.boundedcontext.seat.app.support.SeatStatusEventPublisher;
 import com.ticketrush.boundedcontext.seat.domain.entity.Seat;
@@ -33,6 +34,7 @@ class SeatHoldUseCaseTest {
   void execute_success() {
     // given
     Long seatId = 1L;
+    String bookingNumber = "BOOK-1234";
     LocalDateTime expiredAt = LocalDateTime.now().plusMinutes(5);
 
     // mock() 대신 실제 Seat 객체 생성 (초기 상태: AVAILABLE)
@@ -47,13 +49,41 @@ class SeatHoldUseCaseTest {
     given(seatRepository.findById(seatId)).willReturn(Optional.of(seat));
 
     // when
-    seatHoldUseCase.execute(seatId, expiredAt);
+    seatHoldUseCase.execute(seatId, expiredAt, bookingNumber);
 
     // then
     // verify(mock) 대신 실제 객체의 상태가 변했는지 직접 확인
     assertThat(seat.getSeatStatus()).isEqualTo(SeatStatus.HOLD);
     assertThat(seat.getHoldExpiredAt()).isEqualTo(expiredAt);
+    assertThat(seat.getBookingNumber()).isEqualTo(bookingNumber);
     verify(seatStatusEventPublisher).publishAfterCommit(seat);
+  }
+
+  @Test
+  @DisplayName("실패: 예매 번호가 없으면 BusinessException(SEAT_BOOKING_NUMBER_REQUIRED)이 발생한다")
+  void execute_fail_booking_number_required() {
+    // given
+    Long seatId = 1L;
+    LocalDateTime expiredAt = LocalDateTime.now().plusMinutes(5);
+
+    Seat seat =
+        Seat.builder()
+            .seatLayoutId(10L)
+            .performanceId(100L)
+            .seatNumber("A-01")
+            .seatStatus(SeatStatus.AVAILABLE)
+            .build();
+
+    given(seatRepository.findById(seatId)).willReturn(Optional.of(seat));
+
+    // when & then
+    assertThatThrownBy(() -> seatHoldUseCase.execute(seatId, expiredAt, " "))
+        .isInstanceOf(BusinessException.class)
+        .extracting("errorStatus")
+        .isEqualTo(ErrorStatus.SEAT_BOOKING_NUMBER_REQUIRED);
+
+    assertThat(seat.getSeatStatus()).isEqualTo(SeatStatus.AVAILABLE);
+    verifyNoInteractions(seatStatusEventPublisher);
   }
 
   @Test
@@ -68,7 +98,7 @@ class SeatHoldUseCaseTest {
     given(seatRepository.findById(seatId)).willReturn(Optional.of(seat));
 
     // when & then
-    assertThatThrownBy(() -> seatHoldUseCase.execute(seatId, pastTime))
+    assertThatThrownBy(() -> seatHoldUseCase.execute(seatId, pastTime, "BOOK-1234"))
         .isInstanceOf(BusinessException.class)
         .extracting("errorStatus")
         .isEqualTo(ErrorStatus.SEAT_HOLD_TIME_INVALID);
@@ -84,7 +114,7 @@ class SeatHoldUseCaseTest {
     given(seatRepository.findById(seatId)).willReturn(Optional.empty());
 
     // when & then
-    assertThatThrownBy(() -> seatHoldUseCase.execute(seatId, expiredAt))
+    assertThatThrownBy(() -> seatHoldUseCase.execute(seatId, expiredAt, "BOOK-1234"))
         .isInstanceOf(BusinessException.class)
         .extracting("errorStatus")
         .isEqualTo(ErrorStatus.SEAT_NOT_FOUND);

--- a/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/app/usecase/SeatReleaseBookedSeatUseCaseTest.java
+++ b/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/app/usecase/SeatReleaseBookedSeatUseCaseTest.java
@@ -21,9 +21,9 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
-class SeatReleaseReservationUseCaseTest {
+class SeatReleaseBookedSeatUseCaseTest {
 
-  @InjectMocks private SeatReleaseReservationUseCase seatReleaseReservationUseCase;
+  @InjectMocks private SeatReleaseBookedSeatUseCase seatReleaseBookedSeatUseCase;
 
   @Mock private SeatRepository seatRepository;
   @Mock private SeatStatusEventPublisher seatStatusEventPublisher;
@@ -44,11 +44,21 @@ class SeatReleaseReservationUseCaseTest {
     given(seatRepository.findById(seatId)).willReturn(Optional.of(seat));
 
     // when
-    seatReleaseReservationUseCase.execute(seatId, bookingNumber);
+    seatReleaseBookedSeatUseCase.execute(seatId, bookingNumber);
 
     // then
     assertThat(seat.getSeatStatus()).isEqualTo(SeatStatus.AVAILABLE);
     verify(seatStatusEventPublisher).publishAfterCommit(seat);
+  }
+
+  @Test
+  @DisplayName("성공: 이벤트의 예매 번호가 없으면 안전하게 스킵한다")
+  void execute_skip_when_event_booking_number_is_blank() {
+    // when
+    seatReleaseBookedSeatUseCase.execute(1L, " ");
+
+    // then
+    verifyNoInteractions(seatRepository, seatStatusEventPublisher);
   }
 
   @Test
@@ -62,7 +72,7 @@ class SeatReleaseReservationUseCaseTest {
     given(seatRepository.findById(seatId)).willReturn(Optional.of(seat));
 
     // when
-    seatReleaseReservationUseCase.execute(seatId, bookingNumber);
+    seatReleaseBookedSeatUseCase.execute(seatId, bookingNumber);
 
     // then
     assertThat(seat.getSeatStatus()).isEqualTo(SeatStatus.AVAILABLE);
@@ -79,7 +89,7 @@ class SeatReleaseReservationUseCaseTest {
     given(seatRepository.findById(seatId)).willReturn(Optional.of(seat));
 
     // when
-    seatReleaseReservationUseCase.execute(seatId, "BOOK-1234");
+    seatReleaseBookedSeatUseCase.execute(seatId, "BOOK-1234");
 
     // then
     assertThat(seat.getSeatStatus()).isEqualTo(SeatStatus.SOLD);
@@ -101,7 +111,7 @@ class SeatReleaseReservationUseCaseTest {
     given(seatRepository.findById(seatId)).willReturn(Optional.of(seat));
 
     // when
-    seatReleaseReservationUseCase.execute(seatId, "BOOK-1234");
+    seatReleaseBookedSeatUseCase.execute(seatId, "BOOK-1234");
 
     // then
     assertThat(seat.getSeatStatus()).isEqualTo(SeatStatus.SOLD);
@@ -116,7 +126,7 @@ class SeatReleaseReservationUseCaseTest {
     given(seatRepository.findById(seatId)).willReturn(Optional.empty());
 
     // when & then
-    assertThatThrownBy(() -> seatReleaseReservationUseCase.execute(seatId, "BOOK-1234"))
+    assertThatThrownBy(() -> seatReleaseBookedSeatUseCase.execute(seatId, "BOOK-1234"))
         .isInstanceOf(BusinessException.class)
         .extracting(ex -> ((BusinessException) ex).getErrorStatus())
         .isEqualTo(SEAT_NOT_FOUND);

--- a/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/app/usecase/SeatReleaseReservationUseCaseTest.java
+++ b/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/app/usecase/SeatReleaseReservationUseCaseTest.java
@@ -70,6 +70,23 @@ class SeatReleaseReservationUseCaseTest {
   }
 
   @Test
+  @DisplayName("성공: 좌석의 예매 번호가 없으면 레거시 데이터로 보고 반환을 허용한다")
+  void execute_success_when_seat_booking_number_is_null() {
+    // given
+    Long seatId = 1L;
+    Seat seat =
+        Seat.builder().performanceId(1L).seatNumber("A-1").seatStatus(SeatStatus.SOLD).build();
+    given(seatRepository.findById(seatId)).willReturn(Optional.of(seat));
+
+    // when
+    seatReleaseReservationUseCase.execute(seatId, "BOOK-1234");
+
+    // then
+    assertThat(seat.getSeatStatus()).isEqualTo(SeatStatus.AVAILABLE);
+    verify(seatStatusEventPublisher).publishAfterCommit(seat);
+  }
+
+  @Test
   @DisplayName("성공: 이벤트의 예매 번호와 좌석의 예매 번호가 다르면 스킵한다")
   void execute_skip_when_booking_number_mismatched() {
     // given

--- a/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/app/usecase/SeatReleaseReservationUseCaseTest.java
+++ b/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/app/usecase/SeatReleaseReservationUseCaseTest.java
@@ -70,8 +70,8 @@ class SeatReleaseReservationUseCaseTest {
   }
 
   @Test
-  @DisplayName("성공: 좌석의 예매 번호가 없으면 레거시 데이터로 보고 반환을 허용한다")
-  void execute_success_when_seat_booking_number_is_null() {
+  @DisplayName("성공: 좌석의 예매 번호가 없으면 안전하게 스킵한다")
+  void execute_skip_when_seat_booking_number_is_null() {
     // given
     Long seatId = 1L;
     Seat seat =
@@ -82,8 +82,8 @@ class SeatReleaseReservationUseCaseTest {
     seatReleaseReservationUseCase.execute(seatId, "BOOK-1234");
 
     // then
-    assertThat(seat.getSeatStatus()).isEqualTo(SeatStatus.AVAILABLE);
-    verify(seatStatusEventPublisher).publishAfterCommit(seat);
+    assertThat(seat.getSeatStatus()).isEqualTo(SeatStatus.SOLD);
+    verifyNoInteractions(seatStatusEventPublisher);
   }
 
   @Test

--- a/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/app/usecase/SeatReleaseReservationUseCaseTest.java
+++ b/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/app/usecase/SeatReleaseReservationUseCaseTest.java
@@ -1,0 +1,109 @@
+package com.ticketrush.boundedcontext.seat.app.usecase;
+
+import static com.ticketrush.global.status.ErrorStatus.SEAT_NOT_FOUND;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import com.ticketrush.boundedcontext.seat.app.support.SeatStatusEventPublisher;
+import com.ticketrush.boundedcontext.seat.domain.entity.Seat;
+import com.ticketrush.boundedcontext.seat.out.repository.SeatRepository;
+import com.ticketrush.global.exception.BusinessException;
+import com.ticketrush.global.types.SeatStatus;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class SeatReleaseReservationUseCaseTest {
+
+  @InjectMocks private SeatReleaseReservationUseCase seatReleaseReservationUseCase;
+
+  @Mock private SeatRepository seatRepository;
+  @Mock private SeatStatusEventPublisher seatStatusEventPublisher;
+
+  @Test
+  @DisplayName("성공: SOLD 좌석을 AVAILABLE로 반환하고 상태 변경 이벤트를 발행한다")
+  void execute_success_when_sold() {
+    // given
+    Long seatId = 1L;
+    String bookingNumber = "BOOK-1234";
+    Seat seat =
+        Seat.builder()
+            .performanceId(1L)
+            .seatNumber("A-1")
+            .seatStatus(SeatStatus.SOLD)
+            .bookingNumber(bookingNumber)
+            .build();
+    given(seatRepository.findById(seatId)).willReturn(Optional.of(seat));
+
+    // when
+    seatReleaseReservationUseCase.execute(seatId, bookingNumber);
+
+    // then
+    assertThat(seat.getSeatStatus()).isEqualTo(SeatStatus.AVAILABLE);
+    verify(seatStatusEventPublisher).publishAfterCommit(seat);
+  }
+
+  @Test
+  @DisplayName("성공: 이미 AVAILABLE 좌석이면 멱등하게 스킵한다")
+  void execute_skip_when_already_available() {
+    // given
+    Long seatId = 1L;
+    String bookingNumber = "BOOK-1234";
+    Seat seat =
+        Seat.builder().performanceId(1L).seatNumber("A-1").seatStatus(SeatStatus.AVAILABLE).build();
+    given(seatRepository.findById(seatId)).willReturn(Optional.of(seat));
+
+    // when
+    seatReleaseReservationUseCase.execute(seatId, bookingNumber);
+
+    // then
+    assertThat(seat.getSeatStatus()).isEqualTo(SeatStatus.AVAILABLE);
+    verifyNoInteractions(seatStatusEventPublisher);
+  }
+
+  @Test
+  @DisplayName("성공: 이벤트의 예매 번호와 좌석의 예매 번호가 다르면 스킵한다")
+  void execute_skip_when_booking_number_mismatched() {
+    // given
+    Long seatId = 1L;
+    Seat seat =
+        Seat.builder()
+            .performanceId(1L)
+            .seatNumber("A-1")
+            .seatStatus(SeatStatus.SOLD)
+            .bookingNumber("BOOK-OTHER")
+            .build();
+    given(seatRepository.findById(seatId)).willReturn(Optional.of(seat));
+
+    // when
+    seatReleaseReservationUseCase.execute(seatId, "BOOK-1234");
+
+    // then
+    assertThat(seat.getSeatStatus()).isEqualTo(SeatStatus.SOLD);
+    verifyNoInteractions(seatStatusEventPublisher);
+  }
+
+  @Test
+  @DisplayName("실패: 좌석이 없으면 SEAT_NOT_FOUND를 던진다")
+  void execute_fail_when_seat_not_found() {
+    // given
+    Long seatId = 1L;
+    given(seatRepository.findById(seatId)).willReturn(Optional.empty());
+
+    // when & then
+    assertThatThrownBy(() -> seatReleaseReservationUseCase.execute(seatId, "BOOK-1234"))
+        .isInstanceOf(BusinessException.class)
+        .extracting(ex -> ((BusinessException) ex).getErrorStatus())
+        .isEqualTo(SEAT_NOT_FOUND);
+
+    verifyNoInteractions(seatStatusEventPublisher);
+  }
+}

--- a/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/out/repository/SeatRepositoryTest.java
+++ b/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/out/repository/SeatRepositoryTest.java
@@ -248,6 +248,7 @@ class SeatRepositoryTest {
             .seatNumber("A1")
             .seatStatus(SeatStatus.HOLD)
             .holdExpiredAt(holdExpiredAt)
+            .bookingNumber("BOOK-1234")
             .build();
 
     Seat availableSeat =
@@ -264,7 +265,8 @@ class SeatRepositoryTest {
 
     // when
     int updatedCount =
-        seatRepository.confirmSoldById(holdSeat1.getId(), SeatStatus.HOLD, SeatStatus.SOLD);
+        seatRepository.confirmSoldById(
+            holdSeat1.getId(), "BOOK-1234", SeatStatus.HOLD, SeatStatus.SOLD);
 
     // then
     assertThat(updatedCount).isEqualTo(1);


### PR DESCRIPTION
## 🔗 관련 이슈

- close #39

---

## 📌 주요 변경 사항

- `DELETE /api/v1/booking/{bookingNumber}` 사용자 예매 취소 API 추가
- 예매 취소 시 `BookingCanceledEvent` 발행 및 seat-service 좌석 반환 연동
- 좌석에 `bookingNumber`를 저장해 늦은/중복 이벤트가 다른 예매 좌석을 반환하지 않도록 방어

---

## 🛠 상세 구현 내용

- `BookingCancelMyBookingUseCase` 추가: `bookingNumber + userId`로 본인 예매만 조회하고 `CONFIRMED -> CANCELED` 전이
- `BookingCanceledEvent` 추가 및 seat-service `BookingCanceledEventListener`에서 좌석 반환 처리
- `BookingCreatedEvent`에 `bookingNumber`를 포함하고 seat HOLD/SOLD 처리 시 예매 번호 조건을 함께 검증
- `SeatReleaseReservationUseCase` 추가: SOLD/HOLD 좌석을 AVAILABLE로 반환, 이미 AVAILABLE이거나 예매 번호가 다르면 멱등하게 스킵

---

## ✅ 테스트

### 테스트 방법

- `./gradlew.bat :booking-service:test :seat-service:test`
- `./gradlew.bat :booking-service:check :seat-service:check :common:check`
- `git diff --check`

### 테스트 결과

- booking-service 테스트 통과
- seat-service 테스트 통과
- booking-service / seat-service / common check 통과
- diff whitespace 검사 통과

<!--
### 📸 스크린샷
-->

---

## 👀 리뷰 요청 사항

- 사용자 취소 가능 상태를 `CONFIRMED`로 제한한 정책이 현재 서비스 흐름과 맞는지 확인 부탁드립니다.
- 좌석 테이블에 nullable `booking_number`를 추가해 이벤트 정합성을 방어하는 방식이 적절한지 확인 부탁드립니다.

---

## ⚠️ 배포 시 주의사항

- `seat` 테이블에 nullable `booking_number` 컬럼이 추가됩니다.
- 신규 Kafka topic `booking-canceled-topic`을 사용합니다.