### PR TITLE
[Feat] #188 결제 완료 시 bookingNumber-seatId 검증 후 좌석 SOLD 확정 호출

### DIFF
--- a/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/app/dto/request/SeatSoldConfirmRequest.java
+++ b/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/app/dto/request/SeatSoldConfirmRequest.java
@@ -1,0 +1,7 @@
+package com.ticketrush.boundedcontext.booking.app.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/** seat-service 좌석 판매 확정 API(POST /api/v1/seat/internal/sold) 요청 바디. */
+public record SeatSoldConfirmRequest(
+    @JsonProperty("booking_number") String bookingNumber, @JsonProperty("seat_id") Long seatId) {}

--- a/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/app/usecase/BookingConfirmUseCase.java
+++ b/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/app/usecase/BookingConfirmUseCase.java
@@ -16,12 +16,20 @@ public class BookingConfirmUseCase {
 
   private final BookingRepository bookingRepository;
 
-  public void execute(Long bookingId, LocalDateTime confirmedAt) {
+  public String execute(Long bookingId, LocalDateTime confirmedAt, Long expectedSeatId) {
     Booking booking =
         bookingRepository
             .findById(bookingId)
             .orElseThrow(() -> new BusinessException(ErrorStatus.BOOKING_NOT_FOUND));
 
+    // 결제 컨텍스트의 seatId가 예매의 seatId와 일치하는지 검증한다.
+    // 불일치 시 좌석 SOLD 확정으로 이어지지 않도록 예매 확정 전에 차단한다.
+    if (!booking.getSeatId().equals(expectedSeatId)) {
+      throw new BusinessException(ErrorStatus.BOOKING_SEAT_MISMATCH);
+    }
+
     booking.confirm(confirmedAt);
+
+    return booking.getBookingNumber();
   }
 }

--- a/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/in/eventlistener/PaymentConfirmedEventListener.java
+++ b/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/in/eventlistener/PaymentConfirmedEventListener.java
@@ -1,6 +1,7 @@
 package com.ticketrush.boundedcontext.booking.in.eventlistener;
 
 import com.ticketrush.boundedcontext.booking.app.usecase.BookingConfirmUseCase;
+import com.ticketrush.boundedcontext.booking.out.apiclient.SeatRestClient;
 import com.ticketrush.global.event.DomainEventEnvelope;
 import com.ticketrush.global.json.JsonConverter;
 import com.ticketrush.shared.payment.event.PaymentConfirmedEvent;
@@ -17,6 +18,7 @@ import org.springframework.stereotype.Component;
 public class PaymentConfirmedEventListener {
 
   private final BookingConfirmUseCase bookingConfirmUseCase;
+  private final SeatRestClient seatRestClient;
   private final JsonConverter jsonConverter;
 
   @KafkaListener(topics = PaymentConfirmedEvent.TOPIC, groupId = "booking-group")
@@ -30,8 +32,31 @@ public class PaymentConfirmedEventListener {
       log.info(
           "결제 완료 이벤트 수신. 예매 확정 처리. bookingId: {}, paidAt: {}", event.bookingId(), event.paidAt());
 
+      // 결제 컨텍스트의 seatId가 예매의 seatId와 일치할 때만 확정된다(불일치 시 예외).
       // 중복 수신은 Booking.confirm() 도메인 멱등성으로 안전하게 처리된다.
-      bookingConfirmUseCase.execute(event.bookingId(), event.paidAt());
+      String bookingNumber =
+          bookingConfirmUseCase.execute(event.bookingId(), event.paidAt(), event.seatId());
+
+      // 예매 확정 트랜잭션 커밋 후 좌석 SOLD 확정을 동기 호출한다.
+      // SOLD 호출 실패는 예매 확정과 분리해 처리한다(예매는 확정됐으나 좌석만 미확정인 상태를 구분 추적).
+      try {
+        seatRestClient.confirmSold(bookingNumber, event.seatId());
+      } catch (Exception e) {
+        // SOLD 호출 실패 종류를 구분하지 않고 모두 swallow한다(파티션 블로킹 방지).
+        // - 중복 수신으로 이미 SOLD된 좌석: seat-service가 409(SEAT_NOT_AVAILABLE)를 반환하며 이는 정상 상태다.
+        // - 네트워크/5xx 실패: 예매는 확정됐으나 좌석은 미확정인 불일치 상태로, 수동 복구가 필요할 수 있다.
+        // 현재는 두 경우를 같은 [CRITICAL] 로그로 남긴다. 실패 종류 구분과 자동 보정은 후속 고도화 대상이다.
+        log.error(
+            "[CRITICAL] 예매는 확정됐으나 좌석 SOLD 확정에 실패했습니다. 확인이 필요합니다. "
+                + "eventId: {}, bookingId: {}, seatId: {}, bookingNumber: {}",
+            envelope.eventId(),
+            event.bookingId(),
+            event.seatId(),
+            bookingNumber,
+            e);
+
+        // TODO: 추후 고도화 시, 좌석 미확정 상태를 DLT/아웃박스로 재처리해 정합성을 보정
+      }
 
     } catch (Exception e) {
       // 결제는 이미 완료된 상태라 재시도해도 예매 상태가 바뀌지 않는다.

--- a/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/out/apiclient/SeatRestClient.java
+++ b/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/out/apiclient/SeatRestClient.java
@@ -1,0 +1,39 @@
+package com.ticketrush.boundedcontext.booking.out.apiclient;
+
+import com.ticketrush.boundedcontext.booking.app.dto.request.SeatSoldConfirmRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class SeatRestClient {
+
+  private static final String INTERNAL_TOKEN_HEADER = "X-Internal-Token";
+
+  private final RestClient seatServiceRestClient;
+
+  @Value("${gateway.internal-token}")
+  private String internalToken;
+
+  /**
+   * seat-service에 좌석 SOLD 확정을 요청한다. seat-service가 4xx/5xx로 응답하면 RestClient가 예외를 던지므로, 호출 측(리스너)에서
+   * 처리한다.
+   */
+  public void confirmSold(String bookingNumber, Long seatId) {
+    SeatSoldConfirmRequest request = new SeatSoldConfirmRequest(bookingNumber, seatId);
+
+    seatServiceRestClient
+        .post()
+        .uri("/api/v1/seat/internal/sold")
+        .header(INTERNAL_TOKEN_HEADER, internalToken)
+        .body(request)
+        .retrieve()
+        .toBodilessEntity();
+
+    log.info("[좌석 SOLD 확정 요청 성공] bookingNumber={}, seatId={}", bookingNumber, seatId);
+  }
+}

--- a/booking-service/src/main/java/com/ticketrush/global/config/RestClientConfig.java
+++ b/booking-service/src/main/java/com/ticketrush/global/config/RestClientConfig.java
@@ -1,0 +1,15 @@
+package com.ticketrush.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestClient;
+
+@Configuration
+public class RestClientConfig {
+
+  @Bean
+  public RestClient seatServiceRestClient(@Value("${service.seat.url}") String seatServiceUrl) {
+    return RestClient.builder().baseUrl(seatServiceUrl).build();
+  }
+}

--- a/booking-service/src/main/resources/application.yml
+++ b/booking-service/src/main/resources/application.yml
@@ -8,6 +8,10 @@ spring:
   application:
     name: booking-service
 
+service:
+  seat:
+    url: http://localhost:8086
+
 custom:
   global:
     internalBackUrl: http://localhost:${server.port:8084}

--- a/booking-service/src/test/java/com/ticketrush/boundedcontext/booking/app/usecase/BookingConfirmUseCaseTest.java
+++ b/booking-service/src/test/java/com/ticketrush/boundedcontext/booking/app/usecase/BookingConfirmUseCaseTest.java
@@ -2,6 +2,7 @@ package com.ticketrush.boundedcontext.booking.app.usecase;
 
 import static com.ticketrush.global.status.ErrorStatus.BOOKING_EXPIRED;
 import static com.ticketrush.global.status.ErrorStatus.BOOKING_NOT_FOUND;
+import static com.ticketrush.global.status.ErrorStatus.BOOKING_SEAT_MISMATCH;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
@@ -26,8 +27,10 @@ class BookingConfirmUseCaseTest {
 
   @Mock private BookingRepository bookingRepository;
 
+  private static final Long SEAT_ID = 3L;
+
   @Test
-  @DisplayName("성공: 예매를 확정하고 확정 시각을 기록한다")
+  @DisplayName("성공: 예매를 확정하고 확정 시각을 기록하며 예매 번호를 반환한다")
   void execute_success() {
     // given
     Long bookingId = 1L;
@@ -36,16 +39,17 @@ class BookingConfirmUseCaseTest {
         Booking.builder()
             .userId(1L)
             .performanceId(2L)
-            .seatId(3L)
+            .seatId(SEAT_ID)
             .bookingNumber("BOOK-1234")
             .bookingStatus(BookingStatus.PENDING)
             .build();
     given(bookingRepository.findById(bookingId)).willReturn(Optional.of(booking));
 
     // when
-    bookingConfirmUseCase.execute(bookingId, confirmedAt);
+    String bookingNumber = bookingConfirmUseCase.execute(bookingId, confirmedAt, SEAT_ID);
 
     // then
+    assertThat(bookingNumber).isEqualTo("BOOK-1234");
     assertThat(booking.getBookingStatus()).isEqualTo(BookingStatus.CONFIRMED);
     assertThat(booking.getConfirmedAt()).isEqualTo(confirmedAt);
   }
@@ -60,16 +64,17 @@ class BookingConfirmUseCaseTest {
         Booking.builder()
             .userId(1L)
             .performanceId(2L)
-            .seatId(3L)
+            .seatId(SEAT_ID)
             .bookingNumber("BOOK-1234")
             .bookingStatus(BookingStatus.CONFIRMED)
             .build();
     given(bookingRepository.findById(bookingId)).willReturn(Optional.of(booking));
 
     // when
-    bookingConfirmUseCase.execute(bookingId, confirmedAt);
+    String bookingNumber = bookingConfirmUseCase.execute(bookingId, confirmedAt, SEAT_ID);
 
     // then
+    assertThat(bookingNumber).isEqualTo("BOOK-1234");
     assertThat(booking.getBookingStatus()).isEqualTo(BookingStatus.CONFIRMED);
     assertThat(booking.getConfirmedAt()).isEqualTo(confirmedAt);
   }
@@ -82,10 +87,37 @@ class BookingConfirmUseCaseTest {
     given(bookingRepository.findById(bookingId)).willReturn(Optional.empty());
 
     // when & then
-    assertThatThrownBy(() -> bookingConfirmUseCase.execute(bookingId, LocalDateTime.now()))
+    assertThatThrownBy(() -> bookingConfirmUseCase.execute(bookingId, LocalDateTime.now(), SEAT_ID))
         .isInstanceOf(BusinessException.class)
         .extracting(ex -> ((BusinessException) ex).getErrorStatus())
         .isEqualTo(BOOKING_NOT_FOUND);
+  }
+
+  @Test
+  @DisplayName("실패: 예매의 seatId와 결제 컨텍스트의 seatId가 다르면 확정하지 않고 예외를 던진다")
+  void execute_fail_when_seat_mismatch() {
+    // given
+    Long bookingId = 1L;
+    Long mismatchedSeatId = 999L;
+    Booking booking =
+        Booking.builder()
+            .userId(1L)
+            .performanceId(2L)
+            .seatId(SEAT_ID)
+            .bookingNumber("BOOK-1234")
+            .bookingStatus(BookingStatus.PENDING)
+            .build();
+    given(bookingRepository.findById(bookingId)).willReturn(Optional.of(booking));
+
+    // when & then
+    assertThatThrownBy(
+            () -> bookingConfirmUseCase.execute(bookingId, LocalDateTime.now(), mismatchedSeatId))
+        .isInstanceOf(BusinessException.class)
+        .extracting(ex -> ((BusinessException) ex).getErrorStatus())
+        .isEqualTo(BOOKING_SEAT_MISMATCH);
+
+    // 검증 실패 시 예매는 확정되지 않는다.
+    assertThat(booking.getBookingStatus()).isEqualTo(BookingStatus.PENDING);
   }
 
   @Test
@@ -97,14 +129,14 @@ class BookingConfirmUseCaseTest {
         Booking.builder()
             .userId(1L)
             .performanceId(2L)
-            .seatId(3L)
+            .seatId(SEAT_ID)
             .bookingNumber("BOOK-1234")
             .bookingStatus(BookingStatus.EXPIRED)
             .build();
     given(bookingRepository.findById(bookingId)).willReturn(Optional.of(booking));
 
     // when & then
-    assertThatThrownBy(() -> bookingConfirmUseCase.execute(bookingId, LocalDateTime.now()))
+    assertThatThrownBy(() -> bookingConfirmUseCase.execute(bookingId, LocalDateTime.now(), SEAT_ID))
         .isInstanceOf(BusinessException.class)
         .extracting(ex -> ((BusinessException) ex).getErrorStatus())
         .isEqualTo(BOOKING_EXPIRED);

--- a/booking-service/src/test/java/com/ticketrush/boundedcontext/booking/in/eventlistener/PaymentConfirmedEventListenerTest.java
+++ b/booking-service/src/test/java/com/ticketrush/boundedcontext/booking/in/eventlistener/PaymentConfirmedEventListenerTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 import com.ticketrush.boundedcontext.booking.app.usecase.BookingConfirmUseCase;
+import com.ticketrush.boundedcontext.booking.out.apiclient.SeatRestClient;
 import com.ticketrush.global.event.DomainEventEnvelope;
 import com.ticketrush.global.exception.BusinessException;
 import com.ticketrush.global.json.DeserializationException;
@@ -32,6 +33,8 @@ class PaymentConfirmedEventListenerTest {
 
   @Mock private BookingConfirmUseCase bookingConfirmUseCase;
 
+  @Mock private SeatRestClient seatRestClient;
+
   @Mock private JsonConverter jsonConverter;
 
   @Mock private Acknowledgment acknowledgment;
@@ -39,6 +42,8 @@ class PaymentConfirmedEventListenerTest {
   // jsonConverter를 모킹하므로 payload 문자열은 실제로 파싱되지 않는다(역직렬화 결과는 스텁으로 지정).
   // 따라서 payload는 의미 없는 식별 문자열로 둔다.
   private static final String PAYLOAD = "payload";
+  private static final Long SEAT_ID = 3L;
+  private static final String BOOKING_NUMBER = "BOOK-1234";
 
   private DomainEventEnvelope envelope() {
     return new DomainEventEnvelope(
@@ -51,44 +56,75 @@ class PaymentConfirmedEventListenerTest {
   }
 
   @Test
-  @DisplayName("결제 완료 이벤트를 수신하면 예매를 확정하고 오프셋을 커밋한다")
+  @DisplayName("결제 완료 이벤트를 수신하면 예매를 확정하고 좌석 SOLD를 확정한 뒤 오프셋을 커밋한다")
   void handlePaymentConfirmed() {
     // given
     Long bookingId = 10L;
     LocalDateTime paidAt = LocalDateTime.of(2026, 5, 22, 10, 30);
     DomainEventEnvelope envelope = envelope();
-    PaymentConfirmedEvent event = new PaymentConfirmedEvent(1L, bookingId, 3L, 4L, 50000L, paidAt);
+    PaymentConfirmedEvent event =
+        new PaymentConfirmedEvent(1L, bookingId, SEAT_ID, 4L, 50000L, paidAt);
 
     given(jsonConverter.deserialize(PAYLOAD, PaymentConfirmedEvent.class)).willReturn(event);
+    given(bookingConfirmUseCase.execute(bookingId, paidAt, SEAT_ID)).willReturn(BOOKING_NUMBER);
 
     // when
     listener.handlePaymentConfirmed(envelope, acknowledgment);
 
     // then
-    verify(bookingConfirmUseCase).execute(bookingId, paidAt);
+    verify(bookingConfirmUseCase).execute(bookingId, paidAt, SEAT_ID);
+    verify(seatRestClient).confirmSold(BOOKING_NUMBER, SEAT_ID);
     verify(acknowledgment).acknowledge();
   }
 
   @Test
-  @DisplayName("확정 불가능한 예매로 유스케이스가 예외를 던져도 전파하지 않고 오프셋을 커밋한다")
-  void handlePaymentConfirmedSwallowsUseCaseException() {
+  @DisplayName("seatId 검증 실패 등으로 확정 유스케이스가 예외를 던지면 좌석 SOLD를 호출하지 않고 오프셋을 커밋한다")
+  void handlePaymentConfirmedSkipsSoldWhenConfirmFails() {
     // given
     Long bookingId = 10L;
     LocalDateTime paidAt = LocalDateTime.of(2026, 5, 22, 10, 30);
     DomainEventEnvelope envelope = envelope();
-    PaymentConfirmedEvent event = new PaymentConfirmedEvent(1L, bookingId, 3L, 4L, 50000L, paidAt);
+    PaymentConfirmedEvent event =
+        new PaymentConfirmedEvent(1L, bookingId, SEAT_ID, 4L, 50000L, paidAt);
 
     given(jsonConverter.deserialize(PAYLOAD, PaymentConfirmedEvent.class)).willReturn(event);
-    willThrow(new BusinessException(ErrorStatus.BOOKING_EXPIRED))
+    willThrow(new BusinessException(ErrorStatus.BOOKING_SEAT_MISMATCH))
         .given(bookingConfirmUseCase)
-        .execute(bookingId, paidAt);
+        .execute(bookingId, paidAt, SEAT_ID);
 
     // when & then: 예외를 리스너 밖으로 전파하지 않는다(파티션 블로킹 방지)
     assertThatCode(() -> listener.handlePaymentConfirmed(envelope, acknowledgment))
         .doesNotThrowAnyException();
 
-    // then: 유스케이스는 호출되었고, 예외와 무관하게 오프셋은 커밋된다
-    verify(bookingConfirmUseCase).execute(bookingId, paidAt);
+    // then: 검증 실패 시 좌석 SOLD 확정은 호출되지 않고, 오프셋은 커밋된다
+    verify(bookingConfirmUseCase).execute(bookingId, paidAt, SEAT_ID);
+    verify(seatRestClient, never()).confirmSold(any(), anyLong());
+    verify(acknowledgment).acknowledge();
+  }
+
+  @Test
+  @DisplayName("좌석 SOLD 확정 호출이 실패해도 예외를 전파하지 않고 오프셋을 커밋한다")
+  void handlePaymentConfirmedSwallowsSoldFailure() {
+    // given
+    Long bookingId = 10L;
+    LocalDateTime paidAt = LocalDateTime.of(2026, 5, 22, 10, 30);
+    DomainEventEnvelope envelope = envelope();
+    PaymentConfirmedEvent event =
+        new PaymentConfirmedEvent(1L, bookingId, SEAT_ID, 4L, 50000L, paidAt);
+
+    given(jsonConverter.deserialize(PAYLOAD, PaymentConfirmedEvent.class)).willReturn(event);
+    given(bookingConfirmUseCase.execute(bookingId, paidAt, SEAT_ID)).willReturn(BOOKING_NUMBER);
+    willThrow(new RuntimeException("seat-service 호출 실패"))
+        .given(seatRestClient)
+        .confirmSold(BOOKING_NUMBER, SEAT_ID);
+
+    // when & then: 좌석 SOLD 호출 실패가 리스너 밖으로 전파되지 않는다
+    assertThatCode(() -> listener.handlePaymentConfirmed(envelope, acknowledgment))
+        .doesNotThrowAnyException();
+
+    // then: 예매 확정과 SOLD 호출은 시도되었고, 실패와 무관하게 오프셋은 커밋된다
+    verify(bookingConfirmUseCase).execute(bookingId, paidAt, SEAT_ID);
+    verify(seatRestClient).confirmSold(BOOKING_NUMBER, SEAT_ID);
     verify(acknowledgment).acknowledge();
   }
 
@@ -104,8 +140,9 @@ class PaymentConfirmedEventListenerTest {
     assertThatCode(() -> listener.handlePaymentConfirmed(envelope, acknowledgment))
         .doesNotThrowAnyException();
 
-    // then: 확정 로직은 호출되지 않고, 오프셋은 커밋된다
-    verify(bookingConfirmUseCase, never()).execute(anyLong(), any());
+    // then: 확정 로직과 좌석 SOLD 확정은 호출되지 않고, 오프셋은 커밋된다
+    verify(bookingConfirmUseCase, never()).execute(anyLong(), any(), anyLong());
+    verify(seatRestClient, never()).confirmSold(any(), anyLong());
     verify(acknowledgment).acknowledge();
   }
 }

--- a/common/src/main/java/com/ticketrush/global/status/ErrorStatus.java
+++ b/common/src/main/java/com/ticketrush/global/status/ErrorStatus.java
@@ -80,6 +80,7 @@ public enum ErrorStatus {
   BOOKING_CANCEL_NOT_ALLOWED(HttpStatus.CONFLICT, "BOOKING_409_001", "취소할 수 없는 예매 상태입니다."),
   BOOKING_CONFIRM_NOT_ALLOWED(HttpStatus.CONFLICT, "BOOKING_409_002", "확정할 수 없는 예매 상태입니다."),
   BOOKING_EXPIRED(HttpStatus.CONFLICT, "BOOKING_409_003", "만료된 예매입니다."),
+  BOOKING_SEAT_MISMATCH(HttpStatus.CONFLICT, "BOOKING_409_004", "예매와 좌석 정보가 일치하지 않습니다."),
 
   // Booking 500
   BOOKING_NUMBER_RETRY_EXCEEDED(


### PR DESCRIPTION
## 🔗 관련 이슈

- close #188

---

## 📌 주요 변경 사항

- 결제 완료 이벤트 수신 시 예매의 `seatId`와 이벤트 `seatId` 일치를 선제 검증
- 검증 통과 시에만 seat-service `POST /api/v1/seat/internal/sold`를 동기 호출해 좌석 SOLD 확정
- 검증 실패(미존재·seatId 불일치) 시 SOLD 호출 차단

---

## 🛠 상세 구현 내용

- `ErrorStatus`에 `BOOKING_SEAT_MISMATCH`(409, `BOOKING_409_004`) 추가
- `BookingConfirmUseCase.execute(bookingId, confirmedAt, expectedSeatId)`로 확장 — `findById` 후 `booking.seatId == expectedSeatId` 검증, 불일치 시 `BOOKING_SEAT_MISMATCH`, 통과 시 `confirm()` 후 `bookingNumber` 반환
- `PaymentConfirmedEventListener` — 확정 트랜잭션 커밋 후 `SeatRestClient.confirmSold(bookingNumber, seatId)` 동기 호출. SOLD 호출 실패는 inner try/catch로 구분해 `[CRITICAL]` 로그 후 swallow(파티션 블로킹 방지, 후속 보정은 TODO)
- 신규 `SeatRestClient`(Spring `RestClient`, `X-Internal-Token` 헤더, `toBodilessEntity`) · `RestClientConfig`(`seatServiceRestClient` 빈) · 요청 DTO `SeatSoldConfirmRequest`(`booking_number`/`seat_id`)
- `booking-service` `application.yml`에 `service.seat.url` 추가
- 설계 결정: 이벤트 payload에 `bookingNumber`가 없어 `bookingId`로 조회 후 엔티티의 `bookingNumber`/`seatId`를 신뢰원본으로 사용(이벤트 스키마 불변)

---

## ✅ 테스트

### 테스트 방법

- 단위 테스트 실행: `./gradlew :booking-service:test :common:test`
- 포맷 검증: `./gradlew :booking-service:spotlessCheck :common:spotlessCheck`
- 추가/수정 테스트:
  - `BookingConfirmUseCaseTest` — 정상 확정+bookingNumber 반환 / 예매 미존재(`BOOKING_NOT_FOUND`) / seatId 불일치(`BOOKING_SEAT_MISMATCH`, 확정 안 됨) / 만료(`BOOKING_EXPIRED`)
  - `PaymentConfirmedEventListenerTest` — 정상 시 `confirmSold` 1회 호출+ack / 확정 예외 시 `confirmSold` 미호출+ack / SOLD 호출 실패 시 예외 미전파(swallow)+ack / 역직렬화 실패 시 미호출+ack

### 테스트 결과

- `BUILD SUCCESSFUL` — `:booking-service:test`, `:common:test` 전부 통과
- `spotlessCheck` 통과 (pre-commit 훅 Spotless·Checkstyle 통과)

<!--
### 📸 스크린샷
-->

---

## 👀 리뷰 요청 사항

- 이벤트에 `bookingNumber`가 없어 `bookingId` 조회 → 엔티티값 사용으로 해석한 부분(이슈 문구 "bookingNumber로 조회"와의 차이)에 대한 의견
- confirm 커밋 후 SOLD 동기 호출 / SOLD 실패 swallow 정책의 적절성

---

## ⚠️ 배포 시 주의사항

- `booking-service`에 첫 동기 HTTP 호출 인프라(`RestClient`)가 추가됨 — 컨테이너/운영 환경에서 `service.seat.url`(기본 `http://localhost:8086`)과 `gateway.internal-token`(seat-service와 동일 값) 주입 필요
