### PR TITLE
[Feat] #236 결제 취소 PG 클라이언트 라우팅 구현 (Toss/Stub)

### DIFF
--- a/common/src/main/java/com/ticketrush/global/status/ErrorStatus.java
+++ b/common/src/main/java/com/ticketrush/global/status/ErrorStatus.java
@@ -159,6 +159,7 @@ public enum ErrorStatus {
   PAYMENT_APPROVAL_FAILED(HttpStatus.BAD_GATEWAY, "PAYMENT_502_001", "PG사 결제 승인에 실패했습니다."),
   PAYMENT_PG_AUTH_FAILED(
       HttpStatus.BAD_GATEWAY, "PAYMENT_502_002", "PG사 인증에 실패했습니다. 관리자에게 문의 바랍니다."),
+  PAYMENT_REFUND_FAILED(HttpStatus.BAD_GATEWAY, "PAYMENT_502_003", "PG사 환불 처리에 실패했습니다."),
 
   // Payment 503
   PAYMENT_PG_COMMUNICATION_FAILED(

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/out/apiclient/PaymentCancelClient.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/out/apiclient/PaymentCancelClient.java
@@ -1,0 +1,16 @@
+package com.ticketrush.boundedcontext.payment.out.apiclient;
+
+import com.ticketrush.boundedcontext.payment.domain.types.PaymentProvider;
+
+/**
+ * PG사 결제 취소(환불) API 호출용 클라이언트.
+ *
+ * <p>구현체는 {@link #supports(PaymentProvider)}로 자신이 처리 가능한 PG를 알리고, {@link
+ * PaymentCancelClientRouter}가 요청 provider에 맞는 클라이언트를 선택해 호출한다.
+ */
+public interface PaymentCancelClient {
+
+  boolean supports(PaymentProvider provider);
+
+  PaymentCancelResult cancel(PaymentCancelCommand command);
+}

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/out/apiclient/PaymentCancelClientRouter.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/out/apiclient/PaymentCancelClientRouter.java
@@ -1,0 +1,32 @@
+package com.ticketrush.boundedcontext.payment.out.apiclient;
+
+import com.ticketrush.boundedcontext.payment.domain.types.PaymentProvider;
+import com.ticketrush.global.exception.BusinessException;
+import com.ticketrush.global.status.ErrorStatus;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+/**
+ * 등록된 {@link PaymentCancelClient} 중 요청 provider를 지원하는 첫 번째 구현체로 결제 취소를 위임한다.
+ *
+ * <p>Stub은 {@link org.springframework.core.annotation.Order} 가장 낮은 우선순위로 등록되어 실제 provider 구현체가 우선
+ * 선택되도록 한다.
+ */
+@Component
+@RequiredArgsConstructor
+public class PaymentCancelClientRouter {
+
+  private final List<PaymentCancelClient> clients;
+
+  public PaymentCancelResult cancel(PaymentCancelCommand command) {
+    return resolve(command.provider()).cancel(command);
+  }
+
+  private PaymentCancelClient resolve(PaymentProvider provider) {
+    return clients.stream()
+        .filter(client -> client.supports(provider))
+        .findFirst()
+        .orElseThrow(() -> new BusinessException(ErrorStatus.PAYMENT_PROVIDER_NOT_SUPPORTED));
+  }
+}

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/out/apiclient/PaymentCancelCommand.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/out/apiclient/PaymentCancelCommand.java
@@ -1,0 +1,15 @@
+package com.ticketrush.boundedcontext.payment.out.apiclient;
+
+import com.ticketrush.boundedcontext.payment.domain.types.PaymentProvider;
+
+/**
+ * PG사 결제 취소 요청 커맨드.
+ *
+ * <p>{@code idempotencyKey}는 PG 측 중복 취소 방지를 위한 멱등 키로, 동일 결제의 재요청 시 같은 값을 전달한다.
+ */
+public record PaymentCancelCommand(
+    PaymentProvider provider,
+    String paymentKey,
+    Long amount,
+    String reason,
+    String idempotencyKey) {}

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/out/apiclient/PaymentCancelCommand.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/out/apiclient/PaymentCancelCommand.java
@@ -6,6 +6,9 @@ import com.ticketrush.boundedcontext.payment.domain.types.PaymentProvider;
  * PG사 결제 취소 요청 커맨드.
  *
  * <p>{@code idempotencyKey}는 PG 측 중복 취소 방지를 위한 멱등 키로, 동일 결제의 재요청 시 같은 값을 전달한다.
+ *
+ * <p>{@code amount}는 전액 환불 금액으로 Stub 응답·로깅 및 취소 금액 검증에 사용된다. #22는 전액 취소만 지원하므로 Toss 취소 호출 시에는
+ * {@code cancelAmount}를 생략(전액 취소)하며 amount를 PG로 전송하지 않는다. (부분 취소 지원 시 cancelAmount 전송 추가 필요)
  */
 public record PaymentCancelCommand(
     PaymentProvider provider,

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/out/apiclient/PaymentCancelResult.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/out/apiclient/PaymentCancelResult.java
@@ -1,0 +1,6 @@
+package com.ticketrush.boundedcontext.payment.out.apiclient;
+
+import java.time.LocalDateTime;
+
+public record PaymentCancelResult(
+    String pgRefundKey, Long refundedAmount, LocalDateTime canceledAt) {}

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/out/apiclient/StubPaymentCancelClient.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/out/apiclient/StubPaymentCancelClient.java
@@ -1,0 +1,55 @@
+package com.ticketrush.boundedcontext.payment.out.apiclient;
+
+import com.ticketrush.boundedcontext.payment.domain.types.PaymentProvider;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Profile;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+/**
+ * 실 PG 호출 없이 요청 금액을 그대로 취소된 것으로 응답하는 stub 구현.
+ *
+ * <p>{@code payment.pg.stub.enabled=true} 일 때만 활성화된다. {@link PaymentCancelClientRouter}에서 실제
+ * provider별 구현체가 우선 선택되도록 {@link Order} 우선순위는 가장 낮게 둔다.
+ *
+ * <p>운영(prod) 프로파일에서는 환경변수 설정과 무관하게 절대 활성화되지 않는다.
+ */
+@Slf4j
+@Component
+@Profile("!prod")
+@Order(Integer.MAX_VALUE)
+@ConditionalOnProperty(
+    prefix = "payment.pg.stub",
+    name = "enabled",
+    havingValue = "true",
+    matchIfMissing = false)
+public class StubPaymentCancelClient implements PaymentCancelClient {
+
+  @Override
+  public boolean supports(PaymentProvider provider) {
+    return true;
+  }
+
+  @Override
+  public PaymentCancelResult cancel(PaymentCancelCommand command) {
+    log.info(
+        "[PG-STUB] cancel provider={}, amount={}, paymentKey={}, idempotencyKey={}",
+        command.provider(),
+        command.amount(),
+        mask(command.paymentKey()),
+        command.idempotencyKey());
+
+    return new PaymentCancelResult(
+        UUID.randomUUID().toString(), command.amount(), LocalDateTime.now());
+  }
+
+  private String mask(String value) {
+    if (value == null || value.length() <= 4) {
+      return "****";
+    }
+    return value.substring(0, 4) + "****";
+  }
+}

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/out/apiclient/toss/TossCancelRequest.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/out/apiclient/toss/TossCancelRequest.java
@@ -1,0 +1,10 @@
+package com.ticketrush.boundedcontext.payment.out.apiclient.toss;
+
+/**
+ * Toss Payments 결제 취소 API 요청 페이로드.
+ *
+ * <p>{@code cancelAmount}를 생략하면 전액 취소로 처리된다. (#22는 전액 환불만 다룸)
+ *
+ * <p>참고: https://docs.tosspayments.com/reference#결제-취소
+ */
+public record TossCancelRequest(String cancelReason) {}

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/out/apiclient/toss/TossCancelResponse.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/out/apiclient/toss/TossCancelResponse.java
@@ -1,0 +1,19 @@
+package com.ticketrush.boundedcontext.payment.out.apiclient.toss;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.time.OffsetDateTime;
+import java.util.List;
+
+/**
+ * Toss Payments 결제 취소 응답 (필요 필드만 매핑).
+ *
+ * <p>취소 1건당 {@link Cancel} 한 항목이 {@code cancels} 배열에 누적된다. 전액 환불 시 마지막 항목이 이번 취소 내역이다.
+ *
+ * <p>전체 응답 명세: https://docs.tosspayments.com/reference#payment-객체
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record TossCancelResponse(String paymentKey, String status, List<Cancel> cancels) {
+
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  public record Cancel(String transactionKey, Long cancelAmount, OffsetDateTime canceledAt) {}
+}

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/out/apiclient/toss/TossPaymentCancelClient.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/out/apiclient/toss/TossPaymentCancelClient.java
@@ -69,7 +69,7 @@ public class TossPaymentCancelClient implements PaymentCancelClient {
                     log.warn(
                         "[PG-TOSS] 결제 취소 거절. status={}, paymentKey={}",
                         res.getStatusCode(),
-                        command.paymentKey());
+                        mask(command.paymentKey()));
                     throw new BusinessException(ErrorStatus.PAYMENT_REFUND_FAILED);
                   })
               .onStatus(
@@ -78,7 +78,7 @@ public class TossPaymentCancelClient implements PaymentCancelClient {
                     log.error(
                         "[PG-TOSS] PG 서버 오류. status={}, paymentKey={}",
                         res.getStatusCode(),
-                        command.paymentKey());
+                        mask(command.paymentKey()));
                     throw new BusinessException(ErrorStatus.PAYMENT_PG_COMMUNICATION_FAILED);
                   })
               .body(TossCancelResponse.class);
@@ -88,23 +88,15 @@ public class TossPaymentCancelClient implements PaymentCancelClient {
     } catch (BusinessException e) {
       throw e;
     } catch (ResourceAccessException e) {
-      log.error(
-          "[PG-TOSS] PG 통신 실패(timeout 등). paymentKey={}, message={}",
-          command.paymentKey(),
-          e.getMessage());
-      throw new BusinessException(ErrorStatus.PAYMENT_PG_COMMUNICATION_FAILED);
+      throw toCommunicationFailure("PG 통신 실패(timeout 등)", command, e);
     } catch (RestClientException e) {
-      log.error(
-          "[PG-TOSS] PG 호출 중 예외 발생. paymentKey={}, message={}",
-          command.paymentKey(),
-          e.getMessage());
-      throw new BusinessException(ErrorStatus.PAYMENT_PG_COMMUNICATION_FAILED);
+      throw toCommunicationFailure("PG 호출 중 예외 발생", command, e);
     }
   }
 
   private PaymentCancelResult toResult(TossCancelResponse response, PaymentCancelCommand command) {
     if (response == null || response.cancels() == null || response.cancels().isEmpty()) {
-      log.error("[PG-TOSS] 취소 응답에 cancels 누락. paymentKey={}", command.paymentKey());
+      log.error("[PG-TOSS] 취소 응답에 cancels 누락. paymentKey={}", mask(command.paymentKey()));
       throw new BusinessException(ErrorStatus.PAYMENT_PG_COMMUNICATION_FAILED);
     }
 
@@ -112,7 +104,7 @@ public class TossPaymentCancelClient implements PaymentCancelClient {
     TossCancelResponse.Cancel latest = cancels.get(cancels.size() - 1);
 
     if (latest.canceledAt() == null) {
-      log.error("[PG-TOSS] 취소 응답에 canceledAt 누락. paymentKey={}", command.paymentKey());
+      log.error("[PG-TOSS] 취소 응답에 canceledAt 누락. paymentKey={}", mask(command.paymentKey()));
       throw new BusinessException(ErrorStatus.PAYMENT_PG_COMMUNICATION_FAILED);
     }
 
@@ -125,5 +117,24 @@ public class TossPaymentCancelClient implements PaymentCancelClient {
         latest.canceledAt().atZoneSameInstant(ZoneId.systemDefault()).toLocalDateTime();
 
     return new PaymentCancelResult(pgRefundKey, latest.cancelAmount(), canceledAt);
+  }
+
+  /** 동일하게 {@link ErrorStatus#PAYMENT_PG_COMMUNICATION_FAILED}로 매핑되는 통신 예외의 로깅·변환을 공통화한다. */
+  private BusinessException toCommunicationFailure(
+      String context, PaymentCancelCommand command, Exception e) {
+    log.error(
+        "[PG-TOSS] {}. paymentKey={}, message={}",
+        context,
+        mask(command.paymentKey()),
+        e.getMessage());
+    return new BusinessException(ErrorStatus.PAYMENT_PG_COMMUNICATION_FAILED);
+  }
+
+  /** 로그 노출 시 민감한 paymentKey를 앞 4자리만 남기고 마스킹한다. */
+  private String mask(String value) {
+    if (value == null || value.length() <= 4) {
+      return "****";
+    }
+    return value.substring(0, 4) + "****";
   }
 }

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/out/apiclient/toss/TossPaymentCancelClient.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/out/apiclient/toss/TossPaymentCancelClient.java
@@ -1,0 +1,129 @@
+package com.ticketrush.boundedcontext.payment.out.apiclient.toss;
+
+import com.ticketrush.boundedcontext.payment.domain.types.PaymentProvider;
+import com.ticketrush.boundedcontext.payment.out.apiclient.PaymentCancelClient;
+import com.ticketrush.boundedcontext.payment.out.apiclient.PaymentCancelCommand;
+import com.ticketrush.boundedcontext.payment.out.apiclient.PaymentCancelResult;
+import com.ticketrush.global.exception.BusinessException;
+import com.ticketrush.global.status.ErrorStatus;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.List;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.client.ResourceAccessException;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
+
+/**
+ * Toss Payments 결제 취소(환불) API 연동 구현체.
+ *
+ * <p>{@code payment.pg.toss.enabled=true} 일 때만 활성화된다. secret-key 미설정 시 {@link
+ * com.ticketrush.global.config.RestClientConfig#tossPaymentRestClient}에서 startup 단계에 실패시킨다.
+ *
+ * <p>PG 거절(4xx)은 {@link ErrorStatus#PAYMENT_REFUND_FAILED}, 통신 실패(5xx/timeout)는 {@link
+ * ErrorStatus#PAYMENT_PG_COMMUNICATION_FAILED}로 매핑한다.
+ */
+@Slf4j
+@Component
+@Order(0)
+@ConditionalOnProperty(prefix = "payment.pg.toss", name = "enabled", havingValue = "true")
+public class TossPaymentCancelClient implements PaymentCancelClient {
+
+  private static final String CANCEL_PATH = "/v1/payments/{paymentKey}/cancel";
+  private static final String IDEMPOTENCY_KEY_HEADER = "Idempotency-Key";
+
+  private final RestClient restClient;
+
+  public TossPaymentCancelClient(@Qualifier("tossPaymentRestClient") RestClient restClient) {
+    this.restClient = restClient;
+  }
+
+  @Override
+  public boolean supports(PaymentProvider provider) {
+    return provider == PaymentProvider.TOSS;
+  }
+
+  @Override
+  public PaymentCancelResult cancel(PaymentCancelCommand command) {
+    TossCancelRequest body = new TossCancelRequest(command.reason());
+
+    try {
+      TossCancelResponse response =
+          restClient
+              .post()
+              .uri(CANCEL_PATH, command.paymentKey())
+              .contentType(MediaType.APPLICATION_JSON)
+              .header(IDEMPOTENCY_KEY_HEADER, command.idempotencyKey())
+              .body(body)
+              .retrieve()
+              .onStatus(
+                  HttpStatusCode::is4xxClientError,
+                  (req, res) -> {
+                    log.warn(
+                        "[PG-TOSS] 결제 취소 거절. status={}, paymentKey={}",
+                        res.getStatusCode(),
+                        command.paymentKey());
+                    throw new BusinessException(ErrorStatus.PAYMENT_REFUND_FAILED);
+                  })
+              .onStatus(
+                  HttpStatusCode::is5xxServerError,
+                  (req, res) -> {
+                    log.error(
+                        "[PG-TOSS] PG 서버 오류. status={}, paymentKey={}",
+                        res.getStatusCode(),
+                        command.paymentKey());
+                    throw new BusinessException(ErrorStatus.PAYMENT_PG_COMMUNICATION_FAILED);
+                  })
+              .body(TossCancelResponse.class);
+
+      return toResult(response, command);
+
+    } catch (BusinessException e) {
+      throw e;
+    } catch (ResourceAccessException e) {
+      log.error(
+          "[PG-TOSS] PG 통신 실패(timeout 등). paymentKey={}, message={}",
+          command.paymentKey(),
+          e.getMessage());
+      throw new BusinessException(ErrorStatus.PAYMENT_PG_COMMUNICATION_FAILED);
+    } catch (RestClientException e) {
+      log.error(
+          "[PG-TOSS] PG 호출 중 예외 발생. paymentKey={}, message={}",
+          command.paymentKey(),
+          e.getMessage());
+      throw new BusinessException(ErrorStatus.PAYMENT_PG_COMMUNICATION_FAILED);
+    }
+  }
+
+  private PaymentCancelResult toResult(TossCancelResponse response, PaymentCancelCommand command) {
+    if (response == null || response.cancels() == null || response.cancels().isEmpty()) {
+      log.error("[PG-TOSS] 취소 응답에 cancels 누락. paymentKey={}", command.paymentKey());
+      throw new BusinessException(ErrorStatus.PAYMENT_PG_COMMUNICATION_FAILED);
+    }
+
+    List<TossCancelResponse.Cancel> cancels = response.cancels();
+    TossCancelResponse.Cancel latest = cancels.get(cancels.size() - 1);
+
+    if (latest.canceledAt() == null) {
+      log.error("[PG-TOSS] 취소 응답에 canceledAt 누락. paymentKey={}", command.paymentKey());
+      throw new BusinessException(ErrorStatus.PAYMENT_PG_COMMUNICATION_FAILED);
+    }
+
+    String pgRefundKey =
+        StringUtils.hasText(latest.transactionKey())
+            ? latest.transactionKey()
+            : response.paymentKey();
+
+    LocalDateTime canceledAt =
+        latest.canceledAt().atZoneSameInstant(ZoneId.systemDefault()).toLocalDateTime();
+
+    return new PaymentCancelResult(pgRefundKey, latest.cancelAmount(), canceledAt);
+  }
+}

--- a/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/out/apiclient/PaymentCancelClientRouterTest.java
+++ b/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/out/apiclient/PaymentCancelClientRouterTest.java
@@ -1,0 +1,73 @@
+package com.ticketrush.boundedcontext.payment.out.apiclient;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+import com.ticketrush.boundedcontext.payment.domain.types.PaymentProvider;
+import com.ticketrush.global.exception.BusinessException;
+import com.ticketrush.global.status.ErrorStatus;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class PaymentCancelClientRouterTest {
+
+  @Mock private PaymentCancelClient tossClient;
+  @Mock private PaymentCancelClient stubClient;
+
+  @Test
+  @DisplayName("provider를 지원하는 첫 번째 클라이언트로 위임한다")
+  void cancel_delegates_to_supporting_client() {
+    given(tossClient.supports(PaymentProvider.TOSS)).willReturn(true);
+    PaymentCancelResult result =
+        new PaymentCancelResult("PG-REFUND-1", 1_000L, LocalDateTime.now());
+    given(tossClient.cancel(any())).willReturn(result);
+
+    PaymentCancelClientRouter router = new PaymentCancelClientRouter(List.of(tossClient));
+
+    PaymentCancelResult actual =
+        router.cancel(
+            new PaymentCancelCommand(PaymentProvider.TOSS, "key", 1_000L, "사유", "REFUND-0000001"));
+
+    assertThat(actual).isEqualTo(result);
+  }
+
+  @Test
+  @DisplayName("등록 순서가 빠른 클라이언트가 우선 매칭된다 (Stub은 fallback)")
+  void cancel_picks_first_supporting_client() {
+    given(tossClient.supports(PaymentProvider.TOSS)).willReturn(true);
+    PaymentCancelResult result =
+        new PaymentCancelResult("PG-REFUND-1", 1_000L, LocalDateTime.now());
+    given(tossClient.cancel(any())).willReturn(result);
+
+    PaymentCancelClientRouter router =
+        new PaymentCancelClientRouter(List.of(tossClient, stubClient));
+
+    router.cancel(
+        new PaymentCancelCommand(PaymentProvider.TOSS, "key", 1_000L, "사유", "REFUND-0000001"));
+  }
+
+  @Test
+  @DisplayName("지원하는 클라이언트가 없으면 PAYMENT_400_002 예외가 발생한다")
+  void cancel_throws_when_no_client_supports_provider() {
+    given(tossClient.supports(PaymentProvider.KAKAO)).willReturn(false);
+
+    PaymentCancelClientRouter router = new PaymentCancelClientRouter(List.of(tossClient));
+
+    assertThatThrownBy(
+            () ->
+                router.cancel(
+                    new PaymentCancelCommand(
+                        PaymentProvider.KAKAO, "key", 1_000L, "사유", "REFUND-0000001")))
+        .isInstanceOf(BusinessException.class)
+        .extracting("errorStatus")
+        .isEqualTo(ErrorStatus.PAYMENT_PROVIDER_NOT_SUPPORTED);
+  }
+}

--- a/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/out/apiclient/StubPaymentCancelClientTest.java
+++ b/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/out/apiclient/StubPaymentCancelClientTest.java
@@ -1,0 +1,33 @@
+package com.ticketrush.boundedcontext.payment.out.apiclient;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.ticketrush.boundedcontext.payment.domain.types.PaymentProvider;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class StubPaymentCancelClientTest {
+
+  private final StubPaymentCancelClient client = new StubPaymentCancelClient();
+
+  @Test
+  @DisplayName("모든 provider를 지원한다 (fallback 클라이언트)")
+  void supports_all_providers() {
+    assertThat(client.supports(PaymentProvider.TOSS)).isTrue();
+    assertThat(client.supports(PaymentProvider.KAKAO)).isTrue();
+    assertThat(client.supports(PaymentProvider.NAVER)).isTrue();
+  }
+
+  @Test
+  @DisplayName("요청 금액 그대로 취소 응답을 만든다")
+  void cancel_returns_result_with_request_amount() {
+    PaymentCancelResult result =
+        client.cancel(
+            new PaymentCancelCommand(
+                PaymentProvider.TOSS, "pgKey_xyz", 1_000L, "사유", "REFUND-0000001"));
+
+    assertThat(result.refundedAmount()).isEqualTo(1_000L);
+    assertThat(result.pgRefundKey()).isNotBlank();
+    assertThat(result.canceledAt()).isNotNull();
+  }
+}

--- a/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/out/apiclient/toss/TossPaymentCancelClientTest.java
+++ b/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/out/apiclient/toss/TossPaymentCancelClientTest.java
@@ -1,0 +1,216 @@
+package com.ticketrush.boundedcontext.payment.out.apiclient.toss;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.header;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.jsonPath;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withRawStatus;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withServerError;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withStatus;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+import com.ticketrush.boundedcontext.payment.domain.types.PaymentProvider;
+import com.ticketrush.boundedcontext.payment.out.apiclient.PaymentCancelCommand;
+import com.ticketrush.boundedcontext.payment.out.apiclient.PaymentCancelResult;
+import com.ticketrush.global.exception.BusinessException;
+import com.ticketrush.global.status.ErrorStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestClient;
+
+class TossPaymentCancelClientTest {
+
+  private static final String BASE_URL = "https://api.tosspayments.com";
+  private static final String CANCEL_URL = BASE_URL + "/v1/payments/pgKey_xyz/cancel";
+
+  private MockRestServiceServer mockServer;
+  private TossPaymentCancelClient client;
+
+  @BeforeEach
+  void setUp() {
+    RestClient.Builder builder = RestClient.builder().baseUrl(BASE_URL);
+    mockServer = MockRestServiceServer.bindTo(builder).build();
+    client = new TossPaymentCancelClient(builder.build());
+  }
+
+  @Test
+  @DisplayName("Toss 결제 취소 성공 시 최신 cancel 항목을 매핑하고 멱등 키 헤더를 전송한다")
+  void cancel_success() {
+    String responseBody =
+        """
+        {
+          "paymentKey": "pgKey_xyz",
+          "status": "CANCELED",
+          "cancels": [
+            {
+              "transactionKey": "TX-CANCEL-1",
+              "cancelAmount": 55000,
+              "canceledAt": "2026-05-22T10:00:00+09:00"
+            }
+          ]
+        }
+        """;
+
+    mockServer
+        .expect(requestTo(CANCEL_URL))
+        .andExpect(method(HttpMethod.POST))
+        .andExpect(header("Idempotency-Key", "REFUND-0000001"))
+        .andExpect(jsonPath("$.cancelReason").value("단순 변심"))
+        .andRespond(withSuccess(responseBody, MediaType.APPLICATION_JSON));
+
+    PaymentCancelResult result = client.cancel(command());
+
+    assertThat(result.pgRefundKey()).isEqualTo("TX-CANCEL-1");
+    assertThat(result.refundedAmount()).isEqualTo(55_000L);
+    assertThat(result.canceledAt()).isNotNull();
+
+    mockServer.verify();
+  }
+
+  @Test
+  @DisplayName("transactionKey가 없으면 paymentKey로 폴백한다")
+  void cancel_falls_back_to_payment_key() {
+    String responseBody =
+        """
+        {
+          "paymentKey": "pgKey_xyz",
+          "status": "CANCELED",
+          "cancels": [
+            {
+              "cancelAmount": 55000,
+              "canceledAt": "2026-05-22T10:00:00+09:00"
+            }
+          ]
+        }
+        """;
+
+    mockServer
+        .expect(requestTo(CANCEL_URL))
+        .andRespond(withSuccess(responseBody, MediaType.APPLICATION_JSON));
+
+    PaymentCancelResult result = client.cancel(command());
+
+    assertThat(result.pgRefundKey()).isEqualTo("pgKey_xyz");
+
+    mockServer.verify();
+  }
+
+  @Test
+  @DisplayName("Toss가 4xx를 반환하면 PAYMENT_502_003 예외가 발생한다")
+  void cancel_maps_4xx_to_refund_failed() {
+    mockServer
+        .expect(requestTo(CANCEL_URL))
+        .andRespond(
+            withStatus(HttpStatus.BAD_REQUEST)
+                .contentType(MediaType.APPLICATION_JSON)
+                .body("{\"code\":\"ALREADY_CANCELED_PAYMENT\",\"message\":\"이미 취소됨\"}"));
+
+    assertThatThrownBy(() -> client.cancel(command()))
+        .isInstanceOf(BusinessException.class)
+        .extracting("errorStatus")
+        .isEqualTo(ErrorStatus.PAYMENT_REFUND_FAILED);
+
+    mockServer.verify();
+  }
+
+  @Test
+  @DisplayName("Toss가 5xx를 반환하면 PAYMENT_503_001 예외가 발생한다")
+  void cancel_maps_5xx_to_communication_failed() {
+    mockServer.expect(requestTo(CANCEL_URL)).andRespond(withServerError());
+
+    assertThatThrownBy(() -> client.cancel(command()))
+        .isInstanceOf(BusinessException.class)
+        .extracting("errorStatus")
+        .isEqualTo(ErrorStatus.PAYMENT_PG_COMMUNICATION_FAILED);
+
+    mockServer.verify();
+  }
+
+  @Test
+  @DisplayName("응답 본문이 비어있어도 통신 실패로 처리한다")
+  void cancel_fails_when_response_body_is_empty() {
+    mockServer
+        .expect(requestTo(CANCEL_URL))
+        .andRespond(withRawStatus(200).contentType(MediaType.APPLICATION_JSON).body(""));
+
+    assertThatThrownBy(() -> client.cancel(command()))
+        .isInstanceOf(BusinessException.class)
+        .extracting("errorStatus")
+        .isEqualTo(ErrorStatus.PAYMENT_PG_COMMUNICATION_FAILED);
+
+    mockServer.verify();
+  }
+
+  @Test
+  @DisplayName("응답 cancels가 비어있으면 통신 실패로 처리한다")
+  void cancel_fails_when_cancels_is_empty() {
+    String responseBody =
+        """
+        {
+          "paymentKey": "pgKey_xyz",
+          "status": "CANCELED",
+          "cancels": []
+        }
+        """;
+
+    mockServer
+        .expect(requestTo(CANCEL_URL))
+        .andRespond(withSuccess(responseBody, MediaType.APPLICATION_JSON));
+
+    assertThatThrownBy(() -> client.cancel(command()))
+        .isInstanceOf(BusinessException.class)
+        .extracting("errorStatus")
+        .isEqualTo(ErrorStatus.PAYMENT_PG_COMMUNICATION_FAILED);
+
+    mockServer.verify();
+  }
+
+  @Test
+  @DisplayName("응답에 canceledAt이 없으면 통신 실패로 처리한다")
+  void cancel_fails_when_canceled_at_is_missing() {
+    String responseBody =
+        """
+        {
+          "paymentKey": "pgKey_xyz",
+          "status": "CANCELED",
+          "cancels": [
+            {
+              "transactionKey": "TX-CANCEL-1",
+              "cancelAmount": 55000
+            }
+          ]
+        }
+        """;
+
+    mockServer
+        .expect(requestTo(CANCEL_URL))
+        .andRespond(withSuccess(responseBody, MediaType.APPLICATION_JSON));
+
+    assertThatThrownBy(() -> client.cancel(command()))
+        .isInstanceOf(BusinessException.class)
+        .extracting("errorStatus")
+        .isEqualTo(ErrorStatus.PAYMENT_PG_COMMUNICATION_FAILED);
+
+    mockServer.verify();
+  }
+
+  @Test
+  @DisplayName("TOSS provider만 지원한다")
+  void supports_toss_only() {
+    assertThat(client.supports(PaymentProvider.TOSS)).isTrue();
+    assertThat(client.supports(PaymentProvider.KAKAO)).isFalse();
+    assertThat(client.supports(PaymentProvider.NAVER)).isFalse();
+  }
+
+  private PaymentCancelCommand command() {
+    return new PaymentCancelCommand(
+        PaymentProvider.TOSS, "pgKey_xyz", 55_000L, "단순 변심", "REFUND-0000001");
+  }
+}


### PR DESCRIPTION
## 🔗 관련 이슈

- close #236
- 부모 이슈: #22 (범위가 커서 #235/#236/#237로 분할)

---

## 📌 주요 변경 사항

- 결제 취소(환불) PG 클라이언트 라우팅 구현 (#89 confirm 패턴 차용)
- `PaymentCancelClient` 인터페이스 + `PaymentCancelClientRouter`
- `TossPaymentCancelClient`(실연동) / `StubPaymentCancelClient`(비-prod)
- `ErrorStatus.PAYMENT_REFUND_FAILED` 추가

---

## 🛠 상세 구현 내용

- `PaymentCancelCommand`(provider/paymentKey/amount/reason/idempotencyKey) → `PaymentCancelResult`(pgRefundKey/refundedAmount/canceledAt)
- Router: 요청 provider 지원하는 첫 구현체로 위임, 없으면 `PAYMENT_PROVIDER_NOT_SUPPORTED`
- Toss: `POST /v1/payments/{paymentKey}/cancel`, `Idempotency-Key` 헤더 전송, 4xx → `PAYMENT_REFUND_FAILED` / 5xx·timeout → `PAYMENT_PG_COMMUNICATION_FAILED`(재사용)
- Stub: 비-prod 전용 fallback (요청 금액 그대로 취소 응답)

---

## ✅ 테스트

### 테스트 방법

- `./gradlew :payment-service:spotlessApply :payment-service:checkstyleMain :payment-service:compileJava :payment-service:test`

### 테스트 결과

- 전체 통과
- `PaymentCancelClientRouterTest`(3), `StubPaymentCancelClientTest`(2), `TossPaymentCancelClientTest`(8)

### 📸 스크린샷

---

## 👀 리뷰 요청 사항

- 분할 PR 2/3입니다. **#235(A)와 독립적**이라 머지 순서 무관하게 develop으로 머지 가능합니다.
- 환불 API 본체(UseCase/Controller/이벤트)는 #237에서 본 PR + #235 머지 후 진행합니다.

---

## ⚠️ 배포 시 주의사항

- 없음 (Toss 실연동은 `payment.pg.toss.enabled=true` 시에만 활성, 기본 비활성)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
