### PR TITLE
[Feat] #217 입장권 QR payload 조회 API 구현

### DIFF
--- a/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/app/dto/response/BookingInternalResponse.java
+++ b/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/app/dto/response/BookingInternalResponse.java
@@ -1,0 +1,17 @@
+package com.ticketrush.boundedcontext.booking.app.dto.response;
+
+import com.ticketrush.boundedcontext.booking.domain.entity.Booking;
+import com.ticketrush.boundedcontext.booking.domain.types.BookingStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "예매 내부 조회 응답(서비스 간 통신 전용)")
+public record BookingInternalResponse(
+    @Schema(description = "예매 ID", example = "100") Long bookingId,
+    @Schema(description = "예매 소유자 ID", example = "10") Long userId,
+    @Schema(description = "예매 상태", example = "CONFIRMED") BookingStatus bookingStatus) {
+
+  public static BookingInternalResponse from(Booking booking) {
+    return new BookingInternalResponse(
+        booking.getId(), booking.getUserId(), booking.getBookingStatus());
+  }
+}

--- a/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/app/usecase/BookingGetInternalUseCase.java
+++ b/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/app/usecase/BookingGetInternalUseCase.java
@@ -1,0 +1,26 @@
+package com.ticketrush.boundedcontext.booking.app.usecase;
+
+import com.ticketrush.boundedcontext.booking.app.dto.response.BookingInternalResponse;
+import com.ticketrush.boundedcontext.booking.domain.entity.Booking;
+import com.ticketrush.boundedcontext.booking.out.repository.BookingRepository;
+import com.ticketrush.global.exception.BusinessException;
+import com.ticketrush.global.status.ErrorStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class BookingGetInternalUseCase {
+
+  private final BookingRepository bookingRepository;
+
+  @Transactional(readOnly = true)
+  public BookingInternalResponse execute(Long bookingId) {
+    Booking booking =
+        bookingRepository
+            .findById(bookingId)
+            .orElseThrow(() -> new BusinessException(ErrorStatus.BOOKING_NOT_FOUND));
+    return BookingInternalResponse.from(booking);
+  }
+}

--- a/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/in/api/v1/BookingInternalController.java
+++ b/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/in/api/v1/BookingInternalController.java
@@ -1,0 +1,48 @@
+package com.ticketrush.boundedcontext.booking.in.api.v1;
+
+import com.ticketrush.boundedcontext.booking.app.dto.response.BookingInternalResponse;
+import com.ticketrush.boundedcontext.booking.app.usecase.BookingGetInternalUseCase;
+import com.ticketrush.global.dto.response.ApiResponse;
+import com.ticketrush.global.exception.BusinessException;
+import com.ticketrush.global.status.ErrorStatus;
+import com.ticketrush.global.status.SuccessStatus;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "BookingInternal", description = "예매 내부 통신 API")
+@RestController
+@RequestMapping("/api/v1/booking")
+@RequiredArgsConstructor
+public class BookingInternalController {
+
+  private static final String INTERNAL_TOKEN_HEADER = "X-Internal-Token";
+
+  private final BookingGetInternalUseCase bookingGetInternalUseCase;
+
+  @Value("${gateway.internal-token}")
+  private String internalToken;
+
+  @Operation(summary = "예매 소유자/상태 내부 조회", description = "내부 토큰을 검증한 뒤 예매의 소유자와 상태를 반환합니다.")
+  @GetMapping("/internal/{bookingId}")
+  public ResponseEntity<ApiResponse<BookingInternalResponse>> getBookingInternal(
+      @RequestHeader(value = INTERNAL_TOKEN_HEADER, required = false) String internalTokenHeader,
+      @PathVariable Long bookingId) {
+    validateInternalToken(internalTokenHeader);
+    BookingInternalResponse response = bookingGetInternalUseCase.execute(bookingId);
+    return ApiResponse.onSuccess(SuccessStatus.OK, response);
+  }
+
+  private void validateInternalToken(String internalTokenHeader) {
+    if (!internalToken.equals(internalTokenHeader)) {
+      throw new BusinessException(ErrorStatus.FORBIDDEN);
+    }
+  }
+}

--- a/booking-service/src/test/java/com/ticketrush/boundedcontext/booking/app/usecase/BookingGetInternalUseCaseTest.java
+++ b/booking-service/src/test/java/com/ticketrush/boundedcontext/booking/app/usecase/BookingGetInternalUseCaseTest.java
@@ -1,0 +1,66 @@
+package com.ticketrush.boundedcontext.booking.app.usecase;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+import com.ticketrush.boundedcontext.booking.app.dto.response.BookingInternalResponse;
+import com.ticketrush.boundedcontext.booking.domain.entity.Booking;
+import com.ticketrush.boundedcontext.booking.domain.types.BookingStatus;
+import com.ticketrush.boundedcontext.booking.out.repository.BookingRepository;
+import com.ticketrush.global.exception.BusinessException;
+import com.ticketrush.global.status.ErrorStatus;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class BookingGetInternalUseCaseTest {
+
+  @InjectMocks private BookingGetInternalUseCase bookingGetInternalUseCase;
+
+  @Mock private BookingRepository bookingRepository;
+
+  @Test
+  @DisplayName("성공: 예매 ID로 소유자와 상태를 반환한다")
+  void execute_returns_owner_and_status() {
+    // given
+    Long bookingId = 100L;
+    Booking booking =
+        Booking.builder()
+            .bookingNumber("BOOK-1")
+            .userId(10L)
+            .performanceId(2L)
+            .seatId(3L)
+            .bookingStatus(BookingStatus.CONFIRMED)
+            .build();
+    ReflectionTestUtils.setField(booking, "id", bookingId);
+    given(bookingRepository.findById(bookingId)).willReturn(Optional.of(booking));
+
+    // when
+    BookingInternalResponse response = bookingGetInternalUseCase.execute(bookingId);
+
+    // then
+    assertThat(response.bookingId()).isEqualTo(bookingId);
+    assertThat(response.userId()).isEqualTo(10L);
+    assertThat(response.bookingStatus()).isEqualTo(BookingStatus.CONFIRMED);
+  }
+
+  @Test
+  @DisplayName("실패: 예매가 없으면 BOOKING_NOT_FOUND를 던진다")
+  void execute_fails_when_not_found() {
+    // given
+    Long bookingId = 999L;
+    given(bookingRepository.findById(bookingId)).willReturn(Optional.empty());
+
+    // when & then
+    assertThatThrownBy(() -> bookingGetInternalUseCase.execute(bookingId))
+        .isInstanceOf(BusinessException.class)
+        .hasFieldOrPropertyWithValue("errorStatus", ErrorStatus.BOOKING_NOT_FOUND);
+  }
+}

