### PR TITLE
[Feat] #237 결제 취소(환불) API 및 PaymentCanceledEvent 발행

### DIFF
--- a/common/src/main/java/com/ticketrush/global/status/ErrorStatus.java
+++ b/common/src/main/java/com/ticketrush/global/status/ErrorStatus.java
@@ -147,6 +147,9 @@ public enum ErrorStatus {
   PAYMENT_METHOD_REJECTED(
       HttpStatus.BAD_REQUEST, "PAYMENT_400_003", "결제가 거절되었습니다. 다른 결제수단으로 시도해주세요."),
   PAYMENT_LIMIT_EXCEEDED(HttpStatus.BAD_REQUEST, "PAYMENT_400_004", "카드 한도 또는 결제 한도를 초과했습니다."),
+  /* 환불 가능 기한 검증은 공연 시작 시간(performance 도메인) 연동 후속 작업에서 사용 예정. (#22 보류) */
+  PAYMENT_REFUND_DEADLINE_EXCEEDED(
+      HttpStatus.BAD_REQUEST, "PAYMENT_400_005", "환불 가능 기한이 지나 환불할 수 없습니다."),
 
   // Payment 404
   PAYMENT_SESSION_NOT_FOUND(HttpStatus.NOT_FOUND, "PAYMENT_404_001", "결제 세션이 만료되었거나 존재하지 않습니다."),
@@ -156,6 +159,7 @@ public enum ErrorStatus {
 
   // Payment 409
   PAYMENT_ALREADY_COMPLETED(HttpStatus.CONFLICT, "PAYMENT_409_001", "이미 결제가 완료된 예매입니다."),
+  PAYMENT_NOT_CANCELABLE(HttpStatus.CONFLICT, "PAYMENT_409_002", "환불 가능한 결제 상태가 아닙니다."),
 
   // Payment 502
   PAYMENT_APPROVAL_FAILED(HttpStatus.BAD_GATEWAY, "PAYMENT_502_001", "PG사 결제 승인에 실패했습니다."),

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/dto/request/PaymentCancelRequest.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/dto/request/PaymentCancelRequest.java
@@ -1,0 +1,12 @@
+package com.ticketrush.boundedcontext.payment.app.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+@Schema(description = "결제 취소(환불) 요청 DTO")
+public record PaymentCancelRequest(
+    @Schema(description = "환불 사유", example = "단순 변심")
+        @NotBlank(message = "환불 사유는 필수입니다.")
+        @Size(max = 200, message = "환불 사유는 200자 이하여야 합니다.")
+        String reason) {}

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/dto/response/PaymentCancelResponse.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/dto/response/PaymentCancelResponse.java
@@ -1,0 +1,24 @@
+package com.ticketrush.boundedcontext.payment.app.dto.response;
+
+import com.ticketrush.boundedcontext.payment.domain.entity.Payment;
+import com.ticketrush.boundedcontext.payment.domain.entity.Refund;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+
+@Schema(description = "결제 취소(환불) 응답 DTO")
+public record PaymentCancelResponse(
+    @Schema(description = "결제 데이터의 고유 식별자(PK)", example = "1") Long paymentId,
+    @Schema(description = "결제 상태", example = "CANCELED") String status,
+    @Schema(description = "환불 데이터의 고유 식별자(PK)", example = "1") Long refundId,
+    @Schema(description = "환불 금액", example = "55000") Long refundedAmount,
+    @Schema(description = "환불 확정 시각") LocalDateTime canceledAt) {
+
+  public static PaymentCancelResponse of(Payment payment, Refund refund) {
+    return new PaymentCancelResponse(
+        payment.getId(),
+        payment.getStatus().name(),
+        refund.getId(),
+        refund.getPrice(),
+        refund.getConfirmedAt());
+  }
+}

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/facade/PaymentFacade.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/facade/PaymentFacade.java
@@ -1,9 +1,12 @@
 package com.ticketrush.boundedcontext.payment.app.facade;
 
+import com.ticketrush.boundedcontext.payment.app.dto.request.PaymentCancelRequest;
 import com.ticketrush.boundedcontext.payment.app.dto.request.PaymentConfirmRequest;
+import com.ticketrush.boundedcontext.payment.app.dto.response.PaymentCancelResponse;
 import com.ticketrush.boundedcontext.payment.app.dto.response.PaymentConfirmResponse;
 import com.ticketrush.boundedcontext.payment.app.dto.response.PaymentDetailResponse;
 import com.ticketrush.boundedcontext.payment.app.dto.response.PaymentSummaryResponse;
+import com.ticketrush.boundedcontext.payment.app.usecase.PaymentCancelUseCase;
 import com.ticketrush.boundedcontext.payment.app.usecase.PaymentConfirmUseCase;
 import com.ticketrush.boundedcontext.payment.app.usecase.PaymentGetDetailUseCase;
 import com.ticketrush.boundedcontext.payment.app.usecase.PaymentGetListUseCase;
@@ -17,11 +20,16 @@ import org.springframework.stereotype.Service;
 public class PaymentFacade {
 
   private final PaymentConfirmUseCase paymentConfirmUseCase;
+  private final PaymentCancelUseCase paymentCancelUseCase;
   private final PaymentGetListUseCase paymentGetListUseCase;
   private final PaymentGetDetailUseCase paymentGetDetailUseCase;
 
   public PaymentConfirmResponse confirm(Long userId, PaymentConfirmRequest request) {
     return paymentConfirmUseCase.execute(userId, request);
+  }
+
+  public PaymentCancelResponse cancel(Long userId, Long paymentId, PaymentCancelRequest request) {
+    return paymentCancelUseCase.execute(userId, paymentId, request);
   }
 
   public Page<PaymentSummaryResponse> getPayments(Long userId, Pageable pageable) {

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/facade/PaymentFacade.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/facade/PaymentFacade.java
@@ -11,6 +11,7 @@ import com.ticketrush.boundedcontext.payment.app.usecase.PaymentConfirmUseCase;
 import com.ticketrush.boundedcontext.payment.app.usecase.PaymentGetDetailUseCase;
 import com.ticketrush.boundedcontext.payment.app.usecase.PaymentGetListUseCase;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -29,7 +30,12 @@ public class PaymentFacade {
   }
 
   public PaymentCancelResponse cancel(Long userId, Long paymentId, PaymentCancelRequest request) {
-    return paymentCancelUseCase.execute(userId, paymentId, request);
+    try {
+      return paymentCancelUseCase.execute(userId, paymentId, request);
+    } catch (DataIntegrityViolationException e) {
+      // 동시 취소 요청이 paymentId unique 제약에 막힌 경우, 먼저 확정된 환불을 멱등 반환한다.
+      return paymentCancelUseCase.getCanceledResponse(userId, paymentId);
+    }
   }
 
   public Page<PaymentSummaryResponse> getPayments(Long userId, Pageable pageable) {

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentCancelUseCase.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentCancelUseCase.java
@@ -45,11 +45,7 @@ public class PaymentCancelUseCase {
 
     // 이미 취소된 결제는 기존 환불 내역을 그대로 반환하여 멱등 처리한다.
     if (payment.getStatus() == PaymentStatus.CANCELED) {
-      Refund existing =
-          refundRepository
-              .findByPaymentId(paymentId)
-              .orElseThrow(() -> new BusinessException(ErrorStatus.PAYMENT_REFUND_FAILED));
-      return PaymentCancelResponse.of(payment, existing);
+      return toExistingRefundResponse(payment, paymentId);
     }
 
     if (payment.getStatus() != PaymentStatus.COMPLETED) {
@@ -77,7 +73,9 @@ public class PaymentCancelUseCase {
             .confirmedAt(result.canceledAt())
             .build();
 
-    Refund saved = refundRepository.save(refund);
+    // 동시 취소 요청 시 paymentId unique 제약 위반을 이벤트 발행·상태 전이 이전에 표면화하기 위해 즉시 flush 한다.
+    // 위반(DataIntegrityViolationException)은 트랜잭션 경계 밖(PaymentFacade)에서 멱등 처리한다.
+    Refund saved = refundRepository.saveAndFlush(refund);
     payment.markCanceled();
 
     paymentEventPublisher.publishCanceled(
@@ -90,6 +88,27 @@ public class PaymentCancelUseCase {
         saved.getConfirmedAt());
 
     return PaymentCancelResponse.of(payment, saved);
+  }
+
+  /**
+   * 동시 취소 요청이 unique 제약에 막혀 별도 트랜잭션에서 먼저 환불이 확정된 경우, 그 환불 내역을 멱등하게 반환한다. PaymentFacade가 {@code
+   * DataIntegrityViolationException}을 잡은 뒤 호출한다.
+   */
+  @Transactional(readOnly = true)
+  public PaymentCancelResponse getCanceledResponse(Long userId, Long paymentId) {
+    Payment payment =
+        paymentRepository
+            .findByIdAndUserId(paymentId, userId)
+            .orElseThrow(() -> new BusinessException(ErrorStatus.PAYMENT_NOT_FOUND));
+    return toExistingRefundResponse(payment, paymentId);
+  }
+
+  private PaymentCancelResponse toExistingRefundResponse(Payment payment, Long paymentId) {
+    Refund existing =
+        refundRepository
+            .findByPaymentId(paymentId)
+            .orElseThrow(() -> new BusinessException(ErrorStatus.PAYMENT_REFUND_FAILED));
+    return PaymentCancelResponse.of(payment, existing);
   }
 
   /* 동일 결제의 재요청 시 PG 측 중복 취소를 막기 위해 paymentId 기반 고정 멱등 키를 생성한다. */

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentCancelUseCase.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentCancelUseCase.java
@@ -1,0 +1,99 @@
+package com.ticketrush.boundedcontext.payment.app.usecase;
+
+import com.ticketrush.boundedcontext.payment.app.dto.request.PaymentCancelRequest;
+import com.ticketrush.boundedcontext.payment.app.dto.response.PaymentCancelResponse;
+import com.ticketrush.boundedcontext.payment.app.support.PaymentEventPublisher;
+import com.ticketrush.boundedcontext.payment.domain.entity.Payment;
+import com.ticketrush.boundedcontext.payment.domain.entity.Refund;
+import com.ticketrush.boundedcontext.payment.domain.types.PaymentStatus;
+import com.ticketrush.boundedcontext.payment.domain.types.RefundStatus;
+import com.ticketrush.boundedcontext.payment.out.apiclient.PaymentCancelClientRouter;
+import com.ticketrush.boundedcontext.payment.out.apiclient.PaymentCancelCommand;
+import com.ticketrush.boundedcontext.payment.out.apiclient.PaymentCancelResult;
+import com.ticketrush.boundedcontext.payment.out.repository.PaymentRepository;
+import com.ticketrush.boundedcontext.payment.out.repository.RefundRepository;
+import com.ticketrush.global.exception.BusinessException;
+import com.ticketrush.global.status.ErrorStatus;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 결제 취소(환불) UseCase.
+ *
+ * <p>본인 결제 검증 → 상태 검증 → PG 취소 호출 → {@link Refund} 영속화 → {@code PaymentStatus.CANCELED} 전이 → {@code
+ * PaymentCanceledEvent} 발행까지의 happy path를 담당한다. 동일 결제에 대한 중복 요청은 기존 환불 내역을 반환하여 멱등하게 처리한다.
+ *
+ * <p>환불 기한 검증(공연 시작 시간 기준)과 환불 실패 시 보상 트랜잭션(#91)은 본 UseCase 범위 밖이다.
+ */
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class PaymentCancelUseCase {
+
+  private final PaymentRepository paymentRepository;
+  private final RefundRepository refundRepository;
+  private final PaymentCancelClientRouter paymentCancelClientRouter;
+  private final PaymentEventPublisher paymentEventPublisher;
+
+  public PaymentCancelResponse execute(Long userId, Long paymentId, PaymentCancelRequest request) {
+    Payment payment =
+        paymentRepository
+            .findByIdAndUserId(paymentId, userId)
+            .orElseThrow(() -> new BusinessException(ErrorStatus.PAYMENT_NOT_FOUND));
+
+    // 이미 취소된 결제는 기존 환불 내역을 그대로 반환하여 멱등 처리한다.
+    if (payment.getStatus() == PaymentStatus.CANCELED) {
+      Refund existing =
+          refundRepository
+              .findByPaymentId(paymentId)
+              .orElseThrow(() -> new BusinessException(ErrorStatus.PAYMENT_REFUND_FAILED));
+      return PaymentCancelResponse.of(payment, existing);
+    }
+
+    if (payment.getStatus() != PaymentStatus.COMPLETED) {
+      throw new BusinessException(ErrorStatus.PAYMENT_NOT_CANCELABLE);
+    }
+
+    PaymentCancelResult result =
+        paymentCancelClientRouter.cancel(
+            new PaymentCancelCommand(
+                payment.getProvider(),
+                payment.getPaymentKey(),
+                payment.getAmount(),
+                request.reason(),
+                generateIdempotencyKey(paymentId)));
+
+    Refund refund =
+        Refund.builder()
+            .paymentId(payment.getId())
+            .bookingId(payment.getBookingId())
+            .price(payment.getAmount())
+            .status(RefundStatus.COMPLETED)
+            .pgRefundKey(result.pgRefundKey())
+            .reason(request.reason())
+            .requestedAt(LocalDateTime.now())
+            .confirmedAt(result.canceledAt())
+            .build();
+
+    Refund saved = refundRepository.save(refund);
+    payment.markCanceled();
+
+    paymentEventPublisher.publishCanceled(
+        payment.getId(),
+        payment.getBookingId(),
+        payment.getSeatId(),
+        saved.getId(),
+        saved.getPrice(),
+        request.reason(),
+        saved.getConfirmedAt());
+
+    return PaymentCancelResponse.of(payment, saved);
+  }
+
+  /* 동일 결제의 재요청 시 PG 측 중복 취소를 막기 위해 paymentId 기반 고정 멱등 키를 생성한다. */
+  private String generateIdempotencyKey(Long paymentId) {
+    return "REFUND-%07d".formatted(paymentId);
+  }
+}

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/domain/entity/Payment.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/domain/entity/Payment.java
@@ -71,4 +71,9 @@ public class Payment extends AutoIdBaseEntity {
     this.approvalNumber = approvalNumber;
     this.paidAt = paidAt;
   }
+
+  /** 환불 처리로 결제를 취소 상태로 전이한다. */
+  public void markCanceled() {
+    this.status = PaymentStatus.CANCELED;
+  }
 }

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/domain/entity/Refund.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/domain/entity/Refund.java
@@ -21,8 +21,8 @@ import lombok.NoArgsConstructor;
 @AttributeOverride(name = "id", column = @Column(name = "refund_id"))
 public class Refund extends AutoIdBaseEntity {
 
-  /* paymentId는 #22에서 환불-결제 매핑 및 멱등성 보장을 위해 도입. */
-  @Column(nullable = false)
+  /* paymentId는 #22에서 환불-결제 매핑에 사용. unique 제약으로 동일 결제의 중복 환불을 DB 레벨에서 멱등 보장한다. */
+  @Column(nullable = false, unique = true)
   private Long paymentId;
 
   @Column(nullable = false)

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/in/api/v1/PaymentController.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/in/api/v1/PaymentController.java
@@ -1,6 +1,8 @@
 package com.ticketrush.boundedcontext.payment.in.api.v1;
 
+import com.ticketrush.boundedcontext.payment.app.dto.request.PaymentCancelRequest;
 import com.ticketrush.boundedcontext.payment.app.dto.request.PaymentConfirmRequest;
+import com.ticketrush.boundedcontext.payment.app.dto.response.PaymentCancelResponse;
 import com.ticketrush.boundedcontext.payment.app.dto.response.PaymentConfirmResponse;
 import com.ticketrush.boundedcontext.payment.app.dto.response.PaymentDetailResponse;
 import com.ticketrush.boundedcontext.payment.app.dto.response.PaymentSummaryResponse;
@@ -53,6 +55,20 @@ public class PaymentController {
       @AuthenticationPrincipal CustomUserDetails user,
       @Valid @RequestBody PaymentConfirmRequest request) {
     PaymentConfirmResponse response = paymentFacade.confirm(user.getUserId(), request);
+    return ApiResponse.onSuccess(SuccessStatus.OK, response);
+  }
+
+  @Operation(
+      summary = "결제 취소(환불)",
+      description =
+          "본인의 완료된 결제를 취소하고 PG사 환불을 처리한다. "
+              + "성공 시 PaymentCanceledEvent를 발행하여 booking/seat 도메인이 후속 처리하도록 한다.")
+  @PostMapping("/{paymentId}/cancel")
+  public ResponseEntity<ApiResponse<PaymentCancelResponse>> cancel(
+      @AuthenticationPrincipal CustomUserDetails user,
+      @Parameter(description = "결제 ID") @Positive @PathVariable Long paymentId,
+      @Valid @RequestBody PaymentCancelRequest request) {
+    PaymentCancelResponse response = paymentFacade.cancel(user.getUserId(), paymentId, request);
     return ApiResponse.onSuccess(SuccessStatus.OK, response);
   }
 

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/out/repository/RefundRepository.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/out/repository/RefundRepository.java
@@ -7,4 +7,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface RefundRepository extends JpaRepository<Refund, Long> {
 
   Optional<Refund> findByBookingId(Long bookingId);
+
+  Optional<Refund> findByPaymentId(Long paymentId);
 }

--- a/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/app/facade/PaymentFacadeTest.java
+++ b/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/app/facade/PaymentFacadeTest.java
@@ -1,0 +1,74 @@
+package com.ticketrush.boundedcontext.payment.app.facade;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.ticketrush.boundedcontext.payment.app.dto.request.PaymentCancelRequest;
+import com.ticketrush.boundedcontext.payment.app.dto.response.PaymentCancelResponse;
+import com.ticketrush.boundedcontext.payment.app.usecase.PaymentCancelUseCase;
+import com.ticketrush.boundedcontext.payment.app.usecase.PaymentConfirmUseCase;
+import com.ticketrush.boundedcontext.payment.app.usecase.PaymentGetDetailUseCase;
+import com.ticketrush.boundedcontext.payment.app.usecase.PaymentGetListUseCase;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
+
+@ExtendWith(MockitoExtension.class)
+class PaymentFacadeTest {
+
+  @Mock private PaymentConfirmUseCase paymentConfirmUseCase;
+  @Mock private PaymentCancelUseCase paymentCancelUseCase;
+  @Mock private PaymentGetListUseCase paymentGetListUseCase;
+  @Mock private PaymentGetDetailUseCase paymentGetDetailUseCase;
+
+  @InjectMocks private PaymentFacade paymentFacade;
+
+  @Test
+  @DisplayName("cancel 정상 처리 시 UseCase 결과를 그대로 반환하고 멱등 조회는 호출하지 않는다")
+  void cancel_returns_usecase_result() {
+    // given
+    Long userId = 10L;
+    Long paymentId = 1L;
+    PaymentCancelRequest request = new PaymentCancelRequest("단순 변심");
+    PaymentCancelResponse expected =
+        new PaymentCancelResponse(paymentId, "CANCELED", 999L, 55_000L, LocalDateTime.now());
+    given(paymentCancelUseCase.execute(userId, paymentId, request)).willReturn(expected);
+
+    // when
+    PaymentCancelResponse response = paymentFacade.cancel(userId, paymentId, request);
+
+    // then
+    assertThat(response).isSameAs(expected);
+    verify(paymentCancelUseCase, never()).getCanceledResponse(any(), any());
+  }
+
+  @Test
+  @DisplayName("동시 취소로 unique 제약이 위반되면 먼저 확정된 환불을 멱등 반환한다")
+  void cancel_falls_back_to_existing_refund_on_constraint_violation() {
+    // given
+    Long userId = 10L;
+    Long paymentId = 1L;
+    PaymentCancelRequest request = new PaymentCancelRequest("단순 변심");
+    PaymentCancelResponse existing =
+        new PaymentCancelResponse(paymentId, "CANCELED", 999L, 55_000L, LocalDateTime.now());
+    given(paymentCancelUseCase.execute(userId, paymentId, request))
+        .willThrow(new DataIntegrityViolationException("duplicate paymentId"));
+    given(paymentCancelUseCase.getCanceledResponse(userId, paymentId)).willReturn(existing);
+
+    // when
+    PaymentCancelResponse response = paymentFacade.cancel(userId, paymentId, request);
+
+    // then
+    assertThat(response).isSameAs(existing);
+    verify(paymentCancelUseCase).getCanceledResponse(eq(userId), eq(paymentId));
+  }
+}

--- a/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentCancelUseCaseTest.java
+++ b/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentCancelUseCaseTest.java
@@ -119,7 +119,6 @@ class PaymentCancelUseCaseTest {
     // given
     Long userId = 10L;
     Long paymentId = 1L;
-    PaymentCancelRequest request = new PaymentCancelRequest("단순 변심");
 
     Payment payment = completedPayment(paymentId, userId, 100L, 200L, 55_000L);
     payment.markCanceled();
@@ -135,6 +134,8 @@ class PaymentCancelUseCaseTest {
 
     given(paymentRepository.findByIdAndUserId(paymentId, userId)).willReturn(Optional.of(payment));
     given(refundRepository.findByPaymentId(paymentId)).willReturn(Optional.of(existing));
+
+    PaymentCancelRequest request = new PaymentCancelRequest("단순 변심");
 
     // when
     PaymentCancelResponse response = paymentCancelUseCase.execute(userId, paymentId, request);

--- a/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentCancelUseCaseTest.java
+++ b/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentCancelUseCaseTest.java
@@ -1,0 +1,248 @@
+package com.ticketrush.boundedcontext.payment.app.usecase;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.ticketrush.boundedcontext.payment.app.dto.request.PaymentCancelRequest;
+import com.ticketrush.boundedcontext.payment.app.dto.response.PaymentCancelResponse;
+import com.ticketrush.boundedcontext.payment.app.support.PaymentEventPublisher;
+import com.ticketrush.boundedcontext.payment.domain.entity.Payment;
+import com.ticketrush.boundedcontext.payment.domain.entity.Refund;
+import com.ticketrush.boundedcontext.payment.domain.types.PaymentProvider;
+import com.ticketrush.boundedcontext.payment.domain.types.PaymentStatus;
+import com.ticketrush.boundedcontext.payment.domain.types.RefundStatus;
+import com.ticketrush.boundedcontext.payment.out.apiclient.PaymentCancelClientRouter;
+import com.ticketrush.boundedcontext.payment.out.apiclient.PaymentCancelCommand;
+import com.ticketrush.boundedcontext.payment.out.apiclient.PaymentCancelResult;
+import com.ticketrush.boundedcontext.payment.out.repository.PaymentRepository;
+import com.ticketrush.boundedcontext.payment.out.repository.RefundRepository;
+import com.ticketrush.global.exception.BusinessException;
+import com.ticketrush.global.status.ErrorStatus;
+import java.lang.reflect.Field;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class PaymentCancelUseCaseTest {
+
+  @Mock private PaymentRepository paymentRepository;
+  @Mock private RefundRepository refundRepository;
+  @Mock private PaymentCancelClientRouter paymentCancelClientRouter;
+  @Mock private PaymentEventPublisher paymentEventPublisher;
+
+  @InjectMocks private PaymentCancelUseCase paymentCancelUseCase;
+
+  @Test
+  @DisplayName("COMPLETED 결제 환불 성공 시 PG 취소 호출 + Refund 저장 + 결제 CANCELED 전이 + 이벤트를 발행한다")
+  void execute_success() throws Exception {
+    // given
+    Long userId = 10L;
+    Long paymentId = 1L;
+    Long bookingId = 100L;
+    Long seatId = 200L;
+    Long amount = 55_000L;
+    Long savedRefundId = 999L;
+    LocalDateTime canceledAt = LocalDateTime.of(2026, 5, 22, 10, 0);
+    PaymentCancelRequest request = new PaymentCancelRequest("단순 변심");
+
+    Payment payment = completedPayment(paymentId, userId, bookingId, seatId, amount);
+    given(paymentRepository.findByIdAndUserId(paymentId, userId)).willReturn(Optional.of(payment));
+    given(paymentCancelClientRouter.cancel(any()))
+        .willReturn(new PaymentCancelResult("PG-REFUND-1", amount, canceledAt));
+    given(refundRepository.save(any(Refund.class)))
+        .willAnswer(
+            invocation -> {
+              Refund r = invocation.getArgument(0);
+              setId(r, savedRefundId);
+              return r;
+            });
+
+    // when
+    PaymentCancelResponse response = paymentCancelUseCase.execute(userId, paymentId, request);
+
+    // then
+    assertThat(response.paymentId()).isEqualTo(paymentId);
+    assertThat(response.status()).isEqualTo("CANCELED");
+    assertThat(response.refundId()).isEqualTo(savedRefundId);
+    assertThat(response.refundedAmount()).isEqualTo(amount);
+    assertThat(response.canceledAt()).isEqualTo(canceledAt);
+    assertThat(payment.getStatus()).isEqualTo(PaymentStatus.CANCELED);
+
+    ArgumentCaptor<PaymentCancelCommand> commandCaptor =
+        ArgumentCaptor.forClass(PaymentCancelCommand.class);
+    verify(paymentCancelClientRouter).cancel(commandCaptor.capture());
+    PaymentCancelCommand command = commandCaptor.getValue();
+    assertThat(command.provider()).isEqualTo(PaymentProvider.TOSS);
+    assertThat(command.paymentKey()).isEqualTo("pgKey_xyz");
+    assertThat(command.amount()).isEqualTo(amount);
+    assertThat(command.reason()).isEqualTo("단순 변심");
+    assertThat(command.idempotencyKey()).isEqualTo("REFUND-0000001");
+
+    ArgumentCaptor<Refund> refundCaptor = ArgumentCaptor.forClass(Refund.class);
+    verify(refundRepository).save(refundCaptor.capture());
+    Refund savedRefund = refundCaptor.getValue();
+    assertThat(savedRefund.getPaymentId()).isEqualTo(paymentId);
+    assertThat(savedRefund.getBookingId()).isEqualTo(bookingId);
+    assertThat(savedRefund.getPrice()).isEqualTo(amount);
+    assertThat(savedRefund.getStatus()).isEqualTo(RefundStatus.COMPLETED);
+    assertThat(savedRefund.getPgRefundKey()).isEqualTo("PG-REFUND-1");
+    assertThat(savedRefund.getReason()).isEqualTo("단순 변심");
+    assertThat(savedRefund.getConfirmedAt()).isEqualTo(canceledAt);
+
+    verify(paymentEventPublisher)
+        .publishCanceled(
+            eq(paymentId),
+            eq(bookingId),
+            eq(seatId),
+            eq(savedRefundId),
+            eq(amount),
+            eq("단순 변심"),
+            eq(canceledAt));
+  }
+
+  @Test
+  @DisplayName("이미 CANCELED 된 결제는 PG 재호출 없이 기존 환불 내역을 멱등하게 반환한다")
+  void execute_idempotent_when_already_canceled() throws Exception {
+    // given
+    Long userId = 10L;
+    Long paymentId = 1L;
+    PaymentCancelRequest request = new PaymentCancelRequest("단순 변심");
+
+    Payment payment = completedPayment(paymentId, userId, 100L, 200L, 55_000L);
+    payment.markCanceled();
+    Refund existing =
+        Refund.builder()
+            .paymentId(paymentId)
+            .bookingId(100L)
+            .price(55_000L)
+            .status(RefundStatus.COMPLETED)
+            .confirmedAt(LocalDateTime.of(2026, 5, 22, 10, 0))
+            .build();
+    setId(existing, 999L);
+
+    given(paymentRepository.findByIdAndUserId(paymentId, userId)).willReturn(Optional.of(payment));
+    given(refundRepository.findByPaymentId(paymentId)).willReturn(Optional.of(existing));
+
+    // when
+    PaymentCancelResponse response = paymentCancelUseCase.execute(userId, paymentId, request);
+
+    // then
+    assertThat(response.refundId()).isEqualTo(999L);
+    assertThat(response.status()).isEqualTo("CANCELED");
+    verify(paymentCancelClientRouter, never()).cancel(any());
+    verify(refundRepository, never()).save(any(Refund.class));
+    verify(paymentEventPublisher, never())
+        .publishCanceled(any(), any(), any(), any(), any(), any(), any());
+  }
+
+  @Test
+  @DisplayName("본인 결제가 아니거나 존재하지 않으면 PAYMENT_404_002 예외가 발생한다")
+  void execute_fail_when_not_found() {
+    // given
+    Long userId = 10L;
+    Long paymentId = 999L;
+    PaymentCancelRequest request = new PaymentCancelRequest("단순 변심");
+    given(paymentRepository.findByIdAndUserId(paymentId, userId)).willReturn(Optional.empty());
+
+    // when & then
+    assertThatThrownBy(() -> paymentCancelUseCase.execute(userId, paymentId, request))
+        .isInstanceOf(BusinessException.class)
+        .extracting("errorStatus")
+        .isEqualTo(ErrorStatus.PAYMENT_NOT_FOUND);
+
+    verify(paymentCancelClientRouter, never()).cancel(any());
+    verify(refundRepository, never()).save(any(Refund.class));
+  }
+
+  @Test
+  @DisplayName("COMPLETED/CANCELED 가 아닌 결제는 PAYMENT_409_002 예외가 발생한다")
+  void execute_fail_when_not_cancelable() throws Exception {
+    // given
+    Long userId = 10L;
+    Long paymentId = 1L;
+    PaymentCancelRequest request = new PaymentCancelRequest("단순 변심");
+
+    Payment payment =
+        Payment.builder()
+            .bookingId(100L)
+            .userId(userId)
+            .seatId(200L)
+            .provider(PaymentProvider.TOSS)
+            .amount(55_000L)
+            .status(PaymentStatus.PENDING)
+            .paymentKey("pgKey_xyz")
+            .build();
+    setId(payment, paymentId);
+    given(paymentRepository.findByIdAndUserId(paymentId, userId)).willReturn(Optional.of(payment));
+
+    // when & then
+    assertThatThrownBy(() -> paymentCancelUseCase.execute(userId, paymentId, request))
+        .isInstanceOf(BusinessException.class)
+        .extracting("errorStatus")
+        .isEqualTo(ErrorStatus.PAYMENT_NOT_CANCELABLE);
+
+    verify(paymentCancelClientRouter, never()).cancel(any());
+    verify(refundRepository, never()).save(any(Refund.class));
+  }
+
+  @Test
+  @DisplayName("PG 환불이 실패하면 예외가 전파되고 Refund 저장/이벤트 발행을 하지 않는다")
+  void execute_fail_when_pg_refund_fails() throws Exception {
+    // given
+    Long userId = 10L;
+    Long paymentId = 1L;
+    PaymentCancelRequest request = new PaymentCancelRequest("단순 변심");
+
+    Payment payment = completedPayment(paymentId, userId, 100L, 200L, 55_000L);
+    given(paymentRepository.findByIdAndUserId(paymentId, userId)).willReturn(Optional.of(payment));
+    given(paymentCancelClientRouter.cancel(any()))
+        .willThrow(new BusinessException(ErrorStatus.PAYMENT_REFUND_FAILED));
+
+    // when & then
+    assertThatThrownBy(() -> paymentCancelUseCase.execute(userId, paymentId, request))
+        .isInstanceOf(BusinessException.class)
+        .extracting("errorStatus")
+        .isEqualTo(ErrorStatus.PAYMENT_REFUND_FAILED);
+
+    assertThat(payment.getStatus()).isEqualTo(PaymentStatus.COMPLETED);
+    verify(refundRepository, never()).save(any(Refund.class));
+    verify(paymentEventPublisher, never())
+        .publishCanceled(any(), any(), any(), any(), any(), any(), any());
+  }
+
+  private Payment completedPayment(
+      Long paymentId, Long userId, Long bookingId, Long seatId, Long amount) throws Exception {
+    Payment payment =
+        Payment.builder()
+            .bookingId(bookingId)
+            .userId(userId)
+            .seatId(seatId)
+            .provider(PaymentProvider.TOSS)
+            .amount(amount)
+            .status(PaymentStatus.COMPLETED)
+            .paymentKey("pgKey_xyz")
+            .approvalNumber("APR-1")
+            .paidAt(LocalDateTime.of(2026, 5, 1, 10, 0))
+            .build();
+    setId(payment, paymentId);
+    return payment;
+  }
+
+  private void setId(Object entity, Long id) throws Exception {
+    Field idField = entity.getClass().getSuperclass().getDeclaredField("id");
+    idField.setAccessible(true);
+    idField.set(entity, id);
+  }
+}

--- a/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentCancelUseCaseTest.java
+++ b/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentCancelUseCaseTest.java
@@ -33,6 +33,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
 
 @ExtendWith(MockitoExtension.class)
 class PaymentCancelUseCaseTest {
@@ -61,7 +62,7 @@ class PaymentCancelUseCaseTest {
     given(paymentRepository.findByIdAndUserId(paymentId, userId)).willReturn(Optional.of(payment));
     given(paymentCancelClientRouter.cancel(any()))
         .willReturn(new PaymentCancelResult("PG-REFUND-1", amount, canceledAt));
-    given(refundRepository.save(any(Refund.class)))
+    given(refundRepository.saveAndFlush(any(Refund.class)))
         .willAnswer(
             invocation -> {
               Refund r = invocation.getArgument(0);
@@ -91,7 +92,7 @@ class PaymentCancelUseCaseTest {
     assertThat(command.idempotencyKey()).isEqualTo("REFUND-0000001");
 
     ArgumentCaptor<Refund> refundCaptor = ArgumentCaptor.forClass(Refund.class);
-    verify(refundRepository).save(refundCaptor.capture());
+    verify(refundRepository).saveAndFlush(refundCaptor.capture());
     Refund savedRefund = refundCaptor.getValue();
     assertThat(savedRefund.getPaymentId()).isEqualTo(paymentId);
     assertThat(savedRefund.getBookingId()).isEqualTo(bookingId);
@@ -142,7 +143,7 @@ class PaymentCancelUseCaseTest {
     assertThat(response.refundId()).isEqualTo(999L);
     assertThat(response.status()).isEqualTo("CANCELED");
     verify(paymentCancelClientRouter, never()).cancel(any());
-    verify(refundRepository, never()).save(any(Refund.class));
+    verify(refundRepository, never()).saveAndFlush(any(Refund.class));
     verify(paymentEventPublisher, never())
         .publishCanceled(any(), any(), any(), any(), any(), any(), any());
   }
@@ -163,7 +164,7 @@ class PaymentCancelUseCaseTest {
         .isEqualTo(ErrorStatus.PAYMENT_NOT_FOUND);
 
     verify(paymentCancelClientRouter, never()).cancel(any());
-    verify(refundRepository, never()).save(any(Refund.class));
+    verify(refundRepository, never()).saveAndFlush(any(Refund.class));
   }
 
   @Test
@@ -194,7 +195,7 @@ class PaymentCancelUseCaseTest {
         .isEqualTo(ErrorStatus.PAYMENT_NOT_CANCELABLE);
 
     verify(paymentCancelClientRouter, never()).cancel(any());
-    verify(refundRepository, never()).save(any(Refund.class));
+    verify(refundRepository, never()).saveAndFlush(any(Refund.class));
   }
 
   @Test
@@ -217,9 +218,64 @@ class PaymentCancelUseCaseTest {
         .isEqualTo(ErrorStatus.PAYMENT_REFUND_FAILED);
 
     assertThat(payment.getStatus()).isEqualTo(PaymentStatus.COMPLETED);
-    verify(refundRepository, never()).save(any(Refund.class));
+    verify(refundRepository, never()).saveAndFlush(any(Refund.class));
     verify(paymentEventPublisher, never())
         .publishCanceled(any(), any(), any(), any(), any(), any(), any());
+  }
+
+  @Test
+  @DisplayName("동시 취소로 paymentId unique 제약이 위반되면 예외가 전파되고 이벤트를 발행하지 않는다")
+  void execute_propagates_constraint_violation_without_publishing() throws Exception {
+    // given
+    Long userId = 10L;
+    Long paymentId = 1L;
+    PaymentCancelRequest request = new PaymentCancelRequest("단순 변심");
+
+    Payment payment = completedPayment(paymentId, userId, 100L, 200L, 55_000L);
+    given(paymentRepository.findByIdAndUserId(paymentId, userId)).willReturn(Optional.of(payment));
+    given(paymentCancelClientRouter.cancel(any()))
+        .willReturn(new PaymentCancelResult("PG-REFUND-1", 55_000L, LocalDateTime.now()));
+    given(refundRepository.saveAndFlush(any(Refund.class)))
+        .willThrow(new DataIntegrityViolationException("duplicate paymentId"));
+
+    // when & then
+    assertThatThrownBy(() -> paymentCancelUseCase.execute(userId, paymentId, request))
+        .isInstanceOf(DataIntegrityViolationException.class);
+
+    verify(paymentEventPublisher, never())
+        .publishCanceled(any(), any(), any(), any(), any(), any(), any());
+  }
+
+  @Test
+  @DisplayName("getCanceledResponse 는 기존 환불 내역을 멱등하게 반환한다")
+  void getCanceledResponse_returns_existing_refund() throws Exception {
+    // given
+    Long userId = 10L;
+    Long paymentId = 1L;
+
+    Payment payment = completedPayment(paymentId, userId, 100L, 200L, 55_000L);
+    payment.markCanceled();
+    Refund existing =
+        Refund.builder()
+            .paymentId(paymentId)
+            .bookingId(100L)
+            .price(55_000L)
+            .status(RefundStatus.COMPLETED)
+            .confirmedAt(LocalDateTime.of(2026, 5, 22, 10, 0))
+            .build();
+    setId(existing, 999L);
+
+    given(paymentRepository.findByIdAndUserId(paymentId, userId)).willReturn(Optional.of(payment));
+    given(refundRepository.findByPaymentId(paymentId)).willReturn(Optional.of(existing));
+
+    // when
+    PaymentCancelResponse response = paymentCancelUseCase.getCanceledResponse(userId, paymentId);
+
+    // then
+    assertThat(response.refundId()).isEqualTo(999L);
+    assertThat(response.status()).isEqualTo("CANCELED");
+    verify(paymentCancelClientRouter, never()).cancel(any());
+    verify(refundRepository, never()).saveAndFlush(any(Refund.class));
   }
 
   private Payment completedPayment(

--- a/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/in/api/v1/PaymentControllerTest.java
+++ b/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/in/api/v1/PaymentControllerTest.java
@@ -10,7 +10,9 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.ticketrush.boundedcontext.payment.app.dto.request.PaymentCancelRequest;
 import com.ticketrush.boundedcontext.payment.app.dto.request.PaymentConfirmRequest;
+import com.ticketrush.boundedcontext.payment.app.dto.response.PaymentCancelResponse;
 import com.ticketrush.boundedcontext.payment.app.dto.response.PaymentConfirmResponse;
 import com.ticketrush.boundedcontext.payment.app.dto.response.PaymentDetailResponse;
 import com.ticketrush.boundedcontext.payment.app.dto.response.PaymentSummaryResponse;
@@ -174,6 +176,95 @@ class PaymentControllerTest {
         .andExpect(jsonPath("$.code").value(ErrorStatus.PAYMENT_AMOUNT_MISMATCH.getCode()));
 
     verify(paymentFacade).confirm(eq(userId), any(PaymentConfirmRequest.class));
+  }
+
+  @Test
+  @DisplayName("결제 취소(환불) 요청을 성공하고 200 OK를 반환한다")
+  void cancel_success() throws Exception {
+    // given
+    Long userId = 10L;
+    Long paymentId = 1L;
+    LocalDateTime canceledAt = LocalDateTime.of(2026, 5, 22, 10, 0);
+    PaymentCancelResponse response =
+        new PaymentCancelResponse(paymentId, "CANCELED", 5L, 55_000L, canceledAt);
+    given(paymentFacade.cancel(eq(userId), eq(paymentId), any(PaymentCancelRequest.class)))
+        .willReturn(response);
+
+    String requestBody =
+        """
+        {
+          "reason": "단순 변심"
+        }
+        """;
+
+    // when & then
+    mockMvc
+        .perform(
+            post("/api/v1/payment/{paymentId}/cancel", paymentId)
+                .header("X-Internal-Token", INTERNAL_TOKEN)
+                .header("X-User-Id", userId)
+                .header("X-User-Role", "USER")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestBody))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.is_success").value(true))
+        .andExpect(jsonPath("$.result.payment_id").value(1))
+        .andExpect(jsonPath("$.result.status").value("CANCELED"))
+        .andExpect(jsonPath("$.result.refund_id").value(5))
+        .andExpect(jsonPath("$.result.refunded_amount").value(55000))
+        .andExpect(jsonPath("$.result.canceled_at").value("2026-05-22 10:00:00"));
+
+    verify(paymentFacade).cancel(eq(userId), eq(paymentId), any(PaymentCancelRequest.class));
+  }
+
+  @Test
+  @DisplayName("환불 사유가 비어있으면 400 Bad Request를 반환한다")
+  void cancel_fails_when_reason_missing() throws Exception {
+    // given - reason 누락
+    String requestBody = "{}";
+
+    // when & then
+    mockMvc
+        .perform(
+            post("/api/v1/payment/{paymentId}/cancel", 1L)
+                .header("X-Internal-Token", INTERNAL_TOKEN)
+                .header("X-User-Id", 10L)
+                .header("X-User-Role", "USER")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestBody))
+        .andExpect(status().isBadRequest());
+
+    verifyNoInteractions(paymentFacade);
+  }
+
+  @Test
+  @DisplayName("본인 결제가 아니면 PAYMENT_404_002로 실패한다")
+  void cancel_fails_when_not_found() throws Exception {
+    // given
+    Long userId = 10L;
+    Long paymentId = 999L;
+    given(paymentFacade.cancel(eq(userId), eq(paymentId), any(PaymentCancelRequest.class)))
+        .willThrow(new BusinessException(ErrorStatus.PAYMENT_NOT_FOUND));
+
+    String requestBody =
+        """
+        {
+          "reason": "단순 변심"
+        }
+        """;
+
+    // when & then
+    mockMvc
+        .perform(
+            post("/api/v1/payment/{paymentId}/cancel", paymentId)
+                .header("X-Internal-Token", INTERNAL_TOKEN)
+                .header("X-User-Id", userId)
+                .header("X-User-Role", "USER")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestBody))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.is_success").value(false))
+        .andExpect(jsonPath("$.code").value(ErrorStatus.PAYMENT_NOT_FOUND.getCode()));
   }
 
   @Test


### PR DESCRIPTION
## 🔗 관련 이슈

- close #237

---

## 📌 주요 변경 사항

- 결제 취소(환불) API 추가: `POST /api/v1/payment/{paymentId}/cancel` (본인 결제 검증, 환불 사유 request body)
- 취소 흐름: 소유자/상태 검증 → PG 취소 호출 → `Refund` 저장 → `PaymentStatus.CANCELED` 전이 → `PaymentCanceledEvent` 발행
- 멱등성 보장: `Refund.paymentId` unique 제약 + 동시 취소 요청 시 기존 환불 내역 멱등 반환

---

## 🛠 상세 구현 내용

- **설계 결정(#22 협의):** 진입점은 payment-service 직접 endpoint(안 B), 전액 환불만, 상태는 기존 `PaymentStatus.CANCELED` 재사용
- **PG 취소 라우팅:** `PaymentCancelClientRouter`(Toss/Stub), `Idempotency-Key: REFUND-%07d`(paymentId)로 PG 측 중복 취소 방지
- **멱등 처리 (3중):**
  1. 이미 `CANCELED`면 PG 재호출 없이 기존 환불 반환 (fast-path)
  2. PG 멱등키로 이중 환불(실제 결제) 방지
  3. `Refund.paymentId` unique 제약 + 동시 요청 시 `saveAndFlush`로 제약 위반을 **이벤트 발행 이전에** 표면화하고, `PaymentFacade`가 트랜잭션 경계 **밖**에서 `DataIntegrityViolationException`을 잡아 먼저 확정된 환불을 멱등 반환 → 승자만 이벤트 발행 (#247 ExpiredBooking 패턴과 일관)
- **ErrorStatus:** `PAYMENT_NOT_CANCELABLE`(409_002) 신규, `PAYMENT_REFUND_DEADLINE_EXCEEDED`(400_005)는 정의만(환불 기한 검증은 공연 정보 연동 필요 → 후속 보류)
- **범위 밖:** 환불 실패 보상 트랜잭션(Saga)은 #91, booking/seat 상태 전이는 `PaymentCanceledEvent` 컨슈머 몫

---

## ✅ 테스트

### 테스트 방법

- 빌드 검증: `./gradlew :payment-service:spotlessApply :payment-service:checkstyleMain :payment-service:compileJava :payment-service:compileTestJava`
- 테스트 실행: `./gradlew :payment-service:test`
- 작성/실행한 테스트:
  - `PaymentCancelUseCaseTest` — 환불 성공(PG 호출+Refund 저장+CANCELED 전이+이벤트 발행), 이미 CANCELED 멱등 반환, 404(본인 아님/없음), 409(취소 불가 상태), PG 실패 전파, 동시 제약 위반 시 예외 전파+이벤트 미발행, `getCanceledResponse` 멱등 반환
  - `PaymentControllerTest` — cancel 엔드포인트 3건
  - `PaymentFacadeTest` — 정상 위임(멱등 조회 미호출), 제약 위반 시 기존 환불 멱등 폴백

### 테스트 결과

- payment-service 전체 테스트 통과 / 빌드 검증(spotless·checkstyle·compile) 통과
<!--
### 📸 스크린샷

- (작성 필요)
-->
---

## 👀 리뷰 요청 사항

- 멱등성 구조(`saveAndFlush` + Facade 바깥 `DataIntegrityViolationException` catch)가 #247 패턴과 일관되게 구성되었는지 검토 부탁드립니다.
- #239에서 협의된 구조 지적(라우터 `Map<PaymentProvider>` 통합 / Stub fallback 명시화 / `out/apiclient/toss/` 패키지 평탄화)은 본 PR 범위 밖으로, 승인·취소를 함께 다루는 후속 리팩토링 이슈로 분리 예정입니다.

---

## ⚠️ 배포 시 주의사항

- `refund` 테이블에 `payment_id` **UNIQUE 제약/인덱스 신규 추가**. 운영 DB 반영이 필요하며, 기존 환불 데이터에 중복 `payment_id`가 있으면 인덱스 생성이 실패할 수 있으니 **사전 중복 점검** 권장 (`ddl-auto=update`가 기존 테이블의 unique를 자동 추가하지 않을 수 있음).
- `PaymentConfirmUseCase`가 confirm 시 `Payment.seatId`를 저장(취소 이벤트 발행에 필요) — #235에서 도입된 seatId 흐름에 의존.
