### PR TITLE
[Feat] #216 입장권 QR 토큰 발급

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.0-bin.zip
-networkTimeout=10000
+networkTimeout=60000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/ticket-service/build.gradle
+++ b/ticket-service/build.gradle
@@ -48,6 +48,10 @@ dependencies {
 
 	// swagger
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.1'
+
+	// Kafka
+	implementation 'org.springframework.boot:spring-boot-starter-kafka'
+	testImplementation 'org.springframework.boot:spring-boot-starter-kafka-test'
 }
 
 dependencyManagement {

--- a/ticket-service/src/main/java/com/ticketrush/boundedcontext/ticket/app/dto/response/TicketIssueResponse.java
+++ b/ticket-service/src/main/java/com/ticketrush/boundedcontext/ticket/app/dto/response/TicketIssueResponse.java
@@ -1,0 +1,12 @@
+package com.ticketrush.boundedcontext.ticket.app.dto.response;
+
+public record TicketIssueResponse(boolean issued, String token) {
+
+  public static TicketIssueResponse issued(String token) {
+    return new TicketIssueResponse(true, token);
+  }
+
+  public static TicketIssueResponse alreadyIssued() {
+    return new TicketIssueResponse(false, null);
+  }
+}

--- a/ticket-service/src/main/java/com/ticketrush/boundedcontext/ticket/app/support/TicketSaver.java
+++ b/ticket-service/src/main/java/com/ticketrush/boundedcontext/ticket/app/support/TicketSaver.java
@@ -1,0 +1,26 @@
+package com.ticketrush.boundedcontext.ticket.app.support;
+
+import com.ticketrush.boundedcontext.ticket.domain.entity.Ticket;
+import com.ticketrush.boundedcontext.ticket.out.repository.TicketRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 티켓 저장을 독립된 트랜잭션 경계(REQUIRES_NEW)에서 수행한다.
+ *
+ * <p>unique 제약 충돌로 INSERT가 실패하면 해당 트랜잭션만 rollback-only로 마킹되고, 발급 유스케이스의 바깥 트랜잭션은 오염되지 않는다. 덕분에
+ * 유스케이스가 충돌을 catch한 뒤에도 커밋 시점에 {@code UnexpectedRollbackException}이 발생하지 않는다.
+ */
+@Component
+@RequiredArgsConstructor
+public class TicketSaver {
+
+  private final TicketRepository ticketRepository;
+
+  @Transactional(propagation = Propagation.REQUIRES_NEW)
+  public void saveInNewTransaction(Ticket ticket) {
+    ticketRepository.saveAndFlush(ticket);
+  }
+}

--- a/ticket-service/src/main/java/com/ticketrush/boundedcontext/ticket/app/usecase/TicketIssueUseCase.java
+++ b/ticket-service/src/main/java/com/ticketrush/boundedcontext/ticket/app/usecase/TicketIssueUseCase.java
@@ -1,6 +1,7 @@
 package com.ticketrush.boundedcontext.ticket.app.usecase;
 
 import com.ticketrush.boundedcontext.ticket.app.dto.response.TicketIssueResponse;
+import com.ticketrush.boundedcontext.ticket.app.support.TicketSaver;
 import com.ticketrush.boundedcontext.ticket.domain.entity.Ticket;
 import com.ticketrush.boundedcontext.ticket.domain.policy.TicketTokenGenerator;
 import com.ticketrush.boundedcontext.ticket.domain.policy.TicketTokenHasher;
@@ -9,14 +10,17 @@ import com.ticketrush.boundedcontext.ticket.out.repository.TicketRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@Transactional
 @RequiredArgsConstructor
 public class TicketIssueUseCase {
 
   private final TicketRepository ticketRepository;
   private final TicketTokenGenerator ticketTokenGenerator;
   private final TicketTokenHasher ticketTokenHasher;
+  private final TicketSaver ticketSaver;
 
   public TicketIssueResponse execute(Long bookingId) {
     if (ticketRepository.existsByBookingId(bookingId)) {
@@ -32,10 +36,17 @@ public class TicketIssueUseCase {
             .build();
 
     try {
-      ticketRepository.saveAndFlush(ticket);
+      // 저장은 별도 트랜잭션(REQUIRES_NEW)에서 수행하므로, 충돌이 나도 이 유스케이스 트랜잭션은 정상 커밋된다.
+      ticketSaver.saveInNewTransaction(ticket);
       return TicketIssueResponse.issued(token);
     } catch (DataIntegrityViolationException e) {
-      return TicketIssueResponse.alreadyIssued();
+      // booking_id, ticket_token_hash 두 unique 제약 중 무엇이 깨졌는지 재조회로 구분한다.
+      if (ticketRepository.existsByBookingId(bookingId)) {
+        // booking_id 충돌 = 동시 발급 경쟁에서 진 것이므로 이미 발급된 것으로 간주한다.
+        return TicketIssueResponse.alreadyIssued();
+      }
+      // ticket_token_hash 충돌 = 토큰 재생성 후 재시도하면 해소되므로, 삼키지 않고 던져 재시도를 유도한다.
+      throw e;
     }
   }
 }

--- a/ticket-service/src/main/java/com/ticketrush/boundedcontext/ticket/app/usecase/TicketIssueUseCase.java
+++ b/ticket-service/src/main/java/com/ticketrush/boundedcontext/ticket/app/usecase/TicketIssueUseCase.java
@@ -1,0 +1,36 @@
+package com.ticketrush.boundedcontext.ticket.app.usecase;
+
+import com.ticketrush.boundedcontext.ticket.domain.entity.Ticket;
+import com.ticketrush.boundedcontext.ticket.domain.policy.TicketTokenGenerator;
+import com.ticketrush.boundedcontext.ticket.domain.policy.TicketTokenHasher;
+import com.ticketrush.boundedcontext.ticket.domain.types.TicketStatus;
+import com.ticketrush.boundedcontext.ticket.out.repository.TicketRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class TicketIssueUseCase {
+
+  private final TicketRepository ticketRepository;
+  private final TicketTokenGenerator ticketTokenGenerator;
+  private final TicketTokenHasher ticketTokenHasher;
+
+  public void execute(Long bookingId) {
+    if (ticketRepository.existsByBookingId(bookingId)) {
+      return;
+    }
+
+    String token = ticketTokenGenerator.generate();
+    Ticket ticket =
+        Ticket.builder()
+            .bookingId(bookingId)
+            .ticketTokenHash(ticketTokenHasher.hash(token))
+            .ticketStatus(TicketStatus.UNUSED)
+            .build();
+
+    ticketRepository.save(ticket);
+  }
+}

--- a/ticket-service/src/main/java/com/ticketrush/boundedcontext/ticket/app/usecase/TicketIssueUseCase.java
+++ b/ticket-service/src/main/java/com/ticketrush/boundedcontext/ticket/app/usecase/TicketIssueUseCase.java
@@ -1,16 +1,16 @@
 package com.ticketrush.boundedcontext.ticket.app.usecase;
 
+import com.ticketrush.boundedcontext.ticket.app.dto.response.TicketIssueResponse;
 import com.ticketrush.boundedcontext.ticket.domain.entity.Ticket;
 import com.ticketrush.boundedcontext.ticket.domain.policy.TicketTokenGenerator;
 import com.ticketrush.boundedcontext.ticket.domain.policy.TicketTokenHasher;
 import com.ticketrush.boundedcontext.ticket.domain.types.TicketStatus;
 import com.ticketrush.boundedcontext.ticket.out.repository.TicketRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
-@Transactional
 @RequiredArgsConstructor
 public class TicketIssueUseCase {
 
@@ -18,9 +18,9 @@ public class TicketIssueUseCase {
   private final TicketTokenGenerator ticketTokenGenerator;
   private final TicketTokenHasher ticketTokenHasher;
 
-  public void execute(Long bookingId) {
+  public TicketIssueResponse execute(Long bookingId) {
     if (ticketRepository.existsByBookingId(bookingId)) {
-      return;
+      return TicketIssueResponse.alreadyIssued();
     }
 
     String token = ticketTokenGenerator.generate();
@@ -31,6 +31,11 @@ public class TicketIssueUseCase {
             .ticketStatus(TicketStatus.UNUSED)
             .build();
 
-    ticketRepository.save(ticket);
+    try {
+      ticketRepository.saveAndFlush(ticket);
+      return TicketIssueResponse.issued(token);
+    } catch (DataIntegrityViolationException e) {
+      return TicketIssueResponse.alreadyIssued();
+    }
   }
 }

--- a/ticket-service/src/main/java/com/ticketrush/boundedcontext/ticket/domain/entity/Ticket.java
+++ b/ticket-service/src/main/java/com/ticketrush/boundedcontext/ticket/domain/entity/Ticket.java
@@ -8,6 +8,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.Table;
+import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -20,24 +21,23 @@ import lombok.NoArgsConstructor;
 @AttributeOverride(name = "id", column = @Column(name = "ticket_id"))
 public class Ticket extends AutoIdBaseEntity {
 
-  @Column(name = "booking_id", nullable = false)
+  @Column(name = "booking_id", nullable = false, unique = true)
   private Long bookingId;
 
-  @Column(name = "booking_number", length = 50, nullable = false)
-  private String bookingNumber;
-
-  @Column(name = "qr_code_url", length = 255, nullable = false)
-  private String qrCodeUrl;
+  @Column(name = "ticket_token_hash", length = 64, nullable = false, unique = true)
+  private String ticketTokenHash;
 
   @Enumerated(EnumType.STRING)
   @Column(name = "ticket_status", length = 20, nullable = false)
   private TicketStatus ticketStatus;
 
+  @Column(name = "used_at")
+  private LocalDateTime usedAt;
+
   @Builder
-  public Ticket(Long bookingId, String bookingNumber, String qrCodeUrl, TicketStatus ticketStatus) {
+  public Ticket(Long bookingId, String ticketTokenHash, TicketStatus ticketStatus) {
     this.bookingId = bookingId;
-    this.bookingNumber = bookingNumber;
-    this.qrCodeUrl = qrCodeUrl;
+    this.ticketTokenHash = ticketTokenHash;
     this.ticketStatus = ticketStatus;
   }
 }

--- a/ticket-service/src/main/java/com/ticketrush/boundedcontext/ticket/domain/policy/TicketTokenGenerator.java
+++ b/ticket-service/src/main/java/com/ticketrush/boundedcontext/ticket/domain/policy/TicketTokenGenerator.java
@@ -1,0 +1,18 @@
+package com.ticketrush.boundedcontext.ticket.domain.policy;
+
+import java.security.SecureRandom;
+import java.util.Base64;
+import org.springframework.stereotype.Component;
+
+@Component
+public class TicketTokenGenerator {
+
+  private static final int TOKEN_BYTES = 32;
+  private final SecureRandom random = new SecureRandom();
+
+  public String generate() {
+    byte[] tokenBytes = new byte[TOKEN_BYTES];
+    random.nextBytes(tokenBytes);
+    return Base64.getUrlEncoder().withoutPadding().encodeToString(tokenBytes);
+  }
+}

--- a/ticket-service/src/main/java/com/ticketrush/boundedcontext/ticket/domain/policy/TicketTokenHasher.java
+++ b/ticket-service/src/main/java/com/ticketrush/boundedcontext/ticket/domain/policy/TicketTokenHasher.java
@@ -1,0 +1,21 @@
+package com.ticketrush.boundedcontext.ticket.domain.policy;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
+import org.springframework.stereotype.Component;
+
+@Component
+public class TicketTokenHasher {
+
+  public String hash(String token) {
+    try {
+      MessageDigest digest = MessageDigest.getInstance("SHA-256");
+      byte[] hashed = digest.digest(token.getBytes(StandardCharsets.UTF_8));
+      return HexFormat.of().formatHex(hashed);
+    } catch (NoSuchAlgorithmException e) {
+      throw new IllegalStateException("SHA-256 algorithm is not available.", e);
+    }
+  }
+}

--- a/ticket-service/src/main/java/com/ticketrush/boundedcontext/ticket/domain/types/TicketStatus.java
+++ b/ticket-service/src/main/java/com/ticketrush/boundedcontext/ticket/domain/types/TicketStatus.java
@@ -6,9 +6,9 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum TicketStatus {
-  VALID("유효함"), // 예매가 확정되어 발급된 정상 티켓
-  USED("사용 완료"), // 공연장 입구에서 QR 스캔을 통해 입장이 완료된 상태
-  CANCELED("취소됨"); // 사용자가 예매를 취소하여 무효화된 티켓
+  UNUSED("미사용"),
+  USED("사용 완료"),
+  CANCELED("취소됨");
 
   private final String description;
 }

--- a/ticket-service/src/main/java/com/ticketrush/boundedcontext/ticket/out/repository/TicketRepository.java
+++ b/ticket-service/src/main/java/com/ticketrush/boundedcontext/ticket/out/repository/TicketRepository.java
@@ -1,0 +1,9 @@
+package com.ticketrush.boundedcontext.ticket.out.repository;
+
+import com.ticketrush.boundedcontext.ticket.domain.entity.Ticket;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TicketRepository extends JpaRepository<Ticket, Long> {
+
+  boolean existsByBookingId(Long bookingId);
+}

--- a/ticket-service/src/test/java/com/ticketrush/boundedcontext/ticket/app/usecase/TicketIssueUseCaseTest.java
+++ b/ticket-service/src/test/java/com/ticketrush/boundedcontext/ticket/app/usecase/TicketIssueUseCaseTest.java
@@ -6,6 +6,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.never;
 
+import com.ticketrush.boundedcontext.ticket.app.dto.response.TicketIssueResponse;
 import com.ticketrush.boundedcontext.ticket.domain.entity.Ticket;
 import com.ticketrush.boundedcontext.ticket.domain.policy.TicketTokenGenerator;
 import com.ticketrush.boundedcontext.ticket.domain.policy.TicketTokenHasher;
@@ -18,6 +19,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
 
 @ExtendWith(MockitoExtension.class)
 class TicketIssueUseCaseTest {
@@ -42,12 +44,14 @@ class TicketIssueUseCaseTest {
     given(ticketTokenHasher.hash(token)).willReturn(tokenHash);
 
     // when
-    ticketIssueUseCase.execute(bookingId);
+    TicketIssueResponse response = ticketIssueUseCase.execute(bookingId);
 
     // then
     ArgumentCaptor<Ticket> ticketCaptor = ArgumentCaptor.forClass(Ticket.class);
-    then(ticketRepository).should().save(ticketCaptor.capture());
+    then(ticketRepository).should().saveAndFlush(ticketCaptor.capture());
     Ticket savedTicket = ticketCaptor.getValue();
+    assertThat(response.issued()).isTrue();
+    assertThat(response.token()).isEqualTo(token);
     assertThat(savedTicket.getBookingId()).isEqualTo(bookingId);
     assertThat(savedTicket.getTicketTokenHash()).isEqualTo(tokenHash);
     assertThat(savedTicket.getTicketTokenHash()).doesNotContain("raw-ticket-token");
@@ -63,11 +67,34 @@ class TicketIssueUseCaseTest {
     given(ticketRepository.existsByBookingId(bookingId)).willReturn(true);
 
     // when
-    ticketIssueUseCase.execute(bookingId);
+    TicketIssueResponse response = ticketIssueUseCase.execute(bookingId);
 
     // then
+    assertThat(response.issued()).isFalse();
+    assertThat(response.token()).isNull();
     then(ticketTokenGenerator).should(never()).generate();
     then(ticketTokenHasher).shouldHaveNoInteractions();
-    then(ticketRepository).should(never()).save(any());
+    then(ticketRepository).should(never()).saveAndFlush(any());
+  }
+
+  @Test
+  @DisplayName("성공: 동시 발급으로 unique 제약이 충돌하면 이미 발급된 것으로 처리한다")
+  void execute_handles_duplicate_key_race_as_already_issued() {
+    // given
+    Long bookingId = 1L;
+    String token = "raw-ticket-token";
+    String tokenHash = "5ef9a9d540243d7534e3d322d14817b1290f0f2f7f57feafe57f5e5d1f13b450";
+    given(ticketRepository.existsByBookingId(bookingId)).willReturn(false);
+    given(ticketTokenGenerator.generate()).willReturn(token);
+    given(ticketTokenHasher.hash(token)).willReturn(tokenHash);
+    given(ticketRepository.saveAndFlush(any(Ticket.class)))
+        .willThrow(new DataIntegrityViolationException("duplicate key"));
+
+    // when
+    TicketIssueResponse response = ticketIssueUseCase.execute(bookingId);
+
+    // then
+    assertThat(response.issued()).isFalse();
+    assertThat(response.token()).isNull();
   }
 }

--- a/ticket-service/src/test/java/com/ticketrush/boundedcontext/ticket/app/usecase/TicketIssueUseCaseTest.java
+++ b/ticket-service/src/test/java/com/ticketrush/boundedcontext/ticket/app/usecase/TicketIssueUseCaseTest.java
@@ -1,0 +1,73 @@
+package com.ticketrush.boundedcontext.ticket.app.usecase;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+
+import com.ticketrush.boundedcontext.ticket.domain.entity.Ticket;
+import com.ticketrush.boundedcontext.ticket.domain.policy.TicketTokenGenerator;
+import com.ticketrush.boundedcontext.ticket.domain.policy.TicketTokenHasher;
+import com.ticketrush.boundedcontext.ticket.domain.types.TicketStatus;
+import com.ticketrush.boundedcontext.ticket.out.repository.TicketRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class TicketIssueUseCaseTest {
+
+  @InjectMocks private TicketIssueUseCase ticketIssueUseCase;
+
+  @Mock private TicketRepository ticketRepository;
+
+  @Mock private TicketTokenGenerator ticketTokenGenerator;
+
+  @Mock private TicketTokenHasher ticketTokenHasher;
+
+  @Test
+  @DisplayName("성공: 예매 ID 기준으로 티켓 토큰 해시와 UNUSED 상태를 저장한다")
+  void execute_issues_ticket() {
+    // given
+    Long bookingId = 1L;
+    String token = "raw-ticket-token";
+    String tokenHash = "5ef9a9d540243d7534e3d322d14817b1290f0f2f7f57feafe57f5e5d1f13b450";
+    given(ticketRepository.existsByBookingId(bookingId)).willReturn(false);
+    given(ticketTokenGenerator.generate()).willReturn(token);
+    given(ticketTokenHasher.hash(token)).willReturn(tokenHash);
+
+    // when
+    ticketIssueUseCase.execute(bookingId);
+
+    // then
+    ArgumentCaptor<Ticket> ticketCaptor = ArgumentCaptor.forClass(Ticket.class);
+    then(ticketRepository).should().save(ticketCaptor.capture());
+    Ticket savedTicket = ticketCaptor.getValue();
+    assertThat(savedTicket.getBookingId()).isEqualTo(bookingId);
+    assertThat(savedTicket.getTicketTokenHash()).isEqualTo(tokenHash);
+    assertThat(savedTicket.getTicketTokenHash()).doesNotContain("raw-ticket-token");
+    assertThat(savedTicket.getTicketStatus()).isEqualTo(TicketStatus.UNUSED);
+    assertThat(savedTicket.getUsedAt()).isNull();
+  }
+
+  @Test
+  @DisplayName("성공: 동일 예매에 이미 티켓이 있으면 토큰을 중복 생성하지 않는다")
+  void execute_does_not_issue_duplicate_ticket() {
+    // given
+    Long bookingId = 1L;
+    given(ticketRepository.existsByBookingId(bookingId)).willReturn(true);
+
+    // when
+    ticketIssueUseCase.execute(bookingId);
+
+    // then
+    then(ticketTokenGenerator).should(never()).generate();
+    then(ticketTokenHasher).shouldHaveNoInteractions();
+    then(ticketRepository).should(never()).save(any());
+  }
+}

--- a/ticket-service/src/test/java/com/ticketrush/boundedcontext/ticket/app/usecase/TicketIssueUseCaseTest.java
+++ b/ticket-service/src/test/java/com/ticketrush/boundedcontext/ticket/app/usecase/TicketIssueUseCaseTest.java
@@ -1,12 +1,15 @@
 package com.ticketrush.boundedcontext.ticket.app.usecase;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
+import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.never;
 
 import com.ticketrush.boundedcontext.ticket.app.dto.response.TicketIssueResponse;
+import com.ticketrush.boundedcontext.ticket.app.support.TicketSaver;
 import com.ticketrush.boundedcontext.ticket.domain.entity.Ticket;
 import com.ticketrush.boundedcontext.ticket.domain.policy.TicketTokenGenerator;
 import com.ticketrush.boundedcontext.ticket.domain.policy.TicketTokenHasher;
@@ -32,6 +35,8 @@ class TicketIssueUseCaseTest {
 
   @Mock private TicketTokenHasher ticketTokenHasher;
 
+  @Mock private TicketSaver ticketSaver;
+
   @Test
   @DisplayName("성공: 예매 ID 기준으로 티켓 토큰 해시와 UNUSED 상태를 저장한다")
   void execute_issues_ticket() {
@@ -48,7 +53,7 @@ class TicketIssueUseCaseTest {
 
     // then
     ArgumentCaptor<Ticket> ticketCaptor = ArgumentCaptor.forClass(Ticket.class);
-    then(ticketRepository).should().saveAndFlush(ticketCaptor.capture());
+    then(ticketSaver).should().saveInNewTransaction(ticketCaptor.capture());
     Ticket savedTicket = ticketCaptor.getValue();
     assertThat(response.issued()).isTrue();
     assertThat(response.token()).isEqualTo(token);
@@ -74,21 +79,23 @@ class TicketIssueUseCaseTest {
     assertThat(response.token()).isNull();
     then(ticketTokenGenerator).should(never()).generate();
     then(ticketTokenHasher).shouldHaveNoInteractions();
-    then(ticketRepository).should(never()).saveAndFlush(any());
+    then(ticketSaver).should(never()).saveInNewTransaction(any());
   }
 
   @Test
-  @DisplayName("성공: 동시 발급으로 unique 제약이 충돌하면 이미 발급된 것으로 처리한다")
-  void execute_handles_duplicate_key_race_as_already_issued() {
+  @DisplayName("성공: 동시 발급으로 booking_id 제약이 충돌하면 이미 발급된 것으로 처리한다")
+  void execute_handles_booking_id_race_as_already_issued() {
     // given
     Long bookingId = 1L;
     String token = "raw-ticket-token";
     String tokenHash = "5ef9a9d540243d7534e3d322d14817b1290f0f2f7f57feafe57f5e5d1f13b450";
-    given(ticketRepository.existsByBookingId(bookingId)).willReturn(false);
+    // 선조회 시점엔 없었지만(false), 충돌 후 재조회 시 다른 트랜잭션이 먼저 발급(true)
+    given(ticketRepository.existsByBookingId(bookingId)).willReturn(false, true);
     given(ticketTokenGenerator.generate()).willReturn(token);
     given(ticketTokenHasher.hash(token)).willReturn(tokenHash);
-    given(ticketRepository.saveAndFlush(any(Ticket.class)))
-        .willThrow(new DataIntegrityViolationException("duplicate key"));
+    willThrow(new DataIntegrityViolationException("duplicate key"))
+        .given(ticketSaver)
+        .saveInNewTransaction(any(Ticket.class));
 
     // when
     TicketIssueResponse response = ticketIssueUseCase.execute(bookingId);
@@ -96,5 +103,25 @@ class TicketIssueUseCaseTest {
     // then
     assertThat(response.issued()).isFalse();
     assertThat(response.token()).isNull();
+  }
+
+  @Test
+  @DisplayName("실패: 토큰 해시 제약이 충돌하면 재시도를 위해 예외를 그대로 던진다")
+  void execute_rethrows_when_token_hash_conflicts() {
+    // given
+    Long bookingId = 1L;
+    String token = "raw-ticket-token";
+    String tokenHash = "5ef9a9d540243d7534e3d322d14817b1290f0f2f7f57feafe57f5e5d1f13b450";
+    // 선조회/재조회 모두 false → booking_id 충돌이 아니라 token_hash 충돌임을 의미
+    given(ticketRepository.existsByBookingId(bookingId)).willReturn(false, false);
+    given(ticketTokenGenerator.generate()).willReturn(token);
+    given(ticketTokenHasher.hash(token)).willReturn(tokenHash);
+    willThrow(new DataIntegrityViolationException("duplicate key"))
+        .given(ticketSaver)
+        .saveInNewTransaction(any(Ticket.class));
+
+    // when & then
+    assertThatThrownBy(() -> ticketIssueUseCase.execute(bookingId))
+        .isInstanceOf(DataIntegrityViolationException.class);
   }
 }

--- a/ticket-service/src/test/java/com/ticketrush/boundedcontext/ticket/domain/policy/TicketTokenGeneratorTest.java
+++ b/ticket-service/src/test/java/com/ticketrush/boundedcontext/ticket/domain/policy/TicketTokenGeneratorTest.java
@@ -1,0 +1,32 @@
+package com.ticketrush.boundedcontext.ticket.domain.policy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class TicketTokenGeneratorTest {
+
+  private final TicketTokenGenerator generator = new TicketTokenGenerator();
+
+  @Test
+  @DisplayName("티켓 토큰은 URL-safe 랜덤 문자열로 생성된다")
+  void generate_returns_url_safe_random_token() {
+    // when
+    String token = generator.generate();
+
+    // then
+    assertThat(token).matches("^[A-Za-z0-9_-]{43}$");
+  }
+
+  @Test
+  @DisplayName("티켓 토큰은 호출할 때마다 다른 값으로 생성된다")
+  void generate_returns_different_tokens() {
+    // when
+    String first = generator.generate();
+    String second = generator.generate();
+
+    // then
+    assertThat(first).isNotEqualTo(second);
+  }
+}

--- a/ticket-service/src/test/java/com/ticketrush/boundedcontext/ticket/domain/policy/TicketTokenHasherTest.java
+++ b/ticket-service/src/test/java/com/ticketrush/boundedcontext/ticket/domain/policy/TicketTokenHasherTest.java
@@ -1,0 +1,23 @@
+package com.ticketrush.boundedcontext.ticket.domain.policy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class TicketTokenHasherTest {
+
+  private final TicketTokenHasher hasher = new TicketTokenHasher();
+
+  @Test
+  @DisplayName("티켓 토큰은 SHA-256 해시로 변환되어 저장된다")
+  void hash_returns_sha256_hex() {
+    // when
+    String hash = hasher.hash("raw-ticket-token");
+
+    // then
+    assertThat(hash).hasSize(64);
+    assertThat(hash).matches("^[0-9a-f]{64}$");
+    assertThat(hash).doesNotContain("raw-ticket-token");
+  }
+}


### PR DESCRIPTION
## 🔗 관련 이슈

- close #216

---

## 📌 주요 변경 사항

- ticket-service에 입장권 QR payload용 토큰 발급 유스케이스 추가
- 티켓 저장 모델을 QR 이미지 URL 중심에서 토큰 해시 기반 모델로 변경
- 동일 예매에 대한 티켓 중복 발급 방지 및 관련 단위 테스트 추가

---

## 🛠 상세 구현 내용

- `TicketTokenGenerator`에서 32바이트 난수 기반 URL-safe Base64 토큰을 생성하도록 구현
- `TicketTokenHasher`에서 원문 토큰을 SHA-256 hex 해시로 변환하고, DB에는 해시만 저장하도록 구성
- `TicketIssueUseCase`에서 `bookingId` 기준 기존 티켓 존재 여부를 확인한 뒤, 없을 때만 `UNUSED` 상태 티켓을 저장
- `Ticket.bookingId`와 `ticketTokenHash`에 unique 제약을 두어 중복 발급 및 토큰 충돌에 대한 DB 레벨 방어 추가
- `TicketStatus`를 `UNUSED`, `USED`, `CANCELED`로 정리

---

## ✅ 테스트

### 테스트 방법

- `./gradlew :ticket-service:check`

### 테스트 결과

- ticket-service check 통과

<!--
### 📸 스크린샷
-->

---

## 👀 리뷰 요청 사항

- QR payload에 예매번호, 좌석 정보, 개인정보 원문을 넣지 않고 랜덤 토큰만 사용하는 방향이 적절한지 확인 부탁드립니다.
- 결제 완료 이벤트 기반 예매 확정 처리는 #213 범위라 제외했습니다. #213에서 예매 확정 이벤트 계약이 정해지면 ticket-service 발급 트리거를 해당 이벤트에 연결하는 흐름을 검토하면 됩니다.

---

## ⚠️ 배포 시 주의사항

- `ticket` 테이블 모델이 `booking_number`, `qr_code_url` 중심에서 `ticket_token_hash`, `used_at` 중심으로 변경됩니다.