### PR TITLE
[Feat] #296 동일 booking 동시 confirm 중복 결제 방지 (bookingId 동시성 제약)

### DIFF
--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/facade/PaymentFacade.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/facade/PaymentFacade.java
@@ -35,10 +35,11 @@ public class PaymentFacade {
     try {
       return paymentConfirmUseCase.execute(userId, request);
     } catch (DataIntegrityViolationException e) {
-      // 동시 confirm 요청이 paymentKey unique 제약에 막힌 경우, 먼저 확정된 결제를 멱등 반환한다.
-      // paymentKey 충돌이 아닌 다른 무결성 위반이라 조회되지 않으면, 원인을 숨기지 않도록 원래 예외를 재던진다.
+      // 동시 confirm 요청이 unique 제약에 막힌 경우, 먼저 확정된 결제를 멱등 반환한다. bookingId 조회는 paymentKey 충돌과
+      // 동일 booking·다른 paymentKey 충돌(uk_payment_completed_booking, #296)을 모두 흡수하는 상위집합이다. 유니크
+      // 충돌이 아닌 다른 무결성 위반이라 조회되지 않으면, 원인을 숨기지 않도록 원래 예외를 재던진다.
       try {
-        return paymentConfirmUseCase.getConfirmedResponse(request.paymentKey());
+        return paymentConfirmUseCase.getConfirmedResponseByBookingId(request.bookingId());
       } catch (BusinessException lookupFailure) {
         throw e;
       }

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentConfirmUseCase.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentConfirmUseCase.java
@@ -19,8 +19,10 @@ import org.springframework.stereotype.Service;
 /**
  * 결제 승인(confirm) UseCase.
  *
- * <p>쓰기가 {@code paymentRepository.save} 단건뿐이라 여러 문장을 묶는 트랜잭션이 필요 없다. 따라서 PG 승인(외부 왕복)을 트랜잭션 안에 가두지
- * 않아 DB 커넥션을 장시간 점유하지 않는다. 이벤트는 save(자체 트랜잭션 커밋) 성공 이후에 호출되므로, 커밋에 성공한 데이터만 외부로 전파된다.
+ * <p>쓰기가 {@code paymentRepository.saveAndFlush} 단건뿐이라 여러 문장을 묶는 트랜잭션이 필요 없다. 따라서 PG 승인(외부 왕복)을 트랜잭션
+ * 안에 가두지 않아 DB 커넥션을 장시간 점유하지 않는다. 이벤트는 saveAndFlush(자체 트랜잭션 커밋) 성공 이후에 호출되므로, 커밋에 성공한 데이터만 외부로
+ * 전파된다. (ID 전략이 IDENTITY라 {@code save}만으로도 INSERT가 즉시 실행되지만, 동시 confirm 시 unique 위반을 이벤트 발행 이전에
+ * 표면화한다는 의도를 명시하고 취소 경로({@code PaymentCancelPersister})와 일관성을 맞추기 위해 saveAndFlush를 쓴다, #296.)
  */
 @Service
 @RequiredArgsConstructor
@@ -71,7 +73,10 @@ public class PaymentConfirmUseCase {
             .paidAt(approval.approvedAt())
             .build();
 
-    Payment saved = paymentRepository.save(payment);
+    // 동일 booking 동시 confirm 시 uk_payment_completed_booking unique 위반을 이벤트 발행 이전에 표면화하기 위해
+    // saveAndFlush로 INSERT를 flush한다. 위반(DataIntegrityViolationException)은 PaymentFacade가 멱등
+    // 처리한다(#296).
+    Payment saved = paymentRepository.saveAndFlush(payment);
 
     paymentEventPublisher.publishConfirmed(
         saved.getId(),
@@ -85,15 +90,16 @@ public class PaymentConfirmUseCase {
   }
 
   /**
-   * 이미 확정된 결제를 paymentKey로 조회해 멱등 응답으로 반환한다.
+   * 이미 확정된 결제를 bookingId로 조회해 멱등 응답으로 반환한다.
    *
-   * <p>동시 confirm 요청이 paymentKey unique 제약에 막혔을 때, 먼저 확정된 결제를 돌려주기 위해 {@link
-   * com.ticketrush.boundedcontext.payment.app.facade.PaymentFacade}의 멱등 fallback에서 호출한다.
+   * <p>동시 confirm 요청이 unique 제약에 막혔을 때, 먼저 확정된 COMPLETED 결제를 돌려주기 위해 {@link
+   * com.ticketrush.boundedcontext.payment.app.facade.PaymentFacade}의 멱등 fallback에서 호출한다. bookingId
+   * 기준 조회는 paymentKey 충돌의 상위집합이라, 동일 paymentKey 재수신과 동일 booking·다른 paymentKey 충돌을 모두 흡수한다(#296).
    */
-  public PaymentConfirmResponse getConfirmedResponse(String paymentKey) {
+  public PaymentConfirmResponse getConfirmedResponseByBookingId(Long bookingId) {
     Payment payment =
         paymentRepository
-            .findByPaymentKey(paymentKey)
+            .findFirstByBookingIdAndStatus(bookingId, PaymentStatus.COMPLETED)
             .orElseThrow(() -> new BusinessException(ErrorStatus.PAYMENT_NOT_FOUND));
     return paymentMapper.toConfirmResponse(payment);
   }

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/domain/entity/Payment.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/domain/entity/Payment.java
@@ -52,6 +52,14 @@ public class Payment extends AutoIdBaseEntity {
 
   private LocalDateTime paidAt; // 결제 완료 시점
 
+  /* completedBookingId는 status=COMPLETED일 때만 booking_id 값을 갖는 DB generated 컬럼이다(그 외 NULL). 이 컬럼의
+   * unique 제약(uk_payment_completed_booking)으로 동일 booking에 서로 다른 paymentKey를 가진 confirm이 동시에 들어와도
+   * COMPLETED 결제가 2건 생성되지 못하게 DB 레벨에서 막는다(#296, TOCTOU 최종 방어선). MySQL은 NULL을 unique 중복으로 보지 않으므로
+   * CANCELED/FAILED 후 재결제는 허용된다. 값 계산과 unique 제약은 수동 DDL로만 관리하고(ddl-auto=update가 generated 컬럼을
+   * 만들지 못한다) 애플리케이션은 읽기만 하므로, insertable=false·updatable=false로 매핑한다. */
+  @Column(name = "completed_booking_id", insertable = false, updatable = false)
+  private Long completedBookingId;
+
   @Builder
   private Payment(
       Long bookingId,

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/out/repository/PaymentRepository.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/out/repository/PaymentRepository.java
@@ -11,6 +11,13 @@ public interface PaymentRepository extends JpaRepository<Payment, Long> {
 
   boolean existsByBookingIdAndStatus(Long bookingId, PaymentStatus status);
 
+  /*
+   * 멱등 fallback에서 "먼저 확정된 COMPLETED 결제"를 조회한다. uk_payment_completed_booking 제약이 정상 적용된 환경에서는
+   * booking당 COMPLETED가 최대 1건이지만, 제약이 누락된 비정상 환경에서도 IncorrectResultSizeDataAccessException으로
+   * 깨지지 않도록 findFirst(LIMIT 1)로 조회한다(#296).
+   */
+  Optional<Payment> findFirstByBookingIdAndStatus(Long bookingId, PaymentStatus status);
+
   Page<Payment> findByUserIdAndStatus(Long userId, PaymentStatus status, Pageable pageable);
 
   Optional<Payment> findByIdAndUserId(Long id, Long userId);

--- a/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/app/facade/PaymentFacadeTest.java
+++ b/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/app/facade/PaymentFacadeTest.java
@@ -100,40 +100,40 @@ class PaymentFacadeTest {
 
     // then
     assertThat(response).isSameAs(expected);
-    verify(paymentConfirmUseCase, never()).getConfirmedResponse(any());
+    verify(paymentConfirmUseCase, never()).getConfirmedResponseByBookingId(any());
   }
 
   @Test
-  @DisplayName("동시 confirm으로 paymentKey unique 제약이 위반되면 먼저 확정된 결제를 멱등 반환한다")
+  @DisplayName("동시 confirm으로 booking unique 제약이 위반되면 먼저 확정된 결제를 멱등 반환한다")
   void confirm_falls_back_to_existing_on_constraint_violation() {
     // given
     Long userId = 10L;
-    String paymentKey = "pgKey_xyz";
-    PaymentConfirmRequest request = confirmRequest(paymentKey);
+    Long bookingId = 100L;
+    PaymentConfirmRequest request = confirmRequest("pgKey_xyz");
     PaymentConfirmResponse existing =
         new PaymentConfirmResponse(1L, "COMPLETED", LocalDateTime.now());
     given(paymentConfirmUseCase.execute(userId, request))
-        .willThrow(new DataIntegrityViolationException("duplicate paymentKey"));
-    given(paymentConfirmUseCase.getConfirmedResponse(paymentKey)).willReturn(existing);
+        .willThrow(new DataIntegrityViolationException("duplicate completed_booking_id"));
+    given(paymentConfirmUseCase.getConfirmedResponseByBookingId(bookingId)).willReturn(existing);
 
     // when
     PaymentConfirmResponse response = paymentFacade.confirm(userId, request);
 
     // then
     assertThat(response).isSameAs(existing);
-    verify(paymentConfirmUseCase).getConfirmedResponse(eq(paymentKey));
+    verify(paymentConfirmUseCase).getConfirmedResponseByBookingId(eq(bookingId));
   }
 
   @Test
-  @DisplayName("paymentKey 충돌이 아닌 무결성 위반으로 조회되지 않으면 원래 예외를 재던진다")
+  @DisplayName("유니크 충돌이 아닌 무결성 위반으로 조회되지 않으면 원래 예외를 재던진다")
   void confirm_rethrows_original_when_lookup_fails() {
     // given
     Long userId = 10L;
-    String paymentKey = "pgKey_xyz";
-    PaymentConfirmRequest request = confirmRequest(paymentKey);
+    Long bookingId = 100L;
+    PaymentConfirmRequest request = confirmRequest("pgKey_xyz");
     DataIntegrityViolationException original = new DataIntegrityViolationException("not null 위반");
     given(paymentConfirmUseCase.execute(userId, request)).willThrow(original);
-    given(paymentConfirmUseCase.getConfirmedResponse(paymentKey))
+    given(paymentConfirmUseCase.getConfirmedResponseByBookingId(bookingId))
         .willThrow(new BusinessException(ErrorStatus.PAYMENT_NOT_FOUND));
 
     // when & then

--- a/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentConfirmUseCaseTest.java
+++ b/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentConfirmUseCaseTest.java
@@ -68,7 +68,7 @@ class PaymentConfirmUseCaseTest {
         .willReturn(false);
     given(paymentApprovalClientRouter.approve(any()))
         .willReturn(new PaymentApprovalResponse(approvalNumber, amount, approvedAt));
-    given(paymentRepository.save(any(Payment.class)))
+    given(paymentRepository.saveAndFlush(any(Payment.class)))
         .willAnswer(
             invocation -> {
               Payment p = invocation.getArgument(0);
@@ -95,7 +95,7 @@ class PaymentConfirmUseCaseTest {
     assertThat(sentApproval.amount()).isEqualTo(amount);
 
     ArgumentCaptor<Payment> paymentCaptor = ArgumentCaptor.forClass(Payment.class);
-    verify(paymentRepository).save(paymentCaptor.capture());
+    verify(paymentRepository).saveAndFlush(paymentCaptor.capture());
     Payment savedPayment = paymentCaptor.getValue();
     assertThat(savedPayment.getBookingId()).isEqualTo(bookingId);
     assertThat(savedPayment.getUserId()).isEqualTo(userId);
@@ -110,9 +110,9 @@ class PaymentConfirmUseCaseTest {
         .publishConfirmed(
             eq(savedPaymentId), eq(bookingId), eq(seatId), eq(userId), eq(amount), eq(approvedAt));
 
-    // 이벤트는 save(커밋) 성공 이후에 발행되어야 한다.
+    // 이벤트는 saveAndFlush(커밋) 성공 이후에 발행되어야 한다.
     InOrder inOrder = inOrder(paymentRepository, paymentEventPublisher);
-    inOrder.verify(paymentRepository).save(any(Payment.class));
+    inOrder.verify(paymentRepository).saveAndFlush(any(Payment.class));
     inOrder
         .verify(paymentEventPublisher)
         .publishConfirmed(any(), any(), any(), any(), any(), any());
@@ -148,7 +148,7 @@ class PaymentConfirmUseCaseTest {
         .extracting("errorStatus")
         .isEqualTo(ErrorStatus.PAYMENT_AMOUNT_MISMATCH);
 
-    verify(paymentRepository, never()).save(any(Payment.class));
+    verify(paymentRepository, never()).saveAndFlush(any(Payment.class));
     verify(paymentEventPublisher, never())
         .publishConfirmed(any(), any(), any(), any(), any(), any());
   }
@@ -172,7 +172,7 @@ class PaymentConfirmUseCaseTest {
         .isEqualTo(ErrorStatus.PAYMENT_ALREADY_COMPLETED);
 
     verify(paymentApprovalClientRouter, never()).approve(any());
-    verify(paymentRepository, never()).save(any(Payment.class));
+    verify(paymentRepository, never()).saveAndFlush(any(Payment.class));
     verify(paymentEventPublisher, never())
         .publishConfirmed(any(), any(), any(), any(), any(), any());
   }
@@ -197,34 +197,36 @@ class PaymentConfirmUseCaseTest {
         .isEqualTo(ErrorStatus.BOOKING_EXPIRED);
 
     verify(paymentApprovalClientRouter, never()).approve(any());
-    verify(paymentRepository, never()).save(any(Payment.class));
+    verify(paymentRepository, never()).saveAndFlush(any(Payment.class));
     verify(paymentEventPublisher, never())
         .publishConfirmed(any(), any(), any(), any(), any(), any());
   }
 
   @Test
-  @DisplayName("getConfirmedResponse는 paymentKey로 기존 결제를 찾아 멱등 응답을 반환한다")
-  void getConfirmedResponse_returns_existing() throws Exception {
+  @DisplayName("getConfirmedResponseByBookingId는 bookingId로 먼저 확정된 COMPLETED 결제를 찾아 멱등 응답을 반환한다")
+  void getConfirmedResponseByBookingId_returns_existing() throws Exception {
     // given
-    String paymentKey = "pgKey_xyz";
+    Long bookingId = 100L;
     LocalDateTime paidAt = LocalDateTime.of(2026, 5, 22, 10, 0);
     Payment existing =
         Payment.builder()
-            .bookingId(100L)
+            .bookingId(bookingId)
             .userId(10L)
             .seatId(200L)
             .provider(PaymentProvider.TOSS)
             .amount(55_000L)
             .status(PaymentStatus.COMPLETED)
-            .paymentKey(paymentKey)
+            .paymentKey("pgKey_xyz")
             .approvalNumber("APR-1")
             .paidAt(paidAt)
             .build();
     setId(existing, 999L);
-    given(paymentRepository.findByPaymentKey(paymentKey)).willReturn(Optional.of(existing));
+    given(paymentRepository.findFirstByBookingIdAndStatus(bookingId, PaymentStatus.COMPLETED))
+        .willReturn(Optional.of(existing));
 
     // when
-    PaymentConfirmResponse response = paymentConfirmUseCase.getConfirmedResponse(paymentKey);
+    PaymentConfirmResponse response =
+        paymentConfirmUseCase.getConfirmedResponseByBookingId(bookingId);
 
     // then
     assertThat(response.paymentId()).isEqualTo(999L);
@@ -233,14 +235,15 @@ class PaymentConfirmUseCaseTest {
   }
 
   @Test
-  @DisplayName("getConfirmedResponse는 결제를 찾지 못하면 PAYMENT_404_002 예외가 발생한다")
-  void getConfirmedResponse_throws_when_absent() {
+  @DisplayName("getConfirmedResponseByBookingId는 결제를 찾지 못하면 PAYMENT_404_002 예외가 발생한다")
+  void getConfirmedResponseByBookingId_throws_when_absent() {
     // given
-    String paymentKey = "pgKey_unknown";
-    given(paymentRepository.findByPaymentKey(paymentKey)).willReturn(Optional.empty());
+    Long bookingId = 404L;
+    given(paymentRepository.findFirstByBookingIdAndStatus(bookingId, PaymentStatus.COMPLETED))
+        .willReturn(Optional.empty());
 
     // when & then
-    assertThatThrownBy(() -> paymentConfirmUseCase.getConfirmedResponse(paymentKey))
+    assertThatThrownBy(() -> paymentConfirmUseCase.getConfirmedResponseByBookingId(bookingId))
         .isInstanceOf(BusinessException.class)
         .extracting("errorStatus")
         .isEqualTo(ErrorStatus.PAYMENT_NOT_FOUND);


### PR DESCRIPTION
## 🔗 관련 이슈

- close #296

---

## 📌 주요 변경 사항

- 동일 `bookingId`에 서로 다른 `paymentKey` confirm이 동시에 들어와도 `COMPLETED` 결제가 booking당 1건만 생성되도록 DB 레벨 동시성 제약 추가
- 두 번째(패자) 요청은 중복 결제 없이 멱등 응답으로 흡수
- 기존 `existsByBookingIdAndStatus` 선검사의 TOCTOU 갭 해소

---

## 🛠 상세 구현 내용

- **`Payment`**: `status=COMPLETED`일 때만 `booking_id` 값을 갖는 generated 컬럼 `completed_booking_id`(그 외 NULL)를 읽기전용(`insertable=false, updatable=false`)으로 매핑. MySQL의 "NULL은 unique 중복 아님" 규칙으로 COMPLETED 1건 보장 + CANCELED/FAILED 후 재결제 허용
- **`PaymentConfirmUseCase`**: `save → saveAndFlush`로 전환해 booking unique 위반을 이벤트 발행 이전에 `DataIntegrityViolationException`으로 표면화. `getConfirmedResponse(paymentKey)` → `getConfirmedResponseByBookingId(bookingId)`로 통합(paymentKey 충돌의 상위집합)
- **`PaymentFacade.confirm`**: catch fallback을 bookingId 기준 멱등 재조회로 보강 → paymentKey 충돌과 동일 booking·다른 paymentKey 충돌을 모두 흡수
- **`PaymentRepository`**: `findFirstByBookingIdAndStatus` 추가(제약 누락 환경에서도 다중행 시 `IncorrectResultSizeDataAccessException`으로 깨지지 않도록 LIMIT 1)
- **동시성 방어 원리**: InnoDB에서 중복키 INSERT는 승자 커밋까지 블로킹된 뒤 예외 → 패자가 fallback 조회 시 승자 결제가 이미 조회 가능

---

## ✅ 테스트

### 테스트 방법

- `./gradlew :payment-service:spotlessApply :payment-service:checkstyleMain :payment-service:checkstyleTest :payment-service:test`
- 단위 테스트(Mockito):
  - `PaymentConfirmUseCaseTest` — save→saveAndFlush 전환 검증, `getConfirmedResponseByBookingId` 성공/미존재(PAYMENT_404_002), happy-path·금액불일치·이미완료·만료 회귀
  - `PaymentFacadeTest` — booking unique 위반 시 bookingId 멱등 fallback, 유니크 아닌 무결성 위반 시 원래 예외 재던짐

### 테스트 결과

- `BUILD SUCCESSFUL` — spotless / checkstyleMain / checkstyleTest / test 전부 통과

<!--
### 📸 스크린샷

-
-->

---

## 👀 리뷰 요청 사항

- **동시성 테스트 검증 범위**: 실제 unique 제약은 MySQL generated 컬럼에만 존재하고 H2 테스트 환경엔 생성되지 않아, 단위 테스트는 예외 주입으로 fallback 분기를 검증합니다. 실 DB 동시성 검증(Testcontainers MySQL)은 인프라 도입이 필요해 **후속 이슈로 분리** 제안합니다.
- **fallback userId 스코프**: cancel 경로와 달리 confirm fallback은 bookingId 기준으로만 조회합니다(응답에 민감정보 없음, booking은 단일 사용자 소유). 현 설계 유지가 적절한지 확인 부탁드립니다.

---

## ⚠️ 배포 시 주의사항

- **수동 DDL 선적용 필수** — 이 프로젝트는 마이그레이션 도구(Flyway/Liquibase) 미사용이고 `ddl-auto=update`는 generated 컬럼/unique 인덱스를 자동 생성하지 못합니다. **배포 전** 운영 DB에 아래 DDL을 반드시 적용해야 동시성 보호가 동작합니다(누락 시 앱은 정상 기동하나 방어선 0):
  ```sql
  ALTER TABLE payment ADD COLUMN completed_booking_id BIGINT
    GENERATED ALWAYS AS (CASE WHEN status='COMPLETED' THEN booking_id END) STORED;
  ALTER TABLE payment ADD CONSTRAINT uk_payment_completed_booking UNIQUE (completed_booking_id);
  ```
  - 롤백: `ALTER TABLE payment DROP INDEX uk_payment_completed_booking; ALTER TABLE payment DROP COLUMN completed_booking_id;` (파생 컬럼이라 데이터 무손실)
- **알려진 한계 (별도 이슈 이관 예정)** — DB 제약은 중복 row·중복 티켓·중복 좌석 SOLD를 막지만, 동시 confirm 시 패자 요청이 이미 마친 **PG capture(실제 과금) 자체는 막지 못합니다**. 해당 고아 청구의 보상 취소는 #91(환불 Saga) 또는 신규 이슈에서 다룰 예정입니다.
