### PR TITLE
[Feat] #292 결제 취소 이벤트 구독으로 티켓 취소(→CANCELED) 처리

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -150,3 +150,6 @@ build/
 .claude/feature_list.json
 !.claude/claude-progress.txt.example
 !.claude/feature_list.json.example
+
+# oh-my-claudecode
+.omc/

--- a/ticket-service/src/main/java/com/ticketrush/boundedcontext/ticket/app/usecase/TicketCancelUseCase.java
+++ b/ticket-service/src/main/java/com/ticketrush/boundedcontext/ticket/app/usecase/TicketCancelUseCase.java
@@ -1,0 +1,54 @@
+package com.ticketrush.boundedcontext.ticket.app.usecase;
+
+import com.ticketrush.boundedcontext.ticket.domain.entity.Ticket;
+import com.ticketrush.boundedcontext.ticket.domain.types.TicketStatus;
+import com.ticketrush.boundedcontext.ticket.out.repository.TicketRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 결제 취소(환불)에 따라 발급된 입장권을 UNUSED -> CANCELED로 전이시킨다.
+ *
+ * <p>조건부 UPDATE의 영향행수로 결과를 판정한다. 1행이면 취소 성공, 0행이면 전이 대상이 아니므로(없음/이미 USED/이미 CANCELED) 사유를 구분해 로그만
+ * 남기고 예외를 던지지 않는다. 결제 취소는 이미 확정된 사건이라 재시도해도 결과가 바뀌지 않으므로, 호출 측(이벤트 리스너)의 무한 재시도/파티션 블로킹을 유발하지 않게
+ * 한다.
+ */
+@Slf4j
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class TicketCancelUseCase {
+
+  private final TicketRepository ticketRepository;
+
+  public void execute(Long bookingId) {
+    int updatedCount =
+        ticketRepository.markCanceledByBookingId(
+            bookingId, TicketStatus.CANCELED, TicketStatus.UNUSED);
+
+    if (updatedCount == 1) {
+      log.info("결제 취소로 입장권을 취소 처리했습니다. bookingId: {}", bookingId);
+      return;
+    }
+
+    // 0행: UNUSED가 아니어서 전이되지 않음. 사유를 구분해 로그만 남긴다(예외 전파 금지).
+    Ticket current = ticketRepository.findByBookingId(bookingId).orElse(null);
+
+    if (current == null) {
+      log.warn("취소 대상 입장권이 없어 건너뜁니다. bookingId: {}", bookingId);
+      return;
+    }
+
+    switch (current.getTicketStatus()) {
+      case USED -> log.warn("이미 사용(입장 완료)된 입장권이라 취소를 무시합니다. bookingId: {}", bookingId);
+      case CANCELED -> log.info("이미 취소된 입장권입니다(멱등 처리). bookingId: {}", bookingId);
+      default ->
+          log.warn(
+              "예상치 못한 입장권 상태라 취소를 건너뜁니다. bookingId: {}, status: {}",
+              bookingId,
+              current.getTicketStatus());
+    }
+  }
+}

