### PR TITLE
[Feat] #218 QR 토큰 검증 및 입장 처리 API 구현

### DIFF
--- a/common/src/main/java/com/ticketrush/global/status/ErrorStatus.java
+++ b/common/src/main/java/com/ticketrush/global/status/ErrorStatus.java
@@ -171,11 +171,18 @@ public enum ErrorStatus {
   PAYMENT_PG_COMMUNICATION_FAILED(
       HttpStatus.SERVICE_UNAVAILABLE, "PAYMENT_503_001", "PG사와 통신에 실패했습니다."),
 
+  // Ticket 400
+  TICKET_QR_INVALID(HttpStatus.BAD_REQUEST, "TICKET_400_001", "유효하지 않은 QR입니다."),
+
+  // Ticket 401
+  TICKET_QR_EXPIRED(HttpStatus.UNAUTHORIZED, "TICKET_401_001", "만료된 QR입니다. 다시 발급받아 주세요."),
+
   // Ticket 404
   TICKET_NOT_FOUND(HttpStatus.NOT_FOUND, "TICKET_404_001", "입장권을 찾을 수 없습니다."),
 
   // Ticket 409
   TICKET_NOT_USABLE(HttpStatus.CONFLICT, "TICKET_409_001", "확정된 예매가 아니어서 입장권을 조회할 수 없습니다."),
+  TICKET_ALREADY_USED(HttpStatus.CONFLICT, "TICKET_409_002", "이미 입장 처리된 입장권입니다."),
 
   // Ticket 503
   TICKET_BOOKING_COMMUNICATION_FAILED(

--- a/ticket-service/src/main/java/com/ticketrush/boundedcontext/ticket/app/dto/request/EntryVerifyRequest.java
+++ b/ticket-service/src/main/java/com/ticketrush/boundedcontext/ticket/app/dto/request/EntryVerifyRequest.java
@@ -1,0 +1,10 @@
+package com.ticketrush.boundedcontext.ticket.app.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+@Schema(description = "QR 토큰 검증/입장 처리 요청")
+public record EntryVerifyRequest(
+    @Schema(description = "스캔한 QR payload(JWT)", example = "eyJhbGciOiJIUzI1NiJ9.eyJ0aWQiOjF9...")
+        @NotBlank(message = "QR 토큰은 필수입니다.")
+        String token) {}

--- a/ticket-service/src/main/java/com/ticketrush/boundedcontext/ticket/app/dto/response/EntryCheckInResponse.java
+++ b/ticket-service/src/main/java/com/ticketrush/boundedcontext/ticket/app/dto/response/EntryCheckInResponse.java
@@ -1,0 +1,16 @@
+package com.ticketrush.boundedcontext.ticket.app.dto.response;
+
+import com.ticketrush.boundedcontext.ticket.domain.types.TicketStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+
+@Schema(description = "입장 처리 응답")
+public record EntryCheckInResponse(
+    @Schema(description = "입장권 ID", example = "1") Long ticketId,
+    @Schema(description = "입장권 상태", example = "USED") TicketStatus ticketStatus,
+    @Schema(description = "입장(사용) 처리 시각", example = "2026-06-26 19:30:00") LocalDateTime usedAt) {
+
+  public static EntryCheckInResponse of(Long ticketId, LocalDateTime usedAt) {
+    return new EntryCheckInResponse(ticketId, TicketStatus.USED, usedAt);
+  }
+}

--- a/ticket-service/src/main/java/com/ticketrush/boundedcontext/ticket/app/dto/response/EntryVerifyResponse.java
+++ b/ticket-service/src/main/java/com/ticketrush/boundedcontext/ticket/app/dto/response/EntryVerifyResponse.java
@@ -1,0 +1,16 @@
+package com.ticketrush.boundedcontext.ticket.app.dto.response;
+
+import com.ticketrush.boundedcontext.ticket.domain.entity.Ticket;
+import com.ticketrush.boundedcontext.ticket.domain.types.TicketStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "QR 토큰 검증 응답(입장 가능 상태)")
+public record EntryVerifyResponse(
+    @Schema(description = "입장권 ID", example = "1") Long ticketId,
+    @Schema(description = "예매 ID", example = "100") Long bookingId,
+    @Schema(description = "입장권 상태", example = "UNUSED") TicketStatus ticketStatus) {
+
+  public static EntryVerifyResponse of(Ticket ticket) {
+    return new EntryVerifyResponse(ticket.getId(), ticket.getBookingId(), ticket.getTicketStatus());
+  }
+}

--- a/ticket-service/src/main/java/com/ticketrush/boundedcontext/ticket/app/support/TicketCheckInProcessor.java
+++ b/ticket-service/src/main/java/com/ticketrush/boundedcontext/ticket/app/support/TicketCheckInProcessor.java
@@ -1,0 +1,46 @@
+package com.ticketrush.boundedcontext.ticket.app.support;
+
+import com.ticketrush.boundedcontext.ticket.app.dto.response.EntryCheckInResponse;
+import com.ticketrush.boundedcontext.ticket.domain.entity.Ticket;
+import com.ticketrush.boundedcontext.ticket.domain.types.TicketStatus;
+import com.ticketrush.boundedcontext.ticket.out.repository.TicketRepository;
+import com.ticketrush.global.exception.BusinessException;
+import com.ticketrush.global.status.ErrorStatus;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 입장권을 UNUSED -> USED로 1회만 전이시키는 조건부 UPDATE를 짧은 트랜잭션 경계에서 수행한다.
+ *
+ * <p>외부 동기 호출(검증)은 호출 측이 트랜잭션 밖에서 끝낸 뒤 ticketId만 넘기므로, 이 트랜잭션은 DB 작업만 담아 커넥션 점유를 최소화한다(REST 왕복이
+ * 트랜잭션 경계 안에 들어오지 않게 한다). 동시 스캔 시 조건부 UPDATE의 영향행수로 승패를 가린다(1행이면 성공, 0행이면 경쟁 패자).
+ */
+@Component
+@RequiredArgsConstructor
+public class TicketCheckInProcessor {
+
+  private final TicketRepository ticketRepository;
+
+  @Transactional
+  public EntryCheckInResponse markUsed(Long ticketId) {
+    LocalDateTime usedAt = LocalDateTime.now();
+    int updatedCount =
+        ticketRepository.markUsedById(ticketId, usedAt, TicketStatus.USED, TicketStatus.UNUSED);
+
+    if (updatedCount == 1) {
+      return EntryCheckInResponse.of(ticketId, usedAt);
+    }
+
+    // 0행: UNUSED가 아니어서 전이되지 않음. 사전 검증을 통과했어도 동시 스캔 경쟁에서 졌거나 그 사이 상태가 바뀐 경우다.
+    Ticket current =
+        ticketRepository
+            .findById(ticketId)
+            .orElseThrow(() -> new BusinessException(ErrorStatus.TICKET_NOT_FOUND));
+    if (current.getTicketStatus() == TicketStatus.USED) {
+      throw new BusinessException(ErrorStatus.TICKET_ALREADY_USED);
+    }
+    throw new BusinessException(ErrorStatus.TICKET_NOT_USABLE);
+  }
+}

--- a/ticket-service/src/main/java/com/ticketrush/boundedcontext/ticket/app/usecase/EntryCheckInUseCase.java
+++ b/ticket-service/src/main/java/com/ticketrush/boundedcontext/ticket/app/usecase/EntryCheckInUseCase.java
@@ -1,0 +1,27 @@
+package com.ticketrush.boundedcontext.ticket.app.usecase;
+
+import com.ticketrush.boundedcontext.ticket.app.dto.response.EntryCheckInResponse;
+import com.ticketrush.boundedcontext.ticket.app.support.TicketCheckInProcessor;
+import com.ticketrush.boundedcontext.ticket.domain.entity.Ticket;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class EntryCheckInUseCase {
+
+  private final EntryVerifyUseCase entryVerifyUseCase;
+  private final TicketCheckInProcessor ticketCheckInProcessor;
+
+  /**
+   * 검증을 통과한 입장권을 입장 처리(UNUSED -> USED)한다.
+   *
+   * <p>외부 동기 호출(booking)을 포함한 사전 검증({@link EntryVerifyUseCase#verifyAndLoad})은 트랜잭션 밖에서 수행하고, 상태
+   * 전이(조건부 UPDATE)만 짧은 트랜잭션({@link TicketCheckInProcessor#markUsed})에 담아 DB 커넥션 점유를 최소화한다. 조건부
+   * UPDATE 자체가 멱등·원자적이라, 검증과 전이를 한 트랜잭션으로 묶지 않아도 중복 입장은 막힌다.
+   */
+  public EntryCheckInResponse execute(String token) {
+    Ticket ticket = entryVerifyUseCase.verifyAndLoad(token);
+    return ticketCheckInProcessor.markUsed(ticket.getId());
+  }
+}

--- a/ticket-service/src/main/java/com/ticketrush/boundedcontext/ticket/app/usecase/EntryVerifyUseCase.java
+++ b/ticket-service/src/main/java/com/ticketrush/boundedcontext/ticket/app/usecase/EntryVerifyUseCase.java
@@ -1,0 +1,62 @@
+package com.ticketrush.boundedcontext.ticket.app.usecase;
+
+import com.ticketrush.boundedcontext.ticket.app.dto.response.EntryVerifyResponse;
+import com.ticketrush.boundedcontext.ticket.domain.entity.Ticket;
+import com.ticketrush.boundedcontext.ticket.domain.policy.TicketQrPayloadVerifier;
+import com.ticketrush.boundedcontext.ticket.domain.policy.VerifiedQrClaims;
+import com.ticketrush.boundedcontext.ticket.domain.types.TicketStatus;
+import com.ticketrush.boundedcontext.ticket.out.apiclient.BookingRestClient;
+import com.ticketrush.boundedcontext.ticket.out.apiclient.dto.BookingInfoResponse;
+import com.ticketrush.boundedcontext.ticket.out.repository.TicketRepository;
+import com.ticketrush.global.exception.BusinessException;
+import com.ticketrush.global.status.ErrorStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class EntryVerifyUseCase {
+
+  /** 확정된(CONFIRMED) 예매만 입장 가능하다. booking-service의 BookingStatus enum 이름과 일치. */
+  private static final String CONFIRMED_STATUS = "CONFIRMED";
+
+  private final TicketQrPayloadVerifier ticketQrPayloadVerifier;
+  private final TicketRepository ticketRepository;
+  private final BookingRestClient bookingRestClient;
+
+  /** QR을 검증해 입장 가능 상태를 반환한다(상태 변경 없음). */
+  public EntryVerifyResponse execute(String token) {
+    return EntryVerifyResponse.of(verifyAndLoad(token));
+  }
+
+  /**
+   * QR JWT 검증부터 입장 가능 입장권 로드까지의 공통 검증을 수행한다. verify와 check-in이 공유하며, 어느 한쪽도 검증을 건너뛰지 않도록 단일 진입점으로
+   * 둔다. 두 경로 모두 트랜잭션 밖에서 호출된다(외부 동기 호출인 booking 조회를 트랜잭션 경계에 들이지 않기 위함). check-in의 상태 전이는 검증 이후 별도의
+   * 짧은 트랜잭션({@code TicketCheckInProcessor#markUsed})에서 수행되며, 그 조건부 UPDATE가 멱등·원자적이라 검증과 전이를 한
+   * 트랜잭션으로 묶지 않아도 중복 입장은 막힌다.
+   *
+   * <p>검증 순서: 서명/형식({@code TICKET_QR_INVALID}) → 만료({@code TICKET_QR_EXPIRED}) → 입장권 존재({@code
+   * TICKET_NOT_FOUND}) → 예매 확정/취소({@code TICKET_NOT_USABLE}) → 이미 사용({@code TICKET_ALREADY_USED}).
+   */
+  public Ticket verifyAndLoad(String token) {
+    VerifiedQrClaims claims = ticketQrPayloadVerifier.verify(token);
+
+    Ticket ticket =
+        ticketRepository
+            .findById(claims.ticketId())
+            .orElseThrow(() -> new BusinessException(ErrorStatus.TICKET_NOT_FOUND));
+
+    // 취소 전파가 ticket-service로 들어오지 않으므로(로컬 ticketStatus만으로는 취소를 알 수 없음), 예매 확정/취소 판정은 booking 동기 조회로
+    // 한다.
+    BookingInfoResponse booking = bookingRestClient.getBooking(ticket.getBookingId());
+    if (!CONFIRMED_STATUS.equals(booking.bookingStatus())) {
+      throw new BusinessException(ErrorStatus.TICKET_NOT_USABLE);
+    }
+
+    if (ticket.getTicketStatus() == TicketStatus.USED) {
+      throw new BusinessException(ErrorStatus.TICKET_ALREADY_USED);
+    }
+
+    return ticket;
+  }
+}

--- a/ticket-service/src/main/java/com/ticketrush/boundedcontext/ticket/domain/policy/TicketQrPayloadVerifier.java
+++ b/ticket-service/src/main/java/com/ticketrush/boundedcontext/ticket/domain/policy/TicketQrPayloadVerifier.java
@@ -1,0 +1,45 @@
+package com.ticketrush.boundedcontext.ticket.domain.policy;
+
+import com.ticketrush.global.exception.BusinessException;
+import com.ticketrush.global.status.ErrorStatus;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import java.nio.charset.StandardCharsets;
+import javax.crypto.SecretKey;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+/**
+ * 스캔된 QR payload(JWT)의 서명·만료를 검증하고 입장권 식별자(tid)를 추출한다. {@link TicketQrPayloadGenerator}와 동일한 시크릿을
+ * 사용해 위·변조를 차단하며, 만료(TTL 경과)와 그 외 서명/형식 오류를 서로 다른 에러로 구분한다.
+ */
+@Component
+public class TicketQrPayloadVerifier {
+
+  private final SecretKey key;
+
+  public TicketQrPayloadVerifier(@Value("${ticket.qr.secret}") String secret) {
+    if (secret.getBytes(StandardCharsets.UTF_8).length < 32) {
+      throw new IllegalArgumentException("ticket.qr.secret 은 최소 32바이트 이상이어야 합니다.");
+    }
+    this.key = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+  }
+
+  public VerifiedQrClaims verify(String token) {
+    try {
+      Claims claims = Jwts.parser().verifyWith(key).build().parseSignedClaims(token).getPayload();
+      Long ticketId = ((Number) claims.get("tid")).longValue();
+      return new VerifiedQrClaims(ticketId);
+    } catch (ExpiredJwtException e) {
+      throw new BusinessException(ErrorStatus.TICKET_QR_EXPIRED);
+    } catch (JwtException
+        | IllegalArgumentException
+        | ClassCastException
+        | NullPointerException e) {
+      throw new BusinessException(ErrorStatus.TICKET_QR_INVALID);
+    }
+  }
+}

--- a/ticket-service/src/main/java/com/ticketrush/boundedcontext/ticket/domain/policy/VerifiedQrClaims.java
+++ b/ticket-service/src/main/java/com/ticketrush/boundedcontext/ticket/domain/policy/VerifiedQrClaims.java
@@ -1,0 +1,7 @@
+package com.ticketrush.boundedcontext.ticket.domain.policy;
+
+/**
+ * QR JWT 검증 결과. 서명·만료 검증을 통과한 토큰에서 추출한 입장권 식별자만 담는다. 예매 확정/취소·사용 여부 등 가변 상태는 신뢰 소스인 DB에서 다시 읽으므로
+ * 여기에 포함하지 않는다(생성 시점 스냅샷인 JWT의 {@code st} 클레임은 입장 판정에 쓰지 않는다).
+ */
+public record VerifiedQrClaims(Long ticketId) {}

--- a/ticket-service/src/main/java/com/ticketrush/boundedcontext/ticket/in/api/v1/EntryController.java
+++ b/ticket-service/src/main/java/com/ticketrush/boundedcontext/ticket/in/api/v1/EntryController.java
@@ -1,0 +1,50 @@
+package com.ticketrush.boundedcontext.ticket.in.api.v1;
+
+import com.ticketrush.boundedcontext.ticket.app.dto.request.EntryVerifyRequest;
+import com.ticketrush.boundedcontext.ticket.app.dto.response.EntryCheckInResponse;
+import com.ticketrush.boundedcontext.ticket.app.dto.response.EntryVerifyResponse;
+import com.ticketrush.boundedcontext.ticket.app.usecase.EntryCheckInUseCase;
+import com.ticketrush.boundedcontext.ticket.app.usecase.EntryVerifyUseCase;
+import com.ticketrush.global.dto.response.ApiResponse;
+import com.ticketrush.global.status.SuccessStatus;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Entry", description = "입장(검표) 관련 API")
+@RestController
+@RequestMapping("/api/v1/entries")
+@RequiredArgsConstructor
+public class EntryController {
+
+  private final EntryVerifyUseCase entryVerifyUseCase;
+  private final EntryCheckInUseCase entryCheckInUseCase;
+
+  @Operation(
+      summary = "QR 토큰 검증",
+      description =
+          "스캔한 QR payload의 서명·만료와 입장권/예매 상태를 검증해 입장 가능 여부를 반환합니다(상태 변경 없음). ADMIN 권한이 필요합니다.")
+  @PostMapping("/verify")
+  public ResponseEntity<ApiResponse<EntryVerifyResponse>> verify(
+      @Valid @RequestBody EntryVerifyRequest request) {
+    EntryVerifyResponse response = entryVerifyUseCase.execute(request.token());
+    return ApiResponse.onSuccess(SuccessStatus.OK, response);
+  }
+
+  @Operation(
+      summary = "입장 처리",
+      description =
+          "검증을 통과한 입장권을 사용 완료(USED)로 전이하고 입장 시각을 기록합니다. 동일 QR 중복 스캔은 한 번만 성공합니다. ADMIN 권한이 필요합니다.")
+  @PostMapping("/check-in")
+  public ResponseEntity<ApiResponse<EntryCheckInResponse>> checkIn(
+      @Valid @RequestBody EntryVerifyRequest request) {
+    EntryCheckInResponse response = entryCheckInUseCase.execute(request.token());
+    return ApiResponse.onSuccess(SuccessStatus.OK, response);
+  }
+}

--- a/ticket-service/src/main/java/com/ticketrush/boundedcontext/ticket/out/repository/TicketRepository.java
+++ b/ticket-service/src/main/java/com/ticketrush/boundedcontext/ticket/out/repository/TicketRepository.java
@@ -1,12 +1,31 @@
 package com.ticketrush.boundedcontext.ticket.out.repository;
 
 import com.ticketrush.boundedcontext.ticket.domain.entity.Ticket;
+import com.ticketrush.boundedcontext.ticket.domain.types.TicketStatus;
+import java.time.LocalDateTime;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface TicketRepository extends JpaRepository<Ticket, Long> {
 
   boolean existsByBookingId(Long bookingId);
 
   Optional<Ticket> findByBookingId(Long bookingId);
+
+  /**
+   * 입장권을 UNUSED -> USED로 1회만 전이시키는 조건부 UPDATE. {@code AND ticketStatus = :unused}가 동시성 가드 역할을 하여,
+   * 동일 QR이 동시에 여러 번 스캔돼도 단 1건만 1행을 갱신(영향행수 1)하고 나머지는 0행이 되어 중복 입장을 막는다.
+   */
+  @Modifying(clearAutomatically = true, flushAutomatically = true)
+  @Query(
+      "UPDATE Ticket t SET t.ticketStatus = :used, t.usedAt = :now "
+          + "WHERE t.id = :ticketId AND t.ticketStatus = :unused")
+  int markUsedById(
+      @Param("ticketId") Long ticketId,
+      @Param("now") LocalDateTime now,
+      @Param("used") TicketStatus used,
+      @Param("unused") TicketStatus unused);
 }

--- a/ticket-service/src/main/java/com/ticketrush/global/config/SecurityConfig.java
+++ b/ticket-service/src/main/java/com/ticketrush/global/config/SecurityConfig.java
@@ -33,26 +33,43 @@ public class SecurityConfig {
         .addFilterBefore(gatewayHeaderFilter, UsernamePasswordAuthenticationFilter.class)
         .exceptionHandling(
             exception ->
-                exception.authenticationEntryPoint(
-                    (request, response, authException) -> {
-                      response.setStatus(ErrorStatus.UNAUTHORIZED.getHttpStatus().value());
-                      response.setContentType(MediaType.APPLICATION_JSON_VALUE);
-                      response
-                          .getWriter()
-                          .write(
-                              """
+                exception
+                    .authenticationEntryPoint(
+                        (request, response, authException) -> {
+                          response.setStatus(ErrorStatus.UNAUTHORIZED.getHttpStatus().value());
+                          response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+                          response
+                              .getWriter()
+                              .write(
+                                  """
                               {"is_success":false,"code":"%s","message":"%s"}
                               """
-                                  .formatted(
-                                      ErrorStatus.UNAUTHORIZED.getCode(),
-                                      ErrorStatus.UNAUTHORIZED.getMessage()));
-                    }))
+                                      .formatted(
+                                          ErrorStatus.UNAUTHORIZED.getCode(),
+                                          ErrorStatus.UNAUTHORIZED.getMessage()));
+                        })
+                    .accessDeniedHandler(
+                        (request, response, accessDeniedException) -> {
+                          response.setStatus(ErrorStatus.FORBIDDEN.getHttpStatus().value());
+                          response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+                          response
+                              .getWriter()
+                              .write(
+                                  """
+                                  {"is_success":false,"code":"%s","message":"%s"}
+                                  """
+                                      .formatted(
+                                          ErrorStatus.FORBIDDEN.getCode(),
+                                          ErrorStatus.FORBIDDEN.getMessage()));
+                        }))
         .authorizeHttpRequests(
             auth ->
                 auth.requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html")
                     .permitAll()
                     .requestMatchers(HttpMethod.GET, "/api/v1/ticket/bookings/*/qr")
                     .authenticated()
+                    .requestMatchers(HttpMethod.POST, "/api/v1/entries/**")
+                    .hasRole("ADMIN")
                     .anyRequest()
                     .permitAll());
 

--- a/ticket-service/src/test/java/com/ticketrush/boundedcontext/ticket/app/support/TicketCheckInProcessorTest.java
+++ b/ticket-service/src/test/java/com/ticketrush/boundedcontext/ticket/app/support/TicketCheckInProcessorTest.java
@@ -1,0 +1,106 @@
+package com.ticketrush.boundedcontext.ticket.app.support;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+
+import com.ticketrush.boundedcontext.ticket.app.dto.response.EntryCheckInResponse;
+import com.ticketrush.boundedcontext.ticket.domain.entity.Ticket;
+import com.ticketrush.boundedcontext.ticket.domain.types.TicketStatus;
+import com.ticketrush.boundedcontext.ticket.out.repository.TicketRepository;
+import com.ticketrush.global.exception.BusinessException;
+import com.ticketrush.global.status.ErrorStatus;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class TicketCheckInProcessorTest {
+
+  @InjectMocks private TicketCheckInProcessor ticketCheckInProcessor;
+
+  @Mock private TicketRepository ticketRepository;
+
+  private Ticket ticket(Long id, TicketStatus status) {
+    Ticket ticket =
+        Ticket.builder().bookingId(100L).ticketTokenHash("hash").ticketStatus(status).build();
+    ReflectionTestUtils.setField(ticket, "id", id);
+    return ticket;
+  }
+
+  @Test
+  @DisplayName("성공: 1행 갱신이면 USED/usedAt을 담아 반환하고 재조회하지 않는다")
+  void markUsed_succeeds_when_one_row_updated() {
+    // given
+    given(
+            ticketRepository.markUsedById(
+                eq(1L), any(), eq(TicketStatus.USED), eq(TicketStatus.UNUSED)))
+        .willReturn(1);
+
+    // when
+    EntryCheckInResponse response = ticketCheckInProcessor.markUsed(1L);
+
+    // then
+    assertThat(response.ticketId()).isEqualTo(1L);
+    assertThat(response.ticketStatus()).isEqualTo(TicketStatus.USED);
+    assertThat(response.usedAt()).isNotNull();
+    then(ticketRepository).should(never()).findById(any());
+  }
+
+  @Test
+  @DisplayName("실패: 0행 갱신 + 현재 USED면 동시 스캔 패자로 TICKET_ALREADY_USED를 던진다")
+  void markUsed_fails_when_lost_race_already_used() {
+    // given
+    given(
+            ticketRepository.markUsedById(
+                eq(1L), any(), eq(TicketStatus.USED), eq(TicketStatus.UNUSED)))
+        .willReturn(0);
+    given(ticketRepository.findById(1L)).willReturn(Optional.of(ticket(1L, TicketStatus.USED)));
+
+    // when & then
+    assertThatThrownBy(() -> ticketCheckInProcessor.markUsed(1L))
+        .isInstanceOf(BusinessException.class)
+        .hasFieldOrPropertyWithValue("errorStatus", ErrorStatus.TICKET_ALREADY_USED);
+  }
+
+  @Test
+  @DisplayName("실패: 0행 갱신 + 입장권이 사라졌으면 TICKET_NOT_FOUND를 던진다")
+  void markUsed_fails_when_ticket_disappeared() {
+    // given
+    given(
+            ticketRepository.markUsedById(
+                eq(1L), any(), eq(TicketStatus.USED), eq(TicketStatus.UNUSED)))
+        .willReturn(0);
+    given(ticketRepository.findById(1L)).willReturn(Optional.empty());
+
+    // when & then
+    assertThatThrownBy(() -> ticketCheckInProcessor.markUsed(1L))
+        .isInstanceOf(BusinessException.class)
+        .hasFieldOrPropertyWithValue("errorStatus", ErrorStatus.TICKET_NOT_FOUND);
+  }
+
+  @Test
+  @DisplayName("실패: 0행 갱신 + UNUSED/USED가 아니면 TICKET_NOT_USABLE을 던진다")
+  void markUsed_fails_when_not_usable() {
+    // given
+    given(
+            ticketRepository.markUsedById(
+                eq(1L), any(), eq(TicketStatus.USED), eq(TicketStatus.UNUSED)))
+        .willReturn(0);
+    given(ticketRepository.findById(1L)).willReturn(Optional.of(ticket(1L, TicketStatus.CANCELED)));
+
+    // when & then
+    assertThatThrownBy(() -> ticketCheckInProcessor.markUsed(1L))
+        .isInstanceOf(BusinessException.class)
+        .hasFieldOrPropertyWithValue("errorStatus", ErrorStatus.TICKET_NOT_USABLE);
+  }
+}

--- a/ticket-service/src/test/java/com/ticketrush/boundedcontext/ticket/app/usecase/EntryCheckInUseCaseTest.java
+++ b/ticket-service/src/test/java/com/ticketrush/boundedcontext/ticket/app/usecase/EntryCheckInUseCaseTest.java
@@ -1,0 +1,76 @@
+package com.ticketrush.boundedcontext.ticket.app.usecase;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+
+import com.ticketrush.boundedcontext.ticket.app.dto.response.EntryCheckInResponse;
+import com.ticketrush.boundedcontext.ticket.app.support.TicketCheckInProcessor;
+import com.ticketrush.boundedcontext.ticket.domain.entity.Ticket;
+import com.ticketrush.boundedcontext.ticket.domain.types.TicketStatus;
+import com.ticketrush.global.exception.BusinessException;
+import com.ticketrush.global.status.ErrorStatus;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class EntryCheckInUseCaseTest {
+
+  private static final String TOKEN = "qr-token";
+
+  @InjectMocks private EntryCheckInUseCase entryCheckInUseCase;
+
+  @Mock private EntryVerifyUseCase entryVerifyUseCase;
+
+  @Mock private TicketCheckInProcessor ticketCheckInProcessor;
+
+  private Ticket ticket(Long id) {
+    Ticket ticket =
+        Ticket.builder()
+            .bookingId(100L)
+            .ticketTokenHash("hash")
+            .ticketStatus(TicketStatus.UNUSED)
+            .build();
+    ReflectionTestUtils.setField(ticket, "id", id);
+    return ticket;
+  }
+
+  @Test
+  @DisplayName("성공: 사전 검증 통과 입장권의 ID로 마킹 처리에 위임하고 결과를 반환한다")
+  void execute_delegates_to_processor() {
+    // given
+    given(entryVerifyUseCase.verifyAndLoad(TOKEN)).willReturn(ticket(1L));
+    EntryCheckInResponse expected =
+        EntryCheckInResponse.of(1L, LocalDateTime.of(2026, 6, 26, 19, 30, 0));
+    given(ticketCheckInProcessor.markUsed(1L)).willReturn(expected);
+
+    // when
+    EntryCheckInResponse response = entryCheckInUseCase.execute(TOKEN);
+
+    // then
+    assertThat(response).isEqualTo(expected);
+  }
+
+  @Test
+  @DisplayName("실패: 사전 검증에서 던진 예외는 그대로 전파하고 마킹을 시도하지 않는다")
+  void execute_propagates_verification_error() {
+    // given
+    given(entryVerifyUseCase.verifyAndLoad(TOKEN))
+        .willThrow(new BusinessException(ErrorStatus.TICKET_QR_EXPIRED));
+
+    // when & then
+    assertThatThrownBy(() -> entryCheckInUseCase.execute(TOKEN))
+        .isInstanceOf(BusinessException.class)
+        .hasFieldOrPropertyWithValue("errorStatus", ErrorStatus.TICKET_QR_EXPIRED);
+    then(ticketCheckInProcessor).should(never()).markUsed(any());
+  }
+}

--- a/ticket-service/src/test/java/com/ticketrush/boundedcontext/ticket/app/usecase/EntryVerifyUseCaseTest.java
+++ b/ticket-service/src/test/java/com/ticketrush/boundedcontext/ticket/app/usecase/EntryVerifyUseCaseTest.java
@@ -1,0 +1,126 @@
+package com.ticketrush.boundedcontext.ticket.app.usecase;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+
+import com.ticketrush.boundedcontext.ticket.app.dto.response.EntryVerifyResponse;
+import com.ticketrush.boundedcontext.ticket.domain.entity.Ticket;
+import com.ticketrush.boundedcontext.ticket.domain.policy.TicketQrPayloadVerifier;
+import com.ticketrush.boundedcontext.ticket.domain.policy.VerifiedQrClaims;
+import com.ticketrush.boundedcontext.ticket.domain.types.TicketStatus;
+import com.ticketrush.boundedcontext.ticket.out.apiclient.BookingRestClient;
+import com.ticketrush.boundedcontext.ticket.out.apiclient.dto.BookingInfoResponse;
+import com.ticketrush.boundedcontext.ticket.out.repository.TicketRepository;
+import com.ticketrush.global.exception.BusinessException;
+import com.ticketrush.global.status.ErrorStatus;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class EntryVerifyUseCaseTest {
+
+  private static final String TOKEN = "qr-token";
+
+  @InjectMocks private EntryVerifyUseCase entryVerifyUseCase;
+
+  @Mock private TicketQrPayloadVerifier ticketQrPayloadVerifier;
+
+  @Mock private TicketRepository ticketRepository;
+
+  @Mock private BookingRestClient bookingRestClient;
+
+  private Ticket ticket(Long id, Long bookingId, TicketStatus status) {
+    Ticket ticket =
+        Ticket.builder().bookingId(bookingId).ticketTokenHash("hash").ticketStatus(status).build();
+    ReflectionTestUtils.setField(ticket, "id", id);
+    return ticket;
+  }
+
+  @Test
+  @DisplayName("성공: 확정 예매의 미사용 입장권이면 입장 가능 정보를 반환한다")
+  void execute_returns_verify_response() {
+    // given
+    given(ticketQrPayloadVerifier.verify(TOKEN)).willReturn(new VerifiedQrClaims(1L));
+    given(ticketRepository.findById(1L))
+        .willReturn(Optional.of(ticket(1L, 100L, TicketStatus.UNUSED)));
+    given(bookingRestClient.getBooking(100L))
+        .willReturn(new BookingInfoResponse(100L, 10L, "CONFIRMED"));
+
+    // when
+    EntryVerifyResponse response = entryVerifyUseCase.execute(TOKEN);
+
+    // then
+    assertThat(response.ticketId()).isEqualTo(1L);
+    assertThat(response.bookingId()).isEqualTo(100L);
+    assertThat(response.ticketStatus()).isEqualTo(TicketStatus.UNUSED);
+  }
+
+  @Test
+  @DisplayName("실패: QR 서명/형식 오류는 검증기의 예외를 그대로 전파한다")
+  void execute_propagates_invalid_qr() {
+    // given
+    given(ticketQrPayloadVerifier.verify(TOKEN))
+        .willThrow(new BusinessException(ErrorStatus.TICKET_QR_INVALID));
+
+    // when & then
+    assertThatThrownBy(() -> entryVerifyUseCase.execute(TOKEN))
+        .isInstanceOf(BusinessException.class)
+        .hasFieldOrPropertyWithValue("errorStatus", ErrorStatus.TICKET_QR_INVALID);
+    then(ticketRepository).should(never()).findById(org.mockito.ArgumentMatchers.any());
+  }
+
+  @Test
+  @DisplayName("실패: 입장권이 존재하지 않으면 TICKET_NOT_FOUND를 던진다")
+  void execute_fails_when_ticket_not_found() {
+    // given
+    given(ticketQrPayloadVerifier.verify(TOKEN)).willReturn(new VerifiedQrClaims(1L));
+    given(ticketRepository.findById(1L)).willReturn(Optional.empty());
+
+    // when & then
+    assertThatThrownBy(() -> entryVerifyUseCase.execute(TOKEN))
+        .isInstanceOf(BusinessException.class)
+        .hasFieldOrPropertyWithValue("errorStatus", ErrorStatus.TICKET_NOT_FOUND);
+    then(bookingRestClient).should(never()).getBooking(org.mockito.ArgumentMatchers.any());
+  }
+
+  @Test
+  @DisplayName("실패: 확정되지 않은(취소 포함) 예매는 TICKET_NOT_USABLE을 던진다")
+  void execute_fails_when_not_confirmed() {
+    // given
+    given(ticketQrPayloadVerifier.verify(TOKEN)).willReturn(new VerifiedQrClaims(1L));
+    given(ticketRepository.findById(1L))
+        .willReturn(Optional.of(ticket(1L, 100L, TicketStatus.UNUSED)));
+    given(bookingRestClient.getBooking(100L))
+        .willReturn(new BookingInfoResponse(100L, 10L, "CANCELED"));
+
+    // when & then
+    assertThatThrownBy(() -> entryVerifyUseCase.execute(TOKEN))
+        .isInstanceOf(BusinessException.class)
+        .hasFieldOrPropertyWithValue("errorStatus", ErrorStatus.TICKET_NOT_USABLE);
+  }
+
+  @Test
+  @DisplayName("실패: 이미 사용된 입장권은 TICKET_ALREADY_USED를 던진다")
+  void execute_fails_when_already_used() {
+    // given
+    given(ticketQrPayloadVerifier.verify(TOKEN)).willReturn(new VerifiedQrClaims(1L));
+    given(ticketRepository.findById(1L))
+        .willReturn(Optional.of(ticket(1L, 100L, TicketStatus.USED)));
+    given(bookingRestClient.getBooking(100L))
+        .willReturn(new BookingInfoResponse(100L, 10L, "CONFIRMED"));
+
+    // when & then
+    assertThatThrownBy(() -> entryVerifyUseCase.execute(TOKEN))
+        .isInstanceOf(BusinessException.class)
+        .hasFieldOrPropertyWithValue("errorStatus", ErrorStatus.TICKET_ALREADY_USED);
+  }
+}

--- a/ticket-service/src/test/java/com/ticketrush/boundedcontext/ticket/domain/policy/TicketQrPayloadVerifierTest.java
+++ b/ticket-service/src/test/java/com/ticketrush/boundedcontext/ticket/domain/policy/TicketQrPayloadVerifierTest.java
@@ -1,0 +1,80 @@
+package com.ticketrush.boundedcontext.ticket.domain.policy;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.ticketrush.boundedcontext.ticket.domain.entity.Ticket;
+import com.ticketrush.boundedcontext.ticket.domain.types.TicketStatus;
+import com.ticketrush.global.exception.BusinessException;
+import com.ticketrush.global.status.ErrorStatus;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+class TicketQrPayloadVerifierTest {
+
+  private static final String SECRET = "ticketrush-qr-test-secret-key-0123456789";
+  private static final String OTHER_SECRET = "ticketrush-qr-other-secret-key-9876543210";
+
+  private final TicketQrPayloadGenerator generator = new TicketQrPayloadGenerator(SECRET, 300_000L);
+  private final TicketQrPayloadVerifier verifier = new TicketQrPayloadVerifier(SECRET);
+
+  private Ticket ticket(Long id) {
+    Ticket ticket =
+        Ticket.builder()
+            .bookingId(100L)
+            .ticketTokenHash("hash")
+            .ticketStatus(TicketStatus.UNUSED)
+            .build();
+    ReflectionTestUtils.setField(ticket, "id", id);
+    return ticket;
+  }
+
+  @Test
+  @DisplayName("성공: 유효한 QR 토큰을 검증하면 입장권 ID(tid)를 추출한다")
+  void verify_returns_ticket_id() {
+    // given
+    String token = generator.generate(ticket(7L)).payload();
+
+    // when
+    VerifiedQrClaims claims = verifier.verify(token);
+
+    // then
+    assertThat(claims.ticketId()).isEqualTo(7L);
+  }
+
+  @Test
+  @DisplayName("실패: 다른 시크릿으로 서명된 토큰은 TICKET_QR_INVALID를 던진다")
+  void verify_fails_when_signature_mismatch() {
+    // given
+    TicketQrPayloadGenerator forgedGenerator = new TicketQrPayloadGenerator(OTHER_SECRET, 300_000L);
+    String forgedToken = forgedGenerator.generate(ticket(1L)).payload();
+
+    // when & then
+    assertThatThrownBy(() -> verifier.verify(forgedToken))
+        .isInstanceOf(BusinessException.class)
+        .hasFieldOrPropertyWithValue("errorStatus", ErrorStatus.TICKET_QR_INVALID);
+  }
+
+  @Test
+  @DisplayName("실패: 형식이 깨진 토큰은 TICKET_QR_INVALID를 던진다")
+  void verify_fails_when_malformed() {
+    // when & then
+    assertThatThrownBy(() -> verifier.verify("not-a-jwt-token"))
+        .isInstanceOf(BusinessException.class)
+        .hasFieldOrPropertyWithValue("errorStatus", ErrorStatus.TICKET_QR_INVALID);
+  }
+
+  @Test
+  @DisplayName("실패: 만료된(TTL 경과) 토큰은 TICKET_QR_EXPIRED를 던진다")
+  void verify_fails_when_expired() {
+    // given: 이미 만료된 시점(now - 1s)으로 발급된 토큰
+    TicketQrPayloadGenerator expiredGenerator = new TicketQrPayloadGenerator(SECRET, -1_000L);
+    String expiredToken = expiredGenerator.generate(ticket(1L)).payload();
+
+    // when & then
+    assertThatThrownBy(() -> verifier.verify(expiredToken))
+        .isInstanceOf(BusinessException.class)
+        .hasFieldOrPropertyWithValue("errorStatus", ErrorStatus.TICKET_QR_EXPIRED);
+  }
+}

--- a/ticket-service/src/test/java/com/ticketrush/boundedcontext/ticket/in/api/v1/EntryControllerTest.java
+++ b/ticket-service/src/test/java/com/ticketrush/boundedcontext/ticket/in/api/v1/EntryControllerTest.java
@@ -1,0 +1,202 @@
+package com.ticketrush.boundedcontext.ticket.in.api.v1;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.ticketrush.boundedcontext.ticket.app.dto.response.EntryCheckInResponse;
+import com.ticketrush.boundedcontext.ticket.app.dto.response.EntryVerifyResponse;
+import com.ticketrush.boundedcontext.ticket.app.usecase.EntryCheckInUseCase;
+import com.ticketrush.boundedcontext.ticket.app.usecase.EntryVerifyUseCase;
+import com.ticketrush.boundedcontext.ticket.domain.types.TicketStatus;
+import com.ticketrush.global.config.SecurityConfig;
+import com.ticketrush.global.exception.BusinessException;
+import com.ticketrush.global.filter.GatewayHeaderFilter;
+import com.ticketrush.global.status.ErrorStatus;
+import com.ticketrush.support.WebMvcSliceTest;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcSliceTest(EntryController.class)
+@Import({SecurityConfig.class, GatewayHeaderFilter.class})
+@TestPropertySource(properties = "gateway.internal-token=test-token")
+class EntryControllerTest {
+
+  private static final String INTERNAL_TOKEN = "test-token";
+  private static final String BODY = "{\"token\":\"qr-token\"}";
+
+  @Autowired private MockMvc mockMvc;
+
+  @MockitoBean private EntryVerifyUseCase entryVerifyUseCase;
+
+  @MockitoBean private EntryCheckInUseCase entryCheckInUseCase;
+
+  @Test
+  @DisplayName("성공: ADMIN이 QR을 검증하면 200과 입장 가능 정보를 반환한다")
+  void verify_success_for_admin() throws Exception {
+    // given
+    given(entryVerifyUseCase.execute("qr-token"))
+        .willReturn(new EntryVerifyResponse(1L, 100L, TicketStatus.UNUSED));
+
+    // when & then
+    mockMvc
+        .perform(
+            post("/api/v1/entries/verify")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(BODY)
+                .header("X-Internal-Token", INTERNAL_TOKEN)
+                .header("X-User-Id", 1L)
+                .header("X-User-Role", "ADMIN"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.is_success").value(true))
+        .andExpect(jsonPath("$.result.ticket_id").value(1))
+        .andExpect(jsonPath("$.result.booking_id").value(100))
+        .andExpect(jsonPath("$.result.ticket_status").value("UNUSED"));
+  }
+
+  @Test
+  @DisplayName("성공: ADMIN이 입장 처리하면 200과 USED/usedAt을 반환한다")
+  void checkIn_success_for_admin() throws Exception {
+    // given
+    given(entryCheckInUseCase.execute("qr-token"))
+        .willReturn(EntryCheckInResponse.of(1L, LocalDateTime.of(2026, 6, 26, 19, 30, 0)));
+
+    // when & then
+    mockMvc
+        .perform(
+            post("/api/v1/entries/check-in")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(BODY)
+                .header("X-Internal-Token", INTERNAL_TOKEN)
+                .header("X-User-Id", 1L)
+                .header("X-User-Role", "ADMIN"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.is_success").value(true))
+        .andExpect(jsonPath("$.result.ticket_id").value(1))
+        .andExpect(jsonPath("$.result.ticket_status").value("USED"))
+        .andExpect(jsonPath("$.result.used_at").value("2026-06-26 19:30:00"));
+  }
+
+  @Test
+  @DisplayName("실패: Gateway 인증 헤더가 없으면 401을 반환하고 UseCase를 호출하지 않는다")
+  void verify_fails_when_unauthenticated() throws Exception {
+    // when & then
+    mockMvc
+        .perform(
+            post("/api/v1/entries/verify").contentType(MediaType.APPLICATION_JSON).content(BODY))
+        .andExpect(status().isUnauthorized())
+        .andExpect(jsonPath("$.is_success").value(false))
+        .andExpect(jsonPath("$.code").value(ErrorStatus.UNAUTHORIZED.getCode()));
+
+    verifyNoInteractions(entryVerifyUseCase, entryCheckInUseCase);
+  }
+
+  @Test
+  @DisplayName("실패: ADMIN이 아닌 사용자는 403을 반환하고 UseCase를 호출하지 않는다")
+  void verify_fails_when_not_admin() throws Exception {
+    // when & then
+    mockMvc
+        .perform(
+            post("/api/v1/entries/verify")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(BODY)
+                .header("X-Internal-Token", INTERNAL_TOKEN)
+                .header("X-User-Id", 1L)
+                .header("X-User-Role", "USER"))
+        .andExpect(status().isForbidden())
+        .andExpect(jsonPath("$.is_success").value(false))
+        .andExpect(jsonPath("$.code").value(ErrorStatus.FORBIDDEN.getCode()));
+
+    verifyNoInteractions(entryVerifyUseCase, entryCheckInUseCase);
+  }
+
+  @Test
+  @DisplayName("실패: 이미 사용된 입장권은 409 TICKET_409_002를 반환한다")
+  void checkIn_fails_when_already_used() throws Exception {
+    // given
+    given(entryCheckInUseCase.execute("qr-token"))
+        .willThrow(new BusinessException(ErrorStatus.TICKET_ALREADY_USED));
+
+    // when & then
+    mockMvc
+        .perform(
+            post("/api/v1/entries/check-in")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(BODY)
+                .header("X-Internal-Token", INTERNAL_TOKEN)
+                .header("X-User-Id", 1L)
+                .header("X-User-Role", "ADMIN"))
+        .andExpect(status().isConflict())
+        .andExpect(jsonPath("$.is_success").value(false))
+        .andExpect(jsonPath("$.code").value(ErrorStatus.TICKET_ALREADY_USED.getCode()));
+  }
+
+  @Test
+  @DisplayName("실패: 만료된 QR은 401 TICKET_401_001을 반환한다")
+  void verify_fails_when_qr_expired() throws Exception {
+    // given
+    given(entryVerifyUseCase.execute("qr-token"))
+        .willThrow(new BusinessException(ErrorStatus.TICKET_QR_EXPIRED));
+
+    // when & then
+    mockMvc
+        .perform(
+            post("/api/v1/entries/verify")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(BODY)
+                .header("X-Internal-Token", INTERNAL_TOKEN)
+                .header("X-User-Id", 1L)
+                .header("X-User-Role", "ADMIN"))
+        .andExpect(status().isUnauthorized())
+        .andExpect(jsonPath("$.is_success").value(false))
+        .andExpect(jsonPath("$.code").value(ErrorStatus.TICKET_QR_EXPIRED.getCode()));
+  }
+
+  @Test
+  @DisplayName("실패: 서명/형식이 무효한 QR은 400 TICKET_400_001을 반환한다")
+  void verify_fails_when_qr_invalid() throws Exception {
+    // given
+    given(entryVerifyUseCase.execute("qr-token"))
+        .willThrow(new BusinessException(ErrorStatus.TICKET_QR_INVALID));
+
+    // when & then
+    mockMvc
+        .perform(
+            post("/api/v1/entries/verify")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(BODY)
+                .header("X-Internal-Token", INTERNAL_TOKEN)
+                .header("X-User-Id", 1L)
+                .header("X-User-Role", "ADMIN"))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.is_success").value(false))
+        .andExpect(jsonPath("$.code").value(ErrorStatus.TICKET_QR_INVALID.getCode()));
+  }
+
+  @Test
+  @DisplayName("실패: token이 비어 있으면 400 검증 오류를 반환한다")
+  void verify_fails_when_token_blank() throws Exception {
+    // when & then
+    mockMvc
+        .perform(
+            post("/api/v1/entries/verify")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{\"token\":\"\"}")
+                .header("X-Internal-Token", INTERNAL_TOKEN)
+                .header("X-User-Id", 1L)
+                .header("X-User-Role", "ADMIN"))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.is_success").value(false));
+
+    verifyNoInteractions(entryVerifyUseCase, entryCheckInUseCase);
+  }
+}

--- a/ticket-service/src/test/java/com/ticketrush/boundedcontext/ticket/out/repository/TicketRepositoryTest.java
+++ b/ticket-service/src/test/java/com/ticketrush/boundedcontext/ticket/out/repository/TicketRepositoryTest.java
@@ -1,0 +1,71 @@
+package com.ticketrush.boundedcontext.ticket.out.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.ticketrush.boundedcontext.ticket.domain.entity.Ticket;
+import com.ticketrush.boundedcontext.ticket.domain.types.TicketStatus;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.boot.jpa.test.autoconfigure.TestEntityManager;
+
+@DataJpaTest
+class TicketRepositoryTest {
+
+  @Autowired private TicketRepository ticketRepository;
+
+  @Autowired private TestEntityManager entityManager;
+
+  private Ticket persistUnused(Long bookingId, String hash) {
+    Ticket ticket =
+        Ticket.builder()
+            .bookingId(bookingId)
+            .ticketTokenHash(hash)
+            .ticketStatus(TicketStatus.UNUSED)
+            .build();
+    Ticket saved = entityManager.persist(ticket);
+    entityManager.flush();
+    entityManager.clear();
+    return saved;
+  }
+
+  @Test
+  @DisplayName("markUsedById: UNUSED 입장권을 USED로 전이하고 usedAt을 기록하며 1행을 갱신한다")
+  void markUsedById_changes_unused_to_used() {
+    // given
+    Ticket ticket = persistUnused(100L, "hash-1");
+    LocalDateTime now = LocalDateTime.now();
+
+    // when
+    int updatedCount =
+        ticketRepository.markUsedById(ticket.getId(), now, TicketStatus.USED, TicketStatus.UNUSED);
+
+    // then
+    assertThat(updatedCount).isEqualTo(1);
+    entityManager.clear();
+    Ticket found = ticketRepository.findById(ticket.getId()).orElseThrow();
+    assertThat(found.getTicketStatus()).isEqualTo(TicketStatus.USED);
+    assertThat(found.getUsedAt()).isNotNull();
+  }
+
+  @Test
+  @DisplayName("markUsedById: 이미 USED인 입장권은 0행을 갱신해 중복 입장을 막는다")
+  void markUsedById_returns_zero_when_already_used() {
+    // given
+    Ticket ticket = persistUnused(200L, "hash-2");
+    LocalDateTime now = LocalDateTime.now();
+    int first =
+        ticketRepository.markUsedById(ticket.getId(), now, TicketStatus.USED, TicketStatus.UNUSED);
+    assertThat(first).isEqualTo(1);
+    entityManager.clear();
+
+    // when: 동일 입장권을 다시 입장 처리 시도
+    int second =
+        ticketRepository.markUsedById(ticket.getId(), now, TicketStatus.USED, TicketStatus.UNUSED);
+
+    // then
+    assertThat(second).isEqualTo(0);
+  }
+}


### PR DESCRIPTION
## 🔗 관련 이슈

- close #218

---

## 📌 주요 변경 사항

- 공연장 스태프용 입장(검표) API 2종 신설 (ADMIN 권한 한정)
  - `POST /api/v1/entries/verify` — QR 토큰 유효성 검증 (상태 변경 없음)
  - `POST /api/v1/entries/check-in` — 입장권을 사용 완료(USED)로 전이 + 입장 시각 기록
- 동일 QR 동시 스캔에도 한 번만 입장 처리되도록 중복 입장 방지 적용
- 입장 검증 실패 사유별 에러 코드 정의 및 Swagger 문서 반영

---

## 🛠 상세 구현 내용

- **QR 검증** (`TicketQrPayloadVerifier`, `VerifiedQrClaims`)
  - 관객 앱이 표시하는 동적 QR(JWT)을 발급기와 동일 시크릿으로 서명·만료 검증 후 `tid`(입장권 ID) 추출
  - 만료(`ExpiredJwtException`)와 서명/형식 오류를 각각 `TICKET_QR_EXPIRED`(401)·`TICKET_QR_INVALID`(400)로 구분
- **검증 흐름** (`EntryVerifyUseCase.verifyAndLoad`) — verify·check-in이 공유하는 단일 진입점
  - 서명/형식 → 만료 → 입장권 존재(`TICKET_NOT_FOUND`) → 예매 확정/취소(`BookingRestClient` 동기조회, 미확정·취소 시 `TICKET_NOT_USABLE`) → 이미 사용(`TICKET_ALREADY_USED`) 순서로 검증
  - 취소 전파가 ticket-service로 들어오지 않아, 취소 판정은 booking 동기 조회에 의존
- **중복 입장 방지** (`TicketRepository.markUsedById`, `TicketCheckInProcessor`)
  - 조건부 UPDATE `SET status=USED, usedAt=:now WHERE id=:id AND status=UNUSED` + 영향행수 판정(1행=성공, 0행=경쟁 패자) — `SeatConfirmSoldUseCase` 선례와 동일
  - 외부 동기 호출(검증)은 트랜잭션 밖에서 수행하고, 조건부 UPDATE만 짧은 트랜잭션으로 분리해 DB 커넥션 점유 최소화
- **권한/에러 규격** (`SecurityConfig`)
  - `/api/v1/entries/**` → `hasRole("ADMIN")`. 소유자 검증을 하지 않으므로 ADMIN 권한이 유일 통제선
  - 403(AccessDenied)도 `accessDeniedHandler`로 공통 `ApiResponse` envelope(`COMMON_403`)로 응답
- **에러 코드** (`common ErrorStatus`) — `TICKET_QR_INVALID`(400), `TICKET_QR_EXPIRED`(401), `TICKET_ALREADY_USED`(409) 추가

---

## ✅ 테스트

### 테스트 방법

- `./gradlew spotlessApply :ticket-service:test :common:test`
- 추가한 테스트 클래스 (단위/슬라이스/`@DataJpaTest`)
  - `TicketQrPayloadVerifierTest` — 유효 토큰 tid 추출, 서명 불일치/형식 무효(400), 만료(401)
  - `TicketRepositoryTest`(`@DataJpaTest`) — 조건부 UPDATE: UNUSED→USED 1행 갱신·`usedAt` 기록, 이미 USED면 0행
  - `EntryVerifyUseCaseTest` — 성공 및 NOT_FOUND/NOT_USABLE/ALREADY_USED/QR 예외 전파
  - `TicketCheckInProcessorTest` — 1행 성공, 0행 분기(ALREADY_USED/NOT_FOUND/NOT_USABLE)
  - `EntryCheckInUseCaseTest` — 마킹 위임 및 검증 예외 전파
  - `EntryControllerTest`(`@WebMvcSliceTest`) — 200(verify/check-in), 401(미인증)·403(비ADMIN)·409(이미사용)·401(만료)·400(무효/blank)

### 테스트 결과

- `BUILD SUCCESSFUL` — ticket-service·common 테스트 전체 통과, `spotlessCheck` 통과
<!--
### 📸 스크린샷

- (수동 시연/스크린샷 필요 시 작성)
-->
---

## 👀 리뷰 요청 사항

- 중복 입장 방지를 위한 조건부 UPDATE + 트랜잭션 경계 분리(검증=트랜잭션 밖, 전이=짧은 트랜잭션)가 적절한지
- ADMIN 단독 권한 게이트(소유자 검증 없음)가 입장 처리 정책상 충분한지

---

## ⚠️ 배포 시 주의사항

- ticket-service에 QR 검증용 시크릿 `ticket.qr.secret`(≥32바이트)이 발급기와 **동일 값**으로 주입되어야 함(기존 설정 재사용)
- 입장 가능 시간(공연 시작 전후 윈도우) 검증은 이번 범위에서 제외 — booking/performance 스키마 확장이 필요해 별도 이슈 대상
