### PR TITLE
[Feat] #279 결제 완료 이벤트 구독하여 티켓 발급 트리거 구현

### DIFF
--- a/ticket-service/src/main/java/com/ticketrush/boundedcontext/ticket/in/eventlistener/PaymentConfirmedEventListener.java
+++ b/ticket-service/src/main/java/com/ticketrush/boundedcontext/ticket/in/eventlistener/PaymentConfirmedEventListener.java
@@ -1,0 +1,60 @@
+package com.ticketrush.boundedcontext.ticket.in.eventlistener;
+
+import com.ticketrush.boundedcontext.ticket.app.dto.response.TicketIssueResponse;
+import com.ticketrush.boundedcontext.ticket.app.usecase.TicketIssueUseCase;
+import com.ticketrush.global.event.DomainEventEnvelope;
+import com.ticketrush.global.json.JsonConverter;
+import com.ticketrush.shared.payment.event.PaymentConfirmedEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PaymentConfirmedEventListener {
+
+  private final TicketIssueUseCase ticketIssueUseCase;
+  private final JsonConverter jsonConverter;
+
+  @KafkaListener(topics = PaymentConfirmedEvent.TOPIC, groupId = "ticket-group")
+  public void handlePaymentConfirmed(@Payload DomainEventEnvelope envelope, Acknowledgment ack) {
+
+    PaymentConfirmedEvent event = null;
+
+    try {
+      event = jsonConverter.deserialize(envelope.payload(), PaymentConfirmedEvent.class);
+
+      log.info("결제 완료 이벤트 수신. 티켓 발급 처리. bookingId: {}", event.bookingId());
+
+      // 티켓 발급에는 bookingId만 사용한다.
+      // 중복 수신은 TicketIssueUseCase의 멱등 처리(alreadyIssued)로 안전하게 처리된다.
+      TicketIssueResponse response = ticketIssueUseCase.execute(event.bookingId());
+
+      // 신규 발급/이미 발급 여부를 남겨 멱등 동작을 추적할 수 있게 한다.
+      log.info("티켓 발급 처리 완료. bookingId: {}, issued: {}", event.bookingId(), response.issued());
+
+    } catch (Exception e) {
+      // 결제는 이미 완료된 상태라 재시도해도 결과가 바뀌지 않는다.
+      // 무한 재시도/파티션 블로킹을 피하고, 강한 로그를 남겨 수동 복구가 가능하도록 조치한다.
+      // 역직렬화 실패 시 event가 null이라 bookingId를 못 얻으므로, 항상 살아있는
+      // envelope.eventId()를 함께 남겨 어떤 메시지가 실패했는지 추적할 수 있게 한다.
+      Long failedBookingId = (event != null) ? event.bookingId() : null;
+      log.error(
+          "[CRITICAL] 결제 완료 이벤트로 티켓 발급 중 치명적 오류 발생! "
+              + "결제는 완료되었으나 티켓 발급에 실패했습니다. 확인이 필요합니다. eventId: {}, bookingId: {}",
+          envelope.eventId(),
+          failedBookingId,
+          e);
+
+      // TODO: 추후 고도화 시, 이 위치에서 DLT로 실패한 이벤트를 재발행
+
+    } finally {
+      // 카프카 메시지가 무한 반복되며 파티션을 막는 현상 방지
+      ack.acknowledge();
+    }
+  }
+}