--- a/ticket-service/src/main/java/com/ticketrush/boundedcontext/ticket/in/eventlistener/PaymentCanceledEventListener.java
+++ b/ticket-service/src/main/java/com/ticketrush/boundedcontext/ticket/in/eventlistener/PaymentCanceledEventListener.java
@@ -1,0 +1,58 @@
+package com.ticketrush.boundedcontext.ticket.in.eventlistener;
+
+import com.ticketrush.boundedcontext.ticket.app.usecase.TicketCancelUseCase;
+import com.ticketrush.global.event.DomainEventEnvelope;
+import com.ticketrush.global.json.JsonConverter;
+import com.ticketrush.shared.payment.event.PaymentCanceledEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PaymentCanceledEventListener {
+
+  private final TicketCancelUseCase ticketCancelUseCase;
+  private final JsonConverter jsonConverter;
+
+  @KafkaListener(topics = PaymentCanceledEvent.TOPIC, groupId = "ticket-group")
+  public void handlePaymentCanceled(@Payload DomainEventEnvelope envelope, Acknowledgment ack) {
+
+    PaymentCanceledEvent event = null;
+
+    try {
+      event = jsonConverter.deserialize(envelope.payload(), PaymentCanceledEvent.class);
+
+      log.info("결제 취소 이벤트 수신. 입장권 취소 처리. bookingId: {}", event.bookingId());
+
+      // 입장권 취소에는 bookingId만 사용한다.
+      // 중복 수신/USED 등 비정상 케이스는 TicketCancelUseCase가 멱등하게(로그만) 처리한다.
+      ticketCancelUseCase.execute(event.bookingId());
+
+      log.info("입장권 취소 처리 완료. bookingId: {}", event.bookingId());
+
+    } catch (Exception e) {
+      // 결제는 이미 취소된 상태라 재시도해도 결과가 바뀌지 않는다.
+      // 무한 재시도/파티션 블로킹을 피하고, 강한 로그를 남겨 수동 복구가 가능하도록 조치한다.
+      // 역직렬화 실패 시 event가 null이라 bookingId를 못 얻으므로, 항상 살아있는
+      // envelope.eventId()를 함께 남겨 어떤 메시지가 실패했는지 추적할 수 있게 한다.
+      Long failedBookingId = (event != null) ? event.bookingId() : null;
+      log.error(
+          "[CRITICAL] 결제 취소 이벤트로 입장권 취소 중 치명적 오류 발생! "
+              + "결제는 취소되었으나 입장권 취소에 실패했습니다. 확인이 필요합니다. eventId: {}, bookingId: {}",
+          envelope.eventId(),
+          failedBookingId,
+          e);
+
+      // TODO: 추후 고도화 시, 이 위치에서 DLT로 실패한 이벤트를 재발행
+
+    } finally {
+      // 카프카 메시지가 무한 반복되며 파티션을 막는 현상 방지
+      ack.acknowledge();
+    }
+  }
+}

--- a/ticket-service/src/main/java/com/ticketrush/boundedcontext/ticket/out/repository/TicketRepository.java
+++ b/ticket-service/src/main/java/com/ticketrush/boundedcontext/ticket/out/repository/TicketRepository.java
@@ -28,4 +28,18 @@ public interface TicketRepository extends JpaRepository<Ticket, Long> {
       @Param("now") LocalDateTime now,
       @Param("used") TicketStatus used,
       @Param("unused") TicketStatus unused);
+
+  /**
+   * 입장권을 UNUSED -> CANCELED로 전이시키는 조건부 UPDATE. 결제 취소(환불) 이벤트는 bookingId만 전달하므로 bookingId 기준으로 갱신한다.
+   * {@code AND ticketStatus = :unused}가 가드 역할을 하여, 이미 USED(입장 완료)인 입장권은 0행이 되어 덮어쓰지 않고, 동일 취소 이벤트를
+   * 중복 수신해도 (이미 CANCELED) 0행이 되어 멱등하게 동작한다.
+   */
+  @Modifying(clearAutomatically = true, flushAutomatically = true)
+  @Query(
+      "UPDATE Ticket t SET t.ticketStatus = :canceled "
+          + "WHERE t.bookingId = :bookingId AND t.ticketStatus = :unused")
+  int markCanceledByBookingId(
+      @Param("bookingId") Long bookingId,
+      @Param("canceled") TicketStatus canceled,
+      @Param("unused") TicketStatus unused);
 }

--- a/ticket-service/src/test/java/com/ticketrush/boundedcontext/ticket/app/usecase/TicketCancelUseCaseTest.java
+++ b/ticket-service/src/test/java/com/ticketrush/boundedcontext/ticket/app/usecase/TicketCancelUseCaseTest.java
@@ -1,0 +1,117 @@
+package com.ticketrush.boundedcontext.ticket.app.usecase;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.ticketrush.boundedcontext.ticket.domain.entity.Ticket;
+import com.ticketrush.boundedcontext.ticket.domain.types.TicketStatus;
+import com.ticketrush.boundedcontext.ticket.out.repository.TicketRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class TicketCancelUseCaseTest {
+
+  @InjectMocks private TicketCancelUseCase ticketCancelUseCase;
+
+  @Mock private TicketRepository ticketRepository;
+
+  private static final Long BOOKING_ID = 10L;
+
+  private Ticket ticketWithStatus(TicketStatus status) {
+    return Ticket.builder()
+        .bookingId(BOOKING_ID)
+        .ticketTokenHash("hash")
+        .ticketStatus(status)
+        .build();
+  }
+
+  @Test
+  @DisplayName("성공: UNUSED 입장권은 1행이 갱신되어 취소되고, 사유 재조회는 하지 않는다")
+  void execute_cancels_unused_ticket() {
+    // given: 조건부 UPDATE가 1행을 갱신
+    given(
+            ticketRepository.markCanceledByBookingId(
+                BOOKING_ID, TicketStatus.CANCELED, TicketStatus.UNUSED))
+        .willReturn(1);
+
+    // when & then
+    assertThatCode(() -> ticketCancelUseCase.execute(BOOKING_ID)).doesNotThrowAnyException();
+
+    // then: 성공 시 사유 구분을 위한 재조회는 일어나지 않는다
+    verify(ticketRepository)
+        .markCanceledByBookingId(BOOKING_ID, TicketStatus.CANCELED, TicketStatus.UNUSED);
+    verify(ticketRepository, never()).findByBookingId(anyLong());
+  }
+
+  @Test
+  @DisplayName("0행 + 티켓 없음: 예외 없이 경고 로그만 남기고 종료한다")
+  void execute_skips_when_ticket_not_found() {
+    // given
+    given(
+            ticketRepository.markCanceledByBookingId(
+                BOOKING_ID, TicketStatus.CANCELED, TicketStatus.UNUSED))
+        .willReturn(0);
+    given(ticketRepository.findByBookingId(BOOKING_ID)).willReturn(Optional.empty());
+
+    // when & then
+    assertThatCode(() -> ticketCancelUseCase.execute(BOOKING_ID)).doesNotThrowAnyException();
+    verify(ticketRepository).findByBookingId(BOOKING_ID);
+  }
+
+  @Test
+  @DisplayName("0행 + 이미 USED: 입장 완료 티켓은 덮어쓰지 않고 예외 없이 무시한다")
+  void execute_ignores_already_used_ticket() {
+    // given
+    given(
+            ticketRepository.markCanceledByBookingId(
+                BOOKING_ID, TicketStatus.CANCELED, TicketStatus.UNUSED))
+        .willReturn(0);
+    given(ticketRepository.findByBookingId(BOOKING_ID))
+        .willReturn(Optional.of(ticketWithStatus(TicketStatus.USED)));
+
+    // when & then: 정책상 USED는 무시(예외 없음)
+    assertThatCode(() -> ticketCancelUseCase.execute(BOOKING_ID)).doesNotThrowAnyException();
+    verify(ticketRepository).findByBookingId(BOOKING_ID);
+  }
+
+  @Test
+  @DisplayName("0행 + 이미 CANCELED: 멱등하게 예외 없이 종료한다")
+  void execute_is_idempotent_when_already_canceled() {
+    // given
+    given(
+            ticketRepository.markCanceledByBookingId(
+                BOOKING_ID, TicketStatus.CANCELED, TicketStatus.UNUSED))
+        .willReturn(0);
+    given(ticketRepository.findByBookingId(BOOKING_ID))
+        .willReturn(Optional.of(ticketWithStatus(TicketStatus.CANCELED)));
+
+    // when & then
+    assertThatCode(() -> ticketCancelUseCase.execute(BOOKING_ID)).doesNotThrowAnyException();
+    verify(ticketRepository).findByBookingId(BOOKING_ID);
+  }
+
+  @Test
+  @DisplayName("0행 + 재조회 시 UNUSED(동시성 경합 윈도우): 예외 없이 건너뛴다")
+  void execute_skips_when_still_unused_on_recheck() {
+    // given: UPDATE 직후 재조회 사이에 다른 트랜잭션이 개입한 드문 경합 케이스
+    given(
+            ticketRepository.markCanceledByBookingId(
+                BOOKING_ID, TicketStatus.CANCELED, TicketStatus.UNUSED))
+        .willReturn(0);
+    given(ticketRepository.findByBookingId(BOOKING_ID))
+        .willReturn(Optional.of(ticketWithStatus(TicketStatus.UNUSED)));
+
+    // when & then: default 분기(예외 미발생, 로그만)
+    assertThatCode(() -> ticketCancelUseCase.execute(BOOKING_ID)).doesNotThrowAnyException();
+    verify(ticketRepository).findByBookingId(BOOKING_ID);
+  }
+}