--- a/booking-service/src/test/java/com/ticketrush/boundedcontext/booking/in/api/v1/BookingInternalControllerTest.java
+++ b/booking-service/src/test/java/com/ticketrush/boundedcontext/booking/in/api/v1/BookingInternalControllerTest.java
@@ -1,0 +1,81 @@
+package com.ticketrush.boundedcontext.booking.in.api.v1;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.ticketrush.boundedcontext.booking.app.dto.response.BookingInternalResponse;
+import com.ticketrush.boundedcontext.booking.app.usecase.BookingGetInternalUseCase;
+import com.ticketrush.boundedcontext.booking.domain.types.BookingStatus;
+import com.ticketrush.global.config.JacksonConfig;
+import com.ticketrush.global.config.SecurityConfig;
+import com.ticketrush.global.filter.GatewayHeaderFilter;
+import com.ticketrush.global.status.ErrorStatus;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(BookingInternalController.class)
+@Import({JacksonConfig.class, SecurityConfig.class, GatewayHeaderFilter.class})
+@TestPropertySource(properties = "gateway.internal-token=test-token")
+class BookingInternalControllerTest {
+
+  private static final String INTERNAL_TOKEN = "test-token";
+
+  @Autowired private MockMvc mockMvc;
+
+  @MockitoBean private BookingGetInternalUseCase bookingGetInternalUseCase;
+
+  @Test
+  @DisplayName("성공: 올바른 내부 토큰이면 예매 소유자/상태를 200으로 반환한다")
+  void getBookingInternal_success() throws Exception {
+    // given
+    Long bookingId = 100L;
+    given(bookingGetInternalUseCase.execute(bookingId))
+        .willReturn(new BookingInternalResponse(bookingId, 10L, BookingStatus.CONFIRMED));
+
+    // when & then
+    mockMvc
+        .perform(
+            get("/api/v1/booking/internal/{bookingId}", bookingId)
+                .header("X-Internal-Token", INTERNAL_TOKEN))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.is_success").value(true))
+        .andExpect(jsonPath("$.result.booking_id").value(100))
+        .andExpect(jsonPath("$.result.user_id").value(10))
+        .andExpect(jsonPath("$.result.booking_status").value("CONFIRMED"));
+  }
+
+  @Test
+  @DisplayName("실패: 내부 토큰이 일치하지 않으면 403 FORBIDDEN을 반환한다")
+  void getBookingInternal_fails_when_token_mismatch() throws Exception {
+    // when & then
+    mockMvc
+        .perform(
+            get("/api/v1/booking/internal/{bookingId}", 100L).header("X-Internal-Token", "wrong"))
+        .andExpect(status().isForbidden())
+        .andExpect(jsonPath("$.is_success").value(false))
+        .andExpect(jsonPath("$.code").value(ErrorStatus.FORBIDDEN.getCode()));
+
+    verifyNoInteractions(bookingGetInternalUseCase);
+  }
+
+  @Test
+  @DisplayName("실패: 내부 토큰이 없으면 403 FORBIDDEN을 반환한다")
+  void getBookingInternal_fails_when_token_missing() throws Exception {
+    // when & then
+    mockMvc
+        .perform(get("/api/v1/booking/internal/{bookingId}", 100L))
+        .andExpect(status().isForbidden())
+        .andExpect(jsonPath("$.code").value(ErrorStatus.FORBIDDEN.getCode()));
+
+    verifyNoInteractions(bookingGetInternalUseCase);
+  }
+}

--- a/common/src/main/java/com/ticketrush/global/status/ErrorStatus.java
+++ b/common/src/main/java/com/ticketrush/global/status/ErrorStatus.java
@@ -169,7 +169,17 @@ public enum ErrorStatus {
 
   // Payment 503
   PAYMENT_PG_COMMUNICATION_FAILED(
-      HttpStatus.SERVICE_UNAVAILABLE, "PAYMENT_503_001", "PG사와 통신에 실패했습니다.");
+      HttpStatus.SERVICE_UNAVAILABLE, "PAYMENT_503_001", "PG사와 통신에 실패했습니다."),
+
+  // Ticket 404
+  TICKET_NOT_FOUND(HttpStatus.NOT_FOUND, "TICKET_404_001", "입장권을 찾을 수 없습니다."),
+
+  // Ticket 409
+  TICKET_NOT_USABLE(HttpStatus.CONFLICT, "TICKET_409_001", "확정된 예매가 아니어서 입장권을 조회할 수 없습니다."),
+
+  // Ticket 503
+  TICKET_BOOKING_COMMUNICATION_FAILED(
+      HttpStatus.SERVICE_UNAVAILABLE, "TICKET_503_001", "예매 정보 조회에 실패했습니다. 잠시 후 다시 시도해 주세요.");
 
   private final HttpStatus httpStatus;
   private final String code;

