### PR TITLE
[Refactor] #284 주간 스크럼 메시지 가독성 개선 (코드블록 + 표시 개수 3개)

### DIFF
--- a/.github/workflows/weekly-scrum.yml
+++ b/.github/workflows/weekly-scrum.yml
@@ -44,6 +44,7 @@ jobs:
           #  - PR: author.login 기준, 사람당 최대 $k건 + '…외 N건'
           #  - 이슈: 담당자별, 최근 7일 내 업데이트된 열린 이슈만 (cap 없음)
           #  - 각 항목에 [BE]/[FE] 태그로 레포 표시, 활동량(PR+이슈 수) 많은 순 정렬
+          #  - PR/이슈 목록은 코드블록으로 감싸 가독성 향상(굵게/링크 잡음 제거)
           BODY=$(jq -nr --argjson k "$MAX_PER_AUTHOR" --argjson ki "$MAX_ISSUES_PER_PERSON" --arg since "$SINCE" \
             --argjson bp "$be_pr" --argjson fp "$fe_pr" \
             --argjson bi "$be_is" --argjson fi "$fe_is" '
@@ -55,19 +56,22 @@ jobs:
                       | (if (.assignees|length)==0 then [{login:"_unassigned"}] else .assignees end)
                       | map({login:.login, number:$x.number, title:$x.title, repo:$x.repo, updatedAt:$x.updatedAt}))
                 | add // [] ) as $iss
-            | def pcount($l): ($prs|map(select(.login==$l))|length);
+            | def codeblock($lines): "```\n" + ($lines|join("\n")) + "\n```";
+              def pcount($l): ($prs|map(select(.login==$l))|length);
               def icount($l): ($iss|map(select(.login==$l))|length);
               def block($l):
                 ($prs|map(select(.login==$l))) as $p
                 | ($iss|map(select(.login==$l))|sort_by(.updatedAt)|reverse) as $i
                 | "*👤 @\($l)*\n📦 머지 PR (\($p|length)건)\n"
-                  + (if ($p|length)==0 then "• 없음"
-                     else ($p[0:$k]|map("• [\(.repo)] #\(.number) \(.title)")|join("\n"))
-                          + (if ($p|length)>$k then "\n  …외 \(($p|length)-$k)건" else "" end) end)
+                  + (if ($p|length)==0 then codeblock(["없음"])
+                     else codeblock(
+                       ($p[0:$k]|map("[\(.repo)] #\(.number) \(.title)"))
+                       + (if ($p|length)>$k then ["…외 \(($p|length)-$k)건"] else [] end)) end)
                   + "\n🚧 진행 중 이슈 (\($i|length)건)\n"
-                  + (if ($i|length)==0 then "• 없음"
-                     else ($i[0:$ki]|map("• [\(.repo)] #\(.number) \(.title)")|join("\n"))
-                          + (if ($i|length)>$ki then "\n  …외 \(($i|length)-$ki)건" else "" end) end);
+                  + (if ($i|length)==0 then codeblock(["없음"])
+                     else codeblock(
+                       ($i[0:$ki]|map("[\(.repo)] #\(.number) \(.title)"))
+                       + (if ($i|length)>$ki then ["…외 \(($i|length)-$ki)건"] else [] end)) end);
               ( ( [ $prs[].login ] + [ $iss[].login ] )
                 | map(select(. != "_unassigned")) | unique
                 | sort_by( -(pcount(.) + icount(.)) )
@@ -75,7 +79,7 @@ jobs:
             | ($iss|map(select(.login=="_unassigned"))) as $u
             | $main
               + (if ($u|length)>0
-                 then "\n\n*👤 (담당자 미지정 이슈)*\n" + ($u|map("• [\(.repo)] #\(.number) \(.title)")|join("\n"))
+                 then "\n\n*👤 (담당자 미지정 이슈)*\n" + codeblock($u|map("[\(.repo)] #\(.number) \(.title)"))
                  else "" end)
             ')
 

--- a/.github/workflows/weekly-scrum.yml
+++ b/.github/workflows/weekly-scrum.yml
@@ -21,8 +21,8 @@ jobs:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
       BACKEND_REPO: TicketRush/TicketRush-backend
       FRONTEND_REPO: TicketRush/TicketRush-frontend
-      MAX_PER_AUTHOR: 5          # 사람당 표시할 머지 PR 최대 개수 (초과분은 '…외 N건')
-      MAX_ISSUES_PER_PERSON: 7   # 사람당 표시할 진행 중 이슈 최대 개수 (초과분은 '…외 N건')
+      MAX_PER_AUTHOR: 3          # 사람당 표시할 머지 PR 최대 개수 (초과분은 '…외 N건')
+      MAX_ISSUES_PER_PERSON: 3   # 사람당 표시할 진행 중 이슈 최대 개수 (초과분은 '…외 N건')
     steps:
       - name: Build & send weekly scrum to Slack
         run: |


### PR DESCRIPTION
## 🔗 관련 이슈

- close #284

---

## 📌 주요 변경 사항

- 주간 스크럼 메시지 가독성 개선: 사람별 PR/이슈 목록을 코드블록(```)으로 표시
- 사람당 머지 PR·진행 중 이슈 표시 개수를 각각 최대 3개로 축소 (초과분 `…외 N건`)

---

## 🛠 상세 구현 내용

- jq에 `codeblock` 헬퍼 추가, PR/이슈 목록을 모노스페이스 코드블록으로 감싸 굵게/링크 자동처리 잡음 제거 (• 불릿 제거)
- env `MAX_PER_AUTHOR` 5→3, `MAX_ISSUES_PER_PERSON` 7→3
- 각 섹션 헤더에는 총 개수를 유지해 전체 규모 파악 가능

---

## ✅ 테스트

### 테스트 방법

- 두 레포 실제 데이터로 로컬 dry-run하여 메시지 본문 조립 결과 확인

### 테스트 결과

- 사람당 PR/이슈 각 3개 + `…외 N건`으로 정상 축약, 코드블록 래핑 정상
<!--
### 📸 스크린샷
-->
---

## 👀 리뷰 요청 사항

- 표시 개수(3개)와 코드블록 가독성이 적절한지 확인 부탁드립니다.

---

## ⚠️ 배포 시 주의사항

- 동작/시크릿 변경 없음 (출력 포맷·표시 개수만 조정). 머지 후 Actions `Run workflow`로 확인 가능.
