### PR TITLE
[Feat] #90 PG Webhook 수신 모듈 및 결제 멱등성 보강

### DIFF
--- a/common/src/main/java/com/ticketrush/global/status/ErrorStatus.java
+++ b/common/src/main/java/com/ticketrush/global/status/ErrorStatus.java
@@ -150,6 +150,12 @@ public enum ErrorStatus {
   /* 환불 가능 기한 검증은 공연 시작 시간(performance 도메인) 연동 후속 작업에서 사용 예정. (#22 보류) */
   PAYMENT_REFUND_DEADLINE_EXCEEDED(
       HttpStatus.BAD_REQUEST, "PAYMENT_400_005", "환불 가능 기한이 지나 환불할 수 없습니다."),
+  PAYMENT_WEBHOOK_PAYLOAD_INVALID(
+      HttpStatus.BAD_REQUEST, "PAYMENT_400_006", "Webhook 페이로드를 해석할 수 없습니다."),
+
+  // Payment 401
+  PAYMENT_WEBHOOK_SIGNATURE_INVALID(
+      HttpStatus.UNAUTHORIZED, "PAYMENT_401_001", "Webhook 서명 검증에 실패했습니다."),
 
   // Payment 404
   PAYMENT_SESSION_NOT_FOUND(HttpStatus.NOT_FOUND, "PAYMENT_404_001", "결제 세션이 만료되었거나 존재하지 않습니다."),

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/dto/request/PaymentWebhookRequest.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/dto/request/PaymentWebhookRequest.java
@@ -1,0 +1,34 @@
+package com.ticketrush.boundedcontext.payment.app.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+/**
+ * PG(Toss) 결제 Webhook 페이로드 매핑 (필요 필드만).
+ *
+ * <p>Toss는 결제 상태 변경 시 {@code { "eventType": "...", "data": { "paymentKey": "...", ... } }} 형태로 비동기
+ * 알림을 보낸다. 외부 PG가 보내는 camelCase JSON이므로, 전역 snake_case 매퍼와 분리해 camelCase 기본 매핑을 쓰는 별도 매퍼({@code
+ * PaymentWebhookUseCase}의 {@code tools.jackson} JsonMapper)로 역직렬화한다.
+ *
+ * <p>참고: https://docs.tosspayments.com/reference/webhook-event
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record PaymentWebhookRequest(String eventType, Data data) {
+
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  public record Data(String paymentKey, String orderId, String status) {}
+
+  /** data 내부의 paymentKey를 안전하게 꺼낸다(data 누락 시 null). */
+  public String paymentKey() {
+    return data == null ? null : data.paymentKey();
+  }
+
+  /** data 내부의 orderId를 안전하게 꺼낸다(data 누락 시 null). */
+  public String orderId() {
+    return data == null ? null : data.orderId();
+  }
+
+  /** data 내부의 status를 안전하게 꺼낸다(data 누락 시 null). */
+  public String status() {
+    return data == null ? null : data.status();
+  }
+}

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/facade/PaymentFacade.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/facade/PaymentFacade.java
@@ -10,7 +10,9 @@ import com.ticketrush.boundedcontext.payment.app.usecase.PaymentCancelUseCase;
 import com.ticketrush.boundedcontext.payment.app.usecase.PaymentConfirmUseCase;
 import com.ticketrush.boundedcontext.payment.app.usecase.PaymentGetDetailUseCase;
 import com.ticketrush.boundedcontext.payment.app.usecase.PaymentGetListUseCase;
+import com.ticketrush.boundedcontext.payment.app.usecase.PaymentWebhookUseCase;
 import com.ticketrush.boundedcontext.payment.app.usecase.RegisterExpiredBookingUseCase;
