### PR TITLE
[Infra] #135 payment-service MapStruct 기반 PaymentMapper 도입

### DIFF
--- a/payment-service/build.gradle
+++ b/payment-service/build.gradle
@@ -35,11 +35,17 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-webmvc'
+	// MapStruct
+	implementation 'org.mapstruct:mapstruct:1.5.5.Final'
+
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
 	annotationProcessor 'org.projectlombok:lombok'
+	// Lombok과 MapStruct의 순서 및 바인딩을 위한 필수 설정
+	annotationProcessor 'org.projectlombok:lombok-mapstruct-binding:0.2.0'
+	annotationProcessor 'org.mapstruct:mapstruct-processor:1.5.5.Final'
 
 	// Kafka
 	implementation 'org.springframework.boot:spring-boot-starter-kafka'
@@ -52,6 +58,8 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
 	testImplementation testFixtures(project(":common"))
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	testAnnotationProcessor 'org.mapstruct:mapstruct-processor:1.5.5.Final'
 
 	// swagger
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.1'

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/dto/response/PaymentCancelResponse.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/dto/response/PaymentCancelResponse.java
@@ -1,7 +1,5 @@
 package com.ticketrush.boundedcontext.payment.app.dto.response;
 
-import com.ticketrush.boundedcontext.payment.domain.entity.Payment;
-import com.ticketrush.boundedcontext.payment.domain.entity.Refund;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 
@@ -11,14 +9,4 @@ public record PaymentCancelResponse(
     @Schema(description = "결제 상태", example = "CANCELED") String status,
     @Schema(description = "환불 데이터의 고유 식별자(PK)", example = "1") Long refundId,
     @Schema(description = "환불 금액", example = "55000") Long refundedAmount,
-    @Schema(description = "환불 확정 시각") LocalDateTime canceledAt) {
-
-  public static PaymentCancelResponse of(Payment payment, Refund refund) {
-    return new PaymentCancelResponse(
-        payment.getId(),
-        payment.getStatus().name(),
-        refund.getId(),
-        refund.getPrice(),
-        refund.getConfirmedAt());
-  }
-}
+    @Schema(description = "환불 확정 시각") LocalDateTime canceledAt) {}

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/dto/response/PaymentConfirmResponse.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/dto/response/PaymentConfirmResponse.java
@@ -1,6 +1,5 @@
 package com.ticketrush.boundedcontext.payment.app.dto.response;
 
-import com.ticketrush.boundedcontext.payment.domain.entity.Payment;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 
@@ -8,10 +7,4 @@ import java.time.LocalDateTime;
 public record PaymentConfirmResponse(
     @Schema(description = "결제 데이터의 고유 식별자(PK)", example = "1") Long paymentId,
     @Schema(description = "결제 상태", example = "COMPLETED") String status,
-    @Schema(description = "결제 완료 시각") LocalDateTime paidAt) {
-
-  public static PaymentConfirmResponse from(Payment payment) {
-    return new PaymentConfirmResponse(
-        payment.getId(), payment.getStatus().name(), payment.getPaidAt());
-  }
-}
+    @Schema(description = "결제 완료 시각") LocalDateTime paidAt) {}

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/dto/response/PaymentDetailResponse.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/dto/response/PaymentDetailResponse.java
@@ -1,7 +1,5 @@
 package com.ticketrush.boundedcontext.payment.app.dto.response;
 