--- a/ticket-service/src/test/java/com/ticketrush/boundedcontext/ticket/in/eventlistener/PaymentCanceledEventListenerTest.java
+++ b/ticket-service/src/test/java/com/ticketrush/boundedcontext/ticket/in/eventlistener/PaymentCanceledEventListenerTest.java
@@ -1,0 +1,105 @@
+package com.ticketrush.boundedcontext.ticket.in.eventlistener;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.ticketrush.boundedcontext.ticket.app.usecase.TicketCancelUseCase;
+import com.ticketrush.global.event.DomainEventEnvelope;
+import com.ticketrush.global.json.DeserializationException;
+import com.ticketrush.global.json.JsonConverter;
+import com.ticketrush.shared.payment.event.PaymentCanceledEvent;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.BDDMockito;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.kafka.support.Acknowledgment;
+
+@ExtendWith(MockitoExtension.class)
+class PaymentCanceledEventListenerTest {
+
+  @InjectMocks private PaymentCanceledEventListener listener;
+
+  @Mock private TicketCancelUseCase ticketCancelUseCase;
+
+  @Mock private JsonConverter jsonConverter;
+
+  @Mock private Acknowledgment acknowledgment;
+
+  // jsonConverter를 모킹하므로 payload 문자열은 실제로 파싱되지 않는다(역직렬화 결과는 스텁으로 지정).
+  private static final String PAYLOAD = "payload";
+  private static final Long BOOKING_ID = 10L;
+
+  private DomainEventEnvelope envelope() {
+    return new DomainEventEnvelope(
+        "event-id",
+        PaymentCanceledEvent.EVENT_NAME,
+        Instant.now(),
+        PaymentCanceledEvent.TOPIC,
+        PAYLOAD,
+        null);
+  }
+
+  private PaymentCanceledEvent event() {
+    return new PaymentCanceledEvent(
+        1L, BOOKING_ID, 3L, 4L, 50000L, "단순 변심", LocalDateTime.of(2026, 5, 22, 10, 30));
+  }
+
+  @Test
+  @DisplayName("결제 취소 이벤트를 수신하면 해당 bookingId로 입장권을 취소하고 오프셋을 커밋한다")
+  void handlePaymentCanceled() {
+    // given
+    DomainEventEnvelope envelope = envelope();
+    BDDMockito.given(jsonConverter.deserialize(PAYLOAD, PaymentCanceledEvent.class))
+        .willReturn(event());
+
+    // when
+    listener.handlePaymentCanceled(envelope, acknowledgment);
+
+    // then
+    verify(ticketCancelUseCase).execute(BOOKING_ID);
+    verify(acknowledgment).acknowledge();
+  }
+
+  @Test
+  @DisplayName("취소 유스케이스가 예외를 던져도 예외를 전파하지 않고 오프셋을 커밋한다")
+  void handlePaymentCanceledSwallowsCancelFailure() {
+    // given
+    DomainEventEnvelope envelope = envelope();
+    BDDMockito.given(jsonConverter.deserialize(PAYLOAD, PaymentCanceledEvent.class))
+        .willReturn(event());
+    willThrow(new RuntimeException("입장권 취소 실패")).given(ticketCancelUseCase).execute(BOOKING_ID);
+
+    // when & then: 취소 실패가 리스너 밖으로 전파되지 않는다(파티션 블로킹 방지)
+    assertThatCode(() -> listener.handlePaymentCanceled(envelope, acknowledgment))
+        .doesNotThrowAnyException();
+
+    // then: 취소는 시도되었고, 실패와 무관하게 오프셋은 커밋된다
+    verify(ticketCancelUseCase).execute(BOOKING_ID);
+    verify(acknowledgment).acknowledge();
+  }
+
+  @Test
+  @DisplayName("이벤트 역직렬화에 실패해도 예외를 전파하지 않고 오프셋을 커밋한다")
+  void handlePaymentCanceledSwallowsDeserializationException() {
+    // given: 실제 JsonConverter가 변환 실패 시 던지는 예외 타입으로 스텁한다
+    DomainEventEnvelope envelope = envelope();
+    BDDMockito.given(jsonConverter.deserialize(PAYLOAD, PaymentCanceledEvent.class))
+        .willThrow(new DeserializationException(new RuntimeException("broken payload")));
+
+    // when & then: 예외를 리스너 밖으로 전파하지 않는다
+    assertThatCode(() -> listener.handlePaymentCanceled(envelope, acknowledgment))
+        .doesNotThrowAnyException();
+
+    // then: 취소 유스케이스는 호출되지 않고, 오프셋은 커밋된다
+    verify(ticketCancelUseCase, never()).execute(anyLong());
+    verify(acknowledgment).acknowledge();
+  }
+}