--- a/ticket-service/build.gradle
+++ b/ticket-service/build.gradle
@@ -52,6 +52,14 @@ dependencies {
 	// Kafka
 	implementation 'org.springframework.boot:spring-boot-starter-kafka'
 	testImplementation 'org.springframework.boot:spring-boot-starter-kafka-test'
+
+	// JWT (QR payload 서명)
+	implementation 'io.jsonwebtoken:jjwt-api:0.12.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.5'
+
+	// 공통 테스트 픽스처(WebMvcSliceTest 등)
+	testImplementation(testFixtures(project(":common")))
 }
 
 dependencyManagement {

--- a/ticket-service/src/main/java/com/ticketrush/boundedcontext/ticket/app/dto/response/TicketQrResponse.java
+++ b/ticket-service/src/main/java/com/ticketrush/boundedcontext/ticket/app/dto/response/TicketQrResponse.java
@@ -1,0 +1,23 @@
+package com.ticketrush.boundedcontext.ticket.app.dto.response;
+
+import com.ticketrush.boundedcontext.ticket.domain.entity.Ticket;
+import com.ticketrush.boundedcontext.ticket.domain.types.TicketStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+
+@Schema(description = "입장권 QR payload 조회 응답")
+public record TicketQrResponse(
+    @Schema(
+            description = "QR로 렌더링할 서명 payload(JWT)",
+            example = "eyJhbGciOiJIUzI1NiJ9.eyJ0aWQiOjF9...")
+        String payload,
+    @Schema(description = "입장권 상태", example = "UNUSED") TicketStatus ticketStatus,
+    @Schema(description = "입장권 발급 시각", example = "2026-06-25 10:00:00") LocalDateTime issuedAt,
+    @Schema(description = "QR payload 만료 시각", example = "2026-06-25 10:05:00")
+        LocalDateTime expiresAt) {
+
+  public static TicketQrResponse of(Ticket ticket, String payload, LocalDateTime expiresAt) {
+    return new TicketQrResponse(
+        payload, ticket.getTicketStatus(), ticket.getCreatedAt(), expiresAt);
+  }
+}

--- a/ticket-service/src/main/java/com/ticketrush/boundedcontext/ticket/app/usecase/TicketQrGetUseCase.java
+++ b/ticket-service/src/main/java/com/ticketrush/boundedcontext/ticket/app/usecase/TicketQrGetUseCase.java
@@ -1,0 +1,51 @@
+package com.ticketrush.boundedcontext.ticket.app.usecase;
+
+import com.ticketrush.boundedcontext.ticket.app.dto.response.TicketQrResponse;
+import com.ticketrush.boundedcontext.ticket.domain.entity.Ticket;
+import com.ticketrush.boundedcontext.ticket.domain.policy.QrPayload;
+import com.ticketrush.boundedcontext.ticket.domain.policy.TicketQrPayloadGenerator;
+import com.ticketrush.boundedcontext.ticket.out.apiclient.BookingRestClient;
+import com.ticketrush.boundedcontext.ticket.out.apiclient.dto.BookingInfoResponse;
+import com.ticketrush.boundedcontext.ticket.out.repository.TicketRepository;
+import com.ticketrush.global.exception.BusinessException;
+import com.ticketrush.global.status.ErrorStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class TicketQrGetUseCase {
+
+  /** 확정된(CONFIRMED) 예매만 QR payload 조회를 허용한다. booking-service의 BookingStatus enum 이름과 일치. */
+  private static final String CONFIRMED_STATUS = "CONFIRMED";
+
+  private final BookingRestClient bookingRestClient;
+  private final TicketRepository ticketRepository;
+  private final TicketQrPayloadGenerator ticketQrPayloadGenerator;
+
+  /**
+   * 외부 동기 호출(booking-service)을 트랜잭션 밖에서 먼저 수행해 DB 커넥션을 장시간 점유하지 않는다. 실제 DB 접근은 findByBookingId
+   * 단건뿐이라 Spring Data의 기본 트랜잭션으로 충분하므로 메서드 레벨 트랜잭션을 두지 않는다.
+   */
+  public TicketQrResponse execute(Long userId, Long bookingId) {
+    BookingInfoResponse booking = bookingRestClient.getBooking(bookingId);
+
+    // 본인 예매가 아니면 미존재와 동일하게 404로 통일해 다른 사용자 예매의 존재 여부 노출을 막는다.
+    if (!userId.equals(booking.userId())) {
+      throw new BusinessException(ErrorStatus.TICKET_NOT_FOUND);
+    }
+
+    // 미확정/취소 예매는 입장권 조회가 불가능하다.
+    if (!CONFIRMED_STATUS.equals(booking.bookingStatus())) {
+      throw new BusinessException(ErrorStatus.TICKET_NOT_USABLE);
+    }
+
+    Ticket ticket =
+        ticketRepository
+            .findByBookingId(bookingId)
+            .orElseThrow(() -> new BusinessException(ErrorStatus.TICKET_NOT_FOUND));
+
+    QrPayload qrPayload = ticketQrPayloadGenerator.generate(ticket);
+    return TicketQrResponse.of(ticket, qrPayload.payload(), qrPayload.expiresAt());
+  }
+}

--- a/ticket-service/src/main/java/com/ticketrush/boundedcontext/ticket/domain/policy/QrPayload.java
+++ b/ticket-service/src/main/java/com/ticketrush/boundedcontext/ticket/domain/policy/QrPayload.java
@@ -1,0 +1,6 @@
+package com.ticketrush.boundedcontext.ticket.domain.policy;
+
+import java.time.LocalDateTime;
+
+/** QR payload 생성 결과: 서명 토큰 문자열과 만료 시각. */
+public record QrPayload(String payload, LocalDateTime expiresAt) {}

--- a/ticket-service/src/main/java/com/ticketrush/boundedcontext/ticket/domain/policy/TicketQrPayloadGenerator.java
+++ b/ticket-service/src/main/java/com/ticketrush/boundedcontext/ticket/domain/policy/TicketQrPayloadGenerator.java
@@ -1,0 +1,53 @@
+package com.ticketrush.boundedcontext.ticket.domain.policy;
+
+import com.ticketrush.boundedcontext.ticket.domain.entity.Ticket;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Date;
+import javax.crypto.SecretKey;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+/**
+ * 입장권 QR payload를 조회 시점에 JWT 서명 토큰으로 동적 생성한다. DB에는 비밀 평문을 저장하지 않으며, 짧은 만료(ttl)를 두어 캡처/재사용 위험을 줄인다.
+ * 인증용 JWT와는 별도 시크릿을 사용한다.
+ */
+@Component
+public class TicketQrPayloadGenerator {
+
+  private final SecretKey key;
+  private final long ttlMillis;
+
+  public TicketQrPayloadGenerator(
+      @Value("${ticket.qr.secret}") String secret,
+      @Value("${ticket.qr.ttl-millis:300000}") long ttlMillis) {
+    if (secret.getBytes(StandardCharsets.UTF_8).length < 32) {
+      throw new IllegalArgumentException("ticket.qr.secret 은 최소 32바이트 이상이어야 합니다.");
+    }
+    this.key = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+    this.ttlMillis = ttlMillis;
+  }
+
+  public QrPayload generate(Ticket ticket) {
+    Date now = new Date();
+    Date expiry = new Date(now.getTime() + ttlMillis);
+
+    String token =
+        Jwts.builder()
+            .claim("tid", ticket.getId())
+            .claim("bid", ticket.getBookingId())
+            .claim("st", ticket.getTicketStatus().name())
+            .issuedAt(now)
+            .expiration(expiry)
+            .signWith(key)
+            .compact();
+
+    // issuedAt(Ticket.createdAt)이 JPA Auditing의 LocalDateTime.now()로 JVM 기본 타임존 기준 생성되므로,
+    // expiresAt도 동일하게 systemDefault 기준으로 변환해 두 시각의 기준을 일치시킨다. JVM 타임존 표준화는 전 서비스 공통 인프라 사안.
+    LocalDateTime expiresAt = LocalDateTime.ofInstant(expiry.toInstant(), ZoneId.systemDefault());
+    return new QrPayload(token, expiresAt);
+  }
+}

--- a/ticket-service/src/main/java/com/ticketrush/boundedcontext/ticket/in/api/v1/TicketQrController.java
+++ b/ticket-service/src/main/java/com/ticketrush/boundedcontext/ticket/in/api/v1/TicketQrController.java
@@ -1,0 +1,35 @@
+package com.ticketrush.boundedcontext.ticket.in.api.v1;
+
+import com.ticketrush.boundedcontext.ticket.app.dto.response.TicketQrResponse;
+import com.ticketrush.boundedcontext.ticket.app.usecase.TicketQrGetUseCase;
+import com.ticketrush.global.dto.response.ApiResponse;
+import com.ticketrush.global.security.CustomUserDetails;
+import com.ticketrush.global.status.SuccessStatus;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Ticket", description = "입장권 관련 API")
+@RestController
+@RequestMapping("/api/v1/ticket")
+@RequiredArgsConstructor
+public class TicketQrController {
+
+  private final TicketQrGetUseCase ticketQrGetUseCase;
+
+  @Operation(
+      summary = "입장권 QR payload 조회",
+      description = "로그인 사용자 본인의 확정된 예매에 한해 QR로 렌더링할 payload와 입장권 메타데이터를 반환합니다.")
+  @GetMapping("/bookings/{bookingId}/qr")
+  public ResponseEntity<ApiResponse<TicketQrResponse>> getTicketQr(
+      @AuthenticationPrincipal CustomUserDetails user, @PathVariable Long bookingId) {
+    TicketQrResponse response = ticketQrGetUseCase.execute(user.getUserId(), bookingId);
+    return ApiResponse.onSuccess(SuccessStatus.OK, response);
+  }
+}

--- a/ticket-service/src/main/java/com/ticketrush/boundedcontext/ticket/out/apiclient/BookingRestClient.java
+++ b/ticket-service/src/main/java/com/ticketrush/boundedcontext/ticket/out/apiclient/BookingRestClient.java
@@ -1,0 +1,67 @@
+package com.ticketrush.boundedcontext.ticket.out.apiclient;
+
+import com.ticketrush.boundedcontext.ticket.out.apiclient.dto.BookingApiResponse;
+import com.ticketrush.boundedcontext.ticket.out.apiclient.dto.BookingInfoResponse;
+import com.ticketrush.global.exception.BusinessException;
+import com.ticketrush.global.status.ErrorStatus;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.ResourceAccessException;
+import org.springframework.web.client.RestClient;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class BookingRestClient {
+
+  private static final String INTERNAL_TOKEN_HEADER = "X-Internal-Token";
+
+  private final RestClient bookingServiceRestClient;
+
+  @Value("${gateway.internal-token}")
+  private String internalToken;
+
+  /**
+   * booking-service에서 예매 소유자/상태를 동기 조회한다. 예매가 없으면(404) 입장권 미존재와 동일한 TICKET_NOT_FOUND로 통일해 다른 사용자
+   * 예매의 존재 여부 노출을 막는다. 그 외 4xx/5xx(인증 불일치·다운스트림 장애 등)와 연결 실패/타임아웃은 모두
+   * TICKET_BOOKING_COMMUNICATION_FAILED(503)로 매핑해, 호출 측 사용자에게 500이 새어 나가지 않도록 한다.
+   */
+  public BookingInfoResponse getBooking(Long bookingId) {
+    BookingApiResponse response;
+    try {
+      response =
+          bookingServiceRestClient
+              .get()
+              .uri("/api/v1/booking/internal/{bookingId}", bookingId)
+              .header(INTERNAL_TOKEN_HEADER, internalToken)
+              .retrieve()
+              .onStatus(
+                  status -> status.value() == 404,
+                  (request, clientResponse) -> {
+                    throw new BusinessException(ErrorStatus.TICKET_NOT_FOUND);
+                  })
+              .onStatus(
+                  status -> status.isError(),
+                  (request, clientResponse) -> {
+                    log.warn(
+                        "[BookingRestClient] booking-service 비정상 응답 status={}, bookingId={}",
+                        clientResponse.getStatusCode(),
+                        bookingId);
+                    throw new BusinessException(ErrorStatus.TICKET_BOOKING_COMMUNICATION_FAILED);
+                  })
+              .body(BookingApiResponse.class);
+    } catch (ResourceAccessException e) {
+      log.warn("[BookingRestClient] booking-service 연결 실패/타임아웃 bookingId={}", bookingId, e);
+      throw new BusinessException(ErrorStatus.TICKET_BOOKING_COMMUNICATION_FAILED);
+    }
+
+    if (response == null || response.result() == null) {
+      log.warn(
+          "[BookingRestClient] booking-service 200 응답이나 result 본문이 비어 있음 bookingId={}", bookingId);
+      throw new BusinessException(ErrorStatus.TICKET_BOOKING_COMMUNICATION_FAILED);
+    }
+    return response.result();
+  }
+}

--- a/ticket-service/src/main/java/com/ticketrush/boundedcontext/ticket/out/apiclient/dto/BookingApiResponse.java
+++ b/ticket-service/src/main/java/com/ticketrush/boundedcontext/ticket/out/apiclient/dto/BookingApiResponse.java
@@ -1,0 +1,10 @@
+package com.ticketrush.boundedcontext.ticket.out.apiclient.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/** booking-service의 공통 ApiResponse 래퍼 중 ticket-service가 사용하는 필드만 매핑한다. */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record BookingApiResponse(
+    @JsonProperty("is_success") boolean isSuccess,
+    @JsonProperty("result") BookingInfoResponse result) {}

--- a/ticket-service/src/main/java/com/ticketrush/boundedcontext/ticket/out/apiclient/dto/BookingInfoResponse.java
+++ b/ticket-service/src/main/java/com/ticketrush/boundedcontext/ticket/out/apiclient/dto/BookingInfoResponse.java
@@ -1,0 +1,11 @@
+package com.ticketrush.boundedcontext.ticket.out.apiclient.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/** booking-service internal 조회 API 응답의 result 본문(snake_case JSON)을 매핑한다. */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record BookingInfoResponse(
+    @JsonProperty("booking_id") Long bookingId,
+    @JsonProperty("user_id") Long userId,
+    @JsonProperty("booking_status") String bookingStatus) {}

--- a/ticket-service/src/main/java/com/ticketrush/boundedcontext/ticket/out/repository/TicketRepository.java
+++ b/ticket-service/src/main/java/com/ticketrush/boundedcontext/ticket/out/repository/TicketRepository.java
@@ -1,9 +1,12 @@
 package com.ticketrush.boundedcontext.ticket.out.repository;
 
 import com.ticketrush.boundedcontext.ticket.domain.entity.Ticket;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface TicketRepository extends JpaRepository<Ticket, Long> {
 
   boolean existsByBookingId(Long bookingId);
+
+  Optional<Ticket> findByBookingId(Long bookingId);
 }

--- a/ticket-service/src/main/java/com/ticketrush/global/config/RestClientConfig.java
+++ b/ticket-service/src/main/java/com/ticketrush/global/config/RestClientConfig.java
@@ -1,0 +1,21 @@
+package com.ticketrush.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestClient;
+
+@Configuration
+public class RestClientConfig {
+
+  @Bean
+  public RestClient bookingServiceRestClient(
+      @Value("${service.booking.url}") String bookingServiceUrl,
+      @Value("${service.http.connect-timeout-ms:3000}") long connectTimeoutMs,
+      @Value("${service.http.read-timeout-ms:10000}") long readTimeoutMs) {
+    return RestClient.builder()
+        .baseUrl(bookingServiceUrl)
+        .requestFactory(RestClientFactorySupport.withTimeouts(connectTimeoutMs, readTimeoutMs))
+        .build();
+  }
+}

--- a/ticket-service/src/main/java/com/ticketrush/global/config/SecurityConfig.java
+++ b/ticket-service/src/main/java/com/ticketrush/global/config/SecurityConfig.java
@@ -1,14 +1,19 @@
 package com.ticketrush.global.config;
 
+import com.ticketrush.global.filter.GatewayHeaderFilter;
+import com.ticketrush.global.status.ErrorStatus;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.security.autoconfigure.SecurityProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
 @EnableWebSecurity
@@ -17,15 +22,37 @@ import org.springframework.security.web.SecurityFilterChain;
 @RequiredArgsConstructor
 public class SecurityConfig {
 
+  private final GatewayHeaderFilter gatewayHeaderFilter;
+
   @Bean
   public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
     http.csrf(csrf -> csrf.disable())
         .cors(cors -> {})
+        .httpBasic(httpBasic -> httpBasic.disable())
+        .formLogin(formLogin -> formLogin.disable())
+        .addFilterBefore(gatewayHeaderFilter, UsernamePasswordAuthenticationFilter.class)
+        .exceptionHandling(
+            exception ->
+                exception.authenticationEntryPoint(
+                    (request, response, authException) -> {
+                      response.setStatus(ErrorStatus.UNAUTHORIZED.getHttpStatus().value());
+                      response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+                      response
+                          .getWriter()
+                          .write(
+                              """
+                              {"is_success":false,"code":"%s","message":"%s"}
+                              """
+                                  .formatted(
+                                      ErrorStatus.UNAUTHORIZED.getCode(),
+                                      ErrorStatus.UNAUTHORIZED.getMessage()));
+                    }))
         .authorizeHttpRequests(
             auth ->
                 auth.requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html")
-                    // TODO: 인증 이후 허용 범위 수정
                     .permitAll()
+                    .requestMatchers(HttpMethod.GET, "/api/v1/ticket/bookings/*/qr")
+                    .authenticated()
                     .anyRequest()
                     .permitAll());
 

--- a/ticket-service/src/main/resources/application-local.yml
+++ b/ticket-service/src/main/resources/application-local.yml
@@ -14,11 +14,6 @@ app:
   event-publisher:
     type: kafka
 
-ticket:
-  qr:
-    # 로컬 개발 전용 시크릿. 운영 프로파일에는 기본값이 없어 TICKET_QR_SECRET 주입을 강제한다.
-    secret: ticketrush-qr-local-dev-secret-0123456789
-
 custom:
   security:
     permit-all: false

--- a/ticket-service/src/main/resources/application-local.yml
+++ b/ticket-service/src/main/resources/application-local.yml
@@ -14,6 +14,11 @@ app:
   event-publisher:
     type: kafka
 
+ticket:
+  qr:
+    # 로컬 개발 전용 시크릿. 운영 프로파일에는 기본값이 없어 TICKET_QR_SECRET 주입을 강제한다.
+    secret: ticketrush-qr-local-dev-secret-0123456789
+
 custom:
   security:
     permit-all: false

--- a/ticket-service/src/main/resources/application.yml
+++ b/ticket-service/src/main/resources/application.yml
@@ -8,6 +8,13 @@ spring:
   application:
     name: ticket-service
 
+service:
+  booking:
+    url: ${BOOKING_SERVICE_URL:http://localhost:8084}
+  http:
+    connect-timeout-ms: ${SERVICE_HTTP_CONNECT_TIMEOUT_MS:3000}
+    read-timeout-ms: ${SERVICE_HTTP_READ_TIMEOUT_MS:10000}
+
 custom:
   global:
     internalBackUrl: http://localhost:${server.port:8087}
@@ -22,3 +29,9 @@ springdoc:
 
 gateway:
   internal-token: ${GATEWAY_INTERNAL_TOKEN:test-token}
+
+ticket:
+  qr:
+    # QR 토큰 서명 시크릿. 기본값을 두지 않아 미주입 시 기동을 실패시킨다(공개 시크릿으로 서명되는 사고 방지).
+    secret: ${TICKET_QR_SECRET}
+    ttl-millis: ${TICKET_QR_TTL_MILLIS:300000}

--- a/ticket-service/src/test/java/com/ticketrush/boundedcontext/ticket/app/usecase/TicketQrGetUseCaseTest.java
+++ b/ticket-service/src/test/java/com/ticketrush/boundedcontext/ticket/app/usecase/TicketQrGetUseCaseTest.java
@@ -1,0 +1,139 @@
+package com.ticketrush.boundedcontext.ticket.app.usecase;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+
+import com.ticketrush.boundedcontext.ticket.app.dto.response.TicketQrResponse;
+import com.ticketrush.boundedcontext.ticket.domain.entity.Ticket;
+import com.ticketrush.boundedcontext.ticket.domain.policy.QrPayload;
+import com.ticketrush.boundedcontext.ticket.domain.policy.TicketQrPayloadGenerator;
+import com.ticketrush.boundedcontext.ticket.domain.types.TicketStatus;
+import com.ticketrush.boundedcontext.ticket.out.apiclient.BookingRestClient;
+import com.ticketrush.boundedcontext.ticket.out.apiclient.dto.BookingInfoResponse;
+import com.ticketrush.boundedcontext.ticket.out.repository.TicketRepository;
+import com.ticketrush.global.exception.BusinessException;
+import com.ticketrush.global.status.ErrorStatus;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class TicketQrGetUseCaseTest {
+
+  @InjectMocks private TicketQrGetUseCase ticketQrGetUseCase;
+
+  @Mock private BookingRestClient bookingRestClient;
+
+  @Mock private TicketRepository ticketRepository;
+
+  @Mock private TicketQrPayloadGenerator ticketQrPayloadGenerator;
+
+  private Ticket ticket(Long bookingId, LocalDateTime createdAt) {
+    Ticket ticket =
+        Ticket.builder()
+            .bookingId(bookingId)
+            .ticketTokenHash("hash")
+            .ticketStatus(TicketStatus.UNUSED)
+            .build();
+    ReflectionTestUtils.setField(ticket, "id", 1L);
+    ReflectionTestUtils.setField(ticket, "createdAt", createdAt);
+    return ticket;
+  }
+
+  @Test
+  @DisplayName("성공: 본인 확정 예매면 QR payload와 메타데이터를 반환한다")
+  void execute_returns_qr_payload() {
+    // given
+    Long userId = 10L;
+    Long bookingId = 100L;
+    LocalDateTime issuedAt = LocalDateTime.of(2026, 6, 25, 10, 0);
+    LocalDateTime expiresAt = issuedAt.plusMinutes(5);
+    given(bookingRestClient.getBooking(bookingId))
+        .willReturn(new BookingInfoResponse(bookingId, userId, "CONFIRMED"));
+    Ticket ticket = ticket(bookingId, issuedAt);
+    given(ticketRepository.findByBookingId(bookingId)).willReturn(Optional.of(ticket));
+    given(ticketQrPayloadGenerator.generate(ticket))
+        .willReturn(new QrPayload("jwt-payload", expiresAt));
+
+    // when
+    TicketQrResponse response = ticketQrGetUseCase.execute(userId, bookingId);
+
+    // then
+    assertThat(response.payload()).isEqualTo("jwt-payload");
+    assertThat(response.ticketStatus()).isEqualTo(TicketStatus.UNUSED);
+    assertThat(response.issuedAt()).isEqualTo(issuedAt);
+    assertThat(response.expiresAt()).isEqualTo(expiresAt);
+  }
+
+  @Test
+  @DisplayName("실패: 본인 예매가 아니면 미존재와 동일한 TICKET_NOT_FOUND로 통일한다")
+  void execute_fails_when_not_owner() {
+    // given
+    Long userId = 10L;
+    Long bookingId = 100L;
+    given(bookingRestClient.getBooking(bookingId))
+        .willReturn(new BookingInfoResponse(bookingId, 999L, "CONFIRMED"));
+
+    // when & then
+    assertThatThrownBy(() -> ticketQrGetUseCase.execute(userId, bookingId))
+        .isInstanceOf(BusinessException.class)
+        .hasFieldOrPropertyWithValue("errorStatus", ErrorStatus.TICKET_NOT_FOUND);
+    then(ticketRepository).should(never()).findByBookingId(bookingId);
+  }
+
+  @Test
+  @DisplayName("실패: 미확정 예매는 TICKET_NOT_USABLE로 조회를 막는다")
+  void execute_fails_when_pending() {
+    // given
+    Long userId = 10L;
+    Long bookingId = 100L;
+    given(bookingRestClient.getBooking(bookingId))
+        .willReturn(new BookingInfoResponse(bookingId, userId, "PENDING"));
+
+    // when & then
+    assertThatThrownBy(() -> ticketQrGetUseCase.execute(userId, bookingId))
+        .isInstanceOf(BusinessException.class)
+        .hasFieldOrPropertyWithValue("errorStatus", ErrorStatus.TICKET_NOT_USABLE);
+    then(ticketRepository).should(never()).findByBookingId(bookingId);
+  }
+
+  @Test
+  @DisplayName("실패: 취소된 예매는 TICKET_NOT_USABLE로 조회를 막는다")
+  void execute_fails_when_canceled() {
+    // given
+    Long userId = 10L;
+    Long bookingId = 100L;
+    given(bookingRestClient.getBooking(bookingId))
+        .willReturn(new BookingInfoResponse(bookingId, userId, "CANCELED"));
+
+    // when & then
+    assertThatThrownBy(() -> ticketQrGetUseCase.execute(userId, bookingId))
+        .isInstanceOf(BusinessException.class)
+        .hasFieldOrPropertyWithValue("errorStatus", ErrorStatus.TICKET_NOT_USABLE);
+  }
+
+  @Test
+  @DisplayName("실패: 확정 예매라도 발급된 티켓이 없으면 TICKET_NOT_FOUND를 던진다")
+  void execute_fails_when_ticket_not_issued() {
+    // given
+    Long userId = 10L;
+    Long bookingId = 100L;
+    given(bookingRestClient.getBooking(bookingId))
+        .willReturn(new BookingInfoResponse(bookingId, userId, "CONFIRMED"));
+    given(ticketRepository.findByBookingId(bookingId)).willReturn(Optional.empty());
+
+    // when & then
+    assertThatThrownBy(() -> ticketQrGetUseCase.execute(userId, bookingId))
+        .isInstanceOf(BusinessException.class)
+        .hasFieldOrPropertyWithValue("errorStatus", ErrorStatus.TICKET_NOT_FOUND);
+  }
+}

--- a/ticket-service/src/test/java/com/ticketrush/boundedcontext/ticket/domain/policy/TicketQrPayloadGeneratorTest.java
+++ b/ticket-service/src/test/java/com/ticketrush/boundedcontext/ticket/domain/policy/TicketQrPayloadGeneratorTest.java
@@ -1,0 +1,59 @@
+package com.ticketrush.boundedcontext.ticket.domain.policy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.ticketrush.boundedcontext.ticket.domain.entity.Ticket;
+import com.ticketrush.boundedcontext.ticket.domain.types.TicketStatus;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+import javax.crypto.SecretKey;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class TicketQrPayloadGeneratorTest {
+
+  private static final String SECRET = "ticketrush-qr-test-secret-key-0123456789";
+
+  private final TicketQrPayloadGenerator generator = new TicketQrPayloadGenerator(SECRET, 300_000L);
+
+  private Ticket ticket() {
+    Ticket ticket =
+        Ticket.builder()
+            .bookingId(100L)
+            .ticketTokenHash("hash")
+            .ticketStatus(TicketStatus.UNUSED)
+            .build();
+    ReflectionTestUtils.setField(ticket, "id", 1L);
+    return ticket;
+  }
+
+  @Test
+  @DisplayName("성공: 서명된 JWT payload에 ticketId/bookingId/status 클레임과 만료가 담긴다")
+  void generate_signs_payload_with_claims() {
+    // when
+    QrPayload result = generator.generate(ticket());
+
+    // then
+    SecretKey key = Keys.hmacShaKeyFor(SECRET.getBytes(StandardCharsets.UTF_8));
+    Claims claims =
+        Jwts.parser().verifyWith(key).build().parseSignedClaims(result.payload()).getPayload();
+
+    assertThat(((Number) claims.get("tid")).longValue()).isEqualTo(1L);
+    assertThat(((Number) claims.get("bid")).longValue()).isEqualTo(100L);
+    assertThat(claims.get("st", String.class)).isEqualTo("UNUSED");
+    assertThat(claims.getExpiration()).isAfter(claims.getIssuedAt());
+    assertThat(result.expiresAt()).isAfter(LocalDateTime.now());
+  }
+
+  @Test
+  @DisplayName("실패: 시크릿이 32바이트 미만이면 생성기 구성에 실패한다")
+  void constructor_fails_when_secret_too_short() {
+    assertThatThrownBy(() -> new TicketQrPayloadGenerator("short-secret", 300_000L))
+        .isInstanceOf(IllegalArgumentException.class);
+  }
+}

--- a/ticket-service/src/test/java/com/ticketrush/boundedcontext/ticket/in/api/v1/TicketQrControllerTest.java
+++ b/ticket-service/src/test/java/com/ticketrush/boundedcontext/ticket/in/api/v1/TicketQrControllerTest.java
@@ -1,0 +1,120 @@
+package com.ticketrush.boundedcontext.ticket.in.api.v1;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.ticketrush.boundedcontext.ticket.app.dto.response.TicketQrResponse;
+import com.ticketrush.boundedcontext.ticket.app.usecase.TicketQrGetUseCase;
+import com.ticketrush.boundedcontext.ticket.domain.types.TicketStatus;
+import com.ticketrush.global.config.SecurityConfig;
+import com.ticketrush.global.exception.BusinessException;
+import com.ticketrush.global.filter.GatewayHeaderFilter;
+import com.ticketrush.global.status.ErrorStatus;
+import com.ticketrush.support.WebMvcSliceTest;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcSliceTest(TicketQrController.class)
+@Import({SecurityConfig.class, GatewayHeaderFilter.class})
+@TestPropertySource(properties = "gateway.internal-token=test-token")
+class TicketQrControllerTest {
+
+  private static final String INTERNAL_TOKEN = "test-token";
+
+  @Autowired private MockMvc mockMvc;
+
+  @MockitoBean private TicketQrGetUseCase ticketQrGetUseCase;
+
+  @Test
+  @DisplayName("성공: 인증 사용자가 본인 예매의 QR payload를 200으로 조회한다")
+  void getTicketQr_success() throws Exception {
+    // given
+    Long userId = 10L;
+    Long bookingId = 100L;
+    TicketQrResponse response =
+        new TicketQrResponse(
+            "jwt-payload",
+            TicketStatus.UNUSED,
+            LocalDateTime.of(2026, 6, 25, 10, 0),
+            LocalDateTime.of(2026, 6, 25, 10, 5));
+    given(ticketQrGetUseCase.execute(userId, bookingId)).willReturn(response);
+
+    // when & then
+    mockMvc
+        .perform(
+            get("/api/v1/ticket/bookings/{bookingId}/qr", bookingId)
+                .header("X-Internal-Token", INTERNAL_TOKEN)
+                .header("X-User-Id", userId)
+                .header("X-User-Role", "USER"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.is_success").value(true))
+        .andExpect(jsonPath("$.result.payload").value("jwt-payload"))
+        .andExpect(jsonPath("$.result.ticket_status").value("UNUSED"))
+        .andExpect(jsonPath("$.result.issued_at").value("2026-06-25 10:00:00"))
+        .andExpect(jsonPath("$.result.expires_at").value("2026-06-25 10:05:00"));
+  }
+
+  @Test
+  @DisplayName("실패: Gateway 인증 헤더가 없으면 401을 반환한다")
+  void getTicketQr_fails_when_unauthenticated() throws Exception {
+    // when & then
+    mockMvc
+        .perform(get("/api/v1/ticket/bookings/{bookingId}/qr", 100L))
+        .andExpect(status().isUnauthorized())
+        .andExpect(jsonPath("$.is_success").value(false))
+        .andExpect(jsonPath("$.code").value(ErrorStatus.UNAUTHORIZED.getCode()));
+
+    verifyNoInteractions(ticketQrGetUseCase);
+  }
+
+  @Test
+  @DisplayName("실패: 본인 예매가 아니거나 티켓이 없으면 404 TICKET_404_001을 반환한다")
+  void getTicketQr_fails_when_not_found() throws Exception {
+    // given
+    Long userId = 10L;
+    Long bookingId = 100L;
+    given(ticketQrGetUseCase.execute(userId, bookingId))
+        .willThrow(new BusinessException(ErrorStatus.TICKET_NOT_FOUND));
+
+    // when & then
+    mockMvc
+        .perform(
+            get("/api/v1/ticket/bookings/{bookingId}/qr", bookingId)
+                .header("X-Internal-Token", INTERNAL_TOKEN)
+                .header("X-User-Id", userId)
+                .header("X-User-Role", "USER"))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.is_success").value(false))
+        .andExpect(jsonPath("$.code").value(ErrorStatus.TICKET_NOT_FOUND.getCode()));
+  }
+
+  @Test
+  @DisplayName("실패: 미확정/취소 예매는 409 TICKET_409_001을 반환한다")
+  void getTicketQr_fails_when_not_usable() throws Exception {
+    // given
+    Long userId = 10L;
+    Long bookingId = 100L;
+    given(ticketQrGetUseCase.execute(userId, bookingId))
+        .willThrow(new BusinessException(ErrorStatus.TICKET_NOT_USABLE));
+
+    // when & then
+    mockMvc
+        .perform(
+            get("/api/v1/ticket/bookings/{bookingId}/qr", bookingId)
+                .header("X-Internal-Token", INTERNAL_TOKEN)
+                .header("X-User-Id", userId)
+                .header("X-User-Role", "USER"))
+        .andExpect(status().isConflict())
+        .andExpect(jsonPath("$.is_success").value(false))
+        .andExpect(jsonPath("$.code").value(ErrorStatus.TICKET_NOT_USABLE.getCode()));
+  }
+}

--- a/ticket-service/src/test/java/com/ticketrush/boundedcontext/ticket/out/apiclient/BookingRestClientTest.java
+++ b/ticket-service/src/test/java/com/ticketrush/boundedcontext/ticket/out/apiclient/BookingRestClientTest.java
@@ -1,0 +1,132 @@
+package com.ticketrush.boundedcontext.ticket.out.apiclient;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.header;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withServerError;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withStatus;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+import com.ticketrush.boundedcontext.ticket.out.apiclient.dto.BookingInfoResponse;
+import com.ticketrush.global.exception.BusinessException;
+import com.ticketrush.global.status.ErrorStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestClient;
+
+class BookingRestClientTest {
+
+  private static final String BASE_URL = "http://localhost:8084";
+  private static final String INTERNAL_TOKEN = "test-token";
+  private static final long BOOKING_ID = 100L;
+  private static final String REQUEST_URL = BASE_URL + "/api/v1/booking/internal/" + BOOKING_ID;
+
+  private MockRestServiceServer mockServer;
+  private BookingRestClient client;
+
+  @BeforeEach
+  void setUp() {
+    RestClient.Builder builder = RestClient.builder().baseUrl(BASE_URL);
+    mockServer = MockRestServiceServer.bindTo(builder).build();
+    client = new BookingRestClient(builder.build());
+    ReflectionTestUtils.setField(client, "internalToken", INTERNAL_TOKEN);
+  }
+
+  @Test
+  @DisplayName("성공: 공통 ApiResponse 래퍼의 snake_case 본문을 역직렬화하고 X-Internal-Token을 전송한다")
+  void getBooking_deserializes_snake_case_and_sends_token() {
+    String responseBody =
+        """
+        {
+          "is_success": true,
+          "code": "COMMON_200",
+          "message": "성공입니다.",
+          "result": {
+            "booking_id": 100,
+            "user_id": 10,
+            "booking_status": "CONFIRMED"
+          }
+        }
+        """;
+
+    mockServer
+        .expect(requestTo(REQUEST_URL))
+        .andExpect(method(HttpMethod.GET))
+        .andExpect(header("X-Internal-Token", INTERNAL_TOKEN))
+        .andRespond(withSuccess(responseBody, MediaType.APPLICATION_JSON));
+
+    BookingInfoResponse result = client.getBooking(BOOKING_ID);
+
+    assertThat(result.bookingId()).isEqualTo(100L);
+    assertThat(result.userId()).isEqualTo(10L);
+    assertThat(result.bookingStatus()).isEqualTo("CONFIRMED");
+    mockServer.verify();
+  }
+
+  @Test
+  @DisplayName("실패: 예매 없음(404)은 TICKET_NOT_FOUND로 통일한다")
+  void getBooking_maps_404_to_not_found() {
+    mockServer.expect(requestTo(REQUEST_URL)).andRespond(withStatus(HttpStatus.NOT_FOUND));
+
+    assertThatThrownBy(() -> client.getBooking(BOOKING_ID))
+        .isInstanceOf(BusinessException.class)
+        .hasFieldOrPropertyWithValue("errorStatus", ErrorStatus.TICKET_NOT_FOUND);
+    mockServer.verify();
+  }
+
+  @Test
+  @DisplayName("실패: 토큰 불일치(403)는 사용자에게 500을 노출하지 않고 통신 실패로 매핑한다")
+  void getBooking_maps_403_to_communication_failed() {
+    mockServer.expect(requestTo(REQUEST_URL)).andRespond(withStatus(HttpStatus.FORBIDDEN));
+
+    assertThatThrownBy(() -> client.getBooking(BOOKING_ID))
+        .isInstanceOf(BusinessException.class)
+        .hasFieldOrPropertyWithValue(
+            "errorStatus", ErrorStatus.TICKET_BOOKING_COMMUNICATION_FAILED);
+    mockServer.verify();
+  }
+
+  @Test
+  @DisplayName("실패: booking-service 5xx는 통신 실패로 매핑한다")
+  void getBooking_maps_5xx_to_communication_failed() {
+    mockServer.expect(requestTo(REQUEST_URL)).andRespond(withServerError());
+
+    assertThatThrownBy(() -> client.getBooking(BOOKING_ID))
+        .isInstanceOf(BusinessException.class)
+        .hasFieldOrPropertyWithValue(
+            "errorStatus", ErrorStatus.TICKET_BOOKING_COMMUNICATION_FAILED);
+    mockServer.verify();
+  }
+
+  @Test
+  @DisplayName("실패: 200이지만 result 본문이 비어 있으면 통신 실패로 매핑한다")
+  void getBooking_maps_empty_result_to_communication_failed() {
+    String responseBody =
+        """
+        {
+          "is_success": true,
+          "code": "COMMON_200",
+          "message": "성공입니다.",
+          "result": null
+        }
+        """;
+
+    mockServer
+        .expect(requestTo(REQUEST_URL))
+        .andRespond(withSuccess(responseBody, MediaType.APPLICATION_JSON));
+
+    assertThatThrownBy(() -> client.getBooking(BOOKING_ID))
+        .isInstanceOf(BusinessException.class)
+        .hasFieldOrPropertyWithValue(
+            "errorStatus", ErrorStatus.TICKET_BOOKING_COMMUNICATION_FAILED);
+    mockServer.verify();
+  }
+}


### PR DESCRIPTION
## 🔗 관련 이슈

- close #217

---

## 📌 주요 변경 사항

- 입장권 QR payload 조회 API 신설 (`GET /api/v1/ticket/bookings/{bookingId}/qr`)
- 로그인 본인 + 확정(CONFIRMED) 예매에 한해 조회 허용, QR 이미지가 아닌 payload 문자열 제공
- 검증에 필요한 예매 소유자/상태를 booking-service internal 조회 API로 동기 조회
- 입장권 관련 에러 코드(404/409/503) 공통 모듈에 추가

---

## 🛠 상세 구현 내용

### ticket-service
- `TicketQrController` / `TicketQrGetUseCase` / `TicketQrResponse`: QR payload 조회 엔드포인트
  - 검증 순서: ① booking 소유자 본인 확인 → ② CONFIRMED 상태 확인 → ③ 발급된 티켓 존재 확인
  - 타인 예매·미존재 티켓은 **404 TICKET_NOT_FOUND로 통일**해 예매 존재 여부 노출 방지(payment 선례)
  - 미확정/취소 예매는 **409 TICKET_NOT_USABLE**
- `TicketQrPayloadGenerator` / `QrPayload`: 조회 시점에 JWT를 동적 서명(`tid`/`bid`/`st` 클레임 + 짧은 TTL). 인증용 JWT와 별도 시크릿 사용, 시크릿 32바이트 미만 시 기동 실패
- `BookingRestClient` (+DTO): booking-service internal API 동기 호출, `X-Internal-Token` 부착
  - 예매 없음(404)은 `TICKET_NOT_FOUND`, 그 외 4xx/5xx·연결실패·타임아웃·빈 본문은 `TICKET_BOOKING_COMMUNICATION_FAILED`(503)로 매핑해 사용자에게 500이 새지 않도록 처리
- `RestClientConfig`: booking 호출용 RestClient 빈(타임아웃 설정)
- `SecurityConfig`: QR 경로만 `.authenticated()`, 나머지 permitAll 유지
- `application.yml`: QR 시크릿 기본값 제거(`${TICKET_QR_SECRET}`)로 운영 주입 강제. 로컬 포함 모든 프로파일이 env 주입을 사용(`application-local.yml`에 하드코딩하지 않음 — 타 서비스의 `${ENV_VAR}` 참조 컨벤션과 일치)

### booking-service
- `BookingInternalController` / `BookingGetInternalUseCase` / `BookingInternalResponse`: 예매 소유자/상태 internal 조회 API. `X-Internal-Token` 검증

### common
- `ErrorStatus`: `TICKET_NOT_FOUND`(404) / `TICKET_NOT_USABLE`(409) / `TICKET_BOOKING_COMMUNICATION_FAILED`(503) 추가

---

## ✅ 테스트

### 테스트 방법

- `./gradlew :ticket-service:test :booking-service:test`
- 작성한 테스트
  - `TicketQrGetUseCaseTest`: 성공 / 타인→404 / 미확정·취소→409 / 티켓 미발급→404
  - `TicketQrPayloadGeneratorTest`: JWT 클레임·만료 서명 검증 / 짧은 시크릿 기동 실패
  - `TicketQrControllerTest`(slice): 200 / 무인증 401 / 404 / 409, snake_case 응답
  - `BookingRestClientTest`(MockRestServiceServer): snake_case 역직렬화 / 404 / 403 / 5xx / 빈 result 분기
  - `BookingGetInternalUseCaseTest`: 성공 / 미존재
  - `BookingInternalControllerTest`: 성공 200 / 토큰 불일치 403 / 토큰 없음 403

### 테스트 결과

- `BUILD SUCCESSFUL` (전체 통과), `./gradlew spotlessCheck` 통과

### 📸 스크린샷

- 

---

## 👀 리뷰 요청 사항

- 서비스 간 동기호출 시 에러 매핑 정책(비404 → 503)이 팀 컨벤션과 맞는지
- QR 시크릿 운영 주입 강제 방식(기본값 제거, 로컬도 env 주입) 적절성

---

## ⚠️ 배포 시 주의사항

- **`TICKET_QR_SECRET` 환경변수(32바이트 이상) 주입 필수** — 미설정 시 ticket-service 기동 실패. 로컬은 `.env.local`에 추가 (예: `openssl rand -hex 32`)
- **`GATEWAY_INTERNAL_TOKEN`** 은 gateway·booking·ticket 세 서비스가 동일 값이어야 함
- ticket-service → booking-service 호출 위해 `BOOKING_SERVICE_URL` 설정 확인
- 후속 필요(별도 이슈): ① ticket 발급 트리거(결제완료→발급) ② 게이트웨이 `/internal/**` 외부 차단
