### PR TITLE
[Feat] #235 환불 도메인/스키마 보강 (Refund 필드, Payment seatId)

### DIFF
--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentConfirmUseCase.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentConfirmUseCase.java
@@ -49,6 +49,7 @@ public class PaymentConfirmUseCase {
         Payment.builder()
             .bookingId(request.bookingId())
             .userId(userId)
+            .seatId(request.seatId())
             .provider(request.provider())
             .amount(approval.approvedAmount())
             .status(PaymentStatus.COMPLETED)

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/domain/entity/Payment.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/domain/entity/Payment.java
@@ -28,6 +28,9 @@ public class Payment extends AutoIdBaseEntity {
   /* userId는 #207 시점 신규 도입. 기존 결제 row 호환을 위해 nullable. backfill 후 NOT NULL 전환 예정. */
   private Long userId;
 
+  /* seatId는 #22(환불) 시점 신규 도입. 환불 시 PaymentCanceledEvent로 좌석 복귀를 전파하기 위해 confirm 시 저장한다. */
+  private Long seatId;
+
   @Enumerated(EnumType.STRING)
   @Column(nullable = false)
   private PaymentProvider provider; // 결제 수단 (예: KAKAO, NAVER)
@@ -51,6 +54,7 @@ public class Payment extends AutoIdBaseEntity {
   private Payment(
       Long bookingId,
       Long userId,
+      Long seatId,
       PaymentProvider provider,
       Long amount,
       PaymentStatus status,
@@ -59,6 +63,7 @@ public class Payment extends AutoIdBaseEntity {
       LocalDateTime paidAt) {
     this.bookingId = bookingId;
     this.userId = userId;
+    this.seatId = seatId;
     this.provider = provider;
     this.amount = amount;
     this.status = status;

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/domain/entity/Refund.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/domain/entity/Refund.java
@@ -21,6 +21,10 @@ import lombok.NoArgsConstructor;
 @AttributeOverride(name = "id", column = @Column(name = "refund_id"))
 public class Refund extends AutoIdBaseEntity {
 
+  /* paymentId는 #22에서 환불-결제 매핑 및 멱등성 보장을 위해 도입. */
+  @Column(nullable = false)
+  private Long paymentId;
+
   @Column(nullable = false)
   private Long bookingId;
 
@@ -31,13 +35,33 @@ public class Refund extends AutoIdBaseEntity {
   @Column(name = "status", length = 20)
   private RefundStatus status; // 환불 상태 (PENDING, COMPLETED 등)
 
-  private LocalDateTime confirmedAt;
+  @Column(length = 200)
+  private String pgRefundKey; // PG사 환불 거래 식별자
+
+  @Column(length = 255)
+  private String reason; // 환불 사유
+
+  private LocalDateTime requestedAt; // 환불 요청 시점
+
+  private LocalDateTime confirmedAt; // 환불 확정 시점
 
   @Builder
-  private Refund(Long bookingId, Long price, RefundStatus status, LocalDateTime confirmedAt) {
+  private Refund(
+      Long paymentId,
+      Long bookingId,
+      Long price,
+      RefundStatus status,
+      String pgRefundKey,
+      String reason,
+      LocalDateTime requestedAt,
+      LocalDateTime confirmedAt) {
+    this.paymentId = paymentId;
     this.bookingId = bookingId;
     this.price = price;
     this.status = status;
+    this.pgRefundKey = pgRefundKey;
+    this.reason = reason;
+    this.requestedAt = requestedAt;
     this.confirmedAt = confirmedAt;
   }
 }


### PR DESCRIPTION
## 🔗 관련 이슈

- close #235
- 부모 이슈: #22 (범위가 커서 #235/#236/#237로 분할)

---

## 📌 주요 변경 사항

- `Refund` 엔티티 필드 보강: `paymentId`, `pgRefundKey`, `reason`, `requestedAt`
- `Payment` 엔티티에 `seatId` 필드 추가
- `PaymentConfirmUseCase`: confirm 시 seatId 저장

---

## 🛠 상세 구현 내용

- 환불 흐름(#237)에서 `PaymentCanceledEvent`로 좌석 복귀를 전파하려면 seatId가 필요한데 결제 row에 없어, confirm 시점에 저장하도록 보강 (기존 row 호환 위해 nullable, userId 선례와 동일)
- `Refund`는 #23에서 골격만 생성됨 → 환불 영속화/멱등성에 필요한 필드 추가 (`paymentId`는 NOT NULL)

---

## ✅ 테스트

### 테스트 방법

- `./gradlew :payment-service:spotlessApply :payment-service:checkstyleMain :payment-service:compileJava :payment-service:test`

### 테스트 결과

- 전체 통과 (기존 confirm 테스트 포함)

### 📸 스크린샷

---

## 👀 리뷰 요청 사항

- 분할 PR 1/3입니다. 도메인/스키마 보강만 담은 작은 PR이라 단독 머지 가능합니다.
- 후속: #236(PG 환불 클라이언트), #237(환불 API + 이벤트, 본 PR과 #236 머지 후)

---

## ⚠️ 배포 시 주의사항

- `payment` 테이블에 `seat_id`, `refund` 테이블에 `payment_id`/`pg_refund_key`/`reason`/`requested_at` 컬럼 추가 (ddl-auto=update 자동 반영, 기존 row의 seat_id는 null)

