### PR TITLE
[Infra] #256 검증 파이프라인 문서화 + ci.yml concurrency 보강

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,11 @@ on:
     branches: [ "develop" ]
     types: [opened, synchronize, reopened]
 
+# 같은 PR에 연속 push 시 진행 중이던 이전 run을 취소해 러너를 절약한다.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ TicketRush 백엔드의 **도구 중립 AI 진입점**입니다. Claude Code·Gi
 ## 빌드 · 테스트
 
 ```bash
-./gradlew spotlessCheck   # 코드 포맷 검사 (작업 완료 전 필수)
+./gradlew spotlessCheck   # 코드 포맷 검사 (pre-commit·CI가 자동 검증; 로컬 사전 확인용)
 ./gradlew test            # 테스트 실행
 ./gradlew build           # 빌드
 ```

--- a/docs/ai-workflow-guide.md
+++ b/docs/ai-workflow-guide.md
@@ -315,3 +315,5 @@ Select-String -Path .claude/logs/tools.jsonl -Pattern 'push --force|rm -rf'
 
 * CI는 **base가 `develop`인 PR에서만** 트리거됩니다(`.github/workflows/ci.yml`, `opened`/`synchronize`/`reopened`). 머지 전 **CI 그린**이 조건입니다(9단계).
 * 모든 루프가 끝나면(🔴·실패·코멘트 해소 + CI 그린) 비로소 머지합니다.
+
+> 📌 위 루프는 **AI 사이클 단계와의 매핑**만 다룹니다. **로컬 git 훅 활성화(`core.hooksPath`)·pre-commit 자동교정 루프·CI 게이트 구성·branch protection** 등 검증 파이프라인의 설정·운영은 [`backend-convention.md`](backend-convention.md) §1 "검증 파이프라인"이 SSOT입니다(여기 중복 기재하지 않음).

--- a/docs/backend-convention.md
+++ b/docs/backend-convention.md
@@ -86,7 +86,7 @@ git config core.hooksPath .githooks
 2. 자동 수정으로 바뀐 파일을 **다시 스테이징**합니다(원래 스테이징돼 있던 `.java`만).
 3. **`./gradlew checkstyleMain checkstyleTest`** — 통과해야 커밋이 진행됩니다.
 
-> 자동 수정이 되더라도, 작업을 마무리하기 전에는 **반드시 직접 `./gradlew spotlessCheck`로 통과를 확인**합니다(MEMORY 규칙). 자동교정은 보조 장치이고, 최종 책임은 사람이 `spotlessCheck`로 확인하는 것입니다.
+> 포맷 검증은 **자동으로 보장**됩니다 — pre-commit이 `spotlessApply`로 자동 교정하고, CI(`ci.yml`)가 `spotlessCheck`로 최종 검사합니다. 따라서 사람이 작업 완료 전 별도로 `spotlessCheck`를 돌릴 필요는 없습니다(원하면 로컬에서 `./gradlew spotlessCheck`로 미리 확인할 수는 있음).
 
 #### ③ commit-msg — 형식 검증
 

--- a/docs/backend-convention.md
+++ b/docs/backend-convention.md
@@ -90,7 +90,7 @@ git config core.hooksPath .githooks
 
 #### ③ commit-msg — 형식 검증
 
