### PR TITLE
[Feat] #102 Outbox Message Relay 스케줄러 구현

### DIFF
--- a/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/app/scheduler/OutboxRelayScheduler.java
+++ b/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/app/scheduler/OutboxRelayScheduler.java
@@ -1,0 +1,28 @@
+package com.ticketrush.boundedcontext.booking.app.scheduler;
+
+import com.ticketrush.global.outbox.OutboxRelayService;
+import lombok.RequiredArgsConstructor;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/**
+ * booking-service의 Outbox relay 스케줄러.
+ *
+ * <p>{@code app.event-publisher.type=outbox}일 때만 등록되며(그때만 {@link OutboxRelayService} 빈이 존재), 다중
+ * 인스턴스 중복 실행은 ShedLock으로 방지한다. 자기 소유 애그리거트({@code app.outbox.aggregate-types})만 발행한다.
+ */
+@Component
+@ConditionalOnExpression("'${app.event-publisher.type}' == 'outbox'")
+@RequiredArgsConstructor
+public class OutboxRelayScheduler {
+
+  private final OutboxRelayService outboxRelayService;
+
+  @Scheduled(fixedDelay = 5000)
+  @SchedulerLock(name = "outboxRelay-booking", lockAtLeastFor = "3s", lockAtMostFor = "1m")
+  public void relay() {
+    outboxRelayService.relayBatch();
+  }
+}

--- a/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/app/scheduler/OutboxRelayScheduler.java
+++ b/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/app/scheduler/OutboxRelayScheduler.java
@@ -21,7 +21,9 @@ public class OutboxRelayScheduler {
   private final OutboxRelayService outboxRelayService;
 
   @Scheduled(fixedDelay = 5000)
-  @SchedulerLock(name = "outboxRelay-booking", lockAtLeastFor = "3s", lockAtMostFor = "1m")
+  // lockAtMostFor는 배치 최악 소요(batch-size * SEND_TIMEOUT_SECONDS)를 넉넉히 상회해야 실행 중 lock 만료로 인한 중복 실행을
+  // 막는다.
+  @SchedulerLock(name = "outboxRelay-booking", lockAtLeastFor = "3s", lockAtMostFor = "10m")
   public void relay() {
     outboxRelayService.relayBatch();
   }

--- a/booking-service/src/main/resources/application-local.yml
+++ b/booking-service/src/main/resources/application-local.yml
@@ -13,6 +13,10 @@ spring:
 app:
   event-publisher:
     type: kafka
+  outbox:
+    aggregate-types:
+      - Booking
+    batch-size: 100
 
 custom:
   security:

--- a/common/src/main/java/com/ticketrush/global/outbox/OutboxEntity.java
+++ b/common/src/main/java/com/ticketrush/global/outbox/OutboxEntity.java
@@ -123,4 +123,20 @@ public class OutboxEntity extends AutoIdBaseEntity {
         .retryCount(0)
         .build();
   }
+
+  /** Kafka 발행 성공 시 호출한다. 상태를 {@link OutboxStatus#SENT}로 전이하고 발행 시각을 기록한다. */
+  public void markSent(LocalDateTime publishedAt) {
+    this.status = OutboxStatus.SENT;
+    this.publishedAt = publishedAt;
+  }
+
+  /**
+   * Kafka 발행 실패 시 호출한다. 상태를 {@link OutboxStatus#FAILED}로 전이하고 재시도 횟수를 증가시키며 마지막 실패 사유를 기록한다. 다음
+   * 폴링에서 재발행 대상이 된다.
+   */
+  public void markFailed(String lastError) {
+    this.status = OutboxStatus.FAILED;
+    this.retryCount++;
+    this.lastError = lastError;
+  }
 }

--- a/common/src/main/java/com/ticketrush/global/outbox/OutboxProperties.java
+++ b/common/src/main/java/com/ticketrush/global/outbox/OutboxProperties.java
@@ -1,0 +1,25 @@
+package com.ticketrush.global.outbox;
+
+import java.util.ArrayList;
+import java.util.List;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+/**
+ * Outbox relay 설정.
+ *
+ * <p>여러 서비스가 같은 outbox 테이블을 공유하므로, 각 서비스는 {@link #aggregateTypes}에 자기 소유 애그리거트 타입만 지정해 자신의 이벤트만
+ * 발행한다(예: booking → {@code ["Booking"]}). 값은 {@code OutboxEventPublisher}가 저장하는 aggregateType
+ * 표기(대문자 시작)와 일치해야 한다. 비어 있으면 relay는 아무 것도 발행하지 않는다.
+ */
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "app.outbox")
+public class OutboxProperties {
+
+  private List<String> aggregateTypes = new ArrayList<>();
+  private int batchSize = 100;
+}

