### PR TITLE
[Refactor] #276 결제 confirm/cancel 트랜잭션·이벤트 발행 및 PG 클라이언트 라우터 리팩토링

### DIFF
--- a/common/src/main/java/com/ticketrush/global/status/ErrorStatus.java
+++ b/common/src/main/java/com/ticketrush/global/status/ErrorStatus.java
@@ -161,6 +161,12 @@ public enum ErrorStatus {
   PAYMENT_ALREADY_COMPLETED(HttpStatus.CONFLICT, "PAYMENT_409_001", "이미 결제가 완료된 예매입니다."),
   PAYMENT_NOT_CANCELABLE(HttpStatus.CONFLICT, "PAYMENT_409_002", "환불 가능한 결제 상태가 아닙니다."),
 
+  // Payment 500
+  PAYMENT_REFUND_INCONSISTENT(
+      HttpStatus.INTERNAL_SERVER_ERROR,
+      "PAYMENT_500_001",
+      "취소된 결제의 환불 내역을 찾을 수 없습니다. 관리자에게 문의 바랍니다."),
+
   // Payment 502
   PAYMENT_APPROVAL_FAILED(HttpStatus.BAD_GATEWAY, "PAYMENT_502_001", "PG사 결제 승인에 실패했습니다."),
   PAYMENT_PG_AUTH_FAILED(

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentCancelPersister.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentCancelPersister.java
@@ -28,8 +28,11 @@ public class PaymentCancelPersister {
   /**
    * 환불을 저장하고 결제를 CANCELED로 전이한다.
    *
-   * <p>{@code payment}는 트랜잭션 밖에서 조회된 detached 엔티티이므로, 트랜잭션 안에서 다시 조회해 managed 상태로 만든 뒤 상태를 전이한다.
-   * {@code saveAndFlush}를 먼저 호출해 동시 취소 시 paymentId unique 위반을 상태 전이/이벤트 발행 이전에 표면화한다. 위반({@code
+   * <p>{@code paymentId}만으로 결제를 재조회하므로 본인 결제 검증(인가)을 수행하지 않는다. <b>반드시 호출자({@link
+   * PaymentCancelUseCase})가 {@code userId} 기반 인가·상태 검증을 마친 뒤에만 호출해야 한다.</b>
+   *
+   * <p>트랜잭션 안에서 결제를 다시 조회해 managed 상태로 만든 뒤 상태를 전이한다(호출자가 트랜잭션 밖에서 읽은 엔티티는 detached이기 때문). {@code
+   * saveAndFlush}를 먼저 호출해 동시 취소 시 paymentId unique 위반을 상태 전이/이벤트 발행 이전에 표면화한다. 위반({@code
    * DataIntegrityViolationException})은 트랜잭션 경계 밖({@link
    * com.ticketrush.boundedcontext.payment.app.facade.PaymentFacade})에서 멱등 처리한다.
    */

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentCancelPersister.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentCancelPersister.java
@@ -1,0 +1,51 @@
+package com.ticketrush.boundedcontext.payment.app.usecase;
+
+import com.ticketrush.boundedcontext.payment.domain.entity.Payment;
+import com.ticketrush.boundedcontext.payment.domain.entity.Refund;
+import com.ticketrush.boundedcontext.payment.out.repository.PaymentRepository;
+import com.ticketrush.boundedcontext.payment.out.repository.RefundRepository;
+import com.ticketrush.global.exception.BusinessException;
+import com.ticketrush.global.status.ErrorStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 결제 취소의 영속화(환불 저장 + 결제 상태 전이)만 짧은 트랜잭션으로 묶는 컴포넌트.
+ *
+ * <p>PG 취소 호출은 {@link PaymentCancelUseCase}가 트랜잭션 밖에서 수행하고, 두 쓰기(refund 저장 + {@link
+ * Payment#markCanceled()})만 본 컴포넌트의 트랜잭션 안에서 원자적으로 처리한다. 외부 PG 왕복 동안 DB 커넥션을 점유하지 않기 위함이다.
+ *
+ * <p>self-invocation 프록시 한계 때문에 영속화를 UseCase와 별도 빈으로 분리했다.
+ */
+@Service
+@RequiredArgsConstructor
+public class PaymentCancelPersister {
+
+  private final PaymentRepository paymentRepository;
+  private final RefundRepository refundRepository;
+
+  /**
+   * 환불을 저장하고 결제를 CANCELED로 전이한다.
+   *
+   * <p>{@code payment}는 트랜잭션 밖에서 조회된 detached 엔티티이므로, 트랜잭션 안에서 다시 조회해 managed 상태로 만든 뒤 상태를 전이한다.
+   * {@code saveAndFlush}를 먼저 호출해 동시 취소 시 paymentId unique 위반을 상태 전이/이벤트 발행 이전에 표면화한다. 위반({@code
+   * DataIntegrityViolationException})은 트랜잭션 경계 밖({@link
+   * com.ticketrush.boundedcontext.payment.app.facade.PaymentFacade})에서 멱등 처리한다.
+   */
+  @Transactional
+  public CancelPersisted persist(Long paymentId, Refund refund) {
+    Payment payment =
+        paymentRepository
+            .findById(paymentId)
+            .orElseThrow(() -> new BusinessException(ErrorStatus.PAYMENT_NOT_FOUND));
+
+    Refund saved = refundRepository.saveAndFlush(refund);
+    payment.markCanceled();
+
+    return new CancelPersisted(payment, saved);
+  }
+
+  /** 영속화 결과. {@code payment}는 CANCELED로 전이된 상태다. */
+  public record CancelPersisted(Payment payment, Refund refund) {}
+}

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentCancelUseCase.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentCancelUseCase.java
@@ -3,6 +3,7 @@ package com.ticketrush.boundedcontext.payment.app.usecase;
 import com.ticketrush.boundedcontext.payment.app.dto.request.PaymentCancelRequest;
 import com.ticketrush.boundedcontext.payment.app.dto.response.PaymentCancelResponse;
 import com.ticketrush.boundedcontext.payment.app.support.PaymentEventPublisher;
+import com.ticketrush.boundedcontext.payment.app.usecase.PaymentCancelPersister.CancelPersisted;
 import com.ticketrush.boundedcontext.payment.domain.entity.Payment;
 import com.ticketrush.boundedcontext.payment.domain.entity.Refund;
 import com.ticketrush.boundedcontext.payment.domain.types.PaymentStatus;
@@ -25,16 +26,19 @@ import org.springframework.transaction.annotation.Transactional;
  * <p>본인 결제 검증 → 상태 검증 → PG 취소 호출 → {@link Refund} 영속화 → {@code PaymentStatus.CANCELED} 전이 → {@code
  * PaymentCanceledEvent} 발행까지의 happy path를 담당한다. 동일 결제에 대한 중복 요청은 기존 환불 내역을 반환하여 멱등하게 처리한다.
  *
+ * <p>PG 취소(외부 왕복)는 트랜잭션 밖에서 호출해 DB 커넥션 장시간 점유를 피하고, 영속화(refund 저장 + 상태 전이)만 {@link
+ * PaymentCancelPersister}의 짧은 트랜잭션으로 분리한다. 이벤트는 영속화 커밋 이후(트랜잭션 밖)에 발행하므로, 커밋에 성공한 데이터만 외부로 전파된다.
+ *
  * <p>환불 기한 검증(공연 시작 시간 기준)과 환불 실패 시 보상 트랜잭션(#91)은 본 UseCase 범위 밖이다.
  */
 @Service
-@Transactional
 @RequiredArgsConstructor
 public class PaymentCancelUseCase {
 
   private final PaymentRepository paymentRepository;
   private final RefundRepository refundRepository;
   private final PaymentCancelClientRouter paymentCancelClientRouter;
+  private final PaymentCancelPersister paymentCancelPersister;
   private final PaymentEventPublisher paymentEventPublisher;
 
   public PaymentCancelResponse execute(Long userId, Long paymentId, PaymentCancelRequest request) {
@@ -52,6 +56,7 @@ public class PaymentCancelUseCase {
       throw new BusinessException(ErrorStatus.PAYMENT_NOT_CANCELABLE);
     }
 
+    // PG 취소는 트랜잭션 밖에서 호출한다(외부 왕복 동안 DB 커넥션을 점유하지 않기 위함).
     PaymentCancelResult result =
         paymentCancelClientRouter.cancel(
             new PaymentCancelCommand(
@@ -73,21 +78,22 @@ public class PaymentCancelUseCase {
             .confirmedAt(result.canceledAt())
             .build();
 
-    // 동시 취소 요청 시 paymentId unique 제약 위반을 이벤트 발행·상태 전이 이전에 표면화하기 위해 즉시 flush 한다.
-    // 위반(DataIntegrityViolationException)은 트랜잭션 경계 밖(PaymentFacade)에서 멱등 처리한다.
-    Refund saved = refundRepository.saveAndFlush(refund);
-    payment.markCanceled();
+    // 영속화(refund 저장 + 상태 전이)만 짧은 트랜잭션으로 분리한다. 동시 취소 시 unique 위반은 PaymentFacade가 멱등 처리한다.
+    CancelPersisted persisted = paymentCancelPersister.persist(paymentId, refund);
 
+    // 발행은 영속화 커밋 이후(트랜잭션 밖)에 호출한다 → 커밋에 성공한 데이터만 전파된다.
+    Payment canceled = persisted.payment();
+    Refund saved = persisted.refund();
     paymentEventPublisher.publishCanceled(
-        payment.getId(),
-        payment.getBookingId(),
-        payment.getSeatId(),
+        canceled.getId(),
+        canceled.getBookingId(),
+        canceled.getSeatId(),
         saved.getId(),
         saved.getPrice(),
         saved.getReason(),
         saved.getConfirmedAt());
 
-    return PaymentCancelResponse.of(payment, saved);
+    return PaymentCancelResponse.of(canceled, saved);
   }
 
   /**

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentCancelUseCase.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentCancelUseCase.java
@@ -84,7 +84,7 @@ public class PaymentCancelUseCase {
         payment.getSeatId(),
         saved.getId(),
         saved.getPrice(),
-        request.reason(),
+        saved.getReason(),
         saved.getConfirmedAt());
 
     return PaymentCancelResponse.of(payment, saved);

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentCancelUseCase.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentCancelUseCase.java
@@ -107,7 +107,7 @@ public class PaymentCancelUseCase {
     Refund existing =
         refundRepository
             .findByPaymentId(paymentId)
-            .orElseThrow(() -> new BusinessException(ErrorStatus.PAYMENT_REFUND_FAILED));
+            .orElseThrow(() -> new BusinessException(ErrorStatus.PAYMENT_REFUND_INCONSISTENT));
     return PaymentCancelResponse.of(payment, existing);
   }
 

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentConfirmUseCase.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentConfirmUseCase.java
@@ -14,10 +14,14 @@ import com.ticketrush.global.exception.BusinessException;
 import com.ticketrush.global.status.ErrorStatus;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
+/**
+ * 결제 승인(confirm) UseCase.
+ *
+ * <p>쓰기가 {@code paymentRepository.save} 단건뿐이라 여러 문장을 묶는 트랜잭션이 필요 없다. 따라서 PG 승인(외부 왕복)을 트랜잭션 안에 가두지
+ * 않아 DB 커넥션을 장시간 점유하지 않는다. 이벤트는 save(자체 트랜잭션 커밋) 성공 이후에 호출되므로, 커밋에 성공한 데이터만 외부로 전파된다.
+ */
 @Service
-@Transactional
 @RequiredArgsConstructor
 public class PaymentConfirmUseCase {
 

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/domain/entity/Payment.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/domain/entity/Payment.java
@@ -72,8 +72,16 @@ public class Payment extends AutoIdBaseEntity {
     this.paidAt = paidAt;
   }
 
-  /** 환불 처리로 결제를 취소 상태로 전이한다. */
+  /**
+   * 환불 처리로 결제를 취소 상태로 전이한다.
+   *
+   * <p>COMPLETED 상태에서만 취소로 전이할 수 있다. 그 외 상태에서 호출되면 도메인 불변식 위반이므로 {@link IllegalStateException}을
+   * 던진다. (정상 흐름에서는 UseCase의 상태 검증과 환불 unique 제약이 먼저 막으므로 이 가드는 방어선이다.)
+   */
   public void markCanceled() {
+    if (this.status != PaymentStatus.COMPLETED) {
+      throw new IllegalStateException("결제 취소는 COMPLETED 상태에서만 가능합니다. 현재 상태=" + this.status);
+    }
     this.status = PaymentStatus.CANCELED;
   }
 }

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/out/apiclient/PaymentApprovalClient.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/out/apiclient/PaymentApprovalClient.java
@@ -5,12 +5,19 @@ import com.ticketrush.boundedcontext.payment.domain.types.PaymentProvider;
 /**
  * PG사 결제 승인 API 호출용 클라이언트.
  *
- * <p>구현체는 {@link #supports(PaymentProvider)}로 자신이 처리 가능한 PG를 알리고, {@link
- * PaymentApprovalClientRouter}가 요청 provider에 맞는 클라이언트를 선택해 호출한다.
+ * <p>실제 provider 구현체는 {@link #provider()}로 자신이 담당하는 PG를 알리고, {@link PaymentApprovalClientRouter}가
+ * 이를 키로 매핑해 요청 provider에 맞는 클라이언트를 선택해 호출한다. 모든 provider를 대신 처리하는 fallback 구현체는 {@link
+ * #isFallback()}을 {@code true}로 재정의한다.
  */
 public interface PaymentApprovalClient {
 
-  boolean supports(PaymentProvider provider);
+  /** 이 클라이언트가 담당하는 PG provider. 라우터가 Map 키로 사용한다. fallback 구현체에서는 호출되지 않는다. */
+  PaymentProvider provider();
+
+  /** 실제 provider 구현체가 없을 때 라우터가 선택하는 fallback 여부. */
+  default boolean isFallback() {
+    return false;
+  }
 
   PaymentApprovalResponse approve(PaymentApprovalRequest request);
 }

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/out/apiclient/PaymentApprovalClientRouter.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/out/apiclient/PaymentApprovalClientRouter.java
@@ -4,29 +4,46 @@ import com.ticketrush.boundedcontext.payment.domain.types.PaymentProvider;
 import com.ticketrush.global.exception.BusinessException;
 import com.ticketrush.global.status.ErrorStatus;
 import java.util.List;
-import lombok.RequiredArgsConstructor;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import org.springframework.stereotype.Component;
 
 /**
- * 등록된 {@link PaymentApprovalClient} 중 요청 provider를 지원하는 첫 번째 구현체로 결제 승인을 위임한다.
+ * 요청 provider를 담당하는 {@link PaymentApprovalClient}로 결제 승인을 위임한다.
  *
- * <p>Stub은 {@link org.springframework.core.annotation.Order} 가장 낮은 우선순위로 등록되어 실제 provider 구현체가 우선
- * 선택되도록 한다.
+ * <p>실제 provider 구현체는 {@link PaymentApprovalClient#provider()}를 키로 Map에 등록해 O(1)로 조회하고, 매칭되는 구현체가
+ * 없으면 {@link PaymentApprovalClient#isFallback()} 인 stub으로만 대체한다. 둘 다 없으면 {@link
+ * ErrorStatus#PAYMENT_PROVIDER_NOT_SUPPORTED}를 던진다.
  */
 @Component
-@RequiredArgsConstructor
 public class PaymentApprovalClientRouter {
 
-  private final List<PaymentApprovalClient> clients;
+  private final Map<PaymentProvider, PaymentApprovalClient> clientsByProvider;
+  private final PaymentApprovalClient fallbackClient;
+
+  public PaymentApprovalClientRouter(List<PaymentApprovalClient> clients) {
+    this.clientsByProvider =
+        clients.stream()
+            .filter(client -> !client.isFallback())
+            .collect(
+                Collectors.toUnmodifiableMap(PaymentApprovalClient::provider, Function.identity()));
+    this.fallbackClient =
+        clients.stream().filter(PaymentApprovalClient::isFallback).findFirst().orElse(null);
+  }
 
   public PaymentApprovalResponse approve(PaymentApprovalRequest request) {
     return resolve(request.provider()).approve(request);
   }
 
   private PaymentApprovalClient resolve(PaymentProvider provider) {
-    return clients.stream()
-        .filter(client -> client.supports(provider))
-        .findFirst()
-        .orElseThrow(() -> new BusinessException(ErrorStatus.PAYMENT_PROVIDER_NOT_SUPPORTED));
+    PaymentApprovalClient client = clientsByProvider.get(provider);
+    if (client != null) {
+      return client;
+    }
+    if (fallbackClient != null) {
+      return fallbackClient;
+    }
+    throw new BusinessException(ErrorStatus.PAYMENT_PROVIDER_NOT_SUPPORTED);
   }
 }

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/out/apiclient/PaymentCancelClient.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/out/apiclient/PaymentCancelClient.java
@@ -5,12 +5,19 @@ import com.ticketrush.boundedcontext.payment.domain.types.PaymentProvider;
 /**
  * PG사 결제 취소(환불) API 호출용 클라이언트.
  *
- * <p>구현체는 {@link #supports(PaymentProvider)}로 자신이 처리 가능한 PG를 알리고, {@link
- * PaymentCancelClientRouter}가 요청 provider에 맞는 클라이언트를 선택해 호출한다.
+ * <p>실제 provider 구현체는 {@link #provider()}로 자신이 담당하는 PG를 알리고, {@link PaymentCancelClientRouter}가 이를
+ * 키로 매핑해 요청 provider에 맞는 클라이언트를 선택해 호출한다. 모든 provider를 대신 처리하는 fallback 구현체는 {@link #isFallback()}을
+ * {@code true}로 재정의한다.
  */
 public interface PaymentCancelClient {
 
-  boolean supports(PaymentProvider provider);
+  /** 이 클라이언트가 담당하는 PG provider. 라우터가 Map 키로 사용한다. fallback 구현체에서는 호출되지 않는다. */
+  PaymentProvider provider();
+
+  /** 실제 provider 구현체가 없을 때 라우터가 선택하는 fallback 여부. */
+  default boolean isFallback() {
+    return false;
+  }
 
   PaymentCancelResult cancel(PaymentCancelCommand command);
 }

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/out/apiclient/PaymentCancelClientRouter.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/out/apiclient/PaymentCancelClientRouter.java
@@ -4,29 +4,46 @@ import com.ticketrush.boundedcontext.payment.domain.types.PaymentProvider;
 import com.ticketrush.global.exception.BusinessException;
 import com.ticketrush.global.status.ErrorStatus;
 import java.util.List;
-import lombok.RequiredArgsConstructor;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import org.springframework.stereotype.Component;
 
 /**
- * 등록된 {@link PaymentCancelClient} 중 요청 provider를 지원하는 첫 번째 구현체로 결제 취소를 위임한다.
+ * 요청 provider를 담당하는 {@link PaymentCancelClient}로 결제 취소를 위임한다.
  *
- * <p>Stub은 {@link org.springframework.core.annotation.Order} 가장 낮은 우선순위로 등록되어 실제 provider 구현체가 우선
- * 선택되도록 한다.
+ * <p>실제 provider 구현체는 {@link PaymentCancelClient#provider()}를 키로 Map에 등록해 O(1)로 조회하고, 매칭되는 구현체가 없으면
+ * {@link PaymentCancelClient#isFallback()} 인 stub으로만 대체한다. 둘 다 없으면 {@link
+ * ErrorStatus#PAYMENT_PROVIDER_NOT_SUPPORTED}를 던진다.
  */
 @Component
-@RequiredArgsConstructor
 public class PaymentCancelClientRouter {
 
-  private final List<PaymentCancelClient> clients;
+  private final Map<PaymentProvider, PaymentCancelClient> clientsByProvider;
+  private final PaymentCancelClient fallbackClient;
+
+  public PaymentCancelClientRouter(List<PaymentCancelClient> clients) {
+    this.clientsByProvider =
+        clients.stream()
+            .filter(client -> !client.isFallback())
+            .collect(
+                Collectors.toUnmodifiableMap(PaymentCancelClient::provider, Function.identity()));
+    this.fallbackClient =
+        clients.stream().filter(PaymentCancelClient::isFallback).findFirst().orElse(null);
+  }
 
   public PaymentCancelResult cancel(PaymentCancelCommand command) {
     return resolve(command.provider()).cancel(command);
   }
 
   private PaymentCancelClient resolve(PaymentProvider provider) {
-    return clients.stream()
-        .filter(client -> client.supports(provider))
-        .findFirst()
-        .orElseThrow(() -> new BusinessException(ErrorStatus.PAYMENT_PROVIDER_NOT_SUPPORTED));
+    PaymentCancelClient client = clientsByProvider.get(provider);
+    if (client != null) {
+      return client;
+    }
+    if (fallbackClient != null) {
+      return fallbackClient;
+    }
+    throw new BusinessException(ErrorStatus.PAYMENT_PROVIDER_NOT_SUPPORTED);
   }
 }

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/out/apiclient/StubPaymentApprovalClient.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/out/apiclient/StubPaymentApprovalClient.java
@@ -6,21 +6,19 @@ import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Profile;
-import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 
 /**
  * 실 PG 호출 없이 요청 금액을 그대로 승인된 것으로 응답하는 stub 구현.
  *
- * <p>{@code payment.pg.stub.enabled=true} 일 때만 활성화된다. {@link PaymentApprovalClientRouter}에서 실제
- * provider별 구현체가 우선 선택되도록 {@link Order} 우선순위는 가장 낮게 둔다.
+ * <p>{@code payment.pg.stub.enabled=true} 일 때만 활성화된다. {@link #isFallback()}으로 fallback 임을 명시하며,
+ * {@link PaymentApprovalClientRouter}는 요청 provider에 맞는 실제 구현체가 없을 때만 이 stub을 선택한다.
  *
  * <p>운영(prod) 프로파일에서는 환경변수 설정과 무관하게 절대 활성화되지 않는다.
  */
 @Slf4j
 @Component
 @Profile("!prod")
-@Order(Integer.MAX_VALUE)
 @ConditionalOnProperty(
     prefix = "payment.pg.stub",
     name = "enabled",
@@ -29,8 +27,13 @@ import org.springframework.stereotype.Component;
 public class StubPaymentApprovalClient implements PaymentApprovalClient {
 
   @Override
-  public boolean supports(PaymentProvider provider) {
+  public boolean isFallback() {
     return true;
+  }
+
+  @Override
+  public PaymentProvider provider() {
+    throw new UnsupportedOperationException("fallback stub은 단일 provider에 매핑되지 않습니다.");
   }
 
   @Override

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/out/apiclient/StubPaymentCancelClient.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/out/apiclient/StubPaymentCancelClient.java
@@ -6,21 +6,19 @@ import java.util.UUID;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Profile;
-import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 
 /**
  * 실 PG 호출 없이 요청 금액을 그대로 취소된 것으로 응답하는 stub 구현.
  *
- * <p>{@code payment.pg.stub.enabled=true} 일 때만 활성화된다. {@link PaymentCancelClientRouter}에서 실제
- * provider별 구현체가 우선 선택되도록 {@link Order} 우선순위는 가장 낮게 둔다.
+ * <p>{@code payment.pg.stub.enabled=true} 일 때만 활성화된다. {@link #isFallback()}으로 fallback 임을 명시하며,
+ * {@link PaymentCancelClientRouter}는 요청 provider에 맞는 실제 구현체가 없을 때만 이 stub을 선택한다.
  *
  * <p>운영(prod) 프로파일에서는 환경변수 설정과 무관하게 절대 활성화되지 않는다.
  */
 @Slf4j
 @Component
 @Profile("!prod")
-@Order(Integer.MAX_VALUE)
 @ConditionalOnProperty(
     prefix = "payment.pg.stub",
     name = "enabled",
@@ -29,8 +27,13 @@ import org.springframework.stereotype.Component;
 public class StubPaymentCancelClient implements PaymentCancelClient {
 
   @Override
-  public boolean supports(PaymentProvider provider) {
+  public boolean isFallback() {
     return true;
+  }
+
+  @Override
+  public PaymentProvider provider() {
+    throw new UnsupportedOperationException("fallback stub은 단일 provider에 매핑되지 않습니다.");
   }
 
   @Override

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/out/apiclient/TossCancelRequest.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/out/apiclient/TossCancelRequest.java
@@ -1,4 +1,4 @@
-package com.ticketrush.boundedcontext.payment.out.apiclient.toss;
+package com.ticketrush.boundedcontext.payment.out.apiclient;
 
 /**
  * Toss Payments 결제 취소 API 요청 페이로드.

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/out/apiclient/TossCancelResponse.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/out/apiclient/TossCancelResponse.java
@@ -1,4 +1,4 @@
-package com.ticketrush.boundedcontext.payment.out.apiclient.toss;
+package com.ticketrush.boundedcontext.payment.out.apiclient;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import java.time.OffsetDateTime;

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/out/apiclient/TossConfirmRequest.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/out/apiclient/TossConfirmRequest.java
@@ -1,4 +1,4 @@
-package com.ticketrush.boundedcontext.payment.out.apiclient.toss;
+package com.ticketrush.boundedcontext.payment.out.apiclient;
 
 /**
  * Toss Payments 결제 승인 API 요청 페이로드.

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/out/apiclient/TossConfirmResponse.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/out/apiclient/TossConfirmResponse.java
@@ -1,4 +1,4 @@
-package com.ticketrush.boundedcontext.payment.out.apiclient.toss;
+package com.ticketrush.boundedcontext.payment.out.apiclient;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import java.time.OffsetDateTime;

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/out/apiclient/TossErrorCode.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/out/apiclient/TossErrorCode.java
@@ -1,4 +1,4 @@
-package com.ticketrush.boundedcontext.payment.out.apiclient.toss;
+package com.ticketrush.boundedcontext.payment.out.apiclient;
 
 import com.ticketrush.global.status.ErrorStatus;
 import java.util.Arrays;

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/out/apiclient/TossErrorResponse.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/out/apiclient/TossErrorResponse.java
@@ -1,4 +1,4 @@
-package com.ticketrush.boundedcontext.payment.out.apiclient.toss;
+package com.ticketrush.boundedcontext.payment.out.apiclient;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/out/apiclient/TossPaymentApprovalClient.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/out/apiclient/TossPaymentApprovalClient.java
@@ -10,7 +10,6 @@ import java.time.ZoneId;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.MediaType;
 import org.springframework.http.client.ClientHttpResponse;
@@ -27,7 +26,6 @@ import org.springframework.web.client.RestClientException;
  */
 @Slf4j
 @Component
-@Order(0)
 @ConditionalOnProperty(prefix = "payment.pg.toss", name = "enabled", havingValue = "true")
 public class TossPaymentApprovalClient implements PaymentApprovalClient {
 
@@ -43,8 +41,8 @@ public class TossPaymentApprovalClient implements PaymentApprovalClient {
   }
 
   @Override
-  public boolean supports(PaymentProvider provider) {
-    return provider == PaymentProvider.TOSS;
+  public PaymentProvider provider() {
+    return PaymentProvider.TOSS;
   }
 
   @Override

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/out/apiclient/TossPaymentApprovalClient.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/out/apiclient/TossPaymentApprovalClient.java
@@ -1,10 +1,7 @@
-package com.ticketrush.boundedcontext.payment.out.apiclient.toss;
+package com.ticketrush.boundedcontext.payment.out.apiclient;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.ticketrush.boundedcontext.payment.domain.types.PaymentProvider;
-import com.ticketrush.boundedcontext.payment.out.apiclient.PaymentApprovalClient;
-import com.ticketrush.boundedcontext.payment.out.apiclient.PaymentApprovalRequest;
-import com.ticketrush.boundedcontext.payment.out.apiclient.PaymentApprovalResponse;
 import com.ticketrush.global.exception.BusinessException;
 import com.ticketrush.global.status.ErrorStatus;
 import java.io.IOException;

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/out/apiclient/TossPaymentCancelClient.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/out/apiclient/TossPaymentCancelClient.java
@@ -1,9 +1,6 @@
-package com.ticketrush.boundedcontext.payment.out.apiclient.toss;
+package com.ticketrush.boundedcontext.payment.out.apiclient;
 
 import com.ticketrush.boundedcontext.payment.domain.types.PaymentProvider;
-import com.ticketrush.boundedcontext.payment.out.apiclient.PaymentCancelClient;
-import com.ticketrush.boundedcontext.payment.out.apiclient.PaymentCancelCommand;
-import com.ticketrush.boundedcontext.payment.out.apiclient.PaymentCancelResult;
 import com.ticketrush.global.exception.BusinessException;
 import com.ticketrush.global.status.ErrorStatus;
 import java.time.LocalDateTime;

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/out/apiclient/TossPaymentCancelClient.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/out/apiclient/TossPaymentCancelClient.java
@@ -9,7 +9,6 @@ import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
@@ -29,7 +28,6 @@ import org.springframework.web.client.RestClientException;
  */
 @Slf4j
 @Component
-@Order(0)
 @ConditionalOnProperty(prefix = "payment.pg.toss", name = "enabled", havingValue = "true")
 public class TossPaymentCancelClient implements PaymentCancelClient {
 
@@ -43,8 +41,8 @@ public class TossPaymentCancelClient implements PaymentCancelClient {
   }
 
   @Override
-  public boolean supports(PaymentProvider provider) {
-    return provider == PaymentProvider.TOSS;
+  public PaymentProvider provider() {
+    return PaymentProvider.TOSS;
   }
 
   @Override

--- a/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentCancelPersisterTest.java
+++ b/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentCancelPersisterTest.java
@@ -1,0 +1,133 @@
+package com.ticketrush.boundedcontext.payment.app.usecase;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.ticketrush.boundedcontext.payment.app.usecase.PaymentCancelPersister.CancelPersisted;
+import com.ticketrush.boundedcontext.payment.domain.entity.Payment;
+import com.ticketrush.boundedcontext.payment.domain.entity.Refund;
+import com.ticketrush.boundedcontext.payment.domain.types.PaymentProvider;
+import com.ticketrush.boundedcontext.payment.domain.types.PaymentStatus;
+import com.ticketrush.boundedcontext.payment.domain.types.RefundStatus;
+import com.ticketrush.boundedcontext.payment.out.repository.PaymentRepository;
+import com.ticketrush.boundedcontext.payment.out.repository.RefundRepository;
+import com.ticketrush.global.exception.BusinessException;
+import com.ticketrush.global.status.ErrorStatus;
+import java.lang.reflect.Field;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
+
+@ExtendWith(MockitoExtension.class)
+class PaymentCancelPersisterTest {
+
+  @Mock private PaymentRepository paymentRepository;
+  @Mock private RefundRepository refundRepository;
+
+  @InjectMocks private PaymentCancelPersister paymentCancelPersister;
+
+  @Test
+  @DisplayName("환불을 저장하고 결제를 CANCELED로 전이해 결과를 반환한다")
+  void persist_saves_refund_and_cancels_payment() throws Exception {
+    // given
+    Long paymentId = 1L;
+    Payment payment = completedPayment(paymentId);
+    Refund refund = refund(paymentId);
+    given(paymentRepository.findById(paymentId)).willReturn(Optional.of(payment));
+    given(refundRepository.saveAndFlush(refund))
+        .willAnswer(
+            invocation -> {
+              setId(invocation.getArgument(0), 999L);
+              return invocation.getArgument(0);
+            });
+
+    // when
+    CancelPersisted result = paymentCancelPersister.persist(paymentId, refund);
+
+    // then
+    assertThat(result.payment().getStatus()).isEqualTo(PaymentStatus.CANCELED);
+    assertThat(result.refund().getId()).isEqualTo(999L);
+    verify(refundRepository).saveAndFlush(refund);
+  }
+
+  @Test
+  @DisplayName("paymentId unique 위반은 상태 전이 이전에 전파되고 결제는 CANCELED로 바뀌지 않는다")
+  void persist_propagates_unique_violation_before_state_transition() throws Exception {
+    // given
+    Long paymentId = 1L;
+    Payment payment = completedPayment(paymentId);
+    Refund refund = refund(paymentId);
+    given(paymentRepository.findById(paymentId)).willReturn(Optional.of(payment));
+    given(refundRepository.saveAndFlush(refund))
+        .willThrow(new DataIntegrityViolationException("duplicate paymentId"));
+
+    // when & then
+    assertThatThrownBy(() -> paymentCancelPersister.persist(paymentId, refund))
+        .isInstanceOf(DataIntegrityViolationException.class);
+
+    assertThat(payment.getStatus()).isEqualTo(PaymentStatus.COMPLETED);
+  }
+
+  @Test
+  @DisplayName("결제가 존재하지 않으면 PAYMENT_404_002 예외가 발생한다")
+  void persist_fail_when_payment_not_found() {
+    // given
+    Long paymentId = 1L;
+    Refund refund = refund(paymentId);
+    given(paymentRepository.findById(paymentId)).willReturn(Optional.empty());
+
+    // when & then
+    assertThatThrownBy(() -> paymentCancelPersister.persist(paymentId, refund))
+        .isInstanceOf(BusinessException.class)
+        .extracting("errorStatus")
+        .isEqualTo(ErrorStatus.PAYMENT_NOT_FOUND);
+
+    verify(refundRepository, never()).saveAndFlush(any(Refund.class));
+  }
+
+  private Payment completedPayment(Long paymentId) throws Exception {
+    Payment payment =
+        Payment.builder()
+            .bookingId(100L)
+            .userId(10L)
+            .seatId(200L)
+            .provider(PaymentProvider.TOSS)
+            .amount(55_000L)
+            .status(PaymentStatus.COMPLETED)
+            .paymentKey("pgKey_xyz")
+            .approvalNumber("APR-1")
+            .paidAt(LocalDateTime.of(2026, 5, 1, 10, 0))
+            .build();
+    setId(payment, paymentId);
+    return payment;
+  }
+
+  private Refund refund(Long paymentId) {
+    return Refund.builder()
+        .paymentId(paymentId)
+        .bookingId(100L)
+        .price(55_000L)
+        .status(RefundStatus.COMPLETED)
+        .pgRefundKey("PG-REFUND-1")
+        .reason("단순 변심")
+        .requestedAt(LocalDateTime.of(2026, 5, 22, 10, 0))
+        .confirmedAt(LocalDateTime.of(2026, 5, 22, 10, 0))
+        .build();
+  }
+
+  private void setId(Object entity, Long id) throws Exception {
+    Field idField = entity.getClass().getSuperclass().getDeclaredField("id");
+    idField.setAccessible(true);
+    idField.set(entity, id);
+  }
+}

--- a/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentCancelUseCaseTest.java
+++ b/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentCancelUseCaseTest.java
@@ -150,6 +150,30 @@ class PaymentCancelUseCaseTest {
   }
 
   @Test
+  @DisplayName("CANCELED 결제인데 환불 내역이 없으면 정합성 오류(PAYMENT_500_001)를 던진다")
+  void execute_fail_when_canceled_but_refund_missing() throws Exception {
+    // given
+    Long userId = 10L;
+    Long paymentId = 1L;
+
+    Payment payment = completedPayment(paymentId, userId, 100L, 200L, 55_000L);
+    payment.markCanceled();
+    given(paymentRepository.findByIdAndUserId(paymentId, userId)).willReturn(Optional.of(payment));
+    given(refundRepository.findByPaymentId(paymentId)).willReturn(Optional.empty());
+
+    PaymentCancelRequest request = new PaymentCancelRequest("단순 변심");
+
+    // when & then
+    assertThatThrownBy(() -> paymentCancelUseCase.execute(userId, paymentId, request))
+        .isInstanceOf(BusinessException.class)
+        .extracting("errorStatus")
+        .isEqualTo(ErrorStatus.PAYMENT_REFUND_INCONSISTENT);
+
+    verify(paymentCancelClientRouter, never()).cancel(any());
+    verify(refundRepository, never()).saveAndFlush(any(Refund.class));
+  }
+
+  @Test
   @DisplayName("본인 결제가 아니거나 존재하지 않으면 PAYMENT_404_002 예외가 발생한다")
   void execute_fail_when_not_found() {
     // given

--- a/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentCancelUseCaseTest.java
+++ b/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentCancelUseCaseTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
@@ -30,6 +31,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -41,12 +43,13 @@ class PaymentCancelUseCaseTest {
   @Mock private PaymentRepository paymentRepository;
   @Mock private RefundRepository refundRepository;
   @Mock private PaymentCancelClientRouter paymentCancelClientRouter;
+  @Mock private PaymentCancelPersister paymentCancelPersister;
   @Mock private PaymentEventPublisher paymentEventPublisher;
 
   @InjectMocks private PaymentCancelUseCase paymentCancelUseCase;
 
   @Test
-  @DisplayName("COMPLETED 결제 환불 성공 시 PG 취소 호출 + Refund 저장 + 결제 CANCELED 전이 + 이벤트를 발행한다")
+  @DisplayName("COMPLETED 결제 환불 성공 시 PG 취소 호출 + 영속화 위임 + 이벤트를 발행한다")
   void execute_success() throws Exception {
     // given
     Long userId = 10L;
@@ -54,20 +57,23 @@ class PaymentCancelUseCaseTest {
     Long bookingId = 100L;
     Long seatId = 200L;
     Long amount = 55_000L;
-    Long savedRefundId = 999L;
+    final Long savedRefundId = 999L;
     LocalDateTime canceledAt = LocalDateTime.of(2026, 5, 22, 10, 0);
-    PaymentCancelRequest request = new PaymentCancelRequest("단순 변심");
+    final PaymentCancelRequest request = new PaymentCancelRequest("단순 변심");
 
     Payment payment = completedPayment(paymentId, userId, bookingId, seatId, amount);
     given(paymentRepository.findByIdAndUserId(paymentId, userId)).willReturn(Optional.of(payment));
     given(paymentCancelClientRouter.cancel(any()))
         .willReturn(new PaymentCancelResult("PG-REFUND-1", amount, canceledAt));
-    given(refundRepository.saveAndFlush(any(Refund.class)))
+
+    Payment canceled = completedPayment(paymentId, userId, bookingId, seatId, amount);
+    canceled.markCanceled();
+    given(paymentCancelPersister.persist(eq(paymentId), any(Refund.class)))
         .willAnswer(
             invocation -> {
-              Refund r = invocation.getArgument(0);
+              Refund r = invocation.getArgument(1);
               setId(r, savedRefundId);
-              return r;
+              return new PaymentCancelPersister.CancelPersisted(canceled, r);
             });
 
     // when
@@ -79,7 +85,6 @@ class PaymentCancelUseCaseTest {
     assertThat(response.refundId()).isEqualTo(savedRefundId);
     assertThat(response.refundedAmount()).isEqualTo(amount);
     assertThat(response.canceledAt()).isEqualTo(canceledAt);
-    assertThat(payment.getStatus()).isEqualTo(PaymentStatus.CANCELED);
 
     ArgumentCaptor<PaymentCancelCommand> commandCaptor =
         ArgumentCaptor.forClass(PaymentCancelCommand.class);
@@ -92,15 +97,15 @@ class PaymentCancelUseCaseTest {
     assertThat(command.idempotencyKey()).isEqualTo("REFUND-0000001");
 
     ArgumentCaptor<Refund> refundCaptor = ArgumentCaptor.forClass(Refund.class);
-    verify(refundRepository).saveAndFlush(refundCaptor.capture());
-    Refund savedRefund = refundCaptor.getValue();
-    assertThat(savedRefund.getPaymentId()).isEqualTo(paymentId);
-    assertThat(savedRefund.getBookingId()).isEqualTo(bookingId);
-    assertThat(savedRefund.getPrice()).isEqualTo(amount);
-    assertThat(savedRefund.getStatus()).isEqualTo(RefundStatus.COMPLETED);
-    assertThat(savedRefund.getPgRefundKey()).isEqualTo("PG-REFUND-1");
-    assertThat(savedRefund.getReason()).isEqualTo("단순 변심");
-    assertThat(savedRefund.getConfirmedAt()).isEqualTo(canceledAt);
+    verify(paymentCancelPersister).persist(eq(paymentId), refundCaptor.capture());
+    Refund builtRefund = refundCaptor.getValue();
+    assertThat(builtRefund.getPaymentId()).isEqualTo(paymentId);
+    assertThat(builtRefund.getBookingId()).isEqualTo(bookingId);
+    assertThat(builtRefund.getPrice()).isEqualTo(amount);
+    assertThat(builtRefund.getStatus()).isEqualTo(RefundStatus.COMPLETED);
+    assertThat(builtRefund.getPgRefundKey()).isEqualTo("PG-REFUND-1");
+    assertThat(builtRefund.getReason()).isEqualTo("단순 변심");
+    assertThat(builtRefund.getConfirmedAt()).isEqualTo(canceledAt);
 
     verify(paymentEventPublisher)
         .publishCanceled(
@@ -111,6 +116,13 @@ class PaymentCancelUseCaseTest {
             eq(amount),
             eq("단순 변심"),
             eq(canceledAt));
+
+    // 이벤트는 영속화(persist) 커밋 이후에 발행되어야 한다.
+    InOrder inOrder = inOrder(paymentCancelPersister, paymentEventPublisher);
+    inOrder.verify(paymentCancelPersister).persist(eq(paymentId), any(Refund.class));
+    inOrder
+        .verify(paymentEventPublisher)
+        .publishCanceled(any(), any(), any(), any(), any(), any(), any());
   }
 
   @Test
@@ -144,7 +156,7 @@ class PaymentCancelUseCaseTest {
     assertThat(response.refundId()).isEqualTo(999L);
     assertThat(response.status()).isEqualTo("CANCELED");
     verify(paymentCancelClientRouter, never()).cancel(any());
-    verify(refundRepository, never()).saveAndFlush(any(Refund.class));
+    verify(paymentCancelPersister, never()).persist(any(), any(Refund.class));
     verify(paymentEventPublisher, never())
         .publishCanceled(any(), any(), any(), any(), any(), any(), any());
   }
@@ -170,7 +182,7 @@ class PaymentCancelUseCaseTest {
         .isEqualTo(ErrorStatus.PAYMENT_REFUND_INCONSISTENT);
 
     verify(paymentCancelClientRouter, never()).cancel(any());
-    verify(refundRepository, never()).saveAndFlush(any(Refund.class));
+    verify(paymentCancelPersister, never()).persist(any(), any(Refund.class));
   }
 
   @Test
@@ -189,7 +201,7 @@ class PaymentCancelUseCaseTest {
         .isEqualTo(ErrorStatus.PAYMENT_NOT_FOUND);
 
     verify(paymentCancelClientRouter, never()).cancel(any());
-    verify(refundRepository, never()).saveAndFlush(any(Refund.class));
+    verify(paymentCancelPersister, never()).persist(any(), any(Refund.class));
   }
 
   @Test
@@ -220,7 +232,7 @@ class PaymentCancelUseCaseTest {
         .isEqualTo(ErrorStatus.PAYMENT_NOT_CANCELABLE);
 
     verify(paymentCancelClientRouter, never()).cancel(any());
-    verify(refundRepository, never()).saveAndFlush(any(Refund.class));
+    verify(paymentCancelPersister, never()).persist(any(), any(Refund.class));
   }
 
   @Test
@@ -243,7 +255,7 @@ class PaymentCancelUseCaseTest {
         .isEqualTo(ErrorStatus.PAYMENT_REFUND_FAILED);
 
     assertThat(payment.getStatus()).isEqualTo(PaymentStatus.COMPLETED);
-    verify(refundRepository, never()).saveAndFlush(any(Refund.class));
+    verify(paymentCancelPersister, never()).persist(any(), any(Refund.class));
     verify(paymentEventPublisher, never())
         .publishCanceled(any(), any(), any(), any(), any(), any(), any());
   }
@@ -260,7 +272,7 @@ class PaymentCancelUseCaseTest {
     given(paymentRepository.findByIdAndUserId(paymentId, userId)).willReturn(Optional.of(payment));
     given(paymentCancelClientRouter.cancel(any()))
         .willReturn(new PaymentCancelResult("PG-REFUND-1", 55_000L, LocalDateTime.now()));
-    given(refundRepository.saveAndFlush(any(Refund.class)))
+    given(paymentCancelPersister.persist(eq(paymentId), any(Refund.class)))
         .willThrow(new DataIntegrityViolationException("duplicate paymentId"));
 
     // when & then
@@ -300,7 +312,7 @@ class PaymentCancelUseCaseTest {
     assertThat(response.refundId()).isEqualTo(999L);
     assertThat(response.status()).isEqualTo("CANCELED");
     verify(paymentCancelClientRouter, never()).cancel(any());
-    verify(refundRepository, never()).saveAndFlush(any(Refund.class));
+    verify(paymentCancelPersister, never()).persist(any(), any(Refund.class));
   }
 
   private Payment completedPayment(

--- a/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentConfirmUseCaseTest.java
+++ b/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentConfirmUseCaseTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
@@ -27,6 +28,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -101,6 +103,13 @@ class PaymentConfirmUseCaseTest {
     verify(paymentEventPublisher)
         .publishConfirmed(
             eq(savedPaymentId), eq(bookingId), eq(seatId), eq(userId), eq(amount), eq(approvedAt));
+
+    // 이벤트는 save(커밋) 성공 이후에 발행되어야 한다.
+    InOrder inOrder = inOrder(paymentRepository, paymentEventPublisher);
+    inOrder.verify(paymentRepository).save(any(Payment.class));
+    inOrder
+        .verify(paymentEventPublisher)
+        .publishConfirmed(any(), any(), any(), any(), any(), any());
   }
 
   private void setId(Payment payment, Long id) throws Exception {

--- a/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/domain/entity/PaymentTest.java
+++ b/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/domain/entity/PaymentTest.java
@@ -1,0 +1,60 @@
+package com.ticketrush.boundedcontext.payment.domain.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.ticketrush.boundedcontext.payment.domain.types.PaymentProvider;
+import com.ticketrush.boundedcontext.payment.domain.types.PaymentStatus;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class PaymentTest {
+
+  private Payment payment(PaymentStatus status) {
+    return Payment.builder()
+        .bookingId(100L)
+        .userId(10L)
+        .seatId(200L)
+        .provider(PaymentProvider.TOSS)
+        .amount(55_000L)
+        .status(status)
+        .paymentKey("pgKey_xyz")
+        .approvalNumber("approval-1")
+        .paidAt(LocalDateTime.of(2026, 5, 22, 10, 0))
+        .build();
+  }
+
+  @Test
+  @DisplayName("COMPLETED 결제는 markCanceled로 CANCELED 상태로 전이한다")
+  void markCanceled_transitions_from_completed() {
+    // given
+    Payment payment = payment(PaymentStatus.COMPLETED);
+
+    // when
+    payment.markCanceled();
+
+    // then
+    assertThat(payment.getStatus()).isEqualTo(PaymentStatus.CANCELED);
+  }
+
+  @Test
+  @DisplayName("이미 CANCELED 된 결제에 markCanceled를 호출하면 IllegalStateException을 던진다")
+  void markCanceled_rejects_already_canceled() {
+    // given
+    Payment payment = payment(PaymentStatus.CANCELED);
+
+    // expect
+    assertThatThrownBy(payment::markCanceled).isInstanceOf(IllegalStateException.class);
+  }
+
+  @Test
+  @DisplayName("COMPLETED가 아닌 상태(PENDING)에서 markCanceled를 호출하면 IllegalStateException을 던진다")
+  void markCanceled_rejects_non_completed() {
+    // given
+    Payment payment = payment(PaymentStatus.PENDING);
+
+    // expect
+    assertThatThrownBy(payment::markCanceled).isInstanceOf(IllegalStateException.class);
+  }
+}

--- a/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/out/apiclient/PaymentApprovalClientRouterTest.java
+++ b/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/out/apiclient/PaymentApprovalClientRouterTest.java
@@ -4,6 +4,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
 import com.ticketrush.boundedcontext.payment.domain.types.PaymentProvider;
 import com.ticketrush.global.exception.BusinessException;
@@ -22,27 +24,32 @@ class PaymentApprovalClientRouterTest {
   @Mock private PaymentApprovalClient tossClient;
   @Mock private PaymentApprovalClient stubClient;
 
+  private PaymentApprovalRequest request(PaymentProvider provider) {
+    return new PaymentApprovalRequest(provider, "key", "BKG-0000001", 1L, 1_000L);
+  }
+
   @Test
-  @DisplayName("provider를 지원하는 첫 번째 클라이언트로 위임한다")
-  void approve_delegates_to_supporting_client() {
-    given(tossClient.supports(PaymentProvider.TOSS)).willReturn(true);
+  @DisplayName("provider에 매핑된 실제 클라이언트로 위임한다")
+  void approve_delegates_to_mapped_client() {
+    given(tossClient.isFallback()).willReturn(false);
+    given(tossClient.provider()).willReturn(PaymentProvider.TOSS);
     PaymentApprovalResponse response =
         new PaymentApprovalResponse("APR-1", 1_000L, LocalDateTime.now());
     given(tossClient.approve(any())).willReturn(response);
 
     PaymentApprovalClientRouter router = new PaymentApprovalClientRouter(List.of(tossClient));
 
-    PaymentApprovalResponse actual =
-        router.approve(
-            new PaymentApprovalRequest(PaymentProvider.TOSS, "key", "BKG-0000001", 1L, 1_000L));
+    PaymentApprovalResponse actual = router.approve(request(PaymentProvider.TOSS));
 
     assertThat(actual).isEqualTo(response);
   }
 
   @Test
-  @DisplayName("등록 순서가 빠른 클라이언트가 우선 매칭된다 (Stub은 fallback)")
-  void approve_picks_first_supporting_client() {
-    given(tossClient.supports(PaymentProvider.TOSS)).willReturn(true);
+  @DisplayName("실제 provider 구현체가 있으면 fallback(stub)보다 우선 선택된다")
+  void approve_prefers_real_client_over_fallback() {
+    given(tossClient.isFallback()).willReturn(false);
+    given(tossClient.provider()).willReturn(PaymentProvider.TOSS);
+    given(stubClient.isFallback()).willReturn(true);
     PaymentApprovalResponse response =
         new PaymentApprovalResponse("APR-1", 1_000L, LocalDateTime.now());
     given(tossClient.approve(any())).willReturn(response);
@@ -50,22 +57,40 @@ class PaymentApprovalClientRouterTest {
     PaymentApprovalClientRouter router =
         new PaymentApprovalClientRouter(List.of(tossClient, stubClient));
 
-    router.approve(
-        new PaymentApprovalRequest(PaymentProvider.TOSS, "key", "BKG-0000001", 1L, 1_000L));
+    router.approve(request(PaymentProvider.TOSS));
+
+    verify(tossClient).approve(any());
+    verify(stubClient, never()).approve(any());
   }
 
   @Test
-  @DisplayName("지원하는 클라이언트가 없으면 PAYMENT_400_002 예외가 발생한다")
-  void approve_throws_when_no_client_supports_provider() {
-    given(tossClient.supports(PaymentProvider.KAKAO)).willReturn(false);
+  @DisplayName("매핑된 실제 구현체가 없으면 fallback(stub)으로 위임한다")
+  void approve_falls_back_to_stub_when_no_real_client() {
+    given(tossClient.isFallback()).willReturn(false);
+    given(tossClient.provider()).willReturn(PaymentProvider.TOSS);
+    given(stubClient.isFallback()).willReturn(true);
+    PaymentApprovalResponse response =
+        new PaymentApprovalResponse("APR-1", 1_000L, LocalDateTime.now());
+    given(stubClient.approve(any())).willReturn(response);
+
+    PaymentApprovalClientRouter router =
+        new PaymentApprovalClientRouter(List.of(tossClient, stubClient));
+
+    PaymentApprovalResponse actual = router.approve(request(PaymentProvider.KAKAO));
+
+    assertThat(actual).isEqualTo(response);
+    verify(tossClient, never()).approve(any());
+  }
+
+  @Test
+  @DisplayName("매핑된 구현체도 fallback도 없으면 PAYMENT_400_002 예외가 발생한다")
+  void approve_throws_when_no_client_and_no_fallback() {
+    given(tossClient.isFallback()).willReturn(false);
+    given(tossClient.provider()).willReturn(PaymentProvider.TOSS);
 
     PaymentApprovalClientRouter router = new PaymentApprovalClientRouter(List.of(tossClient));
 
-    assertThatThrownBy(
-            () ->
-                router.approve(
-                    new PaymentApprovalRequest(
-                        PaymentProvider.KAKAO, "key", "BKG-0000001", 1L, 1_000L)))
+    assertThatThrownBy(() -> router.approve(request(PaymentProvider.KAKAO)))
         .isInstanceOf(BusinessException.class)
         .extracting("errorStatus")
         .isEqualTo(ErrorStatus.PAYMENT_PROVIDER_NOT_SUPPORTED);

--- a/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/out/apiclient/PaymentApprovalClientRouterTest.java
+++ b/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/out/apiclient/PaymentApprovalClientRouterTest.java
@@ -23,6 +23,7 @@ class PaymentApprovalClientRouterTest {
 
   @Mock private PaymentApprovalClient tossClient;
   @Mock private PaymentApprovalClient stubClient;
+  @Mock private PaymentApprovalClient duplicateTossClient;
 
   private PaymentApprovalRequest request(PaymentProvider provider) {
     return new PaymentApprovalRequest(provider, "key", "BKG-0000001", 1L, 1_000L);
@@ -94,5 +95,18 @@ class PaymentApprovalClientRouterTest {
         .isInstanceOf(BusinessException.class)
         .extracting("errorStatus")
         .isEqualTo(ErrorStatus.PAYMENT_PROVIDER_NOT_SUPPORTED);
+  }
+
+  @Test
+  @DisplayName("같은 provider 구현체가 둘 이상이면 기동(생성자) 시점에 실패한다")
+  void fails_fast_on_duplicate_provider() {
+    given(tossClient.isFallback()).willReturn(false);
+    given(tossClient.provider()).willReturn(PaymentProvider.TOSS);
+    given(duplicateTossClient.isFallback()).willReturn(false);
+    given(duplicateTossClient.provider()).willReturn(PaymentProvider.TOSS);
+
+    assertThatThrownBy(
+            () -> new PaymentApprovalClientRouter(List.of(tossClient, duplicateTossClient)))
+        .isInstanceOf(IllegalStateException.class);
   }
 }

--- a/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/out/apiclient/PaymentCancelClientRouterTest.java
+++ b/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/out/apiclient/PaymentCancelClientRouterTest.java
@@ -4,6 +4,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
 import com.ticketrush.boundedcontext.payment.domain.types.PaymentProvider;
 import com.ticketrush.global.exception.BusinessException;
@@ -22,27 +24,32 @@ class PaymentCancelClientRouterTest {
   @Mock private PaymentCancelClient tossClient;
   @Mock private PaymentCancelClient stubClient;
 
+  private PaymentCancelCommand command(PaymentProvider provider) {
+    return new PaymentCancelCommand(provider, "key", 1_000L, "사유", "REFUND-0000001");
+  }
+
   @Test
-  @DisplayName("provider를 지원하는 첫 번째 클라이언트로 위임한다")
-  void cancel_delegates_to_supporting_client() {
-    given(tossClient.supports(PaymentProvider.TOSS)).willReturn(true);
+  @DisplayName("provider에 매핑된 실제 클라이언트로 위임한다")
+  void cancel_delegates_to_mapped_client() {
+    given(tossClient.isFallback()).willReturn(false);
+    given(tossClient.provider()).willReturn(PaymentProvider.TOSS);
     PaymentCancelResult result =
         new PaymentCancelResult("PG-REFUND-1", 1_000L, LocalDateTime.now());
     given(tossClient.cancel(any())).willReturn(result);
 
     PaymentCancelClientRouter router = new PaymentCancelClientRouter(List.of(tossClient));
 
-    PaymentCancelResult actual =
-        router.cancel(
-            new PaymentCancelCommand(PaymentProvider.TOSS, "key", 1_000L, "사유", "REFUND-0000001"));
+    PaymentCancelResult actual = router.cancel(command(PaymentProvider.TOSS));
 
     assertThat(actual).isEqualTo(result);
   }
 
   @Test
-  @DisplayName("등록 순서가 빠른 클라이언트가 우선 매칭된다 (Stub은 fallback)")
-  void cancel_picks_first_supporting_client() {
-    given(tossClient.supports(PaymentProvider.TOSS)).willReturn(true);
+  @DisplayName("실제 provider 구현체가 있으면 fallback(stub)보다 우선 선택된다")
+  void cancel_prefers_real_client_over_fallback() {
+    given(tossClient.isFallback()).willReturn(false);
+    given(tossClient.provider()).willReturn(PaymentProvider.TOSS);
+    given(stubClient.isFallback()).willReturn(true);
     PaymentCancelResult result =
         new PaymentCancelResult("PG-REFUND-1", 1_000L, LocalDateTime.now());
     given(tossClient.cancel(any())).willReturn(result);
@@ -50,22 +57,40 @@ class PaymentCancelClientRouterTest {
     PaymentCancelClientRouter router =
         new PaymentCancelClientRouter(List.of(tossClient, stubClient));
 
-    router.cancel(
-        new PaymentCancelCommand(PaymentProvider.TOSS, "key", 1_000L, "사유", "REFUND-0000001"));
+    router.cancel(command(PaymentProvider.TOSS));
+
+    verify(tossClient).cancel(any());
+    verify(stubClient, never()).cancel(any());
   }
 
   @Test
-  @DisplayName("지원하는 클라이언트가 없으면 PAYMENT_400_002 예외가 발생한다")
-  void cancel_throws_when_no_client_supports_provider() {
-    given(tossClient.supports(PaymentProvider.KAKAO)).willReturn(false);
+  @DisplayName("매핑된 실제 구현체가 없으면 fallback(stub)으로 위임한다")
+  void cancel_falls_back_to_stub_when_no_real_client() {
+    given(tossClient.isFallback()).willReturn(false);
+    given(tossClient.provider()).willReturn(PaymentProvider.TOSS);
+    given(stubClient.isFallback()).willReturn(true);
+    PaymentCancelResult result =
+        new PaymentCancelResult("PG-REFUND-1", 1_000L, LocalDateTime.now());
+    given(stubClient.cancel(any())).willReturn(result);
+
+    PaymentCancelClientRouter router =
+        new PaymentCancelClientRouter(List.of(tossClient, stubClient));
+
+    PaymentCancelResult actual = router.cancel(command(PaymentProvider.KAKAO));
+
+    assertThat(actual).isEqualTo(result);
+    verify(tossClient, never()).cancel(any());
+  }
+
+  @Test
+  @DisplayName("매핑된 구현체도 fallback도 없으면 PAYMENT_400_002 예외가 발생한다")
+  void cancel_throws_when_no_client_and_no_fallback() {
+    given(tossClient.isFallback()).willReturn(false);
+    given(tossClient.provider()).willReturn(PaymentProvider.TOSS);
 
     PaymentCancelClientRouter router = new PaymentCancelClientRouter(List.of(tossClient));
 
-    assertThatThrownBy(
-            () ->
-                router.cancel(
-                    new PaymentCancelCommand(
-                        PaymentProvider.KAKAO, "key", 1_000L, "사유", "REFUND-0000001")))
+    assertThatThrownBy(() -> router.cancel(command(PaymentProvider.KAKAO)))
         .isInstanceOf(BusinessException.class)
         .extracting("errorStatus")
         .isEqualTo(ErrorStatus.PAYMENT_PROVIDER_NOT_SUPPORTED);

--- a/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/out/apiclient/PaymentCancelClientRouterTest.java
+++ b/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/out/apiclient/PaymentCancelClientRouterTest.java
@@ -23,6 +23,7 @@ class PaymentCancelClientRouterTest {
 
   @Mock private PaymentCancelClient tossClient;
   @Mock private PaymentCancelClient stubClient;
+  @Mock private PaymentCancelClient duplicateTossClient;
 
   private PaymentCancelCommand command(PaymentProvider provider) {
     return new PaymentCancelCommand(provider, "key", 1_000L, "사유", "REFUND-0000001");
@@ -94,5 +95,18 @@ class PaymentCancelClientRouterTest {
         .isInstanceOf(BusinessException.class)
         .extracting("errorStatus")
         .isEqualTo(ErrorStatus.PAYMENT_PROVIDER_NOT_SUPPORTED);
+  }
+
+  @Test
+  @DisplayName("같은 provider 구현체가 둘 이상이면 기동(생성자) 시점에 실패한다")
+  void fails_fast_on_duplicate_provider() {
+    given(tossClient.isFallback()).willReturn(false);
+    given(tossClient.provider()).willReturn(PaymentProvider.TOSS);
+    given(duplicateTossClient.isFallback()).willReturn(false);
+    given(duplicateTossClient.provider()).willReturn(PaymentProvider.TOSS);
+
+    assertThatThrownBy(
+            () -> new PaymentCancelClientRouter(List.of(tossClient, duplicateTossClient)))
+        .isInstanceOf(IllegalStateException.class);
   }
 }

--- a/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/out/apiclient/StubPaymentApprovalClientTest.java
+++ b/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/out/apiclient/StubPaymentApprovalClientTest.java
@@ -1,6 +1,7 @@
 package com.ticketrush.boundedcontext.payment.out.apiclient;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.ticketrush.boundedcontext.payment.domain.types.PaymentProvider;
 import org.junit.jupiter.api.DisplayName;
@@ -11,11 +12,15 @@ class StubPaymentApprovalClientTest {
   private final StubPaymentApprovalClient client = new StubPaymentApprovalClient();
 
   @Test
-  @DisplayName("모든 provider를 지원한다 (fallback 클라이언트)")
-  void supports_all_providers() {
-    assertThat(client.supports(PaymentProvider.TOSS)).isTrue();
-    assertThat(client.supports(PaymentProvider.KAKAO)).isTrue();
-    assertThat(client.supports(PaymentProvider.NAVER)).isTrue();
+  @DisplayName("fallback 클라이언트로 표시된다")
+  void is_fallback() {
+    assertThat(client.isFallback()).isTrue();
+  }
+
+  @Test
+  @DisplayName("fallback 이므로 단일 provider 매핑 조회 시 예외를 던진다")
+  void provider_throws() {
+    assertThatThrownBy(client::provider).isInstanceOf(UnsupportedOperationException.class);
   }
 
   @Test

--- a/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/out/apiclient/StubPaymentCancelClientTest.java
+++ b/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/out/apiclient/StubPaymentCancelClientTest.java
@@ -1,6 +1,7 @@
 package com.ticketrush.boundedcontext.payment.out.apiclient;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.ticketrush.boundedcontext.payment.domain.types.PaymentProvider;
 import org.junit.jupiter.api.DisplayName;
@@ -11,11 +12,15 @@ class StubPaymentCancelClientTest {
   private final StubPaymentCancelClient client = new StubPaymentCancelClient();
 
   @Test
-  @DisplayName("모든 provider를 지원한다 (fallback 클라이언트)")
-  void supports_all_providers() {
-    assertThat(client.supports(PaymentProvider.TOSS)).isTrue();
-    assertThat(client.supports(PaymentProvider.KAKAO)).isTrue();
-    assertThat(client.supports(PaymentProvider.NAVER)).isTrue();
+  @DisplayName("fallback 클라이언트로 표시된다")
+  void is_fallback() {
+    assertThat(client.isFallback()).isTrue();
+  }
+
+  @Test
+  @DisplayName("fallback 이므로 단일 provider 매핑 조회 시 예외를 던진다")
+  void provider_throws() {
+    assertThatThrownBy(client::provider).isInstanceOf(UnsupportedOperationException.class);
   }
 
   @Test

--- a/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/out/apiclient/TossPaymentApprovalClientTest.java
+++ b/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/out/apiclient/TossPaymentApprovalClientTest.java
@@ -1,4 +1,4 @@
-package com.ticketrush.boundedcontext.payment.out.apiclient.toss;
+package com.ticketrush.boundedcontext.payment.out.apiclient;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -12,8 +12,6 @@ import static org.springframework.test.web.client.response.MockRestResponseCreat
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.ticketrush.boundedcontext.payment.domain.types.PaymentProvider;
-import com.ticketrush.boundedcontext.payment.out.apiclient.PaymentApprovalRequest;
-import com.ticketrush.boundedcontext.payment.out.apiclient.PaymentApprovalResponse;
 import com.ticketrush.global.exception.BusinessException;
 import com.ticketrush.global.status.ErrorStatus;
 import org.junit.jupiter.api.BeforeEach;

--- a/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/out/apiclient/TossPaymentApprovalClientTest.java
+++ b/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/out/apiclient/TossPaymentApprovalClientTest.java
@@ -278,10 +278,9 @@ class TossPaymentApprovalClientTest {
   }
 
   @Test
-  @DisplayName("TOSS provider만 지원한다")
-  void supports_toss_only() {
-    assertThat(client.supports(PaymentProvider.TOSS)).isTrue();
-    assertThat(client.supports(PaymentProvider.KAKAO)).isFalse();
-    assertThat(client.supports(PaymentProvider.NAVER)).isFalse();
+  @DisplayName("TOSS provider를 담당한다")
+  void provider_is_toss() {
+    assertThat(client.provider()).isEqualTo(PaymentProvider.TOSS);
+    assertThat(client.isFallback()).isFalse();
   }
 }

--- a/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/out/apiclient/TossPaymentCancelClientTest.java
+++ b/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/out/apiclient/TossPaymentCancelClientTest.java
@@ -1,4 +1,4 @@
-package com.ticketrush.boundedcontext.payment.out.apiclient.toss;
+package com.ticketrush.boundedcontext.payment.out.apiclient;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -12,8 +12,6 @@ import static org.springframework.test.web.client.response.MockRestResponseCreat
 import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
 
 import com.ticketrush.boundedcontext.payment.domain.types.PaymentProvider;
-import com.ticketrush.boundedcontext.payment.out.apiclient.PaymentCancelCommand;
-import com.ticketrush.boundedcontext.payment.out.apiclient.PaymentCancelResult;
 import com.ticketrush.global.exception.BusinessException;
 import com.ticketrush.global.status.ErrorStatus;
 import org.junit.jupiter.api.BeforeEach;

--- a/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/out/apiclient/TossPaymentCancelClientTest.java
+++ b/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/out/apiclient/TossPaymentCancelClientTest.java
@@ -200,11 +200,10 @@ class TossPaymentCancelClientTest {
   }
 
   @Test
-  @DisplayName("TOSS provider만 지원한다")
-  void supports_toss_only() {
-    assertThat(client.supports(PaymentProvider.TOSS)).isTrue();
-    assertThat(client.supports(PaymentProvider.KAKAO)).isFalse();
-    assertThat(client.supports(PaymentProvider.NAVER)).isFalse();
+  @DisplayName("TOSS provider를 담당한다")
+  void provider_is_toss() {
+    assertThat(client.provider()).isEqualTo(PaymentProvider.TOSS);
+    assertThat(client.isFallback()).isFalse();
   }
 
   private PaymentCancelCommand command() {


### PR DESCRIPTION
## 🔗 관련 이슈

- close #276

---

## 📌 주요 변경 사항

- 결제 confirm/cancel의 PG 외부 호출을 트랜잭션 경계 밖으로 분리해 DB 커넥션 장시간 점유 제거
- 이벤트 발행을 영속화 커밋 이후로 정렬해 dual-write 불일치 구조적 제거
- PG 클라이언트 라우터를 `List + supports()` 순회 → `Map<PaymentProvider, *Client>` 조회로 전환하고 Stub fallback을 명시화
- `out/apiclient/toss/` 하위 패키지 평탄화
- 취소 환불 정합성 오류(502→500) ErrorStatus 분리, `markCanceled` 상태 가드, 환불 이벤트 reason SSOT 정리

---

## 🛠 상세 구현 내용

- **confirm 트랜잭션 제거**: `PaymentConfirmUseCase`는 쓰기가 `save` 단건이라 클래스 레벨 `@Transactional` 제거. PG 승인이 트랜잭션에 갇히지 않으며, 이벤트는 save 커밋 이후 호출되어 커밋된 데이터만 전파.
- **cancel 트랜잭션 분리**: PG 취소(외부 왕복)는 트랜잭션 밖에서 호출하고, 영속화(refund `saveAndFlush` + `markCanceled`)만 신규 `PaymentCancelPersister`(`@Transactional`)의 짧은 트랜잭션으로 분리. detached 엔티티를 트랜잭션 안에서 재조회(managed)해 상태 전이. `saveAndFlush`를 먼저 호출해 동시 취소 시 paymentId unique 위반을 상태 전이/발행 이전에 표면화하며, 위반은 기존대로 `PaymentFacade`의 catch에서 멱등 처리(멱등 동작 보존).
- **PG 라우터 Map 전환**: 인터페이스 `supports(provider)` → `provider()` + `default isFallback()`. 라우터 생성자에서 non-fallback 구현체를 `provider()` 키로 `Map`에 등록(중복 provider는 기동 시 실패), 매칭 없으면 fallback(`isFallback()==true`) → 둘 다 없으면 `PAYMENT_PROVIDER_NOT_SUPPORTED`. Stub은 `isFallback()=true`/`provider()`는 `UnsupportedOperationException`, `@Order` 제거.
- **소규모**: `PAYMENT_REFUND_INCONSISTENT`(500) 신규 — CANCELED인데 환불 없음을 PG 실패(502)가 아닌 내부 정합성 오류로 분리. `Payment.markCanceled()`는 COMPLETED 외 상태에서 `IllegalStateException`. `publishCanceled` reason을 영속화된 `saved.getReason()` 기준으로 통일.

---

## ✅ 테스트

### 테스트 방법

- `./gradlew :common:compileJava :common:checkstyleMain` (ErrorStatus 추가)
- `./gradlew :payment-service:spotlessCheck :payment-service:checkstyleMain :payment-service:checkstyleTest :payment-service:compileJava :payment-service:test`
- 신규/수정 단위 테스트:
  - `PaymentCancelPersisterTest` (신규): 환불 저장+CANCELED 전이, unique 위반 전파 시 상태 미변경, 결제 미존재 예외
  - `PaymentCancelUseCaseTest`: persist 위임 구조 반영, 발행이 persist 이후임을 `InOrder`로 검증, PG 실패/unique 위반 시 미발행, 정합성 오류(500)
  - `PaymentConfirmUseCaseTest`: save→publish 순서 `InOrder` 검증
  - `PaymentTest` (신규): markCanceled 상태 가드(COMPLETED만 허용)
  - `PaymentApprovalClientRouterTest`/`PaymentCancelClientRouterTest`: Map 매핑/fallback/중복 provider 기동 실패
  - `Stub*ClientTest`/`TossPayment*ClientTest`: isFallback/provider 계약

### 테스트 결과

- 전체 BUILD SUCCESSFUL (spotlessCheck·checkstyleMain·checkstyleTest·compileJava·test 통과)

### 📸 스크린샷

-

---

## 👀 리뷰 요청 사항

- cancel의 트랜잭션 경계 분리(`PaymentCancelPersister`) 설계와 멱등성(unique 위반 → `PaymentFacade` catch) 보존 여부를 중점적으로 봐주세요.
- (셀프 리뷰 이월) **"PG 성공 후 영속화 실패" 윈도우**: 환불은 됐는데 DB 반영 실패 시 `DataIntegrityViolationException` 외 예외는 generic 500으로 노출됩니다. 고정 멱등 키로 재시도 복구는 가능하나, 보상 트랜잭션·모니터링은 #91 범위입니다.
- (컨벤션) `PaymentCancelPersister`는 self-invocation 우회를 위해 비-UseCase에 `@Transactional`을 부착했습니다. 트랜잭션 경계 규칙 예외로 봐주시고, 필요 시 컨벤션 문서 보완은 별도 docs 이슈로 다루겠습니다.

---

## ⚠️ 배포 시 주의사항

- `ErrorStatus`(common) 변경 — common 의존 전 모듈 재빌드 필요(코드 추가만, 기존 코드 영향 없음).
- PG 라우터/Stub 동작은 기존 `payment.pg.toss.enabled` / `payment.pg.stub.enabled` 설정 그대로 사용(설정 변경 불필요).