-import com.ticketrush.boundedcontext.payment.domain.entity.Payment;
-import com.ticketrush.boundedcontext.payment.domain.entity.Refund;
 import com.ticketrush.boundedcontext.payment.domain.types.PaymentProvider;
 import com.ticketrush.boundedcontext.payment.domain.types.PaymentStatus;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -16,17 +14,4 @@ public record PaymentDetailResponse(
     @Schema(description = "결제 상태", example = "COMPLETED") PaymentStatus status,
     @Schema(description = "결제 완료 시각") LocalDateTime paidAt,
     @Schema(description = "PG사 응답 승인 번호") String approvalNumber,
-    @Schema(description = "환불 정보 (환불이 있는 경우에만 포함)") RefundResponse refund) {
-
-  public static PaymentDetailResponse of(Payment payment, Refund refund) {
-    return new PaymentDetailResponse(
-        payment.getId(),
-        payment.getBookingId(),
-        payment.getProvider(),
-        payment.getAmount(),
-        payment.getStatus(),
-        payment.getPaidAt(),
-        payment.getApprovalNumber(),
-        refund == null ? null : RefundResponse.from(refund));
-  }
-}
+    @Schema(description = "환불 정보 (환불이 있는 경우에만 포함)") RefundResponse refund) {}

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/dto/response/PaymentSummaryResponse.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/dto/response/PaymentSummaryResponse.java
@@ -1,6 +1,5 @@
 package com.ticketrush.boundedcontext.payment.app.dto.response;
 
-import com.ticketrush.boundedcontext.payment.domain.entity.Payment;
 import com.ticketrush.boundedcontext.payment.domain.types.PaymentProvider;
 import com.ticketrush.boundedcontext.payment.domain.types.PaymentStatus;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -13,15 +12,4 @@ public record PaymentSummaryResponse(
     @Schema(description = "결제 수단", example = "TOSS") PaymentProvider provider,
     @Schema(description = "결제 금액", example = "55000") Long amount,
     @Schema(description = "결제 상태", example = "COMPLETED") PaymentStatus status,
-    @Schema(description = "결제 완료 시각") LocalDateTime paidAt) {
-
-  public static PaymentSummaryResponse from(Payment payment) {
-    return new PaymentSummaryResponse(
-        payment.getId(),
-        payment.getBookingId(),
-        payment.getProvider(),
-        payment.getAmount(),
-        payment.getStatus(),
-        payment.getPaidAt());
-  }
-}
+    @Schema(description = "결제 완료 시각") LocalDateTime paidAt) {}

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/dto/response/RefundResponse.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/dto/response/RefundResponse.java
@@ -1,6 +1,5 @@
 package com.ticketrush.boundedcontext.payment.app.dto.response;
 
-import com.ticketrush.boundedcontext.payment.domain.entity.Refund;
 import com.ticketrush.boundedcontext.payment.domain.types.RefundStatus;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
@@ -10,10 +9,4 @@ public record RefundResponse(
     @Schema(description = "환불 데이터의 고유 식별자(PK)", example = "1") Long refundId,
     @Schema(description = "환불 금액", example = "55000") Long price,
     @Schema(description = "환불 상태", example = "COMPLETED") RefundStatus status,
-    @Schema(description = "환불 확정 시각") LocalDateTime confirmedAt) {
-
-  public static RefundResponse from(Refund refund) {
-    return new RefundResponse(
-        refund.getId(), refund.getPrice(), refund.getStatus(), refund.getConfirmedAt());
-  }
-}
+    @Schema(description = "환불 확정 시각") LocalDateTime confirmedAt) {}

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/mapper/PaymentMapper.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/mapper/PaymentMapper.java
@@ -1,0 +1,41 @@
+package com.ticketrush.boundedcontext.payment.app.mapper;
+
+import com.ticketrush.boundedcontext.payment.app.dto.response.PaymentCancelResponse;
+import com.ticketrush.boundedcontext.payment.app.dto.response.PaymentConfirmResponse;
+import com.ticketrush.boundedcontext.payment.app.dto.response.PaymentDetailResponse;
+import com.ticketrush.boundedcontext.payment.app.dto.response.PaymentSummaryResponse;
+import com.ticketrush.boundedcontext.payment.app.dto.response.RefundResponse;
+import com.ticketrush.boundedcontext.payment.domain.entity.Payment;
+import com.ticketrush.boundedcontext.payment.domain.entity.Refund;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper(componentModel = "spring")
+public interface PaymentMapper {
+
+  @Mapping(source = "id", target = "paymentId")
+  PaymentConfirmResponse toConfirmResponse(Payment payment);
+
+  @Mapping(source = "id", target = "refundId")
+  RefundResponse toRefundResponse(Refund refund);
+
+  @Mapping(source = "id", target = "paymentId")
+  PaymentSummaryResponse toSummaryResponse(Payment payment);
+
+  /*
+   * Payment·Refund 모두 bookingId/status를 보유해 다중 소스 매핑 시 모호하므로 payment 측을 명시한다.
+   * refund가 null이면 MapStruct가 toRefundResponse(null)→null로 전파한다(환불 없는 결제 상세).
+   */
+  @Mapping(source = "payment.id", target = "paymentId")
+  @Mapping(source = "payment.bookingId", target = "bookingId")
+  @Mapping(source = "payment.status", target = "status")
+  @Mapping(source = "refund", target = "refund")
+  PaymentDetailResponse toDetailResponse(Payment payment, Refund refund);
+
+  @Mapping(source = "payment.id", target = "paymentId")
+  @Mapping(source = "payment.status", target = "status")
+  @Mapping(source = "refund.id", target = "refundId")
+  @Mapping(source = "refund.price", target = "refundedAmount")
+  @Mapping(source = "refund.confirmedAt", target = "canceledAt")
+  PaymentCancelResponse toCancelResponse(Payment payment, Refund refund);
+}

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentCancelUseCase.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentCancelUseCase.java
@@ -2,6 +2,7 @@ package com.ticketrush.boundedcontext.payment.app.usecase;
 
 import com.ticketrush.boundedcontext.payment.app.dto.request.PaymentCancelRequest;
 import com.ticketrush.boundedcontext.payment.app.dto.response.PaymentCancelResponse;
