### PR TITLE
[Chore] #281 AGENTS.md 빌드 명령 보완 및 CLAUDE.md 정리

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ TicketRush 백엔드의 **도구 중립 AI 진입점**입니다. Claude Code·Gi
 ./gradlew spotlessApply                 # 코드 포맷 자동 수정 (spotlessCheck 실패 시)
 ./gradlew checkstyleMain checkstyleTest # Checkstyle 검사 (CI 필수 단계; maxWarnings=0)
 ./gradlew test                          # 테스트 실행
-./gradlew build                         # 빌드 (검증 전체 포함)
+./gradlew build -x test                 # 빌드 (CI Build 단계와 동일; test는 위에서 분리 실행)
 ```
 
 > Windows PowerShell에서는 `.\gradlew` 또는 `gradlew.bat`을 사용합니다.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,9 +6,11 @@ TicketRush 백엔드의 **도구 중립 AI 진입점**입니다. Claude Code·Gi
 ## 빌드 · 테스트
 
 ```bash
-./gradlew spotlessCheck   # 코드 포맷 검사 (pre-commit·CI가 자동 검증; 로컬 사전 확인용)
-./gradlew test            # 테스트 실행
-./gradlew build           # 빌드
+./gradlew spotlessCheck                 # 코드 포맷 검사 (CI가 자동 검증; 로컬 사전 확인용)
+./gradlew spotlessApply                 # 코드 포맷 자동 수정 (spotlessCheck 실패 시)
+./gradlew checkstyleMain checkstyleTest # Checkstyle 검사 (CI 필수 단계; maxWarnings=0)
+./gradlew test                          # 테스트 실행
+./gradlew build                         # 빌드 (검증 전체 포함)
 ```
 
 > Windows PowerShell에서는 `.\gradlew` 또는 `gradlew.bat`을 사용합니다.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@
 
 ## 🚫 AI 금지규칙 (Hard Rules)
 
-1. **승인 전 코드 수정 금지** — 플랜/PR 승인 게이트를 통과하기 전에는 프로덕션 코드를 변경하지 않는다. (상세: [`docs/ai-workflow-guide.md`](docs/ai-workflow-guide.md) 6장)
+1. **승인 전 코드 수정 금지** — 플랜/PR 승인 게이트를 통과하기 전에는 프로덕션 코드를 변경하지 않는다.
 2. **작업 범위 밖 임의 변경 금지** — 이슈·플랜에 없는 리팩토링·파일 변경을 하지 않는다.
 3. **추측으로 파일·경로·심볼 단정 금지** — 읽기/검색으로 확인한 뒤에만 단정한다.
 4. **컨벤션 SSOT = [`docs/backend-convention.md`](docs/backend-convention.md)** — 컨벤션은 그 문서에서만 관리하고 여기에 재기술하지 않는다.
@@ -41,7 +41,6 @@ Java · Spring Boot 기반. **버전 등 상세는 [`docs/backend-convention.md`
 
 - 이슈/PR 조회: `gh issue view {번호}` 또는 `gh pr view {번호}` 로 직접 가져옴
 - 브랜치: **`{이슈 label}/{이슈번호}`** 기준으로 작업 (예: label `refactor` → `refactor/250`). 상세는 [`docs/backend-convention.md`](docs/backend-convention.md) 브랜치 규칙.
-- **개발 사이클 자동 진행:** 사용자가 **"이슈 N번 개발 진행하자"**(또는 "N번 이슈 개발 시작", "N번 작업하자" 등 이슈 번호 + 개발 시작 의도)라고 하면, `/dev-cycle N` 커맨드(`.claude/commands/dev-cycle.md`)를 실행해 권장 작업 사이클(조사→계획→승인→구현→검증→커밋→PR)을 순서대로 진행한다. 자세한 흐름은 `docs/ai-workflow-guide.md` 6장 참고.
 - **이슈 생성:** 사용자가 **"이슈 만들어줘"**(또는 "이번 작업 이슈로", "이슈 올려줘" 등 이슈 생성 의도)라고 하면 `/issue` 커맨드(`.claude/commands/issue.md`)를 실행한다.
 - **PR 생성:** 사용자가 **"PR 올려줘"**(또는 "PR 만들어줘", "풀리퀘 올려" 등 PR 생성 의도)라고 하면 `/pr` 커맨드(`.claude/commands/pr.md`)를 실행한다. 초안을 보여주고 승인받은 뒤에만 PR을 생성한다(Draft 아님).
 - **PR 리뷰 반영:** 사용자가 **"PR 리뷰 반영해줘"**(또는 "코드 리뷰 반영", "리뷰 코멘트 처리해줘" 등)라고 하면 `/apply-review` 커맨드(`.claude/commands/apply-review.md`)를 실행한다. 코멘트를 분류표로 제시하고, 사람이 건별 수용/거절을 결정하면 수용 건만 수정한다(승인 전 코드 수정·답글 금지).


### PR DESCRIPTION
## 🔗 관련 이슈

- Refs #281 (트래킹 이슈 — 이 PR로 닫지 않음)

---

## 📌 주요 변경 사항

- `AGENTS.md` 빌드·테스트 섹션을 실제 CI(`ci.yml`) 흐름과 일치하도록 보완
- `CLAUDE.md`에서 유효하지 않은 문서 링크 및 dev-cycle 항목 정리

---

## 🛠 상세 구현 내용

- **AGENTS.md**
  - `checkstyleMain checkstyleTest` 명령 추가 — CI가 필수 단계로 강제(`maxWarnings=0`)하나 문서에 누락돼 있던 것을 반영
  - `spotlessApply`(포맷 자동 수정) 명령 추가 — `spotlessCheck` 실패 시 로컬 대응 편의
  - 근거 없는 "pre-commit" 문구 정정 → "CI가 자동 검증" (저장소에 git hook·`.pre-commit-config.yaml`·`.husky` 부재 확인)
- **CLAUDE.md**
  - AI 금지규칙 1번의 유효하지 않은 문서 링크 제거
  - 워크플로우의 dev-cycle 항목 제거

---

## ✅ 테스트

### 테스트 방법

- 문서(`.md`)만 변경 — 자동화 테스트 대상 아님
- `AGENTS.md`의 각 gradle 명령이 `.github/workflows/ci.yml` 단계와 1:1 대응하는지 대조 확인

### 테스트 결과

- `spotlessCheck` / `checkstyleMain checkstyleTest` / `test` / `build` 모두 CI 단계와 일치 확인
<!--
### 📸 스크린샷

---

## 👀 리뷰 요청 사항

- 

---

## ⚠️ 배포 시 주의사항

- 없음 (문서 변경, 런타임 영향 없음)
-->