### PR TITLE
[Feat] #103 Outbox 전송 결과 콜백 처리 및 상태 업데이트

### DIFF
--- a/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/app/scheduler/OutboxRelayScheduler.java
+++ b/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/app/scheduler/OutboxRelayScheduler.java
@@ -21,9 +21,8 @@ public class OutboxRelayScheduler {
   private final OutboxRelayService outboxRelayService;
 
   @Scheduled(fixedDelay = 5000)
-  // lockAtMostFor는 배치 최악 소요(batch-size * SEND_TIMEOUT_SECONDS)를 넉넉히 상회해야 실행 중 lock 만료로 인한 중복 실행을
-  // 막는다.
-  @SchedulerLock(name = "outboxRelay-booking", lockAtLeastFor = "3s", lockAtMostFor = "10m")
+  // 발행은 비동기(콜백)라 dispatch가 빠르게 끝나므로 lock은 짧게 유지한다(장애 시 failover 지연 단축).
+  @SchedulerLock(name = "outboxRelay-booking", lockAtLeastFor = "3s", lockAtMostFor = "1m")
   public void relay() {
     outboxRelayService.relayBatch();
   }

--- a/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/app/scheduler/OutboxRetentionScheduler.java
+++ b/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/app/scheduler/OutboxRetentionScheduler.java
@@ -1,0 +1,28 @@
+package com.ticketrush.boundedcontext.booking.app.scheduler;
+
+import com.ticketrush.global.outbox.OutboxRetentionService;
+import lombok.RequiredArgsConstructor;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/**
+ * booking-service의 Outbox retention 스케줄러.
+ *
+ * <p>{@code app.event-publisher.type=outbox}일 때만 등록되며, 발행 완료(SENT) 후 보존 기간이 지난 자기 소유 row를 주기적으로
+ * 삭제한다. 다중 인스턴스 중복 실행은 ShedLock으로 방지한다.
+ */
+@Component
+@ConditionalOnExpression("'${app.event-publisher.type}' == 'outbox'")
+@RequiredArgsConstructor
+public class OutboxRetentionScheduler {
+
+  private final OutboxRetentionService outboxRetentionService;
+
+  @Scheduled(fixedDelay = 3600000) // 1시간
+  @SchedulerLock(name = "outboxRetention-booking", lockAtLeastFor = "10s", lockAtMostFor = "5m")
+  public void purge() {
+    outboxRetentionService.purgeExpiredSent();
+  }
+}

--- a/booking-service/src/main/resources/application-local.yml
+++ b/booking-service/src/main/resources/application-local.yml
@@ -17,6 +17,8 @@ app:
     aggregate-types:
       - Booking
     batch-size: 100
+    max-retries: 3
+    retention-hours: 72
 
 custom:
   security:

--- a/common/src/main/java/com/ticketrush/global/outbox/OutboxEntity.java
+++ b/common/src/main/java/com/ticketrush/global/outbox/OutboxEntity.java
@@ -131,12 +131,12 @@ public class OutboxEntity extends AutoIdBaseEntity {
   }
 
   /**
-   * Kafka 발행 실패 시 호출한다. 상태를 {@link OutboxStatus#FAILED}로 전이하고 재시도 횟수를 증가시키며 마지막 실패 사유를 기록한다. 다음
-   * 폴링에서 재발행 대상이 된다.
+   * Kafka 발행 실패 시 호출한다. 재시도 횟수를 증가시키고 마지막 실패 사유를 기록한다. 누적 실패가 {@code maxRetries}에 도달하면 {@link
+   * OutboxStatus#DEAD}(재폴링 제외)로, 그 전이면 {@link OutboxStatus#FAILED}(다음 폴링 재시도 대상)로 전이한다.
    */
-  public void markFailed(String lastError) {
-    this.status = OutboxStatus.FAILED;
+  public void markFailed(String lastError, int maxRetries) {
     this.retryCount++;
+    this.status = this.retryCount >= maxRetries ? OutboxStatus.DEAD : OutboxStatus.FAILED;
     this.lastError = lastError;
   }
 }

--- a/common/src/main/java/com/ticketrush/global/outbox/OutboxEntity.java
+++ b/common/src/main/java/com/ticketrush/global/outbox/OutboxEntity.java
@@ -124,8 +124,16 @@ public class OutboxEntity extends AutoIdBaseEntity {
         .build();
   }
 
-  /** Kafka 발행 성공 시 호출한다. 상태를 {@link OutboxStatus#SENT}로 전이하고 발행 시각을 기록한다. */
+  /**
+   * Kafka 발행 성공 시 호출한다. 상태를 {@link OutboxStatus#SENT}로 전이하고 발행 시각을 기록한다.
+   *
+   * <p>비동기 콜백이 경쟁(중복 dispatch 등)할 수 있어, 비터미널({@link OutboxStatus#PENDING}/{@link
+   * OutboxStatus#FAILED}) 상태일 때만 전이한다. 이미 종단 상태면 무시해 상태 역전을 막는다.
+   */
   public void markSent(LocalDateTime publishedAt) {
+    if (isNotRelayable()) {
+      return;
+    }
     this.status = OutboxStatus.SENT;
     this.publishedAt = publishedAt;
   }
@@ -133,10 +141,20 @@ public class OutboxEntity extends AutoIdBaseEntity {
   /**
    * Kafka 발행 실패 시 호출한다. 재시도 횟수를 증가시키고 마지막 실패 사유를 기록한다. 누적 실패가 {@code maxRetries}에 도달하면 {@link
    * OutboxStatus#DEAD}(재폴링 제외)로, 그 전이면 {@link OutboxStatus#FAILED}(다음 폴링 재시도 대상)로 전이한다.
+   *
+   * <p>{@link #markSent}와 마찬가지로 비터미널 상태일 때만 전이해, 늦게 도착한 실패 콜백이 이미 SENT 처리된 row를 되돌리지 않도록 한다.
    */
   public void markFailed(String lastError, int maxRetries) {
+    if (isNotRelayable()) {
+      return;
+    }
     this.retryCount++;
     this.status = this.retryCount >= maxRetries ? OutboxStatus.DEAD : OutboxStatus.FAILED;
     this.lastError = lastError;
+  }
+
+  /** 종단 상태(SENT/DEAD)면 더는 상태를 전이하지 않는다. */
+  private boolean isNotRelayable() {
+    return this.status != OutboxStatus.PENDING && this.status != OutboxStatus.FAILED;
   }
 }

--- a/common/src/main/java/com/ticketrush/global/outbox/OutboxEntity.java
+++ b/common/src/main/java/com/ticketrush/global/outbox/OutboxEntity.java
@@ -19,15 +19,17 @@ import lombok.NoArgsConstructor;
  * 트랜잭셔널 Outbox 패턴의 이벤트 저장 엔티티.
  *
  * <p>비즈니스 트랜잭션과 동일한 커밋으로 이 row가 저장되고, 폴링 스케줄러가 {@link OutboxStatus#PENDING} 상태의 row를 읽어 Kafka로
- * 발행한다. 폴링 조회가 빠르도록 {@code (status, created_at)} 복합 인덱스를 둔다.
- *
- * <p>이 이슈(#100) 범위는 엔티티와 스키마 설계까지이며, Repository·발행자·폴링 스케줄러·상태 전이 실행 로직은 후속 이슈에서 추가된다.
+ * 발행한다. 폴링 조회가 빠르도록 {@code (status, created_at)} 복합 인덱스를 두고, retention 삭제 조회를 위해 {@code
+ * (aggregate_type, status, published_at)} 복합 인덱스를 둔다.
  */
 @Entity
 @Table(
     name = "outbox",
     indexes = {
       @Index(name = "idx_outbox_status_created_at", columnList = "status, created_at"),
+      @Index(
+          name = "idx_outbox_aggtype_status_published",
+          columnList = "aggregate_type, status, published_at"),
       @Index(name = "uk_outbox_event_id", columnList = "event_id", unique = true)
     })
 @Getter

--- a/common/src/main/java/com/ticketrush/global/outbox/OutboxProperties.java
+++ b/common/src/main/java/com/ticketrush/global/outbox/OutboxProperties.java
@@ -22,4 +22,6 @@ public class OutboxProperties {
 
   private List<String> aggregateTypes = new ArrayList<>();
   private int batchSize = 100;
+  private int maxRetries = 3; // 이 횟수만큼 실패하면 DEAD로 전환해 자동 재발행을 멈춘다.
+  private long retentionHours = 72; // SENT row를 이 시간 이후 retention 배치가 삭제한다.
 }

--- a/common/src/main/java/com/ticketrush/global/outbox/OutboxRelayService.java
+++ b/common/src/main/java/com/ticketrush/global/outbox/OutboxRelayService.java
@@ -5,7 +5,6 @@ import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
@@ -15,7 +14,6 @@ import org.springframework.kafka.support.KafkaHeaders;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 /**
  * Outbox 테이블의 미발송/실패 이벤트를 폴링해 실제 Kafka로 발행하는 relay.
@@ -23,8 +21,8 @@ import org.springframework.transaction.annotation.Transactional;
  * <p>{@code app.event-publisher.type=outbox}일 때만 활성화되며, 서비스별 스케줄러가 {@link #relayBatch()}를 주기적으로
  * 호출한다. 여러 서비스가 같은 outbox 테이블을 공유하므로 {@link OutboxProperties#getAggregateTypes()}로 자기 소유 이벤트만 발행한다.
  *
- * <p>발행 성공 시 {@link OutboxStatus#SENT}, 실패 시 {@link OutboxStatus#FAILED}(다음 폴링에서 재시도)로 전이한다. 발행은
- * at-least-once이며, 중복은 컨슈머가 {@code eventId}로 멱등 처리한다.
+ * <p>발행은 비동기(`whenComplete`)로 수행하고, 결과에 따른 상태 전이는 {@link OutboxStatusUpdater}가 별도 트랜잭션에서 처리한다(콜백이
+ * relay 트랜잭션 밖 프로듀서 IO 스레드에서 실행되기 때문). 발행은 at-least-once이며, 중복은 컨슈머가 {@code eventId}로 멱등 처리한다.
  */
 @Slf4j
 @Service
@@ -32,16 +30,14 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class OutboxRelayService {
 
-  // 건당 최대 대기(초). 배치 최악 소요(batchSize * 이 값)가 스케줄러 lockAtMostFor 안에 들어오도록 유지한다.
-  private static final long SEND_TIMEOUT_SECONDS = 5L;
   private static final List<OutboxStatus> RELAY_TARGET_STATUSES =
       List.of(OutboxStatus.PENDING, OutboxStatus.FAILED);
 
   private final OutboxRepository outboxRepository;
   private final KafkaTemplate<String, DomainEventEnvelope> kafkaTemplate;
   private final OutboxProperties outboxProperties;
+  private final OutboxStatusUpdater outboxStatusUpdater;
 
-  @Transactional
   public void relayBatch() {
     List<String> aggregateTypes = outboxProperties.getAggregateTypes();
     if (aggregateTypes == null || aggregateTypes.isEmpty()) {
@@ -59,24 +55,27 @@ public class OutboxRelayService {
             aggregateTypes, RELAY_TARGET_STATUSES, PageRequest.of(0, batchSize));
 
     for (OutboxEntity row : rows) {
-      relayOne(row);
+      dispatch(row);
     }
   }
 
-  private void relayOne(OutboxEntity row) {
-    try {
-      // 발행 결과에 따라 상태를 전이해야 하므로 동기 대기한다. batchSize가 작아 허용 가능하며,
-      // 필요 시 비동기 일괄 발행으로 최적화할 수 있다.
-      kafkaTemplate.send(toMessage(row)).get(SEND_TIMEOUT_SECONDS, TimeUnit.SECONDS);
-      row.markSent(LocalDateTime.now());
-    } catch (InterruptedException e) {
-      Thread.currentThread().interrupt();
-      row.markFailed(errorMessage(e));
-      log.error("Outbox relay interrupted. eventId={}", row.getEventId(), e);
-    } catch (Exception e) {
-      row.markFailed(errorMessage(e));
-      log.error("Outbox relay failed. eventId={}, topic={}", row.getEventId(), row.getTopic(), e);
-    }
+  private void dispatch(OutboxEntity row) {
+    Long id = row.getId();
+    String eventId = row.getEventId();
+    String topic = row.getTopic();
+    // 비동기 발행 후 완료 콜백에서 상태를 전이한다. 콜백은 프로듀서 IO 스레드(relay tx 밖)에서 실행되므로
+    // OutboxStatusUpdater가 REQUIRES_NEW 트랜잭션으로 처리한다.
+    kafkaTemplate
+        .send(toMessage(row))
+        .whenComplete(
+            (result, ex) -> {
+              if (ex == null) {
+                outboxStatusUpdater.markSuccess(id);
+              } else {
+                outboxStatusUpdater.markFail(id, errorMessage(ex));
+                log.error("Outbox relay failed. eventId={}, topic={}", eventId, topic, ex);
+              }
+            });
   }
 
   private Message<DomainEventEnvelope> toMessage(OutboxEntity row) {
@@ -104,9 +103,9 @@ public class OutboxRelayService {
     return createdAt == null ? Instant.now() : createdAt.atZone(ZoneId.systemDefault()).toInstant();
   }
 
-  private String errorMessage(Exception e) {
-    // send().get() 실패는 보통 ExecutionException으로 감싸지므로 근본 원인(cause)을 우선 남긴다.
-    Throwable cause = e.getCause() != null ? e.getCause() : e;
+  private String errorMessage(Throwable ex) {
+    // 완료 예외는 래핑(CompletionException 등)될 수 있으므로 근본 원인(cause)을 우선 남긴다.
+    Throwable cause = ex.getCause() != null ? ex.getCause() : ex;
     return cause.getMessage() == null ? cause.getClass().getSimpleName() : cause.getMessage();
   }
 }

--- a/common/src/main/java/com/ticketrush/global/outbox/OutboxRepository.java
+++ b/common/src/main/java/com/ticketrush/global/outbox/OutboxRepository.java
@@ -1,14 +1,19 @@
 package com.ticketrush.global.outbox;
 
+import java.time.LocalDateTime;
 import java.util.Collection;
 import java.util.List;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 /**
  * {@link OutboxEntity}에 대한 JPA 저장소.
  *
- * <p>발행 시 Outbox row를 저장하는 {@code save()}(#101)와, relay 폴링용 미발송/실패 row 조회(#102)를 제공한다.
+ * <p>발행 시 Outbox row를 저장하는 {@code save()}(#101), relay 폴링용 미발송/실패 row 조회(#102), 발행 완료 row의
+ * retention 삭제(#103)를 제공한다.
  */
 public interface OutboxRepository extends JpaRepository<OutboxEntity, Long> {
 
@@ -21,4 +26,18 @@ public interface OutboxRepository extends JpaRepository<OutboxEntity, Long> {
    */
   List<OutboxEntity> findByAggregateTypeInAndStatusInOrderByIdAsc(
       Collection<String> aggregateTypes, Collection<OutboxStatus> statuses, Pageable pageable);
+
+  /**
+   * retention 대상 row를 벌크 삭제한다. 자기 소유 {@code aggregateTypes} 중 {@code status}(보통 {@link
+   * OutboxStatus#SENT})이면서 {@code threshold} 이전에 발행된 row만 지운다.
+   */
+  @Modifying(clearAutomatically = true)
+  @Query(
+      "DELETE FROM OutboxEntity o "
+          + "WHERE o.aggregateType IN :aggregateTypes AND o.status = :status "
+          + "AND o.publishedAt < :threshold")
+  int deleteSentBefore(
+      @Param("aggregateTypes") Collection<String> aggregateTypes,
+      @Param("status") OutboxStatus status,
+      @Param("threshold") LocalDateTime threshold);
 }

--- a/common/src/main/java/com/ticketrush/global/outbox/OutboxRetentionService.java
+++ b/common/src/main/java/com/ticketrush/global/outbox/OutboxRetentionService.java
@@ -1,0 +1,40 @@
+package com.ticketrush.global.outbox;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 발행 완료(SENT)된 Outbox row를 보존 기간이 지난 뒤 정리하는 retention 배치.
+ *
+ * <p>성공 즉시 하드삭제하지 않고 일정 기간 보존(감사/디버깅) 후 삭제해 relay 재조회와의 레이스를 피하고 삭제 부하를 분산한다. 여러 서비스가 같은 테이블을 공유하므로
+ * 자기 소유 aggregateType의 row만 삭제한다.
+ */
+@Slf4j
+@Service
+@ConditionalOnExpression("'${app.event-publisher.type}' == 'outbox'")
+@RequiredArgsConstructor
+public class OutboxRetentionService {
+
+  private final OutboxRepository outboxRepository;
+  private final OutboxProperties outboxProperties;
+
+  @Transactional
+  public int purgeExpiredSent() {
+    List<String> aggregateTypes = outboxProperties.getAggregateTypes();
+    if (aggregateTypes == null || aggregateTypes.isEmpty()) {
+      return 0;
+    }
+
+    LocalDateTime threshold = LocalDateTime.now().minusHours(outboxProperties.getRetentionHours());
+    int deleted = outboxRepository.deleteSentBefore(aggregateTypes, OutboxStatus.SENT, threshold);
+    if (deleted > 0) {
+      log.info("Outbox retention: SENT row {}건 삭제 (threshold={})", deleted, threshold);
+    }
+    return deleted;
+  }
+}

--- a/common/src/main/java/com/ticketrush/global/outbox/OutboxStatus.java
+++ b/common/src/main/java/com/ticketrush/global/outbox/OutboxStatus.java
@@ -8,7 +8,8 @@ import lombok.Getter;
 public enum OutboxStatus {
   PENDING("발행 대기"), // Outbox에 저장됐으나 아직 Kafka로 발행되지 않은 상태 (폴링 대상)
   SENT("발행 완료"), // 폴링 스케줄러가 Kafka로 발행을 완료한 상태
-  FAILED("발행 실패"); // 발행에 실패한 상태 (재시도 대상)
+  FAILED("발행 실패"), // 발행에 실패한 상태 (재시도 대상)
+  DEAD("발행 최종 실패"); // 재시도 상한을 초과해 더는 자동 재발행하지 않는 종단 상태
 
   private final String description;
 }

--- a/common/src/main/java/com/ticketrush/global/outbox/OutboxStatusUpdater.java
+++ b/common/src/main/java/com/ticketrush/global/outbox/OutboxStatusUpdater.java
@@ -1,0 +1,48 @@
+package com.ticketrush.global.outbox;
+
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Kafka 비동기 발행 콜백에서 Outbox row의 상태를 전이한다.
+ *
+ * <p>콜백은 프로듀서 IO 스레드(relay 트랜잭션 밖)에서 실행되므로, 각 전이는 {@link Propagation#REQUIRES_NEW}로 독립 트랜잭션에서 수행해
+ * 커밋한다. 콜백 사이에 row가 삭제/변경됐을 수 있어 조회 실패는 조용히 무시한다.
+ */
+@Slf4j
+@Component
+@ConditionalOnExpression("'${app.event-publisher.type}' == 'outbox'")
+@RequiredArgsConstructor
+public class OutboxStatusUpdater {
+
+  private final OutboxRepository outboxRepository;
+  private final OutboxProperties outboxProperties;
+
+  @Transactional(propagation = Propagation.REQUIRES_NEW)
+  public void markSuccess(Long id) {
+    outboxRepository.findById(id).ifPresent(row -> row.markSent(LocalDateTime.now()));
+  }
+
+  @Transactional(propagation = Propagation.REQUIRES_NEW)
+  public void markFail(Long id, String lastError) {
+    outboxRepository
+        .findById(id)
+        .ifPresent(
+            row -> {
+              row.markFailed(lastError, outboxProperties.getMaxRetries());
+              if (row.getStatus() == OutboxStatus.DEAD) {
+                // SlackNotifier(#50) 도입 전까지 CRITICAL 로그로 대체한다.
+                log.error(
+                    "[CRITICAL] Outbox 이벤트가 재시도 상한({})을 초과해 DEAD 처리되었습니다. eventId={}, lastError={}",
+                    outboxProperties.getMaxRetries(),
+                    row.getEventId(),
+                    lastError);
+              }
+            });
+  }
+}

--- a/common/src/test/java/com/ticketrush/global/outbox/OutboxRelayServiceTest.java
+++ b/common/src/test/java/com/ticketrush/global/outbox/OutboxRelayServiceTest.java
@@ -2,6 +2,7 @@ package com.ticketrush.global.outbox;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
@@ -23,6 +24,7 @@ import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.kafka.support.KafkaHeaders;
 import org.springframework.kafka.support.SendResult;
 import org.springframework.messaging.Message;
+import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
 class OutboxRelayServiceTest {
@@ -32,8 +34,9 @@ class OutboxRelayServiceTest {
   @Mock private OutboxRepository outboxRepository;
   @Mock private KafkaTemplate<String, DomainEventEnvelope> kafkaTemplate;
   @Mock private OutboxProperties outboxProperties;
+  @Mock private OutboxStatusUpdater outboxStatusUpdater;
 
-  private OutboxEntity pendingRow(String eventId) {
+  private OutboxEntity pendingRow(Long id, String eventId) {
     DomainEventEnvelope envelope =
         new DomainEventEnvelope(
             eventId,
@@ -42,15 +45,17 @@ class OutboxRelayServiceTest {
             "booking-created-topic",
             "{\"booking_id\":100}",
             "trace-1");
-    return OutboxEntity.from(envelope, "Booking", "100", "100");
+    OutboxEntity row = OutboxEntity.from(envelope, "Booking", "100", "100");
+    ReflectionTestUtils.setField(row, "id", id);
+    return row;
   }
 
   @Test
-  @DisplayName("성공: 발행에 성공하면 SENT로 전이하고 eventId를 보존해 전송한다")
+  @DisplayName("성공: 발행 완료 콜백에서 markSuccess를 호출하고 eventId를 보존해 전송한다")
   @SuppressWarnings("unchecked")
-  void relayBatch_marks_sent_on_success() {
+  void relayBatch_marks_success_via_callback() {
     // given
-    OutboxEntity row = pendingRow("evt-1");
+    OutboxEntity row = pendingRow(1L, "evt-1");
     given(outboxProperties.getAggregateTypes()).willReturn(List.of("Booking"));
     given(outboxProperties.getBatchSize()).willReturn(100);
     given(
@@ -67,8 +72,7 @@ class OutboxRelayServiceTest {
     outboxRelayService.relayBatch();
 
     // then
-    assertThat(row.getStatus()).isEqualTo(OutboxStatus.SENT);
-    assertThat(row.getPublishedAt()).isNotNull();
+    verify(outboxStatusUpdater).markSuccess(1L);
 
     ArgumentCaptor<Message<DomainEventEnvelope>> captor = ArgumentCaptor.forClass(Message.class);
     verify(kafkaTemplate).send(captor.capture());
@@ -79,11 +83,11 @@ class OutboxRelayServiceTest {
   }
 
   @Test
-  @DisplayName("실패: 발행에 실패하면 FAILED로 전이하고 retryCount 증가·사유를 기록한다")
+  @DisplayName("실패: 발행 실패 콜백에서 근본 원인을 담아 markFail을 호출한다")
   @SuppressWarnings("unchecked")
-  void relayBatch_marks_failed_on_error() {
+  void relayBatch_marks_fail_via_callback() {
     // given
-    OutboxEntity row = pendingRow("evt-2");
+    OutboxEntity row = pendingRow(2L, "evt-2");
     given(outboxProperties.getAggregateTypes()).willReturn(List.of("Booking"));
     given(outboxProperties.getBatchSize()).willReturn(100);
     given(
@@ -97,9 +101,8 @@ class OutboxRelayServiceTest {
     outboxRelayService.relayBatch();
 
     // then
-    assertThat(row.getStatus()).isEqualTo(OutboxStatus.FAILED);
-    assertThat(row.getRetryCount()).isEqualTo(1);
-    assertThat(row.getLastError()).contains("kaboom");
+    verify(outboxStatusUpdater).markFail(eq(2L), argThat(msg -> msg.contains("kaboom")));
+    verify(outboxStatusUpdater, never()).markSuccess(any());
   }
 
   @Test

--- a/common/src/test/java/com/ticketrush/global/outbox/OutboxRetentionServiceTest.java
+++ b/common/src/test/java/com/ticketrush/global/outbox/OutboxRetentionServiceTest.java
@@ -1,0 +1,64 @@
+package com.ticketrush.global.outbox;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class OutboxRetentionServiceTest {
+
+  @InjectMocks private OutboxRetentionService outboxRetentionService;
+
+  @Mock private OutboxRepository outboxRepository;
+  @Mock private OutboxProperties outboxProperties;
+
+  @Test
+  @DisplayName("보존 기간이 지난 SENT row를 자기 소유 aggregateType 기준으로 삭제한다")
+  void purge_deletes_expired_sent_rows() {
+    // given
+    given(outboxProperties.getAggregateTypes()).willReturn(List.of("Booking"));
+    given(outboxProperties.getRetentionHours()).willReturn(72L);
+    given(
+            outboxRepository.deleteSentBefore(
+                eq(List.of("Booking")), eq(OutboxStatus.SENT), any(LocalDateTime.class)))
+        .willReturn(5);
+
+    // when
+    int deleted = outboxRetentionService.purgeExpiredSent();
+
+    // then
+    assertThat(deleted).isEqualTo(5);
+    ArgumentCaptor<LocalDateTime> thresholdCaptor = ArgumentCaptor.forClass(LocalDateTime.class);
+    verify(outboxRepository)
+        .deleteSentBefore(eq(List.of("Booking")), eq(OutboxStatus.SENT), thresholdCaptor.capture());
+    // threshold는 대략 now - 72h (경계 오차 감안해 과거 시각인지만 확인)
+    assertThat(thresholdCaptor.getValue()).isBefore(LocalDateTime.now());
+  }
+
+  @Test
+  @DisplayName("소유 aggregateType이 비어 있으면 삭제하지 않는다")
+  void purge_does_nothing_when_no_owned_aggregate_types() {
+    // given
+    given(outboxProperties.getAggregateTypes()).willReturn(List.of());
+
+    // when
+    int deleted = outboxRetentionService.purgeExpiredSent();
+
+    // then
+    assertThat(deleted).isZero();
+    verify(outboxRepository, never()).deleteSentBefore(any(), any(), any());
+  }
+}

--- a/common/src/test/java/com/ticketrush/global/outbox/OutboxStatusUpdaterTest.java
+++ b/common/src/test/java/com/ticketrush/global/outbox/OutboxStatusUpdaterTest.java
@@ -1,0 +1,82 @@
+package com.ticketrush.global.outbox;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+import com.ticketrush.global.event.DomainEventEnvelope;
+import java.time.Instant;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class OutboxStatusUpdaterTest {
+
+  @InjectMocks private OutboxStatusUpdater outboxStatusUpdater;
+
+  @Mock private OutboxRepository outboxRepository;
+  @Mock private OutboxProperties outboxProperties;
+
+  private OutboxEntity row() {
+    DomainEventEnvelope envelope =
+        new DomainEventEnvelope(
+            "evt-1",
+            "BookingCreatedEvent",
+            Instant.parse("2026-05-27T06:00:00Z"),
+            "booking-created-topic",
+            "{}",
+            "trace-1");
+    return OutboxEntity.from(envelope, "Booking", "100", "100");
+  }
+
+  @Test
+  @DisplayName("markSuccess: SENT로 전이하고 publishedAt을 기록한다")
+  void markSuccess_transitions_to_sent() {
+    OutboxEntity row = row();
+    given(outboxRepository.findById(1L)).willReturn(Optional.of(row));
+
+    outboxStatusUpdater.markSuccess(1L);
+
+    assertThat(row.getStatus()).isEqualTo(OutboxStatus.SENT);
+    assertThat(row.getPublishedAt()).isNotNull();
+  }
+
+  @Test
+  @DisplayName("markFail: 재시도 상한 미만이면 FAILED로 전이하고 retryCount를 올린다")
+  void markFail_transitions_to_failed_below_cap() {
+    OutboxEntity row = row();
+    given(outboxRepository.findById(1L)).willReturn(Optional.of(row));
+    given(outboxProperties.getMaxRetries()).willReturn(3);
+
+    outboxStatusUpdater.markFail(1L, "boom");
+
+    assertThat(row.getStatus()).isEqualTo(OutboxStatus.FAILED);
+    assertThat(row.getRetryCount()).isEqualTo(1);
+    assertThat(row.getLastError()).isEqualTo("boom");
+  }
+
+  @Test
+  @DisplayName("markFail: 재시도 상한에 도달하면 DEAD로 전이한다")
+  void markFail_transitions_to_dead_at_cap() {
+    OutboxEntity row = row();
+    given(outboxRepository.findById(1L)).willReturn(Optional.of(row));
+    given(outboxProperties.getMaxRetries()).willReturn(1);
+
+    outboxStatusUpdater.markFail(1L, "boom");
+
+    assertThat(row.getStatus()).isEqualTo(OutboxStatus.DEAD);
+    assertThat(row.getRetryCount()).isEqualTo(1);
+  }
+
+  @Test
+  @DisplayName("row가 없으면 예외 없이 무시한다")
+  void ignores_when_row_not_found() {
+    given(outboxRepository.findById(99L)).willReturn(Optional.empty());
+
+    outboxStatusUpdater.markSuccess(99L);
+  }
+}

--- a/common/src/test/java/com/ticketrush/global/outbox/OutboxStatusUpdaterTest.java
+++ b/common/src/test/java/com/ticketrush/global/outbox/OutboxStatusUpdaterTest.java
@@ -73,6 +73,19 @@ class OutboxStatusUpdaterTest {
   }
 
   @Test
+  @DisplayName("이미 SENT면 늦게 도착한 실패 콜백이 상태를 역전시키지 않는다")
+  void markFail_does_not_revert_already_sent_row() {
+    OutboxEntity row = row();
+    given(outboxRepository.findById(1L)).willReturn(Optional.of(row));
+
+    outboxStatusUpdater.markSuccess(1L);
+    outboxStatusUpdater.markFail(1L, "late failure");
+
+    assertThat(row.getStatus()).isEqualTo(OutboxStatus.SENT);
+    assertThat(row.getRetryCount()).isZero();
+  }
+
+  @Test
   @DisplayName("row가 없으면 예외 없이 무시한다")
   void ignores_when_row_not_found() {
     given(outboxRepository.findById(99L)).willReturn(Optional.empty());

--- a/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/app/scheduler/OutboxRelayScheduler.java
+++ b/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/app/scheduler/OutboxRelayScheduler.java
@@ -21,9 +21,8 @@ public class OutboxRelayScheduler {
   private final OutboxRelayService outboxRelayService;
 
   @Scheduled(fixedDelay = 5000)
-  // lockAtMostFor는 배치 최악 소요(batch-size * SEND_TIMEOUT_SECONDS)를 넉넉히 상회해야 실행 중 lock 만료로 인한 중복 실행을
-  // 막는다.
-  @SchedulerLock(name = "outboxRelay-seat", lockAtLeastFor = "3s", lockAtMostFor = "10m")
+  // 발행은 비동기(콜백)라 dispatch가 빠르게 끝나므로 lock은 짧게 유지한다(장애 시 failover 지연 단축).
+  @SchedulerLock(name = "outboxRelay-seat", lockAtLeastFor = "3s", lockAtMostFor = "1m")
   public void relay() {
     outboxRelayService.relayBatch();
   }

--- a/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/app/scheduler/OutboxRetentionScheduler.java
+++ b/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/app/scheduler/OutboxRetentionScheduler.java
@@ -1,0 +1,28 @@
+package com.ticketrush.boundedcontext.seat.app.scheduler;
+
+import com.ticketrush.global.outbox.OutboxRetentionService;
+import lombok.RequiredArgsConstructor;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/**
+ * seat-service의 Outbox retention 스케줄러.
+ *
+ * <p>{@code app.event-publisher.type=outbox}일 때만 등록되며, 발행 완료(SENT) 후 보존 기간이 지난 자기 소유 row를 주기적으로
+ * 삭제한다. 다중 인스턴스 중복 실행은 ShedLock으로 방지한다.
+ */
+@Component
+@ConditionalOnExpression("'${app.event-publisher.type}' == 'outbox'")
+@RequiredArgsConstructor
+public class OutboxRetentionScheduler {
+
+  private final OutboxRetentionService outboxRetentionService;
+
+  @Scheduled(fixedDelay = 3600000) // 1시간
+  @SchedulerLock(name = "outboxRetention-seat", lockAtLeastFor = "10s", lockAtMostFor = "5m")
+  public void purge() {
+    outboxRetentionService.purgeExpiredSent();
+  }
+}

--- a/seat-service/src/main/resources/application-local.yml
+++ b/seat-service/src/main/resources/application-local.yml
@@ -17,6 +17,8 @@ app:
     aggregate-types:
       - Seat
     batch-size: 100
+    max-retries: 3
+    retention-hours: 72
 
 custom:
   security:


### PR DESCRIPTION
## 🔗 관련 이슈

- close #103

---

## 📌 주요 변경 사항

- Kafka 비동기 전송 결과(성공/실패) 콜백에 따라 Outbox 레코드 상태를 업데이트
- 성공은 SENT(soft) 처리 후 retention 배치로 지연 삭제, 실패는 재시도하다 상한 초과 시 DEAD 전환
- 콜백이 relay 트랜잭션 밖(프로듀서 IO 스레드)에서 실행되는 문제를 별도 트랜잭션(REQUIRES_NEW)으로 처리

---

## 🛠 상세 구현 내용

- **relay 재설계 (`OutboxRelayService`, common)**: 동기 `send().get()` → 비동기 `whenComplete` 콜백. 결과에 따라 `OutboxStatusUpdater` 호출. relay는 읽기+발행만 하므로 `relayBatch()`의 `@Transactional` 제거
- **`OutboxStatusUpdater` (신규, common)**: `@Transactional(propagation = REQUIRES_NEW)`
  - `markSuccess(id)`: `SENT` + `publishedAt`
  - `markFail(id, error)`: `retryCount++` 후 상한 미만 `FAILED`(재폴링 재시도) / 상한 도달 `DEAD`(재폴링 제외). DEAD 시 CRITICAL 로그
- **`OutboxStatus`**: `DEAD`(발행 최종 실패) 추가
- **`OutboxEntity`**: `markFailed(lastError)` → `markFailed(lastError, maxRetries)`로 변경(상한 도달 시 DEAD)
- **`OutboxProperties`**: `maxRetries`(3), `retentionHours`(72) 추가
- **retention 배치 (신규)**: 성공 즉시 하드삭제 대신 보존 후 지연 삭제(감사 보존·relay 재조회 레이스 회피·삭제 부하 분산)
  - `OutboxRepository.deleteSentBefore(aggregateTypes, SENT, threshold)` 벌크 삭제(자기 소유만)
  - `OutboxRetentionService` + booking/seat `OutboxRetentionScheduler`(1시간 주기)
- **스케줄러**: relay가 async라 `lockAtMostFor` 10m→1m 복귀(#102에서 동기 최악 소요 때문에 올렸던 값)
- **yml**: booking/seat에 `max-retries`, `retention-hours` 추가

> 참고: SlackNotifier(#50)가 아직 없어 DEAD 전환 시 `log.error`(CRITICAL)로 대체했습니다. 실제 Slack 연동은 후속입니다. 멱등성은 relay가 eventId를 보존(#102)하고 컨슈머가 흡수하는 at-least-once를 유지합니다.

---

## ✅ 테스트

### 테스트 방법

- 신규: `OutboxStatusUpdaterTest`(성공→SENT / 실패 상한 미만→FAILED / 상한 도달→DEAD / row 없음 무시), `OutboxRetentionServiceTest`(자기 소유 SENT 벌크 삭제 / 빈 소유 시 미삭제)
- 재작성: `OutboxRelayServiceTest` — 성공 콜백→`markSuccess`, 실패 콜백→`markFail`(근본 원인 포함), eventId 보존, 가드
- 실행: `./gradlew :common:test :booking-service:test :seat-service:test` 및 전체 회귀 `./gradlew spotlessCheck test`

### 테스트 결과

- BUILD SUCCESSFUL — 신규/재작성 테스트 포함 전 모듈 통과
<!--
### 📸 스크린샷

- 
-->
---

## 👀 리뷰 요청 사항

- 콜백에서 `OutboxStatusUpdater`가 프로듀서 IO 스레드에서 REQUIRES_NEW 트랜잭션으로 DB 갱신 — IO 스레드 점유 관점의 부하는 MVP 수준에서 허용으로 봤습니다(고throughput 시 별도 executor 오프로딩 여지)
- DEAD 알림을 현재 CRITICAL 로그로 대체 — Slack 연동(#50) 시점에 교체 필요
- retention을 서비스별 자기 소유 aggregateType 기준으로만 삭제하도록 제한한 부분

---

## ⚠️ 배포 시 주의사항

- relay/retention은 `app.event-publisher.type=outbox`일 때만 활성화(현재 기본값 `kafka` 유지)
- `OutboxStatus`에 `DEAD` 추가 — enum을 문자열로 저장하므로 스키마 영향 없음(신규 값)
- 실제 Slack 알림(#50), 컨슈머측 Redis SETNX 멱등, DEAD 수동 재처리는 후속 범위