--- a/ticket-service/src/test/java/com/ticketrush/boundedcontext/ticket/in/eventlistener/PaymentConfirmedEventListenerTest.java
+++ b/ticket-service/src/test/java/com/ticketrush/boundedcontext/ticket/in/eventlistener/PaymentConfirmedEventListenerTest.java
@@ -1,0 +1,124 @@
+package com.ticketrush.boundedcontext.ticket.in.eventlistener;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.ticketrush.boundedcontext.ticket.app.dto.response.TicketIssueResponse;
+import com.ticketrush.boundedcontext.ticket.app.usecase.TicketIssueUseCase;
+import com.ticketrush.global.event.DomainEventEnvelope;
+import com.ticketrush.global.json.DeserializationException;
+import com.ticketrush.global.json.JsonConverter;
+import com.ticketrush.shared.payment.event.PaymentConfirmedEvent;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.kafka.support.Acknowledgment;
+
+@ExtendWith(MockitoExtension.class)
+class PaymentConfirmedEventListenerTest {
+
+  @InjectMocks private PaymentConfirmedEventListener listener;
+
+  @Mock private TicketIssueUseCase ticketIssueUseCase;
+
+  @Mock private JsonConverter jsonConverter;
+
+  @Mock private Acknowledgment acknowledgment;
+
+  // jsonConverter를 모킹하므로 payload 문자열은 실제로 파싱되지 않는다(역직렬화 결과는 스텁으로 지정).
+  // 따라서 payload는 의미 없는 식별 문자열로 둔다.
+  private static final String PAYLOAD = "payload";
+  private static final Long BOOKING_ID = 10L;
+  private static final String TOKEN = "ticket-token";
+
+  private DomainEventEnvelope envelope() {
+    return new DomainEventEnvelope(
+        "event-id",
+        PaymentConfirmedEvent.EVENT_NAME,
+        Instant.now(),
+        PaymentConfirmedEvent.TOPIC,
+        PAYLOAD,
+        null);
+  }
+
+  private PaymentConfirmedEvent event() {
+    return new PaymentConfirmedEvent(
+        1L, BOOKING_ID, 3L, 4L, 50000L, LocalDateTime.of(2026, 5, 22, 10, 30));
+  }
+
+  @Test
+  @DisplayName("결제 완료 이벤트를 수신하면 해당 bookingId로 티켓을 발급하고 오프셋을 커밋한다")
+  void handlePaymentConfirmed() {
+    // given
+    DomainEventEnvelope envelope = envelope();
+    given(jsonConverter.deserialize(PAYLOAD, PaymentConfirmedEvent.class)).willReturn(event());
+    given(ticketIssueUseCase.execute(BOOKING_ID)).willReturn(TicketIssueResponse.issued(TOKEN));
+
+    // when
+    listener.handlePaymentConfirmed(envelope, acknowledgment);
+
+    // then
+    verify(ticketIssueUseCase).execute(BOOKING_ID);
+    verify(acknowledgment).acknowledge();
+  }
+
+  @Test
+  @DisplayName("동일 이벤트를 중복 수신해 이미 발급된 상태(alreadyIssued)여도 정상 처리하고 오프셋을 커밋한다")
+  void handlePaymentConfirmedIsIdempotent() {
+    // given
+    DomainEventEnvelope envelope = envelope();
+    given(jsonConverter.deserialize(PAYLOAD, PaymentConfirmedEvent.class)).willReturn(event());
+    given(ticketIssueUseCase.execute(BOOKING_ID)).willReturn(TicketIssueResponse.alreadyIssued());
+
+    // when & then: 중복 수신이어도 예외 없이 정상 흐름으로 처리된다
+    assertThatCode(() -> listener.handlePaymentConfirmed(envelope, acknowledgment))
+        .doesNotThrowAnyException();
+
+    // then: 발급 유스케이스는 한 번 호출되고(중복 발급 방지는 유스케이스 멱등이 보장), 오프셋은 커밋된다
+    verify(ticketIssueUseCase).execute(BOOKING_ID);
+    verify(acknowledgment).acknowledge();
+  }
+
+  @Test
+  @DisplayName("티켓 발급 유스케이스가 예외를 던져도 예외를 전파하지 않고 오프셋을 커밋한다")
+  void handlePaymentConfirmedSwallowsIssueFailure() {
+    // given
+    DomainEventEnvelope envelope = envelope();
+    given(jsonConverter.deserialize(PAYLOAD, PaymentConfirmedEvent.class)).willReturn(event());
+    willThrow(new RuntimeException("티켓 발급 실패")).given(ticketIssueUseCase).execute(BOOKING_ID);
+
+    // when & then: 발급 실패가 리스너 밖으로 전파되지 않는다(파티션 블로킹 방지)
+    assertThatCode(() -> listener.handlePaymentConfirmed(envelope, acknowledgment))
+        .doesNotThrowAnyException();
+
+    // then: 발급은 시도되었고, 실패와 무관하게 오프셋은 커밋된다
+    verify(ticketIssueUseCase).execute(BOOKING_ID);
+    verify(acknowledgment).acknowledge();
+  }
+
+  @Test
+  @DisplayName("이벤트 역직렬화에 실패해도 예외를 전파하지 않고 오프셋을 커밋한다")
+  void handlePaymentConfirmedSwallowsDeserializationException() {
+    // given: 실제 JsonConverter가 변환 실패 시 던지는 예외 타입으로 스텁한다
+    DomainEventEnvelope envelope = envelope();
+    given(jsonConverter.deserialize(PAYLOAD, PaymentConfirmedEvent.class))
+        .willThrow(new DeserializationException(new RuntimeException("broken payload")));
+
+    // when & then: 예외를 리스너 밖으로 전파하지 않는다
+    assertThatCode(() -> listener.handlePaymentConfirmed(envelope, acknowledgment))
+        .doesNotThrowAnyException();
+
+    // then: 발급 유스케이스는 호출되지 않고, 오프셋은 커밋된다
+    verify(ticketIssueUseCase, never()).execute(anyLong());
+    verify(acknowledgment).acknowledge();
+  }
+}