--- a/ticket-service/src/test/java/com/ticketrush/boundedcontext/ticket/out/repository/TicketRepositoryTest.java
+++ b/ticket-service/src/test/java/com/ticketrush/boundedcontext/ticket/out/repository/TicketRepositoryTest.java
@@ -68,4 +68,61 @@ class TicketRepositoryTest {
     // then
     assertThat(second).isEqualTo(0);
   }
+
+  @Test
+  @DisplayName("markCanceledByBookingId: UNUSED 입장권을 CANCELED로 전이하며 1행을 갱신한다")
+  void markCanceledByBookingId_changes_unused_to_canceled() {
+    // given
+    Ticket ticket = persistUnused(300L, "hash-3");
+
+    // when
+    int updatedCount =
+        ticketRepository.markCanceledByBookingId(300L, TicketStatus.CANCELED, TicketStatus.UNUSED);
+
+    // then
+    assertThat(updatedCount).isEqualTo(1);
+    entityManager.clear();
+    Ticket found = ticketRepository.findById(ticket.getId()).orElseThrow();
+    assertThat(found.getTicketStatus()).isEqualTo(TicketStatus.CANCELED);
+  }
+
+  @Test
+  @DisplayName("markCanceledByBookingId: 이미 USED인 입장권은 0행을 갱신하고 USED 상태를 유지한다")
+  void markCanceledByBookingId_returns_zero_when_already_used() {
+    // given
+    Ticket ticket = persistUnused(400L, "hash-4");
+    int used =
+        ticketRepository.markUsedById(
+            ticket.getId(), LocalDateTime.now(), TicketStatus.USED, TicketStatus.UNUSED);
+    assertThat(used).isEqualTo(1);
+    entityManager.clear();
+
+    // when
+    int updatedCount =
+        ticketRepository.markCanceledByBookingId(400L, TicketStatus.CANCELED, TicketStatus.UNUSED);
+
+    // then
+    assertThat(updatedCount).isEqualTo(0);
+    entityManager.clear();
+    Ticket found = ticketRepository.findById(ticket.getId()).orElseThrow();
+    assertThat(found.getTicketStatus()).isEqualTo(TicketStatus.USED);
+  }
+
+  @Test
+  @DisplayName("markCanceledByBookingId: 이미 CANCELED인 입장권은 0행을 갱신해 멱등하게 동작한다")
+  void markCanceledByBookingId_returns_zero_when_already_canceled() {
+    // given
+    persistUnused(500L, "hash-5");
+    int first =
+        ticketRepository.markCanceledByBookingId(500L, TicketStatus.CANCELED, TicketStatus.UNUSED);
+    assertThat(first).isEqualTo(1);
+    entityManager.clear();
+
+    // when: 동일 예매에 대해 취소를 다시 시도
+    int second =
+        ticketRepository.markCanceledByBookingId(500L, TicketStatus.CANCELED, TicketStatus.UNUSED);
+
+    // then
+    assertThat(second).isEqualTo(0);
+  }
 }


