### PR TITLE
[Refactor] #272 RestClient 타임아웃 설정 및 서비스 URL 키 네이밍 통일

### DIFF
--- a/auth-service/src/main/java/com/ticketrush/boundedcontext/auth/out/apiclient/UserServiceClient.java
+++ b/auth-service/src/main/java/com/ticketrush/boundedcontext/auth/out/apiclient/UserServiceClient.java
@@ -29,7 +29,7 @@ public class UserServiceClient {
   private final RestClient restClient;
   private final CustomSecurityProperties customSecurityProperties;
 
-  @Value("${service.user.base-url}")
+  @Value("${service.user.url}")
   private String userServiceBaseUrl;
 
   private static final String SOCIAL_LOGIN_PATH = "/api/v1/user/social-login";

--- a/auth-service/src/main/java/com/ticketrush/boundedcontext/auth/out/apiclient/UserServiceClient.java
+++ b/auth-service/src/main/java/com/ticketrush/boundedcontext/auth/out/apiclient/UserServiceClient.java
@@ -29,7 +29,7 @@ public class UserServiceClient {
   private final RestClient restClient;
   private final CustomSecurityProperties customSecurityProperties;
 
-  @Value("${service.user-service.base-url}")
+  @Value("${service.user.base-url}")
   private String userServiceBaseUrl;
 
   private static final String SOCIAL_LOGIN_PATH = "/api/v1/user/social-login";

--- a/auth-service/src/main/java/com/ticketrush/global/config/RestClientConfig.java
+++ b/auth-service/src/main/java/com/ticketrush/global/config/RestClientConfig.java
@@ -1,5 +1,6 @@
 package com.ticketrush.global.config;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.client.RestClient;
@@ -8,7 +9,11 @@ import org.springframework.web.client.RestClient;
 public class RestClientConfig {
 
   @Bean
-  public RestClient restClient() {
-    return RestClient.builder().build();
+  public RestClient restClient(
+      @Value("${service.http.connect-timeout-ms:3000}") long connectTimeoutMs,
+      @Value("${service.http.read-timeout-ms:10000}") long readTimeoutMs) {
+    return RestClient.builder()
+        .requestFactory(RestClientFactorySupport.withTimeouts(connectTimeoutMs, readTimeoutMs))
+        .build();
   }
 }

--- a/auth-service/src/main/resources/application.yml
+++ b/auth-service/src/main/resources/application.yml
@@ -35,7 +35,7 @@ custom:
 
 service:
   user:
-    base-url: ${USER_SERVICE_URL:http://localhost:8081}
+    url: ${USER_SERVICE_URL:http://localhost:8081}
   http:
     connect-timeout-ms: ${SERVICE_HTTP_CONNECT_TIMEOUT_MS:3000}
     read-timeout-ms: ${SERVICE_HTTP_READ_TIMEOUT_MS:10000}

--- a/auth-service/src/main/resources/application.yml
+++ b/auth-service/src/main/resources/application.yml
@@ -34,8 +34,11 @@ custom:
     serverUrl: http://localhost:8080
 
 service:
-  user-service:
-    base-url: http://localhost:8081
+  user:
+    base-url: ${USER_SERVICE_URL:http://localhost:8081}
+  http:
+    connect-timeout-ms: ${SERVICE_HTTP_CONNECT_TIMEOUT_MS:3000}
+    read-timeout-ms: ${SERVICE_HTTP_READ_TIMEOUT_MS:10000}
 
 jwt:
   secret: ${JWT_SECRET}

--- a/booking-service/src/main/java/com/ticketrush/global/config/RestClientConfig.java
+++ b/booking-service/src/main/java/com/ticketrush/global/config/RestClientConfig.java
@@ -10,7 +10,7 @@ public class RestClientConfig {
 
   @Bean
   public RestClient seatServiceRestClient(
-      @Value("${service.seat.base-url}") String seatServiceUrl,
+      @Value("${service.seat.url}") String seatServiceUrl,
       @Value("${service.http.connect-timeout-ms:3000}") long connectTimeoutMs,
       @Value("${service.http.read-timeout-ms:10000}") long readTimeoutMs) {
     return RestClient.builder()

--- a/booking-service/src/main/java/com/ticketrush/global/config/RestClientConfig.java
+++ b/booking-service/src/main/java/com/ticketrush/global/config/RestClientConfig.java
@@ -9,7 +9,13 @@ import org.springframework.web.client.RestClient;
 public class RestClientConfig {
 
   @Bean
-  public RestClient seatServiceRestClient(@Value("${service.seat.url}") String seatServiceUrl) {
-    return RestClient.builder().baseUrl(seatServiceUrl).build();
+  public RestClient seatServiceRestClient(
+      @Value("${service.seat.base-url}") String seatServiceUrl,
+      @Value("${service.http.connect-timeout-ms:3000}") long connectTimeoutMs,
+      @Value("${service.http.read-timeout-ms:10000}") long readTimeoutMs) {
+    return RestClient.builder()
+        .baseUrl(seatServiceUrl)
+        .requestFactory(RestClientFactorySupport.withTimeouts(connectTimeoutMs, readTimeoutMs))
+        .build();
   }
 }

--- a/booking-service/src/main/resources/application.yml
+++ b/booking-service/src/main/resources/application.yml
@@ -10,7 +10,10 @@ spring:
 
 service:
   seat:
-    url: http://localhost:8086
+    base-url: ${SEAT_SERVICE_URL:http://localhost:8086}
+  http:
+    connect-timeout-ms: ${SERVICE_HTTP_CONNECT_TIMEOUT_MS:3000}
+    read-timeout-ms: ${SERVICE_HTTP_READ_TIMEOUT_MS:10000}
 
 custom:
   global:

--- a/booking-service/src/main/resources/application.yml
+++ b/booking-service/src/main/resources/application.yml
@@ -10,7 +10,7 @@ spring:
 
 service:
   seat:
-    base-url: ${SEAT_SERVICE_URL:http://localhost:8086}
+    url: ${SEAT_SERVICE_URL:http://localhost:8086}
   http:
     connect-timeout-ms: ${SERVICE_HTTP_CONNECT_TIMEOUT_MS:3000}
     read-timeout-ms: ${SERVICE_HTTP_READ_TIMEOUT_MS:10000}

--- a/common/src/main/java/com/ticketrush/global/config/RestClientFactorySupport.java
+++ b/common/src/main/java/com/ticketrush/global/config/RestClientFactorySupport.java
@@ -1,0 +1,32 @@
+package com.ticketrush.global.config;
+
+import java.net.http.HttpClient;
+import java.time.Duration;
+import org.springframework.http.client.ClientHttpRequestFactory;
+import org.springframework.http.client.JdkClientHttpRequestFactory;
+
+/**
+ * 서비스 간 동기 호출용 {@link org.springframework.web.client.RestClient} 에 connect/read 타임아웃을 적용한 {@link
+ * ClientHttpRequestFactory} 를 생성하는 공통 헬퍼.
+ *
+ * <p>각 서비스의 {@code RestClientConfig} 가 빈을 만들 때 호출한다. 공통 모듈에 {@code @Bean} 으로 두면 컴포넌트 스캔으로 전 서비스에
+ * 주입/충돌하므로 정적 유틸로 제공한다.
+ */
+public final class RestClientFactorySupport {
+
+  private RestClientFactorySupport() {}
+
+  /**
+   * connect/read 타임아웃이 설정된 {@link ClientHttpRequestFactory} 를 생성한다.
+   *
+   * @param connectTimeoutMs 연결 타임아웃(ms)
+   * @param readTimeoutMs 읽기 타임아웃(ms)
+   */
+  public static ClientHttpRequestFactory withTimeouts(long connectTimeoutMs, long readTimeoutMs) {
+    HttpClient httpClient =
+        HttpClient.newBuilder().connectTimeout(Duration.ofMillis(connectTimeoutMs)).build();
+    JdkClientHttpRequestFactory factory = new JdkClientHttpRequestFactory(httpClient);
+    factory.setReadTimeout(Duration.ofMillis(readTimeoutMs));
+    return factory;
+  }
+}

--- a/docs/backend-convention.md
+++ b/docs/backend-convention.md
@@ -134,6 +134,30 @@ git config core.hooksPath .githooks
 > 💡 참고자료:
 > [Naver Hackday Java Convention](https://naver.github.io/hackday-conventions-java/) / [Google Java Style Guide](https://github.com/google/styleguide/blob/gh-pages/intellij-java-google-style.xml)
 
+### ⚙️ 서비스 간 호출 프로퍼티 키 (RestClient)
+
+다른 서비스를 동기 호출(`RestClient`)할 때 `application.yml` 의 프로퍼티 키와 값을 아래 규칙으로 통일합니다.
+
+* **서비스 URL 키:** `service.<name>.base-url`
+    * `<name>` 은 호출 대상 서비스의 **단축명**(`-service` 접미사 제외): `auth`, `user`, `seat` 등
+    * 값은 **환경변수 오버라이드** 형태: `${<NAME>_SERVICE_URL:http://localhost:<port>}`
+    * 예: `service.auth.base-url: ${AUTH_SERVICE_URL:http://localhost:8082}`
+* **공통 타임아웃 키:** 모듈당 호출 대상이 1개이므로 모듈 공통 1쌍으로 둡니다.
+    * `service.http.connect-timeout-ms: ${SERVICE_HTTP_CONNECT_TIMEOUT_MS:3000}`
+    * `service.http.read-timeout-ms: ${SERVICE_HTTP_READ_TIMEOUT_MS:10000}`
+* **타임아웃 적용:** `RestClient` 빈은 공통 모듈의 `RestClientFactorySupport.withTimeouts(connectMs, readMs)`(`common/.../global/config`)로 생성한 `ClientHttpRequestFactory` 를 반드시 적용합니다. 타임아웃 미설정 시 상대 서비스 지연이 Kafka 컨슈머 스레드 등을 장시간 블로킹할 수 있습니다.
+
+```yaml
+service:
+  auth:
+    base-url: ${AUTH_SERVICE_URL:http://localhost:8082}
+  http:
+    connect-timeout-ms: ${SERVICE_HTTP_CONNECT_TIMEOUT_MS:3000}
+    read-timeout-ms: ${SERVICE_HTTP_READ_TIMEOUT_MS:10000}
+```
+
+> **별개 패턴(통일 대상 아님):** 외부 PG 호출은 `payment.pg.toss.*`(외부 결제 네임스페이스), 게이트웨이 라우팅은 `services.<name>.host`(호스트 전용, 자바 주입 없음)로 의미가 달라 위 규칙과 구분합니다.
+
 ## 3. API 및 응답/예외 처리 규칙
 
 ### 🌐 API 엔드포인트 규칙

--- a/docs/backend-convention.md
+++ b/docs/backend-convention.md
@@ -138,10 +138,10 @@ git config core.hooksPath .githooks
 
 다른 서비스를 동기 호출(`RestClient`)할 때 `application.yml` 의 프로퍼티 키와 값을 아래 규칙으로 통일합니다.
 
-* **서비스 URL 키:** `service.<name>.base-url`
+* **서비스 URL 키:** `service.<name>.url`
     * `<name>` 은 호출 대상 서비스의 **단축명**(`-service` 접미사 제외): `auth`, `user`, `seat` 등
     * 값은 **환경변수 오버라이드** 형태: `${<NAME>_SERVICE_URL:http://localhost:<port>}`
-    * 예: `service.auth.base-url: ${AUTH_SERVICE_URL:http://localhost:8082}`
+    * 예: `service.auth.url: ${AUTH_SERVICE_URL:http://localhost:8082}`
 * **공통 타임아웃 키:** 모듈당 호출 대상이 1개이므로 모듈 공통 1쌍으로 둡니다.
     * `service.http.connect-timeout-ms: ${SERVICE_HTTP_CONNECT_TIMEOUT_MS:3000}`
     * `service.http.read-timeout-ms: ${SERVICE_HTTP_READ_TIMEOUT_MS:10000}`
@@ -150,7 +150,7 @@ git config core.hooksPath .githooks
 ```yaml
 service:
   auth:
-    base-url: ${AUTH_SERVICE_URL:http://localhost:8082}
+    url: ${AUTH_SERVICE_URL:http://localhost:8082}
   http:
     connect-timeout-ms: ${SERVICE_HTTP_CONNECT_TIMEOUT_MS:3000}
     read-timeout-ms: ${SERVICE_HTTP_READ_TIMEOUT_MS:10000}

--- a/user-service/src/main/java/com/ticketrush/boundedcontext/user/out/apiclient/EmailVerificationClient.java
+++ b/user-service/src/main/java/com/ticketrush/boundedcontext/user/out/apiclient/EmailVerificationClient.java
@@ -19,7 +19,7 @@ public class EmailVerificationClient {
 
   private final RestClient restClient;
 
-  @Value("${service.auth.base-url}")
+  @Value("${service.auth.url}")
   private String authServiceUrl;
 
   public boolean isVerified(String email) {

--- a/user-service/src/main/java/com/ticketrush/boundedcontext/user/out/apiclient/EmailVerificationClient.java
+++ b/user-service/src/main/java/com/ticketrush/boundedcontext/user/out/apiclient/EmailVerificationClient.java
@@ -19,7 +19,7 @@ public class EmailVerificationClient {
 
   private final RestClient restClient;
 
-  @Value("${service.auth.url}")
+  @Value("${service.auth.base-url}")
   private String authServiceUrl;
 
   public boolean isVerified(String email) {

--- a/user-service/src/main/java/com/ticketrush/global/config/RestClientConfig.java
+++ b/user-service/src/main/java/com/ticketrush/global/config/RestClientConfig.java
@@ -9,7 +9,13 @@ import org.springframework.web.client.RestClient;
 public class RestClientConfig {
 
   @Bean
-  public RestClient authServiceRestClient(@Value("${service.auth.url}") String authServiceUrl) {
-    return RestClient.builder().baseUrl(authServiceUrl).build();
+  public RestClient authServiceRestClient(
+      @Value("${service.auth.base-url}") String authServiceUrl,
+      @Value("${service.http.connect-timeout-ms:3000}") long connectTimeoutMs,
+      @Value("${service.http.read-timeout-ms:10000}") long readTimeoutMs) {
+    return RestClient.builder()
+        .baseUrl(authServiceUrl)
+        .requestFactory(RestClientFactorySupport.withTimeouts(connectTimeoutMs, readTimeoutMs))
+        .build();
   }
 }

--- a/user-service/src/main/java/com/ticketrush/global/config/RestClientConfig.java
+++ b/user-service/src/main/java/com/ticketrush/global/config/RestClientConfig.java
@@ -10,7 +10,7 @@ public class RestClientConfig {
 
   @Bean
   public RestClient authServiceRestClient(
-      @Value("${service.auth.base-url}") String authServiceUrl,
+      @Value("${service.auth.url}") String authServiceUrl,
       @Value("${service.http.connect-timeout-ms:3000}") long connectTimeoutMs,
       @Value("${service.http.read-timeout-ms:10000}") long readTimeoutMs) {
     return RestClient.builder()

--- a/user-service/src/main/resources/application.yml
+++ b/user-service/src/main/resources/application.yml
@@ -10,7 +10,7 @@ spring:
 
 service:
   auth:
-    base-url: ${AUTH_SERVICE_URL:http://localhost:8082}
+    url: ${AUTH_SERVICE_URL:http://localhost:8082}
   http:
     connect-timeout-ms: ${SERVICE_HTTP_CONNECT_TIMEOUT_MS:3000}
     read-timeout-ms: ${SERVICE_HTTP_READ_TIMEOUT_MS:10000}

--- a/user-service/src/main/resources/application.yml
+++ b/user-service/src/main/resources/application.yml
@@ -10,7 +10,10 @@ spring:
 
 service:
   auth:
-    url: http://localhost:8082
+    base-url: ${AUTH_SERVICE_URL:http://localhost:8082}
+  http:
+    connect-timeout-ms: ${SERVICE_HTTP_CONNECT_TIMEOUT_MS:3000}
+    read-timeout-ms: ${SERVICE_HTTP_READ_TIMEOUT_MS:10000}
 
 custom:
   global:


### PR DESCRIPTION
## 🔗 관련 이슈

- close #272

---

## 📌 주요 변경 사항

- 서비스 간 동기 호출용 `RestClient` 빈에 connect/read 타임아웃을 설정 (auth/user/booking)
- 서비스 URL 프로퍼티 키를 `service.<name>.url` 단일 패턴으로 통일 + 환경변수 오버라이드
- 타임아웃 설정 로직을 common 모듈 정적 유틸로 추출(payment 패턴 공통화)
- 서비스 간 호출 프로퍼티 키 컨벤션을 `docs/backend-convention.md`에 신설

---

## 🛠 상세 구현 내용

- **타임아웃 공통 유틸 신규**: `common`에 `RestClientFactorySupport.withTimeouts(connectMs, readMs)` 추가 — `HttpClient.connectTimeout` + `JdkClientHttpRequestFactory.setReadTimeout` 조합으로 `ClientHttpRequestFactory` 생성. 공통 모듈 `@Bean`은 컴포넌트 스캔으로 전 서비스에 주입/충돌하므로 정적 유틸(생성자 private)로 제공.
- **RestClient 빈 타임아웃 적용**: `auth`(`restClient`, baseUrl 없음 유지) · `user`(`authServiceRestClient`) · `booking`(`seatServiceRestClient`) 3개 빈에 `requestFactory(RestClientFactorySupport.withTimeouts(...))` 적용. 기존 타임아웃 무한 대기 → 명시 제한. (특히 `PaymentConfirmedEventListener` → `SeatRestClient` Kafka 컨슈머 스레드 블로킹 리스크 해소)
- **URL 키 네이밍 통일**: 다수가 이미 쓰던 `service.<name>.url`을 표준으로 채택. `service.auth.url`(user) · `service.seat.url`(booking)은 **기존 키 그대로 유지**(변경 최소화), outlier였던 auth만 `service.user-service.base-url` → `service.user.url`로 통일(`-service` 접미사 제거). yml 키와 `@Value`/빈 파라미터를 함께 정리(user-service는 `RestClientConfig`·`EmailVerificationClient` 2곳).
- **환경변수 오버라이드**: URL은 `${<NAME>_SERVICE_URL:http://localhost:<port>}`, 공통 타임아웃 키 `service.http.connect-timeout-ms`/`read-timeout-ms`는 `${SERVICE_HTTP_*:기본값}`(3000/10000)로 운영/컨테이너 주입 가능.
- **컨벤션 문서화**: `docs/backend-convention.md` §2에 서비스 간 호출 프로퍼티 키 규칙 신설. payment(외부 PG `payment.pg.toss.*`)·gateway(`services.<name>.host`)는 별개 패턴으로 명시.
- **범위 제외**: payment·gateway 미변경.

---

## ✅ 테스트

### 테스트 방법

- 변경 모듈 단위/컨텍스트 테스트 실행:
  `./gradlew :common:test :user-service:test :booking-service:test :auth-service:test spotlessCheck`
- 스프링 컨텍스트 로딩으로 yml 키 ↔ `@Value`/빈 파라미터 키 미스매치를 조기 검출(미스매치 시 부팅 실패).

### 테스트 결과

- `BUILD SUCCESSFUL` — common·user·booking·auth 4개 모듈 테스트 전부 통과, spotlessCheck 통과.
- 기존 테스트(`SignupUseCaseTest`, `PaymentConfirmedEventListenerTest` 등)는 클라이언트를 `@Mock` 처리하므로 키 변경 영향 없이 통과.

<!--
### 📸 스크린샷

-
-->
---

## 👀 리뷰 요청 사항

- auth-service `restClient` 공유 빈에 타임아웃(read 10s)이 적용되면서 외부 OAuth(Kakao/Google/Naver) 호출에도 동일 타임아웃이 걸립니다(기존 무한 대기 → 개선). 외부 IdP 전용 빈 분리는 범위 밖 후속 이슈로 둘지 검토 부탁드립니다.
- **user-service 설정 변경** 관련 리뷰 요청 (@kimhyerim01): URL 키 이름(`service.auth.url`)은 그대로 유지되지만, 값이 `${AUTH_SERVICE_URL:http://localhost:8082}` 환경변수 오버라이드 형태로 바뀌고, 공통 타임아웃 키(`service.http.*`)와 RestClient 타임아웃이 새로 추가됩니다. `RestClientConfig.authServiceRestClient`·`EmailVerificationClient` 영향.

---

## ⚠️ 배포 시 주의사항

- **키 변경은 auth-service 한 곳뿐**: `service.user-service.base-url` → `service.user.url`. user-service `service.auth.url`·booking-service `service.seat.url`은 **키 이름 그대로 유지**.
- URL 값이 환경변수 오버라이드 형태로 정리됨. 운영/배포 환경에서 URL·타임아웃을 주입하려면 `AUTH_SERVICE_URL`/`SEAT_SERVICE_URL`/`USER_SERVICE_URL`, `SERVICE_HTTP_CONNECT_TIMEOUT_MS`/`SERVICE_HTTP_READ_TIMEOUT_MS` 환경변수를 사용.
