### PR TITLE
[Chore] #284 주간 스크럼 Slack 알림 워크플로우 추가

### DIFF
--- a/.github/workflows/weekly-scrum.yml
+++ b/.github/workflows/weekly-scrum.yml
@@ -21,7 +21,8 @@ jobs:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
       BACKEND_REPO: TicketRush/TicketRush-backend
       FRONTEND_REPO: TicketRush/TicketRush-frontend
-      MAX_PER_AUTHOR: 5      # 사람당 표시할 머지 PR 최대 개수 (초과분은 '…외 N건')
+      MAX_PER_AUTHOR: 5          # 사람당 표시할 머지 PR 최대 개수 (초과분은 '…외 N건')
+      MAX_ISSUES_PER_PERSON: 7   # 사람당 표시할 진행 중 이슈 최대 개수 (초과분은 '…외 N건')
     steps:
       - name: Build & send weekly scrum to Slack
         run: |
@@ -43,7 +44,7 @@ jobs:
           #  - PR: author.login 기준, 사람당 최대 $k건 + '…외 N건'
           #  - 이슈: 담당자별, 최근 7일 내 업데이트된 열린 이슈만 (cap 없음)
           #  - 각 항목에 [BE]/[FE] 태그로 레포 표시, 활동량(PR+이슈 수) 많은 순 정렬