+import com.ticketrush.global.exception.BusinessException;
 import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -27,9 +29,24 @@ public class PaymentFacade {
   private final PaymentGetListUseCase paymentGetListUseCase;
   private final PaymentGetDetailUseCase paymentGetDetailUseCase;
   private final RegisterExpiredBookingUseCase registerExpiredBookingUseCase;
+  private final PaymentWebhookUseCase paymentWebhookUseCase;
 
   public PaymentConfirmResponse confirm(Long userId, PaymentConfirmRequest request) {
-    return paymentConfirmUseCase.execute(userId, request);
+    try {
+      return paymentConfirmUseCase.execute(userId, request);
+    } catch (DataIntegrityViolationException e) {
+      // 동시 confirm 요청이 paymentKey unique 제약에 막힌 경우, 먼저 확정된 결제를 멱등 반환한다.
+      // paymentKey 충돌이 아닌 다른 무결성 위반이라 조회되지 않으면, 원인을 숨기지 않도록 원래 예외를 재던진다.
+      try {
+        return paymentConfirmUseCase.getConfirmedResponse(request.paymentKey());
+      } catch (BusinessException lookupFailure) {
+        throw e;
+      }
+    }
+  }
+
+  public void handleWebhook(byte[] rawBody, String signature) {
+    paymentWebhookUseCase.handle(rawBody, signature);
   }
 
   public void registerExpiredBooking(Long bookingId, LocalDateTime expiredAt) {

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/support/PaymentWebhookVerifier.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/support/PaymentWebhookVerifier.java
@@ -1,0 +1,78 @@
+package com.ticketrush.boundedcontext.payment.app.support;
+
+import com.ticketrush.global.exception.BusinessException;
+import com.ticketrush.global.status.ErrorStatus;
+import java.nio.charset.StandardCharsets;
+import java.security.InvalidKeyException;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Base64;
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+/**
+ * PG Webhook 서명 검증기.
+ *
+ * <p>Webhook은 게이트웨이를 거치지 않는 외부 PG 직접 호출이므로, 서명 검증이 유일한 인증 수단이다. 시크릿으로 원문 body의 HMAC-SHA256을 재계산해
+ * 헤더로 전달된 서명과 상수시간 비교한다. 검증 실패 시 {@link ErrorStatus#PAYMENT_WEBHOOK_SIGNATURE_INVALID}를 던진다.
+ *
+ * <p>시크릿이 설정되지 않은 환경에서는 모든 webhook을 거부한다(fail-closed).
+ */
+@Slf4j
+@Component
+public class PaymentWebhookVerifier {
+
+  private static final String HMAC_ALGORITHM = "HmacSHA256";
+
+  private final String webhookSecret;
+
+  public PaymentWebhookVerifier(@Value("${payment.pg.toss.webhook-secret:}") String webhookSecret) {
+    this.webhookSecret = webhookSecret;
+  }
+
+  /**
+   * 원문 body와 서명을 검증한다.
+   *
+   * @param rawBody 수신한 원문 바이트 (PG가 서명한 바이트 그대로여야 서명이 일치한다)
+   * @param signature PG가 전달한 Base64 인코딩 HMAC-SHA256 서명
+   * @throws BusinessException 시크릿 미설정·서명 누락·서명 불일치 시
+   */
+  public void verify(byte[] rawBody, String signature) {
+    if (!StringUtils.hasText(webhookSecret)) {
+      log.error("[PG-WEBHOOK] webhook-secret 미설정으로 서명을 검증할 수 없습니다. webhook을 거부합니다.");
+      throw new BusinessException(ErrorStatus.PAYMENT_WEBHOOK_SIGNATURE_INVALID);
+    }
+    if (!StringUtils.hasText(signature)) {
+      log.warn("[PG-WEBHOOK] 서명 헤더가 없습니다.");
+      throw new BusinessException(ErrorStatus.PAYMENT_WEBHOOK_SIGNATURE_INVALID);
+    }
+
+    String expected = computeSignature(rawBody);
+    if (!constantTimeEquals(expected, signature)) {
+      log.warn("[PG-WEBHOOK] 서명이 일치하지 않습니다.");
+      throw new BusinessException(ErrorStatus.PAYMENT_WEBHOOK_SIGNATURE_INVALID);
+    }
+  }
+
+  private String computeSignature(byte[] rawBody) {
+    try {
+      Mac mac = Mac.getInstance(HMAC_ALGORITHM);
+      mac.init(new SecretKeySpec(webhookSecret.getBytes(StandardCharsets.UTF_8), HMAC_ALGORITHM));
+      byte[] hash = mac.doFinal(rawBody);
+      return Base64.getEncoder().encodeToString(hash);
+    } catch (NoSuchAlgorithmException | InvalidKeyException e) {
+      log.error("[PG-WEBHOOK] 서명 계산에 실패했습니다. message={}", e.getMessage());
+      throw new BusinessException(ErrorStatus.PAYMENT_WEBHOOK_SIGNATURE_INVALID, e);
+    }
+  }
+
+  /* 타이밍 공격을 막기 위해 길이/내용 비교를 상수시간으로 수행한다. */
+  private boolean constantTimeEquals(String expected, String actual) {
+    return MessageDigest.isEqual(
+        expected.getBytes(StandardCharsets.UTF_8), actual.getBytes(StandardCharsets.UTF_8));
+  }
+}

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentConfirmUseCase.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentConfirmUseCase.java
@@ -82,6 +82,20 @@ public class PaymentConfirmUseCase {
     return PaymentConfirmResponse.from(saved);
   }
 
+  /**
+   * 이미 확정된 결제를 paymentKey로 조회해 멱등 응답으로 반환한다.
+   *
+   * <p>동시 confirm 요청이 paymentKey unique 제약에 막혔을 때, 먼저 확정된 결제를 돌려주기 위해 {@link
+   * com.ticketrush.boundedcontext.payment.app.facade.PaymentFacade}의 멱등 fallback에서 호출한다.
+   */
+  public PaymentConfirmResponse getConfirmedResponse(String paymentKey) {
+    Payment payment =
+        paymentRepository
+            .findByPaymentKey(paymentKey)
+            .orElseThrow(() -> new BusinessException(ErrorStatus.PAYMENT_NOT_FOUND));
+    return PaymentConfirmResponse.from(payment);
+  }
+
   /* PG 공통 orderId 규격(6~64자, 영문/숫자/_/-, 현재 Toss 기준)을 만족하기 위해 zero-padding 한다. */
   private String generateOrderId(Long bookingId) {
     return "BKG-%07d".formatted(bookingId);

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentWebhookUseCase.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentWebhookUseCase.java
@@ -1,0 +1,85 @@
+package com.ticketrush.boundedcontext.payment.app.usecase;
+
+import com.ticketrush.boundedcontext.payment.app.dto.request.PaymentWebhookRequest;
+import com.ticketrush.boundedcontext.payment.app.support.PaymentWebhookVerifier;
+import com.ticketrush.boundedcontext.payment.out.repository.PaymentRepository;
+import com.ticketrush.global.exception.BusinessException;
+import com.ticketrush.global.status.ErrorStatus;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+import tools.jackson.databind.json.JsonMapper;
+
+/**
+ * PG 결제 Webhook 수신 UseCase.
+ *
+ * <p>Webhook은 confirm 응답이 유실됐을 때를 대비한 최후의 보루다. 서명을 검증한 뒤 {@code paymentKey}로 기존 Payment를 조회해 멱등
+ * 처리한다.
+ *
+ * <p>Toss webhook 페이로드에는 {@code seatId}가 없고 후속 컨슈머({@code PaymentConfirmedEventListener})는 seatId를
+ * 필수로 사용하므로, webhook 단독으로는 Payment를 안전하게 생성할 수 없다. 따라서 정상 케이스(confirm이 서버에서 성공했으나 응답만 유실)는 기존
+ * Payment를 찾아 멱등 처리하고, Payment가 없는 극단 케이스(PG 승인 후 저장 전 유실)는 즉시 생성하지 않고 {@code [CRITICAL]} 로그로 수동
+ * 복구가 가능하도록 남긴다(데이터 유실 추적, #90).
+ *
+ * <p>읽기 전용이라 트랜잭션을 두지 않는다.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PaymentWebhookUseCase {
+
+  private final PaymentWebhookVerifier webhookVerifier;
+  private final PaymentRepository paymentRepository;
+
+  /* 외부 PG가 보내는 camelCase 페이로드를 파싱한다. 앱 전역 매퍼는 snake_case로 설정돼 있어 webhook 파싱에 맞지
+   * 않으므로, camelCase 기본 매핑을 쓰는 전용 매퍼를 둔다(프로젝트 표준인 Jackson3 tools.jackson 사용). */
+  private final JsonMapper jsonMapper = JsonMapper.builder().build();
+
+  public void handle(byte[] rawBody, String signature) {
+    webhookVerifier.verify(rawBody, signature);
+
+    PaymentWebhookRequest request = parse(rawBody);
+    String paymentKey = request.paymentKey();
+    if (!StringUtils.hasText(paymentKey)) {
+      // 구독 대상이 아닌 이벤트(또는 paymentKey가 없는 이벤트)는 처리할 수 없으므로 무시한다(PG 재전송 방지를 위해 200).
+      log.info("[PG-WEBHOOK] 처리 대상이 아닌 이벤트입니다. 무시합니다. eventType={}", request.eventType());
+      return;
+    }
+
+    paymentRepository
+        .findByPaymentKey(paymentKey)
+        .ifPresentOrElse(
+            payment -> {
+              if (payment.isAlreadyProcessed()) {
+                log.info(
+                    "[PG-WEBHOOK] 이미 확정된 결제입니다. 멱등 처리합니다. paymentKey={}, paymentId={}",
+                    paymentKey,
+                    payment.getId());
+              } else {
+                log.warn(
+                    "[PG-WEBHOOK] Payment가 있으나 확정 상태가 아닙니다. paymentKey={}, paymentId={}, status={}",
+                    paymentKey,
+                    payment.getId(),
+                    payment.getStatus());
+              }
+            },
+            () ->
+                log.error(
+                    "[CRITICAL][PG-WEBHOOK] PG 승인 webhook을 수신했으나 해당 Payment가 없습니다. "
+                        + "결제는 승인됐으나 서버 저장에 실패한 상태일 수 있어 수동 확인이 필요합니다. "
+                        + "paymentKey={}, orderId={}, status={}",
+                    paymentKey,
+                    request.orderId(),
+                    request.status()));
+  }
+
+  private PaymentWebhookRequest parse(byte[] rawBody) {
+    try {
+      return jsonMapper.readValue(rawBody, PaymentWebhookRequest.class);
+    } catch (Exception e) {
+      log.warn("[PG-WEBHOOK] 페이로드 파싱에 실패했습니다. message={}", e.getMessage());
+      throw new BusinessException(ErrorStatus.PAYMENT_WEBHOOK_PAYLOAD_INVALID, e);
+    }
+  }
+}

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/domain/entity/Payment.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/domain/entity/Payment.java
@@ -42,7 +42,9 @@ public class Payment extends AutoIdBaseEntity {
   @Column(nullable = false)
   private PaymentStatus status; // 결제 상태 (PENDING, COMPLETED 등)
 
-  @Column(length = 200)
+  /* paymentKey는 PG사가 결제 건마다 유일하게 발급한다. confirm 중복 요청·webhook 재수신이 동일 결제를 중복
+   * 생성하지 못하도록 unique 제약을 둔다. (멱등성 최종 방어선, #90) NULL은 MySQL에서 중복으로 보지 않는다. */
+  @Column(length = 200, unique = true)
   private String paymentKey; // PG사 발급 결제 키
 
   @Column(length = 100)
@@ -83,5 +85,10 @@ public class Payment extends AutoIdBaseEntity {
       throw new IllegalStateException("결제 취소는 COMPLETED 상태에서만 가능합니다. 현재 상태=" + this.status);
     }
     this.status = PaymentStatus.CANCELED;
+  }
+
+  /** 이미 결제가 확정(COMPLETED)된 상태인지 여부. webhook 재수신/중복 confirm 시 멱등 판정에 사용한다. */
+  public boolean isAlreadyProcessed() {
+    return this.status == PaymentStatus.COMPLETED;
   }
 }

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/in/api/v1/PaymentWebhookController.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/in/api/v1/PaymentWebhookController.java
@@ -1,0 +1,43 @@
+package com.ticketrush.boundedcontext.payment.in.api.v1;
+
+import com.ticketrush.boundedcontext.payment.app.facade.PaymentFacade;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * PG 결제 Webhook 수신 컨트롤러.
+ *
+ * <p>게이트웨이를 거치지 않는 외부 PG 직접 호출 경로다(SecurityConfig에서 permitAll). 인증은 서명 검증으로 수행하며, 서명 검증을 위해 역직렬화 전
+ * 원문 body를 그대로 받는다. PG가 재전송하지 않도록 정상 처리 시 200을 반환한다.
+ */
+@Tag(name = "Payment", description = "결제 관련 API")
+@RestController
+@RequestMapping("/api/v1/payment")
+@RequiredArgsConstructor
+public class PaymentWebhookController {
+
+  private static final String SIGNATURE_HEADER = "TossPayments-Webhook-Signature";
+
+  private final PaymentFacade paymentFacade;
+
+  @Operation(
+      summary = "PG 결제 Webhook 수신",
+      description =
+          "PG사가 보내는 비동기 결제 알림을 수신한다. 서명을 검증한 뒤 paymentKey로 기존 결제를 찾아 멱등 처리한다. "
+              + "서명/페이로드 검증 실패 시에만 4xx, 그 외에는 재전송 방지를 위해 200을 반환한다.")
+  @PostMapping("/webhook")
+  public ResponseEntity<Void> webhook(
+      @RequestHeader(name = SIGNATURE_HEADER, required = false) String signature,
+      @RequestBody byte[] rawBody) {
+    // 서명은 PG가 보낸 원문 바이트 기준으로 계산되므로, charset 변환 없이 바이트 그대로 검증/파싱한다.
+    paymentFacade.handleWebhook(rawBody, signature);
+    return ResponseEntity.ok().build();
+  }
+}

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/out/repository/PaymentRepository.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/out/repository/PaymentRepository.java
@@ -14,4 +14,6 @@ public interface PaymentRepository extends JpaRepository<Payment, Long> {
   Page<Payment> findByUserIdAndStatus(Long userId, PaymentStatus status, Pageable pageable);
 
   Optional<Payment> findByIdAndUserId(Long id, Long userId);
+
+  Optional<Payment> findByPaymentKey(String paymentKey);
 }

--- a/payment-service/src/main/java/com/ticketrush/global/config/SecurityConfig.java
+++ b/payment-service/src/main/java/com/ticketrush/global/config/SecurityConfig.java
@@ -49,6 +49,9 @@ public class SecurityConfig {
             auth ->
                 auth.requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html")
                     .permitAll()
+                    // PG webhook은 게이트웨이를 거치지 않는 외부 직접 호출이므로 서명 검증으로 인증한다(permitAll).
+                    .requestMatchers(HttpMethod.POST, "/api/v1/payment/webhook")
+                    .permitAll()
                     .requestMatchers(HttpMethod.POST, "/api/v1/payment/confirm")
                     .authenticated()
                     .anyRequest()

--- a/payment-service/src/main/resources/application.yml
+++ b/payment-service/src/main/resources/application.yml
@@ -31,5 +31,7 @@ payment:
       enabled: ${TOSS_PAYMENTS_ENABLED:false}
       base-url: ${TOSS_PAYMENTS_BASE_URL:https://api.tosspayments.com}
       secret-key: ${TOSS_PAYMENTS_SECRET_KEY:}
+      # Webhook 서명 검증용 시크릿. 결제 승인 API용 secret-key와 별개다(미설정 시 webhook은 모두 거부).
+      webhook-secret: ${TOSS_PAYMENTS_WEBHOOK_SECRET:}
       connect-timeout-ms: ${TOSS_PAYMENTS_CONNECT_TIMEOUT_MS:3000}
       read-timeout-ms: ${TOSS_PAYMENTS_READ_TIMEOUT_MS:10000}

--- a/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/app/facade/PaymentFacadeTest.java
+++ b/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/app/facade/PaymentFacadeTest.java
@@ -1,6 +1,7 @@
 package com.ticketrush.boundedcontext.payment.app.facade;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
@@ -8,11 +9,18 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 import com.ticketrush.boundedcontext.payment.app.dto.request.PaymentCancelRequest;
+import com.ticketrush.boundedcontext.payment.app.dto.request.PaymentConfirmRequest;
 import com.ticketrush.boundedcontext.payment.app.dto.response.PaymentCancelResponse;
+import com.ticketrush.boundedcontext.payment.app.dto.response.PaymentConfirmResponse;
 import com.ticketrush.boundedcontext.payment.app.usecase.PaymentCancelUseCase;
 import com.ticketrush.boundedcontext.payment.app.usecase.PaymentConfirmUseCase;
 import com.ticketrush.boundedcontext.payment.app.usecase.PaymentGetDetailUseCase;
 import com.ticketrush.boundedcontext.payment.app.usecase.PaymentGetListUseCase;
+import com.ticketrush.boundedcontext.payment.app.usecase.PaymentWebhookUseCase;
+import com.ticketrush.boundedcontext.payment.domain.types.PaymentProvider;
+import com.ticketrush.global.exception.BusinessException;
+import com.ticketrush.global.status.ErrorStatus;
+import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -29,8 +37,13 @@ class PaymentFacadeTest {
   @Mock private PaymentCancelUseCase paymentCancelUseCase;
   @Mock private PaymentGetListUseCase paymentGetListUseCase;
   @Mock private PaymentGetDetailUseCase paymentGetDetailUseCase;
+  @Mock private PaymentWebhookUseCase paymentWebhookUseCase;
 
   @InjectMocks private PaymentFacade paymentFacade;
+
+  private PaymentConfirmRequest confirmRequest(String paymentKey) {
+    return new PaymentConfirmRequest(100L, 200L, PaymentProvider.TOSS, 55_000L, paymentKey);
+  }
 
   @Test
   @DisplayName("cancel 정상 처리 시 UseCase 결과를 그대로 반환하고 멱등 조회는 호출하지 않는다")
@@ -70,5 +83,74 @@ class PaymentFacadeTest {
     // then
     assertThat(response).isSameAs(existing);
     verify(paymentCancelUseCase).getCanceledResponse(eq(userId), eq(paymentId));
+  }
+
+  @Test
+  @DisplayName("confirm 정상 처리 시 UseCase 결과를 그대로 반환하고 멱등 조회는 호출하지 않는다")
+  void confirm_returns_usecase_result() {
+    // given
+    Long userId = 10L;
+    PaymentConfirmRequest request = confirmRequest("pgKey_xyz");
+    PaymentConfirmResponse expected =
+        new PaymentConfirmResponse(1L, "COMPLETED", LocalDateTime.now());
+    given(paymentConfirmUseCase.execute(userId, request)).willReturn(expected);
+
+    // when
+    PaymentConfirmResponse response = paymentFacade.confirm(userId, request);
+
+    // then
+    assertThat(response).isSameAs(expected);
+    verify(paymentConfirmUseCase, never()).getConfirmedResponse(any());
+  }
+
+  @Test
+  @DisplayName("동시 confirm으로 paymentKey unique 제약이 위반되면 먼저 확정된 결제를 멱등 반환한다")
+  void confirm_falls_back_to_existing_on_constraint_violation() {
+    // given
+    Long userId = 10L;
+    String paymentKey = "pgKey_xyz";
+    PaymentConfirmRequest request = confirmRequest(paymentKey);
+    PaymentConfirmResponse existing =
+        new PaymentConfirmResponse(1L, "COMPLETED", LocalDateTime.now());
+    given(paymentConfirmUseCase.execute(userId, request))
+        .willThrow(new DataIntegrityViolationException("duplicate paymentKey"));
+    given(paymentConfirmUseCase.getConfirmedResponse(paymentKey)).willReturn(existing);
+
+    // when
+    PaymentConfirmResponse response = paymentFacade.confirm(userId, request);
+
+    // then
+    assertThat(response).isSameAs(existing);
+    verify(paymentConfirmUseCase).getConfirmedResponse(eq(paymentKey));
+  }
+
+  @Test
+  @DisplayName("paymentKey 충돌이 아닌 무결성 위반으로 조회되지 않으면 원래 예외를 재던진다")
+  void confirm_rethrows_original_when_lookup_fails() {
+    // given
+    Long userId = 10L;
+    String paymentKey = "pgKey_xyz";
+    PaymentConfirmRequest request = confirmRequest(paymentKey);
+    DataIntegrityViolationException original = new DataIntegrityViolationException("not null 위반");
+    given(paymentConfirmUseCase.execute(userId, request)).willThrow(original);
+    given(paymentConfirmUseCase.getConfirmedResponse(paymentKey))
+        .willThrow(new BusinessException(ErrorStatus.PAYMENT_NOT_FOUND));
+
+    // when & then
+    assertThatThrownBy(() -> paymentFacade.confirm(userId, request)).isSameAs(original);
+  }
+
+  @Test
+  @DisplayName("handleWebhook은 webhook UseCase에 원문 body와 서명을 위임한다")
+  void handleWebhook_delegates_to_usecase() {
+    // given
+    byte[] rawBody = "{\"eventType\":\"PAYMENT_STATUS_CHANGED\"}".getBytes(StandardCharsets.UTF_8);
+    String signature = "sig";
+
+    // when
+    paymentFacade.handleWebhook(rawBody, signature);
+
+    // then
+    verify(paymentWebhookUseCase).handle(rawBody, signature);
   }
 }

--- a/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/app/support/PaymentWebhookVerifierTest.java
+++ b/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/app/support/PaymentWebhookVerifierTest.java
@@ -1,0 +1,90 @@
+package com.ticketrush.boundedcontext.payment.app.support;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.ticketrush.global.exception.BusinessException;
+import com.ticketrush.global.status.ErrorStatus;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class PaymentWebhookVerifierTest {
+
+  private static final String SECRET = "test-webhook-secret";
+  private static final String BODY = "{\"eventType\":\"PAYMENT_STATUS_CHANGED\",\"data\":{}}";
+
+  private final PaymentWebhookVerifier verifier = new PaymentWebhookVerifier(SECRET);
+
+  private static String sign(String secret, String body) throws Exception {
+    Mac mac = Mac.getInstance("HmacSHA256");
+    mac.init(new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), "HmacSHA256"));
+    return Base64.getEncoder().encodeToString(mac.doFinal(body.getBytes(StandardCharsets.UTF_8)));
+  }
+
+  @Test
+  @DisplayName("올바른 서명이면 검증을 통과한다")
+  void verify_passes_with_valid_signature() throws Exception {
+    // given
+    String signature = sign(SECRET, BODY);
+
+    // expect
+    assertThatCode(() -> verifier.verify(BODY.getBytes(StandardCharsets.UTF_8), signature))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  @DisplayName("body가 변조되면 서명 검증에 실패한다")
+  void verify_fails_when_body_tampered() throws Exception {
+    // given - 원문으로 만든 서명을 변조된 body와 함께 검증
+    String signature = sign(SECRET, BODY);
+    String tamperedBody = BODY.replace("PAYMENT_STATUS_CHANGED", "TAMPERED");
+
+    // expect
+    assertThatThrownBy(
+            () -> verifier.verify(tamperedBody.getBytes(StandardCharsets.UTF_8), signature))
+        .isInstanceOf(BusinessException.class)
+        .extracting("errorStatus")
+        .isEqualTo(ErrorStatus.PAYMENT_WEBHOOK_SIGNATURE_INVALID);
+  }
+
+  @Test
+  @DisplayName("다른 시크릿으로 만든 서명은 검증에 실패한다")
+  void verify_fails_with_wrong_secret_signature() throws Exception {
+    // given
+    String signature = sign("another-secret", BODY);
+
+    // expect
+    assertThatThrownBy(() -> verifier.verify(BODY.getBytes(StandardCharsets.UTF_8), signature))
+        .isInstanceOf(BusinessException.class)
+        .extracting("errorStatus")
+        .isEqualTo(ErrorStatus.PAYMENT_WEBHOOK_SIGNATURE_INVALID);
+  }
+
+  @Test
+  @DisplayName("서명 헤더가 없으면 검증에 실패한다")
+  void verify_fails_when_signature_missing() {
+    // expect
+    assertThatThrownBy(() -> verifier.verify(BODY.getBytes(StandardCharsets.UTF_8), null))
+        .isInstanceOf(BusinessException.class)
+        .extracting("errorStatus")
+        .isEqualTo(ErrorStatus.PAYMENT_WEBHOOK_SIGNATURE_INVALID);
+  }
+
+  @Test
+  @DisplayName("webhook 시크릿이 설정되지 않으면 모든 webhook을 거부한다(fail-closed)")
+  void verify_fails_when_secret_not_configured() throws Exception {
+    // given
+    PaymentWebhookVerifier noSecret = new PaymentWebhookVerifier("");
+    String signature = sign(SECRET, BODY);
+
+    // expect
+    assertThatThrownBy(() -> noSecret.verify(BODY.getBytes(StandardCharsets.UTF_8), signature))
+        .isInstanceOf(BusinessException.class)
+        .extracting("errorStatus")
+        .isEqualTo(ErrorStatus.PAYMENT_WEBHOOK_SIGNATURE_INVALID);
+  }
+}

--- a/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentConfirmUseCaseTest.java
+++ b/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentConfirmUseCaseTest.java
@@ -24,6 +24,7 @@ import com.ticketrush.global.exception.BusinessException;
 import com.ticketrush.global.status.ErrorStatus;
 import java.lang.reflect.Field;
 import java.time.LocalDateTime;
+import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -194,5 +195,49 @@ class PaymentConfirmUseCaseTest {
     verify(paymentRepository, never()).save(any(Payment.class));
     verify(paymentEventPublisher, never())
         .publishConfirmed(any(), any(), any(), any(), any(), any());
+  }
+
+  @Test
+  @DisplayName("getConfirmedResponse는 paymentKey로 기존 결제를 찾아 멱등 응답을 반환한다")
+  void getConfirmedResponse_returns_existing() throws Exception {
+    // given
+    String paymentKey = "pgKey_xyz";
+    LocalDateTime paidAt = LocalDateTime.of(2026, 5, 22, 10, 0);
+    Payment existing =
+        Payment.builder()
+            .bookingId(100L)
+            .userId(10L)
+            .seatId(200L)
+            .provider(PaymentProvider.TOSS)
+            .amount(55_000L)
+            .status(PaymentStatus.COMPLETED)
+            .paymentKey(paymentKey)
+            .approvalNumber("APR-1")
+            .paidAt(paidAt)
+            .build();
+    setId(existing, 999L);
+    given(paymentRepository.findByPaymentKey(paymentKey)).willReturn(Optional.of(existing));
+
+    // when
+    PaymentConfirmResponse response = paymentConfirmUseCase.getConfirmedResponse(paymentKey);
+
+    // then
+    assertThat(response.paymentId()).isEqualTo(999L);
+    assertThat(response.status()).isEqualTo("COMPLETED");
+    assertThat(response.paidAt()).isEqualTo(paidAt);
+  }
+
+  @Test
+  @DisplayName("getConfirmedResponse는 결제를 찾지 못하면 PAYMENT_404_002 예외가 발생한다")
+  void getConfirmedResponse_throws_when_absent() {
+    // given
+    String paymentKey = "pgKey_unknown";
+    given(paymentRepository.findByPaymentKey(paymentKey)).willReturn(Optional.empty());
+
+    // when & then
+    assertThatThrownBy(() -> paymentConfirmUseCase.getConfirmedResponse(paymentKey))
+        .isInstanceOf(BusinessException.class)
+        .extracting("errorStatus")
+        .isEqualTo(ErrorStatus.PAYMENT_NOT_FOUND);
   }
 }

--- a/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentWebhookUseCaseTest.java
+++ b/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentWebhookUseCaseTest.java
@@ -1,0 +1,145 @@
+package com.ticketrush.boundedcontext.payment.app.usecase;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.ticketrush.boundedcontext.payment.app.support.PaymentWebhookVerifier;
+import com.ticketrush.boundedcontext.payment.domain.entity.Payment;
+import com.ticketrush.boundedcontext.payment.domain.types.PaymentProvider;
+import com.ticketrush.boundedcontext.payment.domain.types.PaymentStatus;
+import com.ticketrush.boundedcontext.payment.out.repository.PaymentRepository;
+import com.ticketrush.global.exception.BusinessException;
+import com.ticketrush.global.status.ErrorStatus;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class PaymentWebhookUseCaseTest {
+
+  private static final String SIGNATURE = "valid-signature";
+  private static final String PAYMENT_KEY = "tossKey_abc";
+  private static final byte[] BODY =
+      """
+      {
+        "eventType": "PAYMENT_STATUS_CHANGED",
+        "data": { "paymentKey": "tossKey_abc", "orderId": "BKG-0000100", "status": "DONE" }
+      }
+      """
+          .getBytes(StandardCharsets.UTF_8);
+
+  @Mock private PaymentWebhookVerifier webhookVerifier;
+  @Mock private PaymentRepository paymentRepository;
+
+  private PaymentWebhookUseCase paymentWebhookUseCase;
+
+  @BeforeEach
+  void setUp() {
+    paymentWebhookUseCase = new PaymentWebhookUseCase(webhookVerifier, paymentRepository);
+  }
+
+  private Payment payment(PaymentStatus status) {
+    return Payment.builder()
+        .bookingId(100L)
+        .userId(10L)
+        .seatId(200L)
+        .provider(PaymentProvider.TOSS)
+        .amount(55_000L)
+        .status(status)
+        .paymentKey(PAYMENT_KEY)
+        .approvalNumber("APR-1")
+        .paidAt(LocalDateTime.of(2026, 5, 22, 10, 0))
+        .build();
+  }
+
+  @Test
+  @DisplayName("기존 COMPLETED 결제가 있으면 멱등 처리하고 예외 없이 끝난다")
+  void handle_idempotent_when_payment_completed() {
+    // given
+    given(paymentRepository.findByPaymentKey(PAYMENT_KEY))
+        .willReturn(Optional.of(payment(PaymentStatus.COMPLETED)));
+
+    // when & then
+    assertThatCode(() -> paymentWebhookUseCase.handle(BODY, SIGNATURE)).doesNotThrowAnyException();
+    verify(webhookVerifier).verify(any(byte[].class), eq(SIGNATURE));
+    verify(paymentRepository).findByPaymentKey(PAYMENT_KEY);
+  }
+
+  @Test
+  @DisplayName("Payment가 없으면(누락) 예외 없이 끝난다(CRITICAL 로그로만 추적)")
+  void handle_logs_and_returns_when_payment_missing() {
+    // given
+    given(paymentRepository.findByPaymentKey(PAYMENT_KEY)).willReturn(Optional.empty());
+
+    // when & then
+    assertThatCode(() -> paymentWebhookUseCase.handle(BODY, SIGNATURE)).doesNotThrowAnyException();
+    verify(paymentRepository).findByPaymentKey(PAYMENT_KEY);
+  }
+
+  @Test
+  @DisplayName("서명 검증에 실패하면 예외가 전파되고 조회하지 않는다")
+  void handle_propagates_when_signature_invalid() {
+    // given
+    willThrow(new BusinessException(ErrorStatus.PAYMENT_WEBHOOK_SIGNATURE_INVALID))
+        .given(webhookVerifier)
+        .verify(any(byte[].class), any());
+
+    // when & then
+    assertThatThrownBy(() -> paymentWebhookUseCase.handle(BODY, SIGNATURE))
+        .isInstanceOf(BusinessException.class)
+        .extracting("errorStatus")
+        .isEqualTo(ErrorStatus.PAYMENT_WEBHOOK_SIGNATURE_INVALID);
+    verify(paymentRepository, never()).findByPaymentKey(any());
+  }
+
+  @Test
+  @DisplayName("paymentKey가 없는 이벤트는 예외 없이 무시한다(처리 대상 아님)")
+  void handle_ignores_when_payment_key_missing() {
+    // given
+    byte[] bodyWithoutKey =
+        "{ \"eventType\": \"PAYMENT_STATUS_CHANGED\", \"data\": { \"orderId\": \"BKG-0000100\" } }"
+            .getBytes(StandardCharsets.UTF_8);
+
+    // when & then
+    assertThatCode(() -> paymentWebhookUseCase.handle(bodyWithoutKey, SIGNATURE))
+        .doesNotThrowAnyException();
+    verify(paymentRepository, never()).findByPaymentKey(any());
+  }
+
+  @Test
+  @DisplayName("페이로드 JSON이 깨졌으면 PAYMENT_400_006으로 실패한다")
+  void handle_fails_when_payload_malformed() {
+    // given
+    byte[] malformed = "{ not-a-json".getBytes(StandardCharsets.UTF_8);
+
+    // when & then
+    assertThatThrownBy(() -> paymentWebhookUseCase.handle(malformed, SIGNATURE))
+        .isInstanceOf(BusinessException.class)
+        .extracting("errorStatus")
+        .isEqualTo(ErrorStatus.PAYMENT_WEBHOOK_PAYLOAD_INVALID);
+  }
+
+  @Test
+  @DisplayName("Payment가 존재하나 COMPLETED가 아니어도 예외 없이 끝난다")
+  void handle_returns_when_payment_not_completed() {
+    // given
+    given(paymentRepository.findByPaymentKey(PAYMENT_KEY))
+        .willReturn(Optional.of(payment(PaymentStatus.PENDING)));
+
+    // when & then
+    assertThatCode(() -> paymentWebhookUseCase.handle(BODY, SIGNATURE)).doesNotThrowAnyException();
+    verify(webhookVerifier).verify(any(byte[].class), eq(SIGNATURE));
+  }
+}

--- a/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/domain/entity/PaymentTest.java
+++ b/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/domain/entity/PaymentTest.java
@@ -57,4 +57,23 @@ class PaymentTest {
     // expect
     assertThatThrownBy(payment::markCanceled).isInstanceOf(IllegalStateException.class);
   }
+
+  @Test
+  @DisplayName("COMPLETED 결제는 isAlreadyProcessed가 true다")
+  void isAlreadyProcessed_true_when_completed() {
+    // given
+    Payment payment = payment(PaymentStatus.COMPLETED);
+
+    // expect
+    assertThat(payment.isAlreadyProcessed()).isTrue();
+  }
+
+  @Test
+  @DisplayName("COMPLETED가 아닌 결제는 isAlreadyProcessed가 false다")
+  void isAlreadyProcessed_false_when_not_completed() {
+    // expect
+    assertThat(payment(PaymentStatus.PENDING).isAlreadyProcessed()).isFalse();
+    assertThat(payment(PaymentStatus.CANCELED).isAlreadyProcessed()).isFalse();
+    assertThat(payment(PaymentStatus.FAILED).isAlreadyProcessed()).isFalse();
+  }
 }