### PR DESCRIPTION
## 🔗 관련 이슈

- close #279

---

## 📌 주요 변경 사항

- ticket-service에 결제 완료(`PaymentConfirmedEvent`) Kafka 이벤트를 구독해 티켓 발급을 트리거하는 리스너 신설
- 결제완료 → 티켓 발급 파이프라인 공백 해소 (#216에서 발급 로직만 구현, 트리거는 제외됐었음)

---

## 🛠 상세 구현 내용

- `PaymentConfirmedEventListener`(`ticket-service/.../in/eventlistener`) 신설
  - `@KafkaListener(topics = PaymentConfirmedEvent.TOPIC, groupId = "ticket-group")`
  - `DomainEventEnvelope` 수신 → `JsonConverter`로 `PaymentConfirmedEvent` 역직렬화 → `TicketIssueUseCase.execute(event.bookingId())` 호출
  - **멱등성**: 중복 수신은 `TicketIssueUseCase`의 기존 멱등 처리(`alreadyIssued`)에 위임해 티켓 중복 발급 방지
  - **실패 처리**: 모든 예외를 swallow하고 `finally`에서 `ack.acknowledge()`하여 무한 재시도/파티션 블로킹 방지. 실패 시 `envelope.eventId()`를 포함한 `[CRITICAL]` 로그로 추적 (역직렬화 실패로 `event`가 null이어도 eventId는 항상 기록)
  - booking-service의 동일 이름 리스너 패턴을 준수
- 공통 인프라(`spring-boot-starter-kafka`, `KafkaConfig`의 `MANUAL_IMMEDIATE` ack/DLT, `PaymentConfirmedEvent`)가 이미 갖춰져 있어 **설정·의존성 추가 없음**

---

## ✅ 테스트

### 테스트 방법

- 리스너 단위 테스트 신설: `PaymentConfirmedEventListenerTest` (`@ExtendWith(MockitoExtension.class)`, `TicketIssueUseCase`/`JsonConverter`/`Acknowledgment` mock)
  1. 정상 발급 — `execute(bookingId)` 호출 + `ack.acknowledge()` 검증
  2. 중복 수신 멱등 — `alreadyIssued()` 응답도 정상 처리 + ack 검증
  3. 발급 실패 swallow — UseCase 예외가 전파되지 않고 ack 검증
  4. 역직렬화 실패 — `DeserializationException` 시 UseCase 미호출 + ack 검증
- 실행 명령:
  - `./gradlew :ticket-service:test --tests "com.ticketrush.boundedcontext.ticket.in.eventlistener.PaymentConfirmedEventListenerTest"`
  - `./gradlew :ticket-service:test :ticket-service:spotlessCheck`

### 테스트 결과

- 단위 테스트 4종 전부 통과 (BUILD SUCCESSFUL)
- `spotlessCheck` 통과

<!--
### 📸 스크린샷

-
-->
---

## 👀 리뷰 요청 사항

- 처리 실패 시 모든 예외를 swallow + `finally` ack 하는 정책은 booking-service 패턴을 따른 의도된 트레이드오프입니다(컨테이너의 DLT/재시도 인프라는 우회). 이 정책이 적절한지 의견 주시면 감사하겠습니다.

---

## ⚠️ 배포 시 주의사항

- 신규 컨슈머 그룹 `ticket-group`이 추가됩니다. `AUTO_OFFSET_RESET=latest`이므로 배포 후 발생하는 결제완료 이벤트부터 구독합니다(과거 미발급분 백필은 본 PR 범위 밖).
