### PR TITLE
[Feat] #77 테스트용 토큰 발급 API

### DIFF
--- a/auth-service/build.gradle
+++ b/auth-service/build.gradle
@@ -46,6 +46,7 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-security-test'
 	testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	testImplementation testFixtures(project(":common"))
 
 	// swagger
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.1'

--- a/auth-service/src/main/java/com/ticketrush/boundedcontext/auth/app/dto/request/DevTokenIssueRequest.java
+++ b/auth-service/src/main/java/com/ticketrush/boundedcontext/auth/app/dto/request/DevTokenIssueRequest.java
@@ -1,0 +1,5 @@
+package com.ticketrush.boundedcontext.auth.app.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+
+public record DevTokenIssueRequest(@NotNull(message = "userId는 필수입니다.") Long userId) {}

--- a/auth-service/src/main/java/com/ticketrush/boundedcontext/auth/app/facade/AuthFacade.java
+++ b/auth-service/src/main/java/com/ticketrush/boundedcontext/auth/app/facade/AuthFacade.java
@@ -1,6 +1,5 @@
 package com.ticketrush.boundedcontext.auth.app.facade;
 
-import com.ticketrush.boundedcontext.auth.app.dto.request.DevTokenIssueRequest;
 import com.ticketrush.boundedcontext.auth.app.dto.request.LoginRequest;
 import com.ticketrush.boundedcontext.auth.app.dto.request.SignupEmailAuthNumberSendRequest;
 import com.ticketrush.boundedcontext.auth.app.dto.request.SignupEmailAuthNumberVerifyRequest;
@@ -9,7 +8,6 @@ import com.ticketrush.boundedcontext.auth.app.dto.response.login.LoginResponse;
 import com.ticketrush.boundedcontext.auth.app.dto.response.signup.SignupEmailAuthNumberSendResponse;
 import com.ticketrush.boundedcontext.auth.app.dto.response.signup.SignupEmailAuthNumberVerifyResponse;
 import com.ticketrush.boundedcontext.auth.app.dto.response.signup.SignupEmailVerificationCheckResponse;
-import com.ticketrush.boundedcontext.auth.app.usecase.DevTokenIssueUseCase;
 import com.ticketrush.boundedcontext.auth.app.usecase.LoginUseCase;
 import com.ticketrush.boundedcontext.auth.app.usecase.SignupEmailAuthNumberSendUseCase;
 import com.ticketrush.boundedcontext.auth.app.usecase.SignupEmailAuthNumberVerifyUseCase;