--- a/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/in/api/v1/PaymentWebhookControllerTest.java
+++ b/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/in/api/v1/PaymentWebhookControllerTest.java
@@ -1,0 +1,104 @@
+package com.ticketrush.boundedcontext.payment.in.api.v1;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.ticketrush.boundedcontext.payment.app.facade.PaymentFacade;
+import com.ticketrush.global.config.SecurityConfig;
+import com.ticketrush.global.exception.BusinessException;
+import com.ticketrush.global.filter.GatewayHeaderFilter;
+import com.ticketrush.global.status.ErrorStatus;
+import com.ticketrush.support.WebMvcSliceTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcSliceTest(PaymentWebhookController.class)
+@Import({SecurityConfig.class, GatewayHeaderFilter.class})
+@TestPropertySource(properties = "gateway.internal-token=test-token")
+class PaymentWebhookControllerTest {
+
+  private static final String SIGNATURE_HEADER = "TossPayments-Webhook-Signature";
+  private static final String SIGNATURE = "valid-signature";
+  private static final String BODY =
+      """
+      {
+        "eventType": "PAYMENT_STATUS_CHANGED",
+        "data": { "paymentKey": "tossKey_abc", "orderId": "BKG-0000100", "status": "DONE" }
+      }
+      """;
+
+  @Autowired private MockMvc mockMvc;
+
+  @MockitoBean private PaymentFacade paymentFacade;
+
+  @Test
+  @DisplayName("게이트웨이 헤더 없이도 Webhook을 수신하고 200 OK를 반환한다")
+  void webhook_success_without_gateway_headers() throws Exception {
+    // given
+    willDoNothing().given(paymentFacade).handleWebhook(any(byte[].class), eq(SIGNATURE));
+
+    // when & then
+    mockMvc
+        .perform(
+            post("/api/v1/payment/webhook")
+                .header(SIGNATURE_HEADER, SIGNATURE)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(BODY))
+        .andExpect(status().isOk());
+
+    verify(paymentFacade).handleWebhook(any(byte[].class), eq(SIGNATURE));
+  }
+
+  @Test
+  @DisplayName("서명 검증 실패 시 PAYMENT_401_001로 거부한다")
+  void webhook_fails_when_signature_invalid() throws Exception {
+    // given
+    willThrow(new BusinessException(ErrorStatus.PAYMENT_WEBHOOK_SIGNATURE_INVALID))
+        .given(paymentFacade)
+        .handleWebhook(any(byte[].class), eq(SIGNATURE));
+
+    // when & then
+    mockMvc
+        .perform(
+            post("/api/v1/payment/webhook")
+                .header(SIGNATURE_HEADER, SIGNATURE)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(BODY))
+        .andExpect(status().isUnauthorized())
+        .andExpect(jsonPath("$.is_success").value(false))
+        .andExpect(
+            jsonPath("$.code").value(ErrorStatus.PAYMENT_WEBHOOK_SIGNATURE_INVALID.getCode()));
+  }
+
+  @Test
+  @DisplayName("페이로드 파싱 실패 시 PAYMENT_400_006으로 거부한다")
+  void webhook_fails_when_payload_invalid() throws Exception {
+    // given
+    willThrow(new BusinessException(ErrorStatus.PAYMENT_WEBHOOK_PAYLOAD_INVALID))
+        .given(paymentFacade)
+        .handleWebhook(any(byte[].class), eq(SIGNATURE));
+
+    // when & then
+    mockMvc
+        .perform(
+            post("/api/v1/payment/webhook")
+                .header(SIGNATURE_HEADER, SIGNATURE)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("{ malformed"))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.is_success").value(false))
+        .andExpect(jsonPath("$.code").value(ErrorStatus.PAYMENT_WEBHOOK_PAYLOAD_INVALID.getCode()));
+  }
+}