--- a/common/src/main/java/com/ticketrush/global/outbox/OutboxRelayService.java
+++ b/common/src/main/java/com/ticketrush/global/outbox/OutboxRelayService.java
@@ -32,7 +32,8 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class OutboxRelayService {
 
-  private static final long SEND_TIMEOUT_SECONDS = 10L;
+  // 건당 최대 대기(초). 배치 최악 소요(batchSize * 이 값)가 스케줄러 lockAtMostFor 안에 들어오도록 유지한다.
+  private static final long SEND_TIMEOUT_SECONDS = 5L;
   private static final List<OutboxStatus> RELAY_TARGET_STATUSES =
       List.of(OutboxStatus.PENDING, OutboxStatus.FAILED);
 

--- a/common/src/main/java/com/ticketrush/global/outbox/OutboxRelayService.java
+++ b/common/src/main/java/com/ticketrush/global/outbox/OutboxRelayService.java
@@ -47,11 +47,15 @@ public class OutboxRelayService {
       return;
     }
 
+    int batchSize = outboxProperties.getBatchSize();
+    if (batchSize < 1) {
+      log.warn("Outbox relay batchSize가 1 미만으로 설정되어 실행을 건너뜁니다. batchSize={}", batchSize);
+      return;
+    }
+
     List<OutboxEntity> rows =
         outboxRepository.findByAggregateTypeInAndStatusInOrderByIdAsc(
-            aggregateTypes,
-            RELAY_TARGET_STATUSES,
-            PageRequest.of(0, outboxProperties.getBatchSize()));
+            aggregateTypes, RELAY_TARGET_STATUSES, PageRequest.of(0, batchSize));
 
     for (OutboxEntity row : rows) {
       relayOne(row);
@@ -100,6 +104,8 @@ public class OutboxRelayService {
   }
 
   private String errorMessage(Exception e) {
-    return e.getMessage() == null ? e.getClass().getSimpleName() : e.getMessage();
+    // send().get() 실패는 보통 ExecutionException으로 감싸지므로 근본 원인(cause)을 우선 남긴다.
+    Throwable cause = e.getCause() != null ? e.getCause() : e;
+    return cause.getMessage() == null ? cause.getClass().getSimpleName() : cause.getMessage();
   }
 }

