### PR TITLE
[Chore] 주간 스크럼 Slack 알림 워크플로우 추가

### DIFF
--- a/.github/workflows/weekly-scrum.yml
+++ b/.github/workflows/weekly-scrum.yml
@@ -1,0 +1,60 @@
+name: Weekly Scrum
+
+on:
+  schedule:
+    # 매주 목요일 09:00 UTC = 목요일 오후 6시(18:00) KST
+    - cron: '0 9 * * 4'
+  workflow_dispatch:   # GitHub Actions 탭에서 수동 실행(테스트)도 가능
+
+permissions:
+  contents: read
+  issues: read
+  pull-requests: read
+
+jobs:
+  scrum:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Build & send weekly scrum to Slack
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        run: |
+          set -euo pipefail
+          SINCE=$(date -u -d '7 days ago' +%Y-%m-%d)
+          TODAY=$(date -u +%Y-%m-%d)
+
+          # 1) 이번 주 develop에 머지된 PR — 작성자(author)별로 그룹핑
+          PR_COUNT=$(gh pr list --state merged --base develop \
+                  --search "merged:>=$SINCE" --json number --jq 'length')
+          PR_SECTION=$(gh pr list --state merged --base develop \
+                  --search "merged:>=$SINCE" \
+                  --json number,title,author \
+                  --jq 'group_by(.author.login)
+                        | map("*@\(.[0].author.login) (\(length)건)*\n"
+                              + (map("• #\(.number) \(.title)") | join("\n")))
+                        | join("\n\n")')
+
+          # 2) 진행 중(열린) 이슈 — 최대 15개
+          OPEN=$(gh issue list --state open --limit 15 \
+                  --json number,title \
+                  --jq '[.[] | "• #\(.number) \(.title)"] | join("\n")')
+
+          # 메시지 조립
+          MESSAGE="<!channel> 🗓 *주간 스크럼* — $TODAY (최근 7일 진행상황)
+
+          *📦 이번 주 머지된 PR (${PR_COUNT}건)*
+          ${PR_SECTION:-• 없음}
+
+          *🚧 진행 중인 이슈*
+          ${OPEN:-• 없음}
+
+          ──────────
+          👋 *팀원 여러분, 이 스레드에 댓글로 이번 주 진행상황을 남겨주세요!*
+          • 이번 주 한 일 / 다음 주 할 일 / 막힌 점"
+
+          # Slack 전송 (jq로 JSON escape)
+          curl -sS -X POST -H 'Content-type: application/json' \
+            --data "$(jq -nc --arg t "$MESSAGE" '{text:$t}')" \
+            "$SLACK_WEBHOOK_URL"


### PR DESCRIPTION
## 🔗 관련 이슈

- 연결된 이슈 없음 (운영 자동화 작업)

---

## 📌 주요 변경 사항

- 매주 목요일 18:00(KST) 실행되는 주간 스크럼 GitHub Actions 워크플로우 추가
- 최근 7일간 `develop`에 머지된 PR을 작성자별로 그룹핑하여 요약
- 진행 중(열린) 이슈 목록(최대 15개) 포함
- `<!channel>` 멘션과 함께 Slack 채널로 전송, 팀원이 스레드에 진행상황을 댓글로 작성

---

## 🛠 상세 구현 내용

- `on.schedule` cron `0 9 * * 4` (09:00 UTC = 18:00 KST) + `workflow_dispatch`(수동 실행)
- `gh` CLI로 머지 PR / 열린 이슈 수집, `jq`로 작성자별 그룹핑 및 메시지 조립
- Webhook URL은 레포 시크릿 `SLACK_WEBHOOK_URL`에서 주입 (값 노출 없음)
- 권한 최소화: `contents/issues/pull-requests: read`

---

## ✅ 테스트

### 테스트 방법

- 머지 후 Actions 탭에서 `Run workflow`(workflow_dispatch)로 수동 실행
- 사전 준비: 레포 Settings → Secrets에 `SLACK_WEBHOOK_URL` 등록 필요

### 테스트 결과

- (머지 후 수동 실행으로 확인 예정)

### 📸 스크린샷

---

## 👀 리뷰 요청 사항

- 실행 시각(목 18:00 KST), 멘션 방식(`<!channel>`), 진행 중 이슈 노출 범위(열린 이슈 15개) 적절한지 확인 부탁드립니다.

---

## ⚠️ 배포 시 주의사항

- **머지 전** 레포 시크릿 `SLACK_WEBHOOK_URL`(TicketRush Slack Incoming Webhook) 등록이 선행되어야 정상 동작합니다.
- `schedule`/`workflow_dispatch`는 워크플로우가 default 브랜치(`develop`)에 올라간 뒤에만 트리거됩니다.