### PR DESCRIPTION
## 🔗 관련 이슈
- close #90

---

## 📌 주요 변경 사항

- PG 결제 Webhook 수신 엔드포인트(`POST /api/v1/payment/webhook`) 신규 구현
- Webhook HMAC-SHA256 서명 검증 도입 (게이트웨이 미경유 경로의 유일 인증 수단)
- 결제 confirm 경로 멱등성 보강 (`paymentKey` unique + Facade 멱등 fallback)

---

## 🛠 상세 구현 내용

- **Webhook 수신**: 원문 `byte[]`로 수신해 charset 변환 없이 서명 검증/파싱. `paymentKey`로 기존 결제를 조회해 멱등 처리하고, PG 콜백 재전송 방지를 위해 정상 처리 시 `200` 반환
- **서명 검증**(`PaymentWebhookVerifier`): 시크릿(`payment.pg.toss.webhook-secret`)으로 HMAC 재계산 후 상수시간 비교, 시크릿 미설정 시 fail-closed
- **이벤트 기반 준수**: payment-service는 `BookingStatus`를 직접 변경하지 않음. Toss 페이로드에 `seatId`가 없고 컨슈머(`PaymentConfirmedEventListener`)가 필수로 쓰므로, Payment 누락 시 생성하지 않고 `[CRITICAL]` 로그로 수동 복구 추적
- **멱등성**: `Payment.paymentKey` unique 제약 + `isAlreadyProcessed()`, confirm 동시성 충돌 시 `DataIntegrityViolationException`을 잡아 기확정 결제를 멱등 반환(충돌 외 무결성 위반은 원래 예외 보존)
- **에러 코드**: `PAYMENT_401_001`(서명 실패), `PAYMENT_400_006`(페이로드 파싱 실패) 추가 (common)