-커밋 메시지 첫 줄이 `[Type] #이슈번호 요약` 형식이어야 통과합니다(Merge/Revert/fixup/squash 커밋은 예외). 형식은 위 [커밋 메시지 규칙](#-커밋commit-메시지-규칙)과 동일합니다.
+커밋 메시지 첫 줄이 `[Type] #이슈번호 요약` 형식이어야 통과합니다(Merge/Revert/fixup/squash 커밋은 예외). 형식은 위 **커밋 메시지 규칙**(§1)과 동일합니다.
 
 #### ④ CI 게이트 (`.github/workflows/ci.yml`)
 

--- a/docs/backend-convention.md
+++ b/docs/backend-convention.md
@@ -63,6 +63,46 @@
     * 우선적으로 `develop`에만 Push하며, `main`은 완벽히 준비되었을 때만 머지합니다.
     * 별도의 **Approve(코드 리뷰)는 머지 필수 조건이 아닙니다.**
 
+### 🔒 검증 파이프라인 (로컬 훅 + CI)
+
+커밋·PR이 팀 형식과 코드 스타일을 자동으로 지키도록 **로컬 git 훅**과 **CI 게이트** 2중으로 검증합니다.
+(AI 작업 사이클에서 이 파이프라인이 어떤 회복 루프로 도는지는 [`ai-workflow-guide.md`](ai-workflow-guide.md) 10장 참고.)
+
+#### ① 로컬 git 훅 활성화 (신규 합류자 1회 설정)
+
+훅은 `.githooks/`에 들어 있으며, **각자 로컬에서 한 번** 아래를 실행해야 동작합니다(빠뜨리면 커밋 시 검증이 돌지 않습니다).
+
+```bash
+git config core.hooksPath .githooks
+```
+
+> 저장소 클론 직후 한 번만 설정하면 됩니다. 설정 여부는 `git config core.hooksPath`로 확인할 수 있습니다(값이 `.githooks`면 활성).
+
+#### ② pre-commit — 자동교정 루프
+
+커밋 시 스테이징된 `.java` 파일이 있으면 다음 순서로 돕니다.
+
+1. **`./gradlew spotlessApply`** — 포맷을 **자동 수정**합니다.
+2. 자동 수정으로 바뀐 파일을 **다시 스테이징**합니다(원래 스테이징돼 있던 `.java`만).
+3. **`./gradlew checkstyleMain checkstyleTest`** — 통과해야 커밋이 진행됩니다.
+
+> 자동 수정이 되더라도, 작업을 마무리하기 전에는 **반드시 직접 `./gradlew spotlessCheck`로 통과를 확인**합니다(MEMORY 규칙). 자동교정은 보조 장치이고, 최종 책임은 사람이 `spotlessCheck`로 확인하는 것입니다.
+
+#### ③ commit-msg — 형식 검증
+
+커밋 메시지 첫 줄이 `[Type] #이슈번호 요약` 형식이어야 통과합니다(Merge/Revert/fixup/squash 커밋은 예외). 형식은 위 [커밋 메시지 규칙](#-커밋commit-메시지-규칙)과 동일합니다.
+
+#### ④ CI 게이트 (`.github/workflows/ci.yml`)
+
+`develop`을 대상으로 하는 PR(`opened`/`synchronize`/`reopened`)에서 자동 실행됩니다.
+
+* **단계:** `spotlessCheck` → `checkstyle` → `test` → `build` (job 이름 `build`).
+* **PR 제목 검증:** 별도 워크플로우 `pr-title.yml`(job `validate-title`)이 `[Type] #이슈번호 내용` 형식을 검사합니다.
+* **concurrency:** 같은 PR에 연속 push하면 진행 중이던 이전 run을 자동 취소해 러너를 절약합니다.
+* 머지 전 **CI 그린**이 조건입니다(Approve는 필수 아님 — 위 머지 규칙 참고).
+
+> `develop` 브랜치에는 **branch protection이 이미 적용**되어 `build`(`ci.yml`)·`validate-title`(`pr-title.yml`)가 필수 상태 체크로 요구됩니다(Approve는 강제하지 않음). 적용 변경은 admin 권한이 필요합니다.
+
 ## 2. 코드 및 네이밍 규칙
 
 ### 📁 디렉토리 구조 및 파일명


### PR DESCRIPTION
## 🔗 관련 이슈

- close #256

---

## 📌 주요 변경 사항

- `ci.yml`에 concurrency 추가 — 같은 PR 연속 push 시 이전 run 자동 취소(러너 절약)
- `backend-convention.md` §1에 "검증 파이프라인" 섹션 신설 — 로컬 git 훅 활성화 / 자동교정 루프 / CI 게이트 문서화
- `ai-workflow-guide.md` 10장에 검증 파이프라인 SSOT 교차참조 추가(중복 0 유지)

---

## 🛠 상세 구현 내용

- **ci.yml**: 현행(spotless→checkstyle→test→build)·`cache: gradle`는 충분하여 유지, 빠져 있던 `concurrency`(group `ci-${{ github.ref }}`, cancel-in-progress)만 보강
- **backend-convention.md**: ① `git config core.hooksPath .githooks` 활성화 안내(신규 합류자 1회) ② pre-commit 자동교정 루프(`spotlessApply`→재stage→checkstyle) + 완료 전 `spotlessCheck` 연결 ③ commit-msg 형식 검증 ④ CI 게이트 + branch protection **이미 적용** 현황 명시
- **ai-workflow-guide.md**: 10장 피드백 루프는 AI 사이클 매핑만 유지, 설정·운영 SSOT는 backend-convention.md로 라우팅

---
<!--
## ✅ 테스트

### 테스트 방법

- 문서·CI 설정 변경(프로덕션 코드 없음). `./gradlew spotlessCheck`로 포맷 게이트 통과 확인

### 테스트 결과

- `./gradlew spotlessCheck` → BUILD SUCCESSFUL

### 📸 스크린샷

---
-->
## 👀 리뷰 요청 사항

- 문서 위치(SSOT 분담)가 적절한지 — git 훅·CI·branch protection을 `backend-convention.md`(협업 컨벤션)에 두고 `ai-workflow-guide.md`는 교차참조만

---

## ⚠️ 배포 시 주의사항

- 없음 (런타임 영향 없는 CI/문서 변경)