@@ -27,7 +25,6 @@ public class AuthFacade {
   private final SignupEmailVerificationCheckUseCase signupEmailVerificationCheckUseCase;
   private final SignupEmailVerificationConsumeUseCase signupEmailVerificationConsumeUseCase;
   private final LoginUseCase loginUseCase;
-  private final DevTokenIssueUseCase devTokenIssueUseCase;
 
   // Email 인증번호 발송
   public SignupEmailAuthNumberSendResponse sendSignupEmailAuthNumber(
@@ -52,9 +49,5 @@ public class AuthFacade {
 
   public LoginResponse login(LoginRequest request) {
     return loginUseCase.execute(request);
-  }
-
-  public LoginResponse issueDevToken(DevTokenIssueRequest request) {
-    return devTokenIssueUseCase.execute(request);
   }
 }

--- a/auth-service/src/main/java/com/ticketrush/boundedcontext/auth/app/facade/AuthFacade.java
+++ b/auth-service/src/main/java/com/ticketrush/boundedcontext/auth/app/facade/AuthFacade.java
@@ -1,5 +1,6 @@
 package com.ticketrush.boundedcontext.auth.app.facade;
 
+import com.ticketrush.boundedcontext.auth.app.dto.request.DevTokenIssueRequest;
 import com.ticketrush.boundedcontext.auth.app.dto.request.LoginRequest;
 import com.ticketrush.boundedcontext.auth.app.dto.request.SignupEmailAuthNumberSendRequest;
 import com.ticketrush.boundedcontext.auth.app.dto.request.SignupEmailAuthNumberVerifyRequest;
@@ -8,6 +9,7 @@ import com.ticketrush.boundedcontext.auth.app.dto.response.login.LoginResponse;
 import com.ticketrush.boundedcontext.auth.app.dto.response.signup.SignupEmailAuthNumberSendResponse;
 import com.ticketrush.boundedcontext.auth.app.dto.response.signup.SignupEmailAuthNumberVerifyResponse;
 import com.ticketrush.boundedcontext.auth.app.dto.response.signup.SignupEmailVerificationCheckResponse;
+import com.ticketrush.boundedcontext.auth.app.usecase.DevTokenIssueUseCase;
 import com.ticketrush.boundedcontext.auth.app.usecase.LoginUseCase;
 import com.ticketrush.boundedcontext.auth.app.usecase.SignupEmailAuthNumberSendUseCase;
 import com.ticketrush.boundedcontext.auth.app.usecase.SignupEmailAuthNumberVerifyUseCase;
@@ -25,6 +27,7 @@ public class AuthFacade {
   private final SignupEmailVerificationCheckUseCase signupEmailVerificationCheckUseCase;
   private final SignupEmailVerificationConsumeUseCase signupEmailVerificationConsumeUseCase;
   private final LoginUseCase loginUseCase;
+  private final DevTokenIssueUseCase devTokenIssueUseCase;
 
   // Email 인증번호 발송
   public SignupEmailAuthNumberSendResponse sendSignupEmailAuthNumber(
@@ -49,5 +52,9 @@ public class AuthFacade {
 
   public LoginResponse login(LoginRequest request) {
     return loginUseCase.execute(request);
+  }
+
+  public LoginResponse issueDevToken(DevTokenIssueRequest request) {
+    return devTokenIssueUseCase.execute(request);
   }
 }

--- a/auth-service/src/main/java/com/ticketrush/boundedcontext/auth/app/facade/DevAuthFacade.java
+++ b/auth-service/src/main/java/com/ticketrush/boundedcontext/auth/app/facade/DevAuthFacade.java
@@ -1,0 +1,20 @@
+package com.ticketrush.boundedcontext.auth.app.facade;
+
+import com.ticketrush.boundedcontext.auth.app.dto.request.DevTokenIssueRequest;
+import com.ticketrush.boundedcontext.auth.app.dto.response.login.LoginResponse;
+import com.ticketrush.boundedcontext.auth.app.usecase.DevTokenIssueUseCase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+@Profile({"local", "dev"})
+@Component
+@RequiredArgsConstructor
+public class DevAuthFacade {
+
+  private final DevTokenIssueUseCase devTokenIssueUseCase;
+
+  public LoginResponse issueDevToken(DevTokenIssueRequest request) {
+    return devTokenIssueUseCase.execute(request);
+  }
+}

--- a/auth-service/src/main/java/com/ticketrush/boundedcontext/auth/app/usecase/DevTokenIssueUseCase.java
+++ b/auth-service/src/main/java/com/ticketrush/boundedcontext/auth/app/usecase/DevTokenIssueUseCase.java
@@ -1,0 +1,41 @@
+package com.ticketrush.boundedcontext.auth.app.usecase;
+
+import com.ticketrush.boundedcontext.auth.app.dto.request.DevTokenIssueRequest;
+import com.ticketrush.boundedcontext.auth.app.dto.response.login.LoginResponse;
+import com.ticketrush.boundedcontext.auth.app.dto.response.login.UserServiceAuthInfoResponse;
+import com.ticketrush.boundedcontext.auth.out.apiclient.UserServiceClient;
+import com.ticketrush.global.security.JwtTokenProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Profile({"local", "dev"})
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class DevTokenIssueUseCase {
+
+  private final UserServiceClient userServiceClient;
+  private final JwtTokenProvider jwtTokenProvider;
+
+  public LoginResponse execute(DevTokenIssueRequest request) {
+    UserServiceAuthInfoResponse user = userServiceClient.getUserAuthInfoByUserId(request.userId());
+
+    String normalizedRole = normalizeRole(user.role());
+
+    String accessToken = jwtTokenProvider.createAccessToken(user.userId(), normalizedRole);
+    String refreshToken = jwtTokenProvider.createRefreshToken(user.userId());
+
+    return new LoginResponse(
+        user.userId(), user.email(), normalizedRole, accessToken, refreshToken);
+  }
+
+  private String normalizeRole(String role) {
+    return switch (role) {
+      case "MEMBER" -> "USER";
+      case "ADMIN" -> "ADMIN";
+      default -> throw new IllegalArgumentException("지원하지 않는 사용자 역할입니다: " + role);
+    };
+  }
+}

--- a/auth-service/src/main/java/com/ticketrush/boundedcontext/auth/in/api/v1/DevTokenController.java
+++ b/auth-service/src/main/java/com/ticketrush/boundedcontext/auth/in/api/v1/DevTokenController.java
@@ -1,0 +1,38 @@
+package com.ticketrush.boundedcontext.auth.in.api.v1;
+
+import com.ticketrush.boundedcontext.auth.app.dto.request.DevTokenIssueRequest;
+import com.ticketrush.boundedcontext.auth.app.dto.response.login.LoginResponse;
+import com.ticketrush.boundedcontext.auth.app.facade.AuthFacade;
+import com.ticketrush.global.dto.response.ApiResponse;
+import com.ticketrush.global.status.SuccessStatus;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Profile({"local", "dev"})
+@Tag(name = "Dev Auth", description = "개발 및 테스트용 인증 API")
+@RestController
+@RequestMapping("/api/v1/dev/auth")
+@RequiredArgsConstructor
+public class DevTokenController {
+
+  private final AuthFacade authFacade;
+
+  @Operation(
+      summary = "테스트용 토큰 발급",
+      description = "프론트엔드 테스트를 위해 userId 기준으로 access token과 refresh token을 발급합니다.")
+  @PostMapping("/token")
+  public ResponseEntity<ApiResponse<LoginResponse>> issueDevToken(
+      @Valid @RequestBody DevTokenIssueRequest request) {
+    LoginResponse response = authFacade.issueDevToken(request);
+
+    return ApiResponse.onSuccess(SuccessStatus.OK, response);
+  }
+}

--- a/auth-service/src/main/java/com/ticketrush/boundedcontext/auth/in/api/v1/DevTokenController.java
+++ b/auth-service/src/main/java/com/ticketrush/boundedcontext/auth/in/api/v1/DevTokenController.java
@@ -2,7 +2,7 @@ package com.ticketrush.boundedcontext.auth.in.api.v1;
 
 import com.ticketrush.boundedcontext.auth.app.dto.request.DevTokenIssueRequest;
 import com.ticketrush.boundedcontext.auth.app.dto.response.login.LoginResponse;
-import com.ticketrush.boundedcontext.auth.app.facade.AuthFacade;
+import com.ticketrush.boundedcontext.auth.app.facade.DevAuthFacade;
 import com.ticketrush.global.dto.response.ApiResponse;
 import com.ticketrush.global.status.SuccessStatus;
 import io.swagger.v3.oas.annotations.Operation;
@@ -23,7 +23,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class DevTokenController {
 
-  private final AuthFacade authFacade;
+  private final DevAuthFacade devAuthFacade;
 
   @Operation(
       summary = "테스트용 토큰 발급",
@@ -31,7 +31,7 @@ public class DevTokenController {
   @PostMapping("/token")
   public ResponseEntity<ApiResponse<LoginResponse>> issueDevToken(
       @Valid @RequestBody DevTokenIssueRequest request) {
-    LoginResponse response = authFacade.issueDevToken(request);
+    LoginResponse response = devAuthFacade.issueDevToken(request);
 
     return ApiResponse.onSuccess(SuccessStatus.OK, response);
   }

--- a/auth-service/src/main/java/com/ticketrush/boundedcontext/auth/out/apiclient/UserServiceClient.java
+++ b/auth-service/src/main/java/com/ticketrush/boundedcontext/auth/out/apiclient/UserServiceClient.java
@@ -36,6 +36,8 @@ public class UserServiceClient {
   private static final String EMAIL_EXISTS_PATH = "/api/v1/user/exists/email?email={email}";
   private static final String USER_AUTH_INFO_PATH = "/api/v1/internal/user/auth-info";
   private static final String INTERNAL_TOKEN_HEADER = "X-Internal-Token";
+  private static final String USER_AUTH_INFO_BY_USER_ID_PATH =
+      "/api/v1/internal/user/{userId}/auth-info";
 
   public UserServiceSocialLoginResponse socialLogin(UserServiceSocialLoginRequest request) {
 
@@ -161,6 +163,51 @@ public class UserServiceClient {
       throw e;
     } catch (Exception e) {
       log.error("user-service 로그인용 회원 정보 조회 통신 실패 email={}", email, e);
+      throw new BusinessException(ErrorStatus.AUTH_USER_COMMUNICATION_FAILED);
+    }
+  }
+
+  // 테스트 토큰 발급용 회원 정보 조회
+  public UserServiceAuthInfoResponse getUserAuthInfoByUserId(Long userId) {
+    if (userId == null) {
+      throw new BusinessException(ErrorStatus.AUTH_LOGIN_BAD_REQUEST);
+    }
+
+    try {
+      UserServiceApiResponse<UserServiceAuthInfoResponse> response =
+          restClient
+              .get()
+              .uri(userServiceBaseUrl + USER_AUTH_INFO_BY_USER_ID_PATH, userId)
+              .header(INTERNAL_TOKEN_HEADER, customSecurityProperties.getInternalToken())
+              .retrieve()
+              .onStatus(
+                  HttpStatusCode::is4xxClientError,
+                  (req, res) -> {
+                    log.error(
+                        "user-service 테스트 토큰용 회원 정보 조회 4xx 에러 발생: status={}", res.getStatusCode());
+                    throw new BusinessException(ErrorStatus.AUTH_LOGIN_FAILED);
+                  })
+              .onStatus(
+                  HttpStatusCode::is5xxServerError,
+                  (req, res) -> {
+                    log.error(
+                        "user-service 테스트 토큰용 회원 정보 조회 5xx 에러 발생: status={}", res.getStatusCode());
+                    throw new BusinessException(ErrorStatus.AUTH_USER_SERVER_ERROR);
+                  })
+              .body(
+                  new ParameterizedTypeReference<
+                      UserServiceApiResponse<UserServiceAuthInfoResponse>>() {});
+
+      if (response == null || response.result() == null) {
+        throw new BusinessException(ErrorStatus.AUTH_USER_COMMUNICATION_FAILED);
+      }
+
+      return response.result();
+
+    } catch (BusinessException e) {
+      throw e;
+    } catch (Exception e) {
+      log.error("user-service 테스트 토큰용 회원 정보 조회 통신 실패 userId={}", userId, e);
       throw new BusinessException(ErrorStatus.AUTH_USER_COMMUNICATION_FAILED);
     }
   }

--- a/auth-service/src/main/java/com/ticketrush/global/security/InternalApiTokenFilter.java
+++ b/auth-service/src/main/java/com/ticketrush/global/security/InternalApiTokenFilter.java
@@ -31,6 +31,8 @@ public class InternalApiTokenFilter extends OncePerRequestFilter {
   private static final String SIGNUP_EMAIL_VERIFICATION_CONSUME_PATH =
       "/api/v1/auth/signup/email-verification/consume";
 
+  private static final String INTERNAL_USER_API_PREFIX = "/api/v1/internal/user";
+
   private final CustomSecurityProperties securityProperties;
 
   @Override
@@ -63,10 +65,15 @@ public class InternalApiTokenFilter extends OncePerRequestFilter {
   }
 
   private boolean isInternalApi(HttpServletRequest request) {
-    String path = request.getRequestURI();
+    String path = request.getServletPath();
     String method = request.getMethod();
 
-    return (HttpMethod.GET.matches(method) && SIGNUP_EMAIL_VERIFICATION_VERIFIED_PATH.equals(path))
+    return isInternalUserApi(path)
+        || (HttpMethod.GET.matches(method) && SIGNUP_EMAIL_VERIFICATION_VERIFIED_PATH.equals(path))
         || (HttpMethod.POST.matches(method) && SIGNUP_EMAIL_VERIFICATION_CONSUME_PATH.equals(path));
+  }
+
+  private boolean isInternalUserApi(String path) {
+    return INTERNAL_USER_API_PREFIX.equals(path) || path.startsWith(INTERNAL_USER_API_PREFIX + "/");
   }
 }

--- a/auth-service/src/test/java/com/ticketrush/boundedcontext/auth/app/usecase/DevTokenIssueUseCaseTest.java
+++ b/auth-service/src/test/java/com/ticketrush/boundedcontext/auth/app/usecase/DevTokenIssueUseCaseTest.java
@@ -1,0 +1,112 @@
+package com.ticketrush.boundedcontext.auth.app.usecase;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.anyLong;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.ticketrush.boundedcontext.auth.app.dto.request.DevTokenIssueRequest;
+import com.ticketrush.boundedcontext.auth.app.dto.response.login.LoginResponse;
+import com.ticketrush.boundedcontext.auth.app.dto.response.login.UserServiceAuthInfoResponse;
+import com.ticketrush.boundedcontext.auth.out.apiclient.UserServiceClient;
+import com.ticketrush.global.exception.BusinessException;
+import com.ticketrush.global.security.JwtTokenProvider;
+import com.ticketrush.global.status.ErrorStatus;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class DevTokenIssueUseCaseTest {
+
+  @Mock private UserServiceClient userServiceClient;
+
+  @Mock private JwtTokenProvider jwtTokenProvider;
+
+  @InjectMocks private DevTokenIssueUseCase devTokenIssueUseCase;
+
+  @Test
+  @DisplayName("userId로 회원 정보를 조회한 뒤 테스트용 토큰을 발급한다")
+  void issueDevToken_success() {
+    // given
+    Long userId = 1L;
+    String email = "test@example.com";
+    String passwordHash = "$2a$10$encoded-password";
+    String userServiceRole = "MEMBER";
+    String tokenRole = "USER";
+
+    DevTokenIssueRequest request = new DevTokenIssueRequest(userId);
+
+    UserServiceAuthInfoResponse userInfo =
+        new UserServiceAuthInfoResponse(userId, email, passwordHash, userServiceRole);
+
+    when(userServiceClient.getUserAuthInfoByUserId(userId)).thenReturn(userInfo);
+    when(jwtTokenProvider.createAccessToken(userId, tokenRole)).thenReturn("access-token");
+    when(jwtTokenProvider.createRefreshToken(userId)).thenReturn("refresh-token");
+
+    // when
+    LoginResponse response = devTokenIssueUseCase.execute(request);
+
+    // then
+    assertThat(response.userId()).isEqualTo(userId);
+    assertThat(response.email()).isEqualTo(email);
+    assertThat(response.role()).isEqualTo(tokenRole);
+    assertThat(response.accessToken()).isEqualTo("access-token");
+    assertThat(response.refreshToken()).isEqualTo("refresh-token");
+
+    verify(userServiceClient).getUserAuthInfoByUserId(userId);
+    verify(jwtTokenProvider).createAccessToken(userId, tokenRole);
+    verify(jwtTokenProvider).createRefreshToken(userId);
+  }
+
+  @Test
+  @DisplayName("user-service에서 회원 정보를 찾지 못하면 테스트 토큰 발급에 실패한다")
+  void issueDevToken_fail_whenUserServiceThrowsException() {
+    // given
+    Long userId = 999L;
+    DevTokenIssueRequest request = new DevTokenIssueRequest(userId);
+
+    when(userServiceClient.getUserAuthInfoByUserId(userId))
+        .thenThrow(new BusinessException(ErrorStatus.AUTH_LOGIN_FAILED));
+
+    // when & then
+    assertThatThrownBy(() -> devTokenIssueUseCase.execute(request))
+        .isInstanceOf(BusinessException.class);
+
+    verify(userServiceClient).getUserAuthInfoByUserId(userId);
+    verify(jwtTokenProvider, never()).createAccessToken(anyLong(), anyString());
+    verify(jwtTokenProvider, never()).createRefreshToken(anyLong());
+  }
+
+  @Test
+  @DisplayName("지원하지 않는 role이면 테스트 토큰 발급에 실패한다")
+  void issueDevToken_fail_whenUnsupportedRole() {
+    // given
+    Long userId = 1L;
+    String email = "test@example.com";
+    String passwordHash = "$2a$10$encoded-password";
+    String unsupportedRole = "MANAGER";
+
+    DevTokenIssueRequest request = new DevTokenIssueRequest(userId);
+
+    UserServiceAuthInfoResponse userInfo =
+        new UserServiceAuthInfoResponse(userId, email, passwordHash, unsupportedRole);
+
+    when(userServiceClient.getUserAuthInfoByUserId(userId)).thenReturn(userInfo);
+
+    // when & then
+    assertThatThrownBy(() -> devTokenIssueUseCase.execute(request))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("지원하지 않는 사용자 역할입니다");
+
+    verify(userServiceClient).getUserAuthInfoByUserId(userId);
+    verify(jwtTokenProvider, never()).createAccessToken(anyLong(), anyString());
+    verify(jwtTokenProvider, never()).createRefreshToken(anyLong());
+  }
+}

--- a/auth-service/src/test/java/com/ticketrush/boundedcontext/auth/in/api/v1/DevTokenControllerTest.java
+++ b/auth-service/src/test/java/com/ticketrush/boundedcontext/auth/in/api/v1/DevTokenControllerTest.java
@@ -9,7 +9,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.ticketrush.boundedcontext.auth.app.dto.request.DevTokenIssueRequest;
 import com.ticketrush.boundedcontext.auth.app.dto.response.login.LoginResponse;
-import com.ticketrush.boundedcontext.auth.app.facade.AuthFacade;
+import com.ticketrush.boundedcontext.auth.app.facade.DevAuthFacade;
 import com.ticketrush.global.config.CustomSecurityProperties;
 import com.ticketrush.global.config.SecurityConfig;
 import com.ticketrush.global.filter.GatewayHeaderFilter;
@@ -46,7 +46,7 @@ class DevTokenControllerTest {
 
   @Autowired private MockMvc mockMvc;
 
-  @MockitoBean private AuthFacade authFacade;
+  @MockitoBean private DevAuthFacade devAuthFacade;
 
   @Test
   @DisplayName("userId를 전달하면 테스트용 토큰을 발급한다")
@@ -57,7 +57,7 @@ class DevTokenControllerTest {
     LoginResponse response =
         new LoginResponse(userId, "test@example.com", "USER", "access-token", "refresh-token");
 
-    given(authFacade.issueDevToken(any(DevTokenIssueRequest.class))).willReturn(response);
+    given(devAuthFacade.issueDevToken(any(DevTokenIssueRequest.class))).willReturn(response);
 
     // when & then
     mockMvc

--- a/auth-service/src/test/java/com/ticketrush/boundedcontext/auth/in/api/v1/DevTokenControllerTest.java
+++ b/auth-service/src/test/java/com/ticketrush/boundedcontext/auth/in/api/v1/DevTokenControllerTest.java
@@ -1,0 +1,99 @@
+package com.ticketrush.boundedcontext.auth.in.api.v1;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.ticketrush.boundedcontext.auth.app.dto.request.DevTokenIssueRequest;
+import com.ticketrush.boundedcontext.auth.app.dto.response.login.LoginResponse;
+import com.ticketrush.boundedcontext.auth.app.facade.AuthFacade;
+import com.ticketrush.global.config.CustomSecurityProperties;
+import com.ticketrush.global.config.SecurityConfig;
+import com.ticketrush.global.filter.GatewayHeaderFilter;
+import com.ticketrush.global.security.InternalApiTokenFilter;
+import com.ticketrush.support.WebMvcSliceTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@ActiveProfiles("local")
+@WebMvcSliceTest(DevTokenController.class)
+@Import({
+  SecurityConfig.class,
+  InternalApiTokenFilter.class,
+  GatewayHeaderFilter.class,
+  CustomSecurityProperties.class
+})
+@TestPropertySource(
+    properties = {
+      "custom.security.internal-token=test-internal-token",
+      "custom.security.permit-all=true",
+      "gateway.internal-token=test-internal-token"
+    })
+class DevTokenControllerTest {
+
+  private static final String INTERNAL_TOKEN_HEADER = "X-Internal-Token";
+  private static final String INTERNAL_TOKEN = "test-internal-token";
+
+  @Autowired private MockMvc mockMvc;
+
+  @MockitoBean private AuthFacade authFacade;
+
+  @Test
+  @DisplayName("userId를 전달하면 테스트용 토큰을 발급한다")
+  void issueDevToken_success() throws Exception {
+    // given
+    Long userId = 1L;
+
+    LoginResponse response =
+        new LoginResponse(userId, "test@example.com", "USER", "access-token", "refresh-token");
+
+    given(authFacade.issueDevToken(any(DevTokenIssueRequest.class))).willReturn(response);
+
+    // when & then
+    mockMvc
+        .perform(
+            post("/api/v1/dev/auth/token")
+                .header(INTERNAL_TOKEN_HEADER, INTERNAL_TOKEN)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(
+                    """
+            {
+              "user_id": 1
+            }
+            """))
+        .andDo(print())
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.is_success").value(true))
+        .andExpect(jsonPath("$.code").value("COMMON_200"))
+        .andExpect(jsonPath("$.message").value("성공입니다."))
+        .andExpect(jsonPath("$.result.user_id").value(userId))
+        .andExpect(jsonPath("$.result.email").value("test@example.com"))
+        .andExpect(jsonPath("$.result.role").value("USER"))
+        .andExpect(jsonPath("$.result.access_token").value("access-token"))
+        .andExpect(jsonPath("$.result.refresh_token").value("refresh-token"));
+  }
+
+  @Test
+  @DisplayName("userId가 없으면 테스트용 토큰 발급 요청에 실패한다")
+  void issueDevToken_fail_whenUserIdIsNull() throws Exception {
+    // when & then
+    mockMvc
+        .perform(
+            post("/api/v1/dev/auth/token")
+                .header(INTERNAL_TOKEN_HEADER, INTERNAL_TOKEN)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{}"))
+        .andDo(print())
+        .andExpect(status().isBadRequest());
+  }
+}

--- a/user-service/src/main/java/com/ticketrush/boundedcontext/user/app/facade/UserFacade.java
+++ b/user-service/src/main/java/com/ticketrush/boundedcontext/user/app/facade/UserFacade.java
@@ -9,6 +9,7 @@ import com.ticketrush.boundedcontext.user.app.dto.response.UserAuthInfoResponse;
 import com.ticketrush.boundedcontext.user.app.dto.response.UserMeResponse;
 import com.ticketrush.boundedcontext.user.app.usecase.EmailExistsUseCase;
 import com.ticketrush.boundedcontext.user.app.usecase.GetUserAuthInfoByEmailUseCase;
+import com.ticketrush.boundedcontext.user.app.usecase.GetUserAuthInfoByUserIdUseCase;
 import com.ticketrush.boundedcontext.user.app.usecase.GetUserMeUseCase;
 import com.ticketrush.boundedcontext.user.app.usecase.SignupUseCase;
 import com.ticketrush.boundedcontext.user.app.usecase.SocialLoginUseCase;
@@ -24,6 +25,7 @@ public class UserFacade {
   private final SignupUseCase signupUseCase;
   private final GetUserAuthInfoByEmailUseCase getUserAuthInfoByEmailUseCase;
   private final GetUserMeUseCase getUserMeUseCase;
+  private final GetUserAuthInfoByUserIdUseCase getUserAuthInfoByUserIdUseCase;
 
   // 소셜 로그인
   public SocialLoginResponse socialLogin(SocialLoginRequest request) {
@@ -48,5 +50,10 @@ public class UserFacade {
   // 회원정보 조회
   public UserMeResponse getMyInfo(Long userId) {
     return getUserMeUseCase.execute(userId);
+  }
+
+  // userId로 회원 인증 정보 조회
+  public UserAuthInfoResponse getUserAuthInfoByUserId(Long userId) {
+    return getUserAuthInfoByUserIdUseCase.execute(userId);
   }
 }

--- a/user-service/src/main/java/com/ticketrush/boundedcontext/user/app/usecase/GetUserAuthInfoByUserIdUseCase.java
+++ b/user-service/src/main/java/com/ticketrush/boundedcontext/user/app/usecase/GetUserAuthInfoByUserIdUseCase.java
@@ -1,0 +1,35 @@
+package com.ticketrush.boundedcontext.user.app.usecase;
+
+import com.ticketrush.boundedcontext.user.app.dto.response.UserAuthInfoResponse;
+import com.ticketrush.boundedcontext.user.domain.entity.User;
+import com.ticketrush.boundedcontext.user.domain.entity.UserAccount;
+import com.ticketrush.boundedcontext.user.out.repository.UserAccountRepository;
+import com.ticketrush.global.exception.BusinessException;
+import com.ticketrush.global.status.ErrorStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class GetUserAuthInfoByUserIdUseCase {
+
+  private final UserAccountRepository userAccountRepository;
+
+  @Transactional(readOnly = true)
+  public UserAuthInfoResponse execute(Long userId) {
+    UserAccount userAccount =
+        userAccountRepository
+            .findByUserId(userId)
+            .orElseThrow(() -> new BusinessException(ErrorStatus.USER_NOT_FOUND));
+
+    if (userAccount.getPassword() == null || userAccount.getPassword().isBlank()) {
+      throw new BusinessException(ErrorStatus.USER_NOT_FOUND);
+    }
+
+    User user = userAccount.getUser();
+
+    return new UserAuthInfoResponse(
+        user.getId(), user.getEmail(), userAccount.getPassword(), user.getUserRole().name());
+  }
+}

--- a/user-service/src/main/java/com/ticketrush/boundedcontext/user/in/api/v1/InternalUserController.java
+++ b/user-service/src/main/java/com/ticketrush/boundedcontext/user/in/api/v1/InternalUserController.java
@@ -9,6 +9,8 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -27,6 +29,15 @@ public class InternalUserController {
   public ResponseEntity<ApiResponse<UserAuthInfoResponse>> getUserAuthInfoByEmail(
       @RequestBody UserAuthInfoRequest request) {
     UserAuthInfoResponse response = userFacade.getUserAuthInfoByEmail(request.email());
+
+    return ApiResponse.onSuccess(SuccessStatus.OK, response);
+  }
+
+  @Operation(summary = "테스트 토큰 발급용 회원 정보 조회", description = "userId로 토큰 발급에 필요한 회원 정보를 조회합니다.")
+  @GetMapping("/{userId}/auth-info")
+  public ResponseEntity<ApiResponse<UserAuthInfoResponse>> getUserAuthInfoByUserId(
+      @PathVariable Long userId) {
+    UserAuthInfoResponse response = userFacade.getUserAuthInfoByUserId(userId);
 
     return ApiResponse.onSuccess(SuccessStatus.OK, response);
   }

--- a/user-service/src/main/java/com/ticketrush/boundedcontext/user/out/repository/UserAccountRepository.java
+++ b/user-service/src/main/java/com/ticketrush/boundedcontext/user/out/repository/UserAccountRepository.java
@@ -10,4 +10,7 @@ public interface UserAccountRepository extends JpaRepository<UserAccount, Long> 
 
   @Query("select ua from UserAccount ua join fetch ua.user u where u.email = :email")
   Optional<UserAccount> findByEmail(@Param("email") String email);
+
+  @Query("select ua from UserAccount ua join fetch ua.user u where u.id = :userId")
+  Optional<UserAccount> findByUserId(@Param("userId") Long userId);
 }

--- a/user-service/src/main/java/com/ticketrush/global/config/SecurityConfig.java
+++ b/user-service/src/main/java/com/ticketrush/global/config/SecurityConfig.java
@@ -30,7 +30,7 @@ public class SecurityConfig {
             auth ->
                 auth.requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html")
                     .permitAll()
-                    .requestMatchers(HttpMethod.POST, "/api/v1/internal/user/auth-info")
+                    .requestMatchers("/api/v1/internal/user/**")
                     .hasRole("INTERNAL")
                     .requestMatchers(HttpMethod.GET, "/api/v1/user/me")
                     .authenticated()


### PR DESCRIPTION
## 🔗 관련 이슈

- close #77 

---

## 📌 주요 변경 사항

- auth-service에 프론트엔드 개발 편의를 위한 테스트용 토큰 발급 API 추가
- userId 기준으로 회원 정보를 조회한 뒤 기존 로그인 응답과 동일한 형태의 access token / refresh token 발급
- 테스트용 API는 local, dev 프로필에서만 활성화되도록 제한
- auth-service ↔ user-service 내부 통신을 통해 userId 기반 회원 인증 정보 조회 기능 추가
- 기존 로그인 응답 DTO인 LoginResponse를 재사용하여 프론트엔드에서 기존 로그인 성공 처리 로직을 그대로 사용할 수 있도록 구현

---

## 🛠 상세 구현 내용

- auth-service에 `DevTokenController`, `DevTokenIssueRequest`, `DevTokenIssueUseCase`를 추가하여 `userId` 기반 테스트용 토큰 발급 흐름을 구현했습니다.
- 테스트용 토큰 발급 시 user-service 내부 API로 회원 인증 정보를 조회하고, 기존 `LoginUseCase`와 동일하게 role 정규화 후 access token / refresh token을 발급합니다.
- 응답은 기존 `LoginResponse`를 재사용하여 프론트엔드가 기존 로그인 성공 처리 로직을 그대로 사용할 수 있도록 했습니다.
- user-service에는 `GET /api/v1/internal/user/{userId}/auth-info` API와 userId 기반 인증 정보 조회 UseCase를 추가했습니다.
- `UserAccountRepository`에 userId 기반 fetch join 조회 쿼리를 추가하여 `UserAuthInfoResponse` 생성에 필요한 회원 계정 정보를 조회하도록 했습니다.

---

## ✅ 테스트

### 테스트 방법

- ./gradlew :auth-service:check :user-service:check :gateway-service:check

### 테스트 결과

- 신규/수정 테스트
  - DevTokenIssueUseCaseTest
    - userId 기반 테스트용 토큰 발급 성공
    - user-service에서 회원 정보 조회 실패 시 토큰 발급 실패
    - 지원하지 않는 role인 경우 토큰 발급 실패
  - DevTokenControllerTest
    - userId 전달 시 테스트용 토큰 발급 성공
    - userId 누락 시 요청 검증 실패
  - GetUserAuthInfoByUserIdUseCaseTest
    - userId 기반 회원 인증 정보 조회 성공
    - 회원 계정이 없을 경우 예외 발생
    - 비밀번호가 없는 계정일 경우 예외 발생
  - InternalUserControllerTest
    - 내부 API에서 userId 기반 회원 인증 정보 조회 성공

- auth-service / user-service / gateway-service check 통과 확인

### 📸 스크린샷
<img width="870" height="199" alt="image" src="https://github.com/user-attachments/assets/e79fcf57-23c3-4224-b61b-3899cdc6ecfc" />

---

## 👀 리뷰 요청 사항

- 테스트용 토큰 발급 API는 프론트엔드 개발 편의를 위한 기능이므로 local, dev 프로필에서만 활성화되도록 제한했습니다.
- 프론트엔드는 POST /api/v1/dev/auth/token에 userId만 전달하면 기존 로그인 API와 동일한 LoginResponse를 받을 수 있습니다.
- 응답 형태가 기존 로그인과 동일하므로 프론트엔드에서는 기존 로그인 성공 처리 로직을 그대로 재사용할 수 있습니다.
- 토큰 발급 책임은 auth-service가 담당하고, user-service는 userId 기반 회원 인증 정보 조회만 담당하도록 책임을 분리했습니다.
- 테스트용 API 경로를 /api/v1/dev/auth/token으로 두었는데, 개발용 API 네이밍 관점에서 적절한지 리뷰 부탁드립니다.

---

## ⚠️ 배포 시 주의사항

- 해당 API는 local, dev 프로필에서만 활성화됩니다.
- 운영 환경에서는 테스트용 토큰 발급 API가 노출되지 않아야 합니다.
- 프론트엔드 테스트 시 요청 형식은 아래와 같습니다.

```http
POST /api/v1/dev/auth/token
Content-Type: application/json