---

## ✅ 테스트

### 테스트 방법

- `./gradlew :common:checkstyleMain :common:checkstyleTest :payment-service:checkstyleMain :payment-service:checkstyleTest :payment-service:compileJava :payment-service:test`

### 테스트 결과

- payment-service 104개 테스트 전부 통과, checkstyle(main/test)·compile 클린
- 신규: WebhookVerifier(서명 통과/변조/오시크릿/누락/시크릿미설정), WebhookUseCase(멱등/누락/서명실패/이벤트무시/파싱실패), WebhookController(permitAll 200/401/400), confirm 멱등 fallback·재던짐, `isAlreadyProcessed`

### 📸 스크린샷

---

## 👀 리뷰 요청 사항

- Webhook 서명 헤더명(`TossPayments-Webhook-Signature`)·시크릿 정책이 실제 Toss 콘솔 설정과 맞는지 확인 필요
- Payment 누락 시 "생성하지 않고 로그만" 정책(Option A) 동의 여부

---

## ⚠️ 배포 시 주의사항

- `Payment.paymentKey`에 unique 제약 추가됨. **Flyway 미사용·`ddl-auto=update` 환경**이므로, 운영 DB에 기존 중복 `paymentKey`가 있으면 인덱스 생성이 실패할 수 있어 사전 점검 필요
- 환경변수 `TOSS_PAYMENTS_WEBHOOK_SECRET` 설정 필요(미설정 시 모든 webhook 거부)