-          BODY=$(jq -nr --argjson k "$MAX_PER_AUTHOR" --arg since "$SINCE" \
+          BODY=$(jq -nr --argjson k "$MAX_PER_AUTHOR" --argjson ki "$MAX_ISSUES_PER_PERSON" --arg since "$SINCE" \
             --argjson bp "$be_pr" --argjson fp "$fe_pr" \
             --argjson bi "$be_is" --argjson fi "$fe_is" '
             ( ($bp|map(.+{repo:"BE"})) + ($fp|map(.+{repo:"FE"})) )
@@ -52,20 +53,21 @@ jobs:
                 | map(select(.updatedAt >= $since))
                 | map(. as $x
                       | (if (.assignees|length)==0 then [{login:"_unassigned"}] else .assignees end)
-                      | map({login:.login, number:$x.number, title:$x.title, repo:$x.repo}))
+                      | map({login:.login, number:$x.number, title:$x.title, repo:$x.repo, updatedAt:$x.updatedAt}))
                 | add // [] ) as $iss
             | def pcount($l): ($prs|map(select(.login==$l))|length);
               def icount($l): ($iss|map(select(.login==$l))|length);
               def block($l):
                 ($prs|map(select(.login==$l))) as $p
-                | ($iss|map(select(.login==$l))) as $i
+                | ($iss|map(select(.login==$l))|sort_by(.updatedAt)|reverse) as $i
                 | "*👤 @\($l)*\n📦 머지 PR (\($p|length)건)\n"
                   + (if ($p|length)==0 then "• 없음"
                      else ($p[0:$k]|map("• [\(.repo)] #\(.number) \(.title)")|join("\n"))
                           + (if ($p|length)>$k then "\n  …외 \(($p|length)-$k)건" else "" end) end)
-                  + "\n🚧 진행 중 이슈\n"
+                  + "\n🚧 진행 중 이슈 (\($i|length)건)\n"
                   + (if ($i|length)==0 then "• 없음"
-                     else ($i|map("• [\(.repo)] #\(.number) \(.title)")|join("\n")) end);
+                     else ($i[0:$ki]|map("• [\(.repo)] #\(.number) \(.title)")|join("\n"))
+                          + (if ($i|length)>$ki then "\n  …외 \(($i|length)-$ki)건" else "" end) end);
               ( ( [ $prs[].login ] + [ $iss[].login ] )
                 | map(select(. != "_unassigned")) | unique
                 | sort_by( -(pcount(.) + icount(.)) )

--- a/.github/workflows/weekly-scrum.yml
+++ b/.github/workflows/weekly-scrum.yml
@@ -14,46 +14,65 @@ permissions:
 jobs:
   scrum:
     runs-on: ubuntu-latest
+    env:
+      # 두 레포 모두 PUBLIC이므로 기본 토큰으로 교차 조회 가능.
+      # (private로 전환되면 두 레포 read 권한을 가진 PAT를 secrets로 주입해야 함)
+      GH_TOKEN: ${{ github.token }}
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      BACKEND_REPO: TicketRush/TicketRush-backend
+      FRONTEND_REPO: TicketRush/TicketRush-frontend
+      MAX_PER_AUTHOR: 5      # 작성자당 표시할 PR 최대 개수
+      MAX_ISSUES: 10         # 레포당 표시할 진행 중 이슈 최대 개수
     steps:
       - name: Build & send weekly scrum to Slack
-        env:
-          GH_TOKEN: ${{ github.token }}
-          GH_REPO: ${{ github.repository }}
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         run: |
           set -euo pipefail
           SINCE=$(date -u -d '7 days ago' +%Y-%m-%d)
           TODAY=$(date -u +%Y-%m-%d)
 
-          # 1) 이번 주 develop에 머지된 PR — 작성자(author)별로 그룹핑, 작성자당 최대 N건만 표시
-          MAX_PER_AUTHOR=5
-          PR_JSON=$(gh pr list --state merged --base develop \
-                  --search "merged:>=$SINCE" --json number,title,author)
-          PR_COUNT=$(echo "$PR_JSON" | jq 'length')
-          PR_SECTION=$(echo "$PR_JSON" | jq -r --argjson k "$MAX_PER_AUTHOR" '
-                  group_by(.author.login)
-                  | map(
-                      length as $n
-                      | (.[0].author.login) as $login
-                      | "*@\($login) (\($n)건)*\n"
-                        + (.[0:$k] | map("• #\(.number) \(.title)") | join("\n"))
-                        + (if $n > $k then "\n  …외 \($n - $k)건" else "" end)
-                    )
-                  | join("\n\n")')
+          # 한 레포의 머지 PR 블록 생성 ($1=repo, $2=표시 라벨)
+          pr_block() {
+            local json count body
+            json=$(gh pr list -R "$1" --state merged --base develop \
+                    --search "merged:>=$SINCE" --json number,title,author)
+            count=$(echo "$json" | jq 'length')
+            body=$(echo "$json" | jq -r --argjson k "$MAX_PER_AUTHOR" '
+                    group_by(.author.login)
+                    | map(
+                        length as $n
+                        | (.[0].author.login) as $login
+                        | "*@\($login) (\($n)건)*\n"
+                          + (.[0:$k] | map("• #\(.number) \(.title)") | join("\n"))
+                          + (if $n > $k then "\n  …외 \($n - $k)건" else "" end)
+                      )
+                    | join("\n\n")')
+            printf '*📦 %s — 이번 주 머지된 PR (%s건)*\n%s' "$2" "$count" "${body:-• 없음}"
+          }
 
-          # 2) 진행 중(열린) 이슈 — 최대 15개
-          OPEN=$(gh issue list --state open --limit 15 \
-                  --json number,title \
-                  --jq '[.[] | "• #\(.number) \(.title)"] | join("\n")')
+          # 한 레포의 진행 중(열린) 이슈 블록 생성 ($1=repo, $2=표시 라벨)
+          issue_block() {
+            local body
+            body=$(gh issue list -R "$1" --state open --limit "$MAX_ISSUES" \
+                    --json number,title \
+                    --jq '[.[] | "• #\(.number) \(.title)"] | join("\n")')
+            printf '*%s*\n%s' "$2" "${body:-• 없음}"
+          }
 
-          # 메시지 조립
+          BE_PR=$(pr_block "$BACKEND_REPO" "백엔드")
+          FE_PR=$(pr_block "$FRONTEND_REPO" "프론트엔드")
+          BE_ISSUE=$(issue_block "$BACKEND_REPO" "백엔드")
+          FE_ISSUE=$(issue_block "$FRONTEND_REPO" "프론트엔드")
+
           MESSAGE="<!channel> 🗓 *주간 스크럼* — $TODAY (최근 7일 진행상황)
 
-          *📦 이번 주 머지된 PR (${PR_COUNT}건)*
-          ${PR_SECTION:-• 없음}
+          $BE_PR
+
+          $FE_PR
 
           *🚧 진행 중인 이슈*
-          ${OPEN:-• 없음}
+          $BE_ISSUE
+
+          $FE_ISSUE
 
           ──────────
           👋 *팀원 여러분, 이 스레드에 댓글로 이번 주 진행상황을 남겨주세요!*

--- a/.github/workflows/weekly-scrum.yml
+++ b/.github/workflows/weekly-scrum.yml
@@ -1,0 +1,60 @@
+name: Weekly Scrum
+
+on:
+  schedule:
+    # 매주 목요일 09:00 UTC = 목요일 오후 6시(18:00) KST
+    - cron: '0 9 * * 4'
+  workflow_dispatch:   # GitHub Actions 탭에서 수동 실행(테스트)도 가능
+
+permissions:
+  contents: read
+  issues: read
+  pull-requests: read
+
+jobs:
+  scrum:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Build & send weekly scrum to Slack
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        run: |
+          set -euo pipefail
+          SINCE=$(date -u -d '7 days ago' +%Y-%m-%d)
+          TODAY=$(date -u +%Y-%m-%d)
+
+          # 1) 이번 주 develop에 머지된 PR — 작성자(author)별로 그룹핑
+          PR_COUNT=$(gh pr list --state merged --base develop \
+                  --search "merged:>=$SINCE" --json number --jq 'length')
+          PR_SECTION=$(gh pr list --state merged --base develop \
+                  --search "merged:>=$SINCE" \
+                  --json number,title,author \
+                  --jq 'group_by(.author.login)
+                        | map("*@\(.[0].author.login) (\(length)건)*\n"
+                              + (map("• #\(.number) \(.title)") | join("\n")))
+                        | join("\n\n")')
+
+          # 2) 진행 중(열린) 이슈 — 최대 15개
+          OPEN=$(gh issue list --state open --limit 15 \
+                  --json number,title \
+                  --jq '[.[] | "• #\(.number) \(.title)"] | join("\n")')
+
+          # 메시지 조립
+          MESSAGE="<!channel> 🗓 *주간 스크럼* — $TODAY (최근 7일 진행상황)
+
+          *📦 이번 주 머지된 PR (${PR_COUNT}건)*
+          ${PR_SECTION:-• 없음}
+
+          *🚧 진행 중인 이슈*
+          ${OPEN:-• 없음}
+
+          ──────────
+          👋 *팀원 여러분, 이 스레드에 댓글로 이번 주 진행상황을 남겨주세요!*
+          • 이번 주 한 일 / 다음 주 할 일 / 막힌 점"
+
+          # Slack 전송 (jq로 JSON escape)
+          curl -sS -X POST -H 'Content-type: application/json' \
+            --data "$(jq -nc --arg t "$MESSAGE" '{text:$t}')" \
+            "$SLACK_WEBHOOK_URL"

--- a/.github/workflows/weekly-scrum.yml
+++ b/.github/workflows/weekly-scrum.yml
@@ -21,7 +21,7 @@ jobs:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
       BACKEND_REPO: TicketRush/TicketRush-backend
       FRONTEND_REPO: TicketRush/TicketRush-frontend
-      MAX_PER_AUTHOR: 5      # 작성자당 표시할 PR 최대 개수
+      MAX_PER_AUTHOR: 5      # 사람당 표시할 머지 PR 최대 개수 (초과분은 '…외 N건')
     steps:
       - name: Build & send weekly scrum to Slack
         run: |
@@ -29,55 +29,60 @@ jobs:
           SINCE=$(date -u -d '7 days ago' +%Y-%m-%d)
           TODAY=$(date -u +%Y-%m-%d)
 
-          # 한 레포의 머지 PR 블록 생성 ($1=repo, $2=표시 라벨)
-          pr_block() {
-            local json count body
-            json=$(gh pr list -R "$1" --state merged --base develop \
+          # 두 레포에서 원시 데이터 수집 (PR=머지/최근 7일, 이슈=열림 전체)
+          be_pr=$(gh pr list -R "$BACKEND_REPO"  --state merged --base develop \
                     --search "merged:>=$SINCE" --json number,title,author)
-            count=$(echo "$json" | jq 'length')
-            body=$(echo "$json" | jq -r --argjson k "$MAX_PER_AUTHOR" '
-                    group_by(.author.login)
-                    | map(
-                        length as $n
-                        | (.[0].author.login) as $login
-                        | "*@\($login) (\($n)건)*\n"
-                          + (.[0:$k] | map("• #\(.number) \(.title)") | join("\n"))
-                          + (if $n > $k then "\n  …외 \($n - $k)건" else "" end)
-                      )
-                    | join("\n\n")')
-            printf '*📦 %s — 이번 주 머지된 PR (%s건)*\n%s' "$2" "$count" "${body:-• 없음}"
-          }
+          fe_pr=$(gh pr list -R "$FRONTEND_REPO" --state merged --base develop \
+                    --search "merged:>=$SINCE" --json number,title,author)
+          be_is=$(gh issue list -R "$BACKEND_REPO"  --state open --limit 200 \
+                    --json number,title,updatedAt,assignees)
+          fe_is=$(gh issue list -R "$FRONTEND_REPO" --state open --limit 200 \
+                    --json number,title,updatedAt,assignees)
 
-          # 한 레포의 진행 중 이슈 블록 생성 ($1=repo, $2=표시 라벨)
-          # "진행 중" = 최근 7일 내 업데이트된 열린 이슈 (별도 cap 없음, 활동 기준 필터)
-          issue_block() {
-            local json body
-            json=$(gh issue list -R "$1" --state open --limit 200 \
-                    --json number,title,updatedAt)
-            body=$(echo "$json" | jq -r --arg since "$SINCE" '
-                    [.[] | select(.updatedAt >= $since) | "• #\(.number) \(.title)"]
-                    | join("\n")')
-            printf '*%s*\n%s' "$2" "${body:-• 없음}"
-          }
-
-          BE_PR=$(pr_block "$BACKEND_REPO" "백엔드")
-          FE_PR=$(pr_block "$FRONTEND_REPO" "프론트엔드")
-          BE_ISSUE=$(issue_block "$BACKEND_REPO" "백엔드")
-          FE_ISSUE=$(issue_block "$FRONTEND_REPO" "프론트엔드")
+          # 사람(=PR 작성자 / 이슈 담당자)별로 묶어 본문 생성.
+          #  - PR: author.login 기준, 사람당 최대 $k건 + '…외 N건'
+          #  - 이슈: 담당자별, 최근 7일 내 업데이트된 열린 이슈만 (cap 없음)
+          #  - 각 항목에 [BE]/[FE] 태그로 레포 표시, 활동량(PR+이슈 수) 많은 순 정렬
+          BODY=$(jq -nr --argjson k "$MAX_PER_AUTHOR" --arg since "$SINCE" \
+            --argjson bp "$be_pr" --argjson fp "$fe_pr" \
+            --argjson bi "$be_is" --argjson fi "$fe_is" '
+            ( ($bp|map(.+{repo:"BE"})) + ($fp|map(.+{repo:"FE"})) )
+              | map({login:.author.login, number, title, repo}) as $prs
+            | ( ( ($bi|map(.+{repo:"BE"})) + ($fi|map(.+{repo:"FE"})) )
+                | map(select(.updatedAt >= $since))
+                | map(. as $x
+                      | (if (.assignees|length)==0 then [{login:"_unassigned"}] else .assignees end)
+                      | map({login:.login, number:$x.number, title:$x.title, repo:$x.repo}))
+                | add // [] ) as $iss
+            | def pcount($l): ($prs|map(select(.login==$l))|length);
+              def icount($l): ($iss|map(select(.login==$l))|length);
+              def block($l):
+                ($prs|map(select(.login==$l))) as $p
+                | ($iss|map(select(.login==$l))) as $i
+                | "*👤 @\($l)*\n📦 머지 PR (\($p|length)건)\n"
+                  + (if ($p|length)==0 then "• 없음"
+                     else ($p[0:$k]|map("• [\(.repo)] #\(.number) \(.title)")|join("\n"))
+                          + (if ($p|length)>$k then "\n  …외 \(($p|length)-$k)건" else "" end) end)
+                  + "\n🚧 진행 중 이슈\n"
+                  + (if ($i|length)==0 then "• 없음"
+                     else ($i|map("• [\(.repo)] #\(.number) \(.title)")|join("\n")) end);
+              ( ( [ $prs[].login ] + [ $iss[].login ] )
+                | map(select(. != "_unassigned")) | unique
+                | sort_by( -(pcount(.) + icount(.)) )
+                | map(block(.)) | join("\n\n") ) as $main
+            | ($iss|map(select(.login=="_unassigned"))) as $u
+            | $main
+              + (if ($u|length)>0
+                 then "\n\n*👤 (담당자 미지정 이슈)*\n" + ($u|map("• [\(.repo)] #\(.number) \(.title)")|join("\n"))
+                 else "" end)
+            ')
 
           MESSAGE="<!channel> 🗓 *주간 스크럼* — $TODAY (최근 7일 진행상황)
 
-          $BE_PR
-
-          $FE_PR
-
-          *🚧 진행 중인 이슈 (최근 7일 업데이트)*
-          $BE_ISSUE
-
-          $FE_ISSUE
+          $BODY
 
           ──────────
-          👋 *팀원 여러분, 이 스레드에 댓글로 이번 주 진행상황을 남겨주세요!*
+          👋 *팀원 여러분, 이 스레드에 댓글로 이번 주 진행상황을 보충해주세요!*
           • 이번 주 한 일 / 다음 주 할 일 / 막힌 점"
 
           # Slack 전송 (jq로 JSON escape)

--- a/.github/workflows/weekly-scrum.yml
+++ b/.github/workflows/weekly-scrum.yml
@@ -25,16 +25,21 @@ jobs:
           SINCE=$(date -u -d '7 days ago' +%Y-%m-%d)
           TODAY=$(date -u +%Y-%m-%d)
 
-          # 1) 이번 주 develop에 머지된 PR — 작성자(author)별로 그룹핑
-          PR_COUNT=$(gh pr list --state merged --base develop \
-                  --search "merged:>=$SINCE" --json number --jq 'length')
-          PR_SECTION=$(gh pr list --state merged --base develop \
-                  --search "merged:>=$SINCE" \
-                  --json number,title,author \
-                  --jq 'group_by(.author.login)
-                        | map("*@\(.[0].author.login) (\(length)건)*\n"
-                              + (map("• #\(.number) \(.title)") | join("\n")))
-                        | join("\n\n")')
+          # 1) 이번 주 develop에 머지된 PR — 작성자(author)별로 그룹핑, 작성자당 최대 N건만 표시
+          MAX_PER_AUTHOR=5
+          PR_JSON=$(gh pr list --state merged --base develop \
+                  --search "merged:>=$SINCE" --json number,title,author)
+          PR_COUNT=$(echo "$PR_JSON" | jq 'length')
+          PR_SECTION=$(echo "$PR_JSON" | jq -r --argjson k "$MAX_PER_AUTHOR" '
+                  group_by(.author.login)
+                  | map(
+                      length as $n
+                      | (.[0].author.login) as $login
+                      | "*@\($login) (\($n)건)*\n"
+                        + (.[0:$k] | map("• #\(.number) \(.title)") | join("\n"))
+                        + (if $n > $k then "\n  …외 \($n - $k)건" else "" end)
+                    )
+                  | join("\n\n")')
 
           # 2) 진행 중(열린) 이슈 — 최대 15개
           OPEN=$(gh issue list --state open --limit 15 \

--- a/.github/workflows/weekly-scrum.yml
+++ b/.github/workflows/weekly-scrum.yml
@@ -22,7 +22,6 @@ jobs:
       BACKEND_REPO: TicketRush/TicketRush-backend
       FRONTEND_REPO: TicketRush/TicketRush-frontend
       MAX_PER_AUTHOR: 5      # 작성자당 표시할 PR 최대 개수
-      MAX_ISSUES: 10         # 레포당 표시할 진행 중 이슈 최대 개수
     steps:
       - name: Build & send weekly scrum to Slack
         run: |
@@ -49,12 +48,15 @@ jobs:
             printf '*📦 %s — 이번 주 머지된 PR (%s건)*\n%s' "$2" "$count" "${body:-• 없음}"
           }
 
-          # 한 레포의 진행 중(열린) 이슈 블록 생성 ($1=repo, $2=표시 라벨)
+          # 한 레포의 진행 중 이슈 블록 생성 ($1=repo, $2=표시 라벨)
+          # "진행 중" = 최근 7일 내 업데이트된 열린 이슈 (별도 cap 없음, 활동 기준 필터)
           issue_block() {
-            local body
-            body=$(gh issue list -R "$1" --state open --limit "$MAX_ISSUES" \
-                    --json number,title \
-                    --jq '[.[] | "• #\(.number) \(.title)"] | join("\n")')
+            local json body
+            json=$(gh issue list -R "$1" --state open --limit 200 \
+                    --json number,title,updatedAt)
+            body=$(echo "$json" | jq -r --arg since "$SINCE" '
+                    [.[] | select(.updatedAt >= $since) | "• #\(.number) \(.title)"]
+                    | join("\n")')
             printf '*%s*\n%s' "$2" "${body:-• 없음}"
           }
 
@@ -69,7 +71,7 @@ jobs:
 
           $FE_PR
 
-          *🚧 진행 중인 이슈*
+          *🚧 진행 중인 이슈 (최근 7일 업데이트)*
           $BE_ISSUE
 
           $FE_ISSUE


### PR DESCRIPTION
## 🔗 관련 이슈

- close #284

---

## 📌 주요 변경 사항

- 매주 목요일 18:00(KST) 실행되는 주간 스크럼 GitHub Actions 워크플로우 추가
- 최근 7일간 `develop`에 머지된 PR을 작성자별로 그룹핑하여 요약
- 진행 중(열린) 이슈 목록(최대 15개) 포함
- `<!channel>` 멘션과 함께 Slack 채널로 전송, 팀원이 스레드에 진행상황을 댓글로 작성

---

## 🛠 상세 구현 내용

- `on.schedule` cron `0 9 * * 4` (09:00 UTC = 18:00 KST) + `workflow_dispatch`(수동 실행)
- `gh` CLI로 머지 PR / 열린 이슈 수집, `jq`로 작성자별 그룹핑 및 메시지 조립
- Webhook URL은 레포 시크릿 `SLACK_WEBHOOK_URL`에서 주입 (값 노출 없음)
- 권한 최소화: `contents/issues/pull-requests: read`

---

## ✅ 테스트

### 테스트 방법

- 머지 후 Actions 탭에서 `Run workflow`(workflow_dispatch)로 수동 실행
- 사전 준비: 레포 Settings → Secrets에 `SLACK_WEBHOOK_URL` 등록 필요

### 테스트 결과

- (머지 후 수동 실행으로 확인 예정)

### 📸 스크린샷

---

## 👀 리뷰 요청 사항

- 실행 시각(목 18:00 KST), 멘션 방식(`<!channel>`), 진행 중 이슈 노출 범위(열린 이슈 15개) 적절한지 확인 부탁드립니다.

---

## ⚠️ 배포 시 주의사항

- **머지 전** 레포 시크릿 `SLACK_WEBHOOK_URL`(TicketRush Slack Incoming Webhook) 등록이 선행되어야 정상 동작합니다.
- `schedule`/`workflow_dispatch`는 워크플로우가 default 브랜치(`develop`)에 올라간 뒤에만 트리거됩니다.