### PR DESCRIPTION
## 🔗 관련 이슈

- close #292

---

## 📌 주요 변경 사항

- 결제 취소(환불) 시 발급된 입장권을 자동으로 취소(→CANCELED) 처리하는 이벤트 구독 추가
- 기존 자동발급(`PaymentConfirmedEvent` 구독)과 동일한 이벤트 구독 방식으로 통일

---

## 🛠 상세 구현 내용

- **`PaymentCanceledEventListener` 신설** — `PaymentCanceledEvent`(`payment-canceled-topic`)를 Kafka로 구독. `PaymentConfirmedEventListener` 패턴 그대로(멱등 처리, 모든 예외 흡수 + `finally`에서 `ack.acknowledge()`, 실패 시 강한 로그 + DLT TODO)
- **`TicketRepository.markCanceledByBookingId` 추가** — `UPDATE ... SET status=CANCELED WHERE bookingId=:bookingId AND status=UNUSED` 조건부 UPDATE. `markUsedById`와 동일한 멱등/동시성 가드(이미 USED/CANCELED면 0행 no-op)
- **`TicketCancelUseCase` 신설** — 영향행수 판정(1행=취소 성공). 0행이면 `findByBookingId`로 사유 구분(없음/USED/CANCELED)해 로그만 남기고 예외를 전파하지 않음. **이미 입장(USED)한 티켓은 덮어쓰지 않고 무시 + 경고 로그**(정책)

---

## ✅ 테스트

### 테스트 방법

- `./gradlew :ticket-service:test :ticket-service:spotlessCheck`
- 추가한 자동화 테스트:
  - `TicketRepositoryTest` (@DataJpaTest): `markCanceledByBookingId` — UNUSED→CANCELED 1행 / 이미 USED는 0행·USED 유지 / 이미 CANCELED는 0행(멱등)
  - `TicketCancelUseCaseTest` (Mockito): 1행 성공(재조회 안 함) / 0행+없음 / 0행+USED 무시 / 0행+CANCELED 멱등 / 0행+UNUSED(경합) 분기
  - `PaymentCanceledEventListenerTest` (Mockito): 정상 처리+ack / UseCase 예외 흡수+ack / 역직렬화 실패 흡수+ack(UseCase 미호출)

### 테스트 결과

- `BUILD SUCCESSFUL` — 위 테스트 전부 통과, spotlessCheck 통과
<!--
### 📸 스크린샷

- 
-->
---

## 👀 리뷰 요청 사항

- 입장 완료(USED)된 티켓에 취소 이벤트가 와도 CANCELED로 덮지 않고 무시하는 정책이 적절한지 확인 부탁드립니다.
- **알려진 한계(known limitation):** 발급(`PaymentConfirmedEvent`)과 취소(`PaymentCanceledEvent`)는 서로 다른 토픽이라 처리 순서가 보장되지 않습니다. 취소가 발급보다 먼저 소비되는 극히 드문 경우, 취소가 경고 로그만 남기고 UNUSED 티켓이 잔존할 수 있습니다(환불은 결제 확정 후 발생하므로 현실적 발생 가능성은 낮아 현 범위에서는 수용).

---

## ⚠️ 배포 시 주의사항

- ticket-service가 신규로 `payment-canceled-topic`을 구독합니다. 브로커에 해당 토픽이 존재(또는 자동 생성 허용)하는지 확인 필요.