--- a/common/src/main/java/com/ticketrush/global/outbox/OutboxRelayService.java
+++ b/common/src/main/java/com/ticketrush/global/outbox/OutboxRelayService.java
@@ -1,0 +1,105 @@
+package com.ticketrush.global.outbox;
+
+import com.ticketrush.global.event.DomainEventEnvelope;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.KafkaHeaders;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Outbox 테이블의 미발송/실패 이벤트를 폴링해 실제 Kafka로 발행하는 relay.
+ *
+ * <p>{@code app.event-publisher.type=outbox}일 때만 활성화되며, 서비스별 스케줄러가 {@link #relayBatch()}를 주기적으로
+ * 호출한다. 여러 서비스가 같은 outbox 테이블을 공유하므로 {@link OutboxProperties#getAggregateTypes()}로 자기 소유 이벤트만 발행한다.
+ *
+ * <p>발행 성공 시 {@link OutboxStatus#SENT}, 실패 시 {@link OutboxStatus#FAILED}(다음 폴링에서 재시도)로 전이한다. 발행은
+ * at-least-once이며, 중복은 컨슈머가 {@code eventId}로 멱등 처리한다.
+ */
+@Slf4j
+@Service
+@ConditionalOnExpression("'${app.event-publisher.type}' == 'outbox'")
+@RequiredArgsConstructor
+public class OutboxRelayService {
+
+  private static final long SEND_TIMEOUT_SECONDS = 10L;
+  private static final List<OutboxStatus> RELAY_TARGET_STATUSES =
+      List.of(OutboxStatus.PENDING, OutboxStatus.FAILED);
+
+  private final OutboxRepository outboxRepository;
+  private final KafkaTemplate<String, DomainEventEnvelope> kafkaTemplate;
+  private final OutboxProperties outboxProperties;
+
+  @Transactional
+  public void relayBatch() {
+    List<String> aggregateTypes = outboxProperties.getAggregateTypes();
+    if (aggregateTypes == null || aggregateTypes.isEmpty()) {
+      return;
+    }
+
+    List<OutboxEntity> rows =
+        outboxRepository.findByAggregateTypeInAndStatusInOrderByIdAsc(
+            aggregateTypes,
+            RELAY_TARGET_STATUSES,
+            PageRequest.of(0, outboxProperties.getBatchSize()));
+
+    for (OutboxEntity row : rows) {
+      relayOne(row);
+    }
+  }
+
+  private void relayOne(OutboxEntity row) {
+    try {
+      // 발행 결과에 따라 상태를 전이해야 하므로 동기 대기한다. batchSize가 작아 허용 가능하며,
+      // 필요 시 비동기 일괄 발행으로 최적화할 수 있다.
+      kafkaTemplate.send(toMessage(row)).get(SEND_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+      row.markSent(LocalDateTime.now());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      row.markFailed(errorMessage(e));
+      log.error("Outbox relay interrupted. eventId={}", row.getEventId(), e);
+    } catch (Exception e) {
+      row.markFailed(errorMessage(e));
+      log.error("Outbox relay failed. eventId={}, topic={}", row.getEventId(), row.getTopic(), e);
+    }
+  }
+
+  private Message<DomainEventEnvelope> toMessage(OutboxEntity row) {
+    // of()는 새 eventId를 생성하므로 쓰지 않고, 저장된 eventId를 보존해 envelope를 재구성한다.
+    DomainEventEnvelope envelope =
+        new DomainEventEnvelope(
+            row.getEventId(),
+            row.getEventType(),
+            toInstant(row.getCreatedAt()),
+            row.getTopic(),
+            row.getPayload(),
+            row.getTraceId());
+
+    // KafkaDomainEventPublisher와 동일한 헤더 형태로 발행한다.
+    return MessageBuilder.withPayload(envelope)
+        .setHeader(KafkaHeaders.TOPIC, row.getTopic())
+        .setHeader(KafkaHeaders.KEY, row.getMessageKey())
+        .setHeader("eventType", envelope.eventType())
+        .setHeader("eventId", envelope.eventId())
+        .build();
+  }
+
+  private Instant toInstant(LocalDateTime createdAt) {
+    // outbox는 envelope의 원본 createdAt(Instant)을 보존하지 않아 행 auditing 시각으로 근사한다.
+    return createdAt == null ? Instant.now() : createdAt.atZone(ZoneId.systemDefault()).toInstant();
+  }
+
+  private String errorMessage(Exception e) {
+    return e.getMessage() == null ? e.getClass().getSimpleName() : e.getMessage();
+  }
+}

--- a/common/src/main/java/com/ticketrush/global/outbox/OutboxRepository.java
+++ b/common/src/main/java/com/ticketrush/global/outbox/OutboxRepository.java
@@ -1,11 +1,24 @@
 package com.ticketrush.global.outbox;
 
+import java.util.Collection;
+import java.util.List;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 /**
  * {@link OutboxEntity}에 대한 JPA 저장소.
  *
- * <p>이 이슈(#101) 범위에서는 발행 시 Outbox row를 저장하는 {@code save()}만 사용한다. 폴링 relay용 조회/상태 전이 쿼리는 후속
- * 이슈(#102)에서 추가된다.
+ * <p>발행 시 Outbox row를 저장하는 {@code save()}(#101)와, relay 폴링용 미발송/실패 row 조회(#102)를 제공한다.
  */
-public interface OutboxRepository extends JpaRepository<OutboxEntity, Long> {}
+public interface OutboxRepository extends JpaRepository<OutboxEntity, Long> {
+
+  /**
+   * relay 폴링 대상 row를 오래된 순(PK 오름차순)으로 조회한다.
+   *
+   * <p>여러 서비스가 같은 outbox 테이블을 공유하므로, 호출 서비스는 자기 소유 {@code aggregateTypes}만 넘겨 자신의 이벤트만 발행한다. {@code
+   * statuses}에는 보통 {@link OutboxStatus#PENDING}(미발송)과 {@link OutboxStatus#FAILED}(재시도 대상)를 넘기고,
+   * {@code pageable}로 배치 크기를 제한한다.
+   */
+  List<OutboxEntity> findByAggregateTypeInAndStatusInOrderByIdAsc(
+      Collection<String> aggregateTypes, Collection<OutboxStatus> statuses, Pageable pageable);
+}

--- a/common/src/test/java/com/ticketrush/global/outbox/OutboxRelayServiceTest.java
+++ b/common/src/test/java/com/ticketrush/global/outbox/OutboxRelayServiceTest.java
@@ -1,0 +1,119 @@
+package com.ticketrush.global.outbox;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.ticketrush.global.event.DomainEventEnvelope;
+import java.time.Instant;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Pageable;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.KafkaHeaders;
+import org.springframework.kafka.support.SendResult;
+import org.springframework.messaging.Message;
+
+@ExtendWith(MockitoExtension.class)
+class OutboxRelayServiceTest {
+
+  @InjectMocks private OutboxRelayService outboxRelayService;
+
+  @Mock private OutboxRepository outboxRepository;
+  @Mock private KafkaTemplate<String, DomainEventEnvelope> kafkaTemplate;
+  @Mock private OutboxProperties outboxProperties;
+
+  private OutboxEntity pendingRow(String eventId) {
+    DomainEventEnvelope envelope =
+        new DomainEventEnvelope(
+            eventId,
+            "BookingCreatedEvent",
+            Instant.parse("2026-05-27T06:00:00Z"),
+            "booking-created-topic",
+            "{\"booking_id\":100}",
+            "trace-1");
+    return OutboxEntity.from(envelope, "Booking", "100", "100");
+  }
+
+  @Test
+  @DisplayName("성공: 발행에 성공하면 SENT로 전이하고 eventId를 보존해 전송한다")
+  @SuppressWarnings("unchecked")
+  void relayBatch_marks_sent_on_success() {
+    // given
+    OutboxEntity row = pendingRow("evt-1");
+    given(outboxProperties.getAggregateTypes()).willReturn(List.of("Booking"));
+    given(outboxProperties.getBatchSize()).willReturn(100);
+    given(
+            outboxRepository.findByAggregateTypeInAndStatusInOrderByIdAsc(
+                eq(List.of("Booking")),
+                eq(List.of(OutboxStatus.PENDING, OutboxStatus.FAILED)),
+                any(Pageable.class)))
+        .willReturn(List.of(row));
+    given(kafkaTemplate.send(any(Message.class)))
+        .willReturn(
+            CompletableFuture.completedFuture((SendResult<String, DomainEventEnvelope>) null));
+
+    // when
+    outboxRelayService.relayBatch();
+
+    // then
+    assertThat(row.getStatus()).isEqualTo(OutboxStatus.SENT);
+    assertThat(row.getPublishedAt()).isNotNull();
+
+    ArgumentCaptor<Message<DomainEventEnvelope>> captor = ArgumentCaptor.forClass(Message.class);
+    verify(kafkaTemplate).send(captor.capture());
+    Message<DomainEventEnvelope> sent = captor.getValue();
+    assertThat(sent.getPayload().eventId()).isEqualTo("evt-1"); // eventId 보존
+    assertThat(sent.getHeaders().get(KafkaHeaders.TOPIC)).isEqualTo("booking-created-topic");
+    assertThat(sent.getHeaders().get(KafkaHeaders.KEY)).isEqualTo("100");
+  }
+
+  @Test
+  @DisplayName("실패: 발행에 실패하면 FAILED로 전이하고 retryCount 증가·사유를 기록한다")
+  @SuppressWarnings("unchecked")
+  void relayBatch_marks_failed_on_error() {
+    // given
+    OutboxEntity row = pendingRow("evt-2");
+    given(outboxProperties.getAggregateTypes()).willReturn(List.of("Booking"));
+    given(outboxProperties.getBatchSize()).willReturn(100);
+    given(
+            outboxRepository.findByAggregateTypeInAndStatusInOrderByIdAsc(
+                any(), any(), any(Pageable.class)))
+        .willReturn(List.of(row));
+    given(kafkaTemplate.send(any(Message.class)))
+        .willReturn(CompletableFuture.failedFuture(new RuntimeException("kaboom")));
+
+    // when
+    outboxRelayService.relayBatch();
+
+    // then
+    assertThat(row.getStatus()).isEqualTo(OutboxStatus.FAILED);
+    assertThat(row.getRetryCount()).isEqualTo(1);
+    assertThat(row.getLastError()).contains("kaboom");
+  }
+
+  @Test
+  @DisplayName("소유 aggregateType이 비어 있으면 아무 것도 조회·발행하지 않는다")
+  void relayBatch_does_nothing_when_no_owned_aggregate_types() {
+    // given
+    given(outboxProperties.getAggregateTypes()).willReturn(List.of());
+
+    // when
+    outboxRelayService.relayBatch();
+
+    // then
+    verify(outboxRepository, never())
+        .findByAggregateTypeInAndStatusInOrderByIdAsc(any(), any(), any());
+    verify(kafkaTemplate, never()).send(any(Message.class));
+  }
+}

--- a/common/src/test/java/com/ticketrush/global/outbox/OutboxRelayServiceTest.java
+++ b/common/src/test/java/com/ticketrush/global/outbox/OutboxRelayServiceTest.java
@@ -116,4 +116,20 @@ class OutboxRelayServiceTest {
         .findByAggregateTypeInAndStatusInOrderByIdAsc(any(), any(), any());
     verify(kafkaTemplate, never()).send(any(Message.class));
   }
+
+  @Test
+  @DisplayName("batchSize가 1 미만이면 PageRequest 예외 대신 조회를 건너뛴다")
+  void relayBatch_skips_when_batch_size_is_not_positive() {
+    // given
+    given(outboxProperties.getAggregateTypes()).willReturn(List.of("Booking"));
+    given(outboxProperties.getBatchSize()).willReturn(0);
+
+    // when
+    outboxRelayService.relayBatch();
+
+    // then
+    verify(outboxRepository, never())
+        .findByAggregateTypeInAndStatusInOrderByIdAsc(any(), any(), any());
+    verify(kafkaTemplate, never()).send(any(Message.class));
+  }
 }

--- a/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/app/scheduler/OutboxRelayScheduler.java
+++ b/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/app/scheduler/OutboxRelayScheduler.java
@@ -1,0 +1,28 @@
+package com.ticketrush.boundedcontext.seat.app.scheduler;
+
+import com.ticketrush.global.outbox.OutboxRelayService;
+import lombok.RequiredArgsConstructor;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/**
+ * seat-service의 Outbox relay 스케줄러.
+ *
+ * <p>{@code app.event-publisher.type=outbox}일 때만 등록되며(그때만 {@link OutboxRelayService} 빈이 존재), 다중
+ * 인스턴스 중복 실행은 ShedLock으로 방지한다. 자기 소유 애그리거트({@code app.outbox.aggregate-types})만 발행한다.
+ */
+@Component
+@ConditionalOnExpression("'${app.event-publisher.type}' == 'outbox'")
+@RequiredArgsConstructor
+public class OutboxRelayScheduler {
+
+  private final OutboxRelayService outboxRelayService;
+
+  @Scheduled(fixedDelay = 5000)
+  @SchedulerLock(name = "outboxRelay-seat", lockAtLeastFor = "3s", lockAtMostFor = "1m")
+  public void relay() {
+    outboxRelayService.relayBatch();
+  }
+}

--- a/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/app/scheduler/OutboxRelayScheduler.java
+++ b/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/app/scheduler/OutboxRelayScheduler.java
@@ -21,7 +21,9 @@ public class OutboxRelayScheduler {
   private final OutboxRelayService outboxRelayService;
 
   @Scheduled(fixedDelay = 5000)
-  @SchedulerLock(name = "outboxRelay-seat", lockAtLeastFor = "3s", lockAtMostFor = "1m")
+  // lockAtMostFor는 배치 최악 소요(batch-size * SEND_TIMEOUT_SECONDS)를 넉넉히 상회해야 실행 중 lock 만료로 인한 중복 실행을
+  // 막는다.
+  @SchedulerLock(name = "outboxRelay-seat", lockAtLeastFor = "3s", lockAtMostFor = "10m")
   public void relay() {
     outboxRelayService.relayBatch();
   }

--- a/seat-service/src/main/resources/application-local.yml
+++ b/seat-service/src/main/resources/application-local.yml
@@ -13,6 +13,10 @@ spring:
 app:
   event-publisher:
     type: kafka
+  outbox:
+    aggregate-types:
+      - Seat
+    batch-size: 100
 
 custom:
   security:


### PR DESCRIPTION
## 🔗 관련 이슈

- close #102

---

## 📌 주요 변경 사항

- Outbox 테이블의 미발송(PENDING)·실패(FAILED) 이벤트를 주기적으로 폴링해 Kafka로 발행하는 relay 구현
- 발행 결과에 따라 상태를 SENT/FAILED로 전이 (실패 시 다음 폴링에서 재시도)
- 여러 서비스가 공유하는 outbox 테이블에서 각 서비스가 자기 소유 애그리거트만 발행하도록 격리
- booking·seat에 relay 스케줄러 배치 (payment/performance는 인프라 신설이 필요해 후속)

---

## 🛠 상세 구현 내용

- **`OutboxRelayService` (common)**: `@ConditionalOnExpression("...=='outbox'")`, `@Transactional relayBatch()`
  - `OutboxProperties.aggregateTypes` + `[PENDING, FAILED]`로 배치 폴링(`findByAggregateTypeInAndStatusInOrderByIdAsc`)
  - 각 행에서 **eventId를 보존**해 `DomainEventEnvelope` 재구성(`of()`는 새 UUID를 만들어 미사용) → `KafkaDomainEventPublisher`와 동일한 헤더 형태(topic/key/eventType/eventId)로 `KafkaTemplate` 발행
  - 발행 결과를 동기 확인 후 성공 `markSent`, 실패 `markFailed`. at-least-once이며 중복은 컨슈머가 eventId로 멱등 처리
- **`OutboxEntity` (common)**: `markSent(publishedAt)`, `markFailed(lastError)` 상태 전이 메서드 추가
- **`OutboxRepository` (common)**: `findByAggregateTypeInAndStatusInOrderByIdAsc(aggregateTypes, statuses, pageable)` 폴링 쿼리 추가
- **`OutboxProperties` (common)**: `@ConfigurationProperties("app.outbox")` — `aggregate-types`, `batch-size`
- **`OutboxRelayScheduler` (booking, seat)**: `@Scheduled(fixedDelay=5000)` + `@SchedulerLock`(기존 `ShedLockConfig` 재사용), `type=outbox`일 때만 등록
- **yml**: booking `aggregate-types: [Booking]`, seat `[Seat]` (기본 `type=kafka`는 유지)

> 참고: 실제 상태 enum은 `PENDING/SENT/FAILED`입니다(이슈 본문의 `INIT`/`FAIL`은 표기 차이). 여러 서비스가 같은 outbox 테이블을 공유하므로, relay를 배치한 서비스는 반드시 자기 소유 `aggregate-types`만 지정해야 중복 발행이 방지됩니다.

---

## ✅ 테스트

### 테스트 방법

- 단위 테스트 작성: `OutboxRelayServiceTest` — 발행 성공→`SENT`(publishedAt 세팅)·eventId 보존 전송, 발행 실패→`FAILED`(retryCount 증가·사유 기록), 소유 aggregateType이 비면 미조회·미발행
- 실행: `./gradlew :common:test :booking-service:test :seat-service:test` 및 전체 회귀 `./gradlew spotlessCheck test`

### 테스트 결과

- BUILD SUCCESSFUL — 신규 relay 테스트 포함 전 모듈 테스트 통과
<!--
### 📸 스크린샷

- 
-->
---

## 👀 리뷰 요청 사항

- relay 발행을 `send().get()` 동기 방식으로 처리(배치 크기 작음 전제). 처리량 이슈 시 비동기 일괄 발행으로 최적화 여지
- `type=outbox` 전환 시 relay 미배치 서비스(payment/performance)는 이벤트가 적체됨 → 후속 이슈에서 배치 예정
- envelope `createdAt`은 원본 Instant 미보존으로 행 auditing 시각(`created_at`)으로 근사

---

## ⚠️ 배포 시 주의사항

- relay는 `app.event-publisher.type=outbox`일 때만 활성화됨(현재 기본값 `kafka` 유지 — 값 변경 없음)
- `type=outbox`로 전환 시 각 발행 주체 서비스에 relay + 소유 `app.outbox.aggregate-types` 설정이 반드시 필요
- 후속(#103 발행 콜백)의 선행 작업