+import com.ticketrush.boundedcontext.payment.app.mapper.PaymentMapper;
 import com.ticketrush.boundedcontext.payment.app.support.PaymentEventPublisher;
 import com.ticketrush.boundedcontext.payment.app.usecase.PaymentCancelPersister.CancelPersisted;
 import com.ticketrush.boundedcontext.payment.domain.entity.Payment;
@@ -40,6 +41,7 @@ public class PaymentCancelUseCase {
   private final PaymentCancelClientRouter paymentCancelClientRouter;
   private final PaymentCancelPersister paymentCancelPersister;
   private final PaymentEventPublisher paymentEventPublisher;
+  private final PaymentMapper paymentMapper;
 
   public PaymentCancelResponse execute(Long userId, Long paymentId, PaymentCancelRequest request) {
     Payment payment =
@@ -93,7 +95,7 @@ public class PaymentCancelUseCase {
         saved.getReason(),
         saved.getConfirmedAt());
 
-    return PaymentCancelResponse.of(canceled, saved);
+    return paymentMapper.toCancelResponse(canceled, saved);
   }
 
   /**
@@ -114,7 +116,7 @@ public class PaymentCancelUseCase {
         refundRepository
             .findByPaymentId(paymentId)
             .orElseThrow(() -> new BusinessException(ErrorStatus.PAYMENT_REFUND_INCONSISTENT));
-    return PaymentCancelResponse.of(payment, existing);
+    return paymentMapper.toCancelResponse(payment, existing);
   }
 
   /* 동일 결제의 재요청 시 PG 측 중복 취소를 막기 위해 paymentId 기반 고정 멱등 키를 생성한다. */

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentConfirmUseCase.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentConfirmUseCase.java
@@ -2,6 +2,7 @@ package com.ticketrush.boundedcontext.payment.app.usecase;
 
 import com.ticketrush.boundedcontext.payment.app.dto.request.PaymentConfirmRequest;
 import com.ticketrush.boundedcontext.payment.app.dto.response.PaymentConfirmResponse;
+import com.ticketrush.boundedcontext.payment.app.mapper.PaymentMapper;
 import com.ticketrush.boundedcontext.payment.app.support.PaymentEventPublisher;
 import com.ticketrush.boundedcontext.payment.domain.entity.Payment;
 import com.ticketrush.boundedcontext.payment.domain.types.PaymentStatus;
@@ -29,6 +30,7 @@ public class PaymentConfirmUseCase {
   private final PaymentApprovalClientRouter paymentApprovalClientRouter;
   private final PaymentEventPublisher paymentEventPublisher;
   private final ExpiredBookingRepository expiredBookingRepository;
+  private final PaymentMapper paymentMapper;
 
   public PaymentConfirmResponse execute(Long userId, PaymentConfirmRequest request) {
     if (paymentRepository.existsByBookingIdAndStatus(
@@ -79,7 +81,7 @@ public class PaymentConfirmUseCase {
         saved.getAmount(),
         saved.getPaidAt());
 
-    return PaymentConfirmResponse.from(saved);
+    return paymentMapper.toConfirmResponse(saved);
   }
 
   /**
@@ -93,7 +95,7 @@ public class PaymentConfirmUseCase {
         paymentRepository
             .findByPaymentKey(paymentKey)
             .orElseThrow(() -> new BusinessException(ErrorStatus.PAYMENT_NOT_FOUND));
-    return PaymentConfirmResponse.from(payment);
+    return paymentMapper.toConfirmResponse(payment);
   }
 
   /* PG 공통 orderId 규격(6~64자, 영문/숫자/_/-, 현재 Toss 기준)을 만족하기 위해 zero-padding 한다. */

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentGetDetailUseCase.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentGetDetailUseCase.java
@@ -1,6 +1,7 @@
 package com.ticketrush.boundedcontext.payment.app.usecase;
 
 import com.ticketrush.boundedcontext.payment.app.dto.response.PaymentDetailResponse;
+import com.ticketrush.boundedcontext.payment.app.mapper.PaymentMapper;
 import com.ticketrush.boundedcontext.payment.domain.entity.Payment;
 import com.ticketrush.boundedcontext.payment.domain.entity.Refund;
 import com.ticketrush.boundedcontext.payment.out.repository.PaymentRepository;
@@ -17,6 +18,7 @@ public class PaymentGetDetailUseCase {
 
   private final PaymentRepository paymentRepository;
   private final RefundRepository refundRepository;
+  private final PaymentMapper paymentMapper;
 
   @Transactional(readOnly = true)
   public PaymentDetailResponse execute(Long userId, Long paymentId) {
@@ -28,6 +30,6 @@ public class PaymentGetDetailUseCase {
 
     Refund refund = refundRepository.findByBookingId(payment.getBookingId()).orElse(null);
 
-    return PaymentDetailResponse.of(payment, refund);
+    return paymentMapper.toDetailResponse(payment, refund);
   }
 }

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentGetListUseCase.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentGetListUseCase.java
@@ -1,6 +1,7 @@
 package com.ticketrush.boundedcontext.payment.app.usecase;
 
 import com.ticketrush.boundedcontext.payment.app.dto.response.PaymentSummaryResponse;
+import com.ticketrush.boundedcontext.payment.app.mapper.PaymentMapper;
 import com.ticketrush.boundedcontext.payment.domain.types.PaymentStatus;
 import com.ticketrush.boundedcontext.payment.out.repository.PaymentRepository;
 import lombok.RequiredArgsConstructor;
@@ -14,11 +15,12 @@ import org.springframework.transaction.annotation.Transactional;
 public class PaymentGetListUseCase {
 
   private final PaymentRepository paymentRepository;
+  private final PaymentMapper paymentMapper;
 
   @Transactional(readOnly = true)
   public Page<PaymentSummaryResponse> execute(Long userId, Pageable pageable) {
     return paymentRepository
         .findByUserIdAndStatus(userId, PaymentStatus.COMPLETED, pageable)
-        .map(PaymentSummaryResponse::from);
+        .map(paymentMapper::toSummaryResponse);
   }
 }

--- a/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentCancelUseCaseTest.java
+++ b/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentCancelUseCaseTest.java
@@ -11,6 +11,7 @@ import static org.mockito.Mockito.verify;
 
 import com.ticketrush.boundedcontext.payment.app.dto.request.PaymentCancelRequest;
 import com.ticketrush.boundedcontext.payment.app.dto.response.PaymentCancelResponse;
+import com.ticketrush.boundedcontext.payment.app.mapper.PaymentMapper;
 import com.ticketrush.boundedcontext.payment.app.support.PaymentEventPublisher;
 import com.ticketrush.boundedcontext.payment.domain.entity.Payment;
 import com.ticketrush.boundedcontext.payment.domain.entity.Refund;
@@ -30,10 +31,12 @@ import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mapstruct.factory.Mappers;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InOrder;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.dao.DataIntegrityViolationException;
 
@@ -45,6 +48,8 @@ class PaymentCancelUseCaseTest {
   @Mock private PaymentCancelClientRouter paymentCancelClientRouter;
   @Mock private PaymentCancelPersister paymentCancelPersister;
   @Mock private PaymentEventPublisher paymentEventPublisher;
+
+  @Spy private PaymentMapper paymentMapper = Mappers.getMapper(PaymentMapper.class);
 
   @InjectMocks private PaymentCancelUseCase paymentCancelUseCase;
 

--- a/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentConfirmUseCaseTest.java
+++ b/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentConfirmUseCaseTest.java
@@ -11,6 +11,7 @@ import static org.mockito.Mockito.verify;
 
 import com.ticketrush.boundedcontext.payment.app.dto.request.PaymentConfirmRequest;
 import com.ticketrush.boundedcontext.payment.app.dto.response.PaymentConfirmResponse;
+import com.ticketrush.boundedcontext.payment.app.mapper.PaymentMapper;
 import com.ticketrush.boundedcontext.payment.app.support.PaymentEventPublisher;
 import com.ticketrush.boundedcontext.payment.domain.entity.Payment;
 import com.ticketrush.boundedcontext.payment.domain.types.PaymentProvider;
@@ -28,10 +29,12 @@ import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mapstruct.factory.Mappers;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InOrder;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
@@ -41,6 +44,8 @@ class PaymentConfirmUseCaseTest {
   @Mock private PaymentApprovalClientRouter paymentApprovalClientRouter;
   @Mock private PaymentEventPublisher paymentEventPublisher;
   @Mock private ExpiredBookingRepository expiredBookingRepository;
+
+  @Spy private PaymentMapper paymentMapper = Mappers.getMapper(PaymentMapper.class);
 
   @InjectMocks private PaymentConfirmUseCase paymentConfirmUseCase;
 

--- a/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentGetDetailUseCaseTest.java
+++ b/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentGetDetailUseCaseTest.java
@@ -6,6 +6,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verifyNoInteractions;
 
 import com.ticketrush.boundedcontext.payment.app.dto.response.PaymentDetailResponse;
+import com.ticketrush.boundedcontext.payment.app.mapper.PaymentMapper;
 import com.ticketrush.boundedcontext.payment.domain.entity.Payment;
 import com.ticketrush.boundedcontext.payment.domain.entity.Refund;
 import com.ticketrush.boundedcontext.payment.domain.types.PaymentProvider;
@@ -21,8 +22,10 @@ import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mapstruct.factory.Mappers;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
@@ -30,6 +33,8 @@ class PaymentGetDetailUseCaseTest {
 
   @Mock private PaymentRepository paymentRepository;
   @Mock private RefundRepository refundRepository;
+
+  @Spy private PaymentMapper paymentMapper = Mappers.getMapper(PaymentMapper.class);
 
   @InjectMocks private PaymentGetDetailUseCase paymentGetDetailUseCase;
 

--- a/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentGetListUseCaseTest.java
+++ b/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentGetListUseCaseTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 
 import com.ticketrush.boundedcontext.payment.app.dto.response.PaymentSummaryResponse;
+import com.ticketrush.boundedcontext.payment.app.mapper.PaymentMapper;
 import com.ticketrush.boundedcontext.payment.domain.entity.Payment;
 import com.ticketrush.boundedcontext.payment.domain.types.PaymentProvider;
 import com.ticketrush.boundedcontext.payment.domain.types.PaymentStatus;
@@ -14,8 +15,10 @@ import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mapstruct.factory.Mappers;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -27,6 +30,8 @@ import org.springframework.data.domain.Sort;
 class PaymentGetListUseCaseTest {
 
   @Mock private PaymentRepository paymentRepository;
+
+  @Spy private PaymentMapper paymentMapper = Mappers.getMapper(PaymentMapper.class);
 
   @InjectMocks private PaymentGetListUseCase paymentGetListUseCase;
 


### PR DESCRIPTION
## 🔗 관련 이슈

- close #135

---

## 📌 주요 변경 사항

- payment-service에 MapStruct 기반 `PaymentMapper`를 도입해 응답 DTO 변환을 일원화
- 응답 DTO 5종의 정적 팩토리(`from`/`of`)를 제거하고 변환 책임을 Mapper로 위임
- 팀 표준(performance/user/booking-service, `docs/mapstruct-guide.md`)과 동일한 설정 복제

---

## 🛠 상세 구현 내용

- **의존성**: `mapstruct:1.5.5.Final` + `lombok-mapstruct-binding:0.2.0` 추가. 엔티티가 `@Builder/@Getter`라 binding을 `mapstruct-processor`보다 먼저 선언. `testAnnotationProcessor`는 user/booking 선례대로 `mapstruct-processor` 한 줄
- **PaymentMapper (신규)**: `@Mapper(componentModel = "spring")`. 응답 5종 변환 + `RefundResponse` 위임 메서드
  - 필드명 불일치(`id→paymentId`/`refundId`)는 `@Mapping(source/target)`으로 처리, enum→String은 MapStruct 자동 `.name()`
  - 다중소스(`PaymentDetailResponse`/`PaymentCancelResponse`)는 `bookingId`/`status` 모호성을 `payment.*` 명시로 해소, `refund` 중첩은 위임 메서드 자동 호출 + null 전파로 기존 삼항 의미 보존
- **UseCase 4종**(`Confirm`/`Cancel`/`GetDetail`/`GetList`): `PaymentMapper` 주입, 정적 팩토리 호출부를 Mapper 호출로 치환 (`GetList`는 `Page.map(paymentMapper::toSummaryResponse)`)
- **범위 제외(의도적)**: PG 어댑터 변환(타임존/null/리스트 로직)·이벤트 발행(`PaymentEventPublisher`)은 비즈니스 로직이라 현행 유지. request→Entity 조립 2종도 비즈니스 의미(`approvedAmount` 신뢰·`now()` 주입성) 보존 위해 보류

---

## ✅ 테스트

### 테스트 방법

- 기존 UseCase 단위 테스트 4종(`PaymentConfirmUseCaseTest`/`PaymentCancelUseCaseTest`/`PaymentGetDetailUseCaseTest`/`PaymentGetListUseCaseTest`)에 `@Spy private PaymentMapper = Mappers.getMapper(PaymentMapper.class)`로 실제 Mapper 구현체를 주입해 응답 단언을 그대로 검증
- 빌드 검증: `./gradlew :payment-service:spotlessApply :payment-service:checkstyleMain :payment-service:checkstyleTest :payment-service:test`

### 테스트 결과

- spotlessApply / checkstyleMain / checkstyleTest / test 전부 **BUILD SUCCESSFUL** (회귀 없음)
- 생성된 `PaymentMapperImpl`을 기존 정적 팩토리와 1:1 대조 → 필드 매핑·enum 변환·refund null 전파 모두 동일 확인

### 📸 스크린샷

- 

---

## 👀 리뷰 요청 사항

- 다중소스 매핑(`toDetailResponse`/`toCancelResponse`)의 `@Mapping` 명시 범위가 적절한지
- `unmappedTargetPolicy` 미설정(선례 일관성) 유지 결정에 대한 의견

---

## ⚠️ 배포 시 주의사항

- 순수 변환 리팩토링으로 API 응답 스펙·DB 스키마 변경 없음. 동작 변화 없음
