### PR TITLE
[Feat] #50 DLT 실패 메시지 영구 저장 및 운영 알림(Slack) 구현

### DIFF
--- a/booking-service/src/main/resources/application-test.yml
+++ b/booking-service/src/main/resources/application-test.yml
@@ -1,3 +1,9 @@
 app:
   event-publisher:
     type: kafka
+  # 테스트 환경에서는 DLT 모니터/Slack 알림을 명시적으로 비활성화한다.
+  dlt:
+    monitor:
+      enabled: false
+  slack:
+    enabled: false

--- a/booking-service/src/main/resources/application.yml
+++ b/booking-service/src/main/resources/application.yml
@@ -29,3 +29,15 @@ springdoc:
 
 gateway:
   internal-token: ${GATEWAY_INTERNAL_TOKEN:test-token}
+
+# DLT 모니터링/운영 알림(#50). 모든 .DLT를 이 서비스 한 곳에서 소비·저장한다.
+# 기본은 비활성이며, 운영 환경에서 환경변수로 켠다(DLT_MONITOR_ENABLED=true, SLACK_ENABLED=true, SLACK_WEBHOOK_URL=...).
+# local/test는 미설정(기본 false)으로 비활성.
+app:
+  dlt:
+    monitor:
+      enabled: ${DLT_MONITOR_ENABLED:false}
+  slack:
+    enabled: ${SLACK_ENABLED:false}
+    webhook-url: ${SLACK_WEBHOOK_URL:}
+    channel: ${SLACK_CHANNEL:}

--- a/booking-service/src/main/resources/application.yml
+++ b/booking-service/src/main/resources/application.yml
@@ -40,4 +40,3 @@ app:
   slack:
     enabled: ${SLACK_ENABLED:false}
     webhook-url: ${SLACK_WEBHOOK_URL:}
-    channel: ${SLACK_CHANNEL:}

--- a/common/src/main/java/com/ticketrush/global/dlt/DeadLetterConsumer.java
+++ b/common/src/main/java/com/ticketrush/global/dlt/DeadLetterConsumer.java
@@ -1,0 +1,230 @@
+package com.ticketrush.global.dlt;
+
+import com.ticketrush.global.event.DomainEventEnvelope;
+import com.ticketrush.global.notification.Notifier;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.core.log.LogAccessor;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.kafka.support.KafkaHeaders;
+import org.springframework.kafka.support.KafkaUtils;
+import org.springframework.kafka.support.serializer.DeserializationException;
+import org.springframework.kafka.support.serializer.SerializationUtils;
+import org.springframework.messaging.handler.annotation.Header;
+import org.springframework.stereotype.Component;
+
+/**
+ * 최대 재시도 초과로 {@code .DLT}에 적재된 실패 메시지를 소비해 영구 저장하고 운영자에게 알린다.
+ *
+ * <p>{@code app.dlt.monitor.enabled=true}인 <b>단일 서비스</b>(기본: booking-service)에서만 활성화된다.
+ *
+ * <p><b>topicPattern</b>: {@code .*(?<!\.DLT)\.DLT} — 접미사가 정확히 하나인 {@code .DLT} 토픽만 매칭하며 {@code
+ * .DLT.DLT}(DB 저장 실패 재시도 소진 후 생성될 수 있는 중첩 DLT)는 제외한다. 부정형 lookbehind {@code (?<!\.DLT)}로 바로 앞에
+ * {@code .DLT}가 없는 경우만 매칭한다.
+ *
+ * <p>처리 순서: <b>에러 로그 → {@link DeadLetterRecord} 저장 → {@link Notifier#send} → 수동 ack</b>. 컨테이너는
+ * {@code AckMode.MANUAL_IMMEDIATE}(KafkaConfig)이므로 반드시 수동 ack 한다.
+ *
+ * <p><b>실패 정책(#50 결정4)</b>:
+ *
+ * <ul>
+ *   <li>알림 실패는 본 흐름을 깨지 않도록 삼킨다.
+ *   <li>DB 저장 성공 후에만 ack 한다.
+ *   <li>DB 저장 실패 시엔 ack하지 않고 예외를 던져 {@code KafkaConfig}의 {@code DefaultErrorHandler}가 재시도(지수 백오프
+ *       5회)하게 한다. 재시도가 모두 소진되면 {@code .DLT.DLT}로 재발행될 수 있으나, 위 topicPattern이 이를 매칭하지 않아 무한 증식을
+ *       차단한다. 이는 5회 상한 뒤에만 발생하는 지속적 DB 장애(별도 P1)에 한정된다.
+ * </ul>
+ *
+ * <p><b>보안(#6)</b>: 알림 본문에는 예외 타입(exceptionFqcn)과 안전한 식별자만 포함한다. 자유서식 예외 메시지(exceptionMessage)는
+ * DB에만 저장하고 외부 알림에는 보내지 않는다.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(prefix = "app.dlt.monitor", name = "enabled", havingValue = "true")
+public class DeadLetterConsumer {
+
+  private static final String DLT_SUFFIX = ".DLT";
+
+  /**
+   * spring-kafka {@link SerializationUtils#getExceptionFromHeader} 호출에 필요한 LogAccessor.
+   *
+   * <p>SLF4J {@code @Slf4j}와 별개로, spring-kafka 헬퍼 API 시그니처가 {@link LogAccessor}를 요구해 유지한다.
+   */
+  private static final LogAccessor LOG_ACCESSOR = new LogAccessor(DeadLetterConsumer.class);
+
+  private final DeadLetterRecordRepository deadLetterRecordRepository;
+  private final Notifier notifier;
+
+  /**
+   * topicPattern: 접미사가 정확히 하나인 {@code .DLT} 토픽만 매칭. {@code .DLT.DLT}는 부정형 lookbehind로 제외한다.
+   *
+   * <p>검증: {@code "X.DLT".matches(".*(?<!\\.DLT)\\.DLT")} → true, {@code
+   * "X.DLT.DLT".matches(".*(?<!\\.DLT)\\.DLT")} → false.
+   */
+  @KafkaListener(topicPattern = ".*(?<!\\.DLT)\\.DLT", groupId = "dlt-monitor-group")
+  public void consume(
+      ConsumerRecord<String, Object> record,
+      @Header(name = KafkaHeaders.DLT_ORIGINAL_TOPIC, required = false) byte[] originalTopicHeader,
+      @Header(name = KafkaHeaders.DLT_ORIGINAL_PARTITION, required = false)
+          byte[] originalPartitionHeader,
+      @Header(name = KafkaHeaders.DLT_ORIGINAL_OFFSET, required = false)
+          byte[] originalOffsetHeader,
+      @Header(name = KafkaHeaders.DLT_EXCEPTION_FQCN, required = false) byte[] exceptionFqcnHeader,
+      @Header(name = KafkaHeaders.DLT_EXCEPTION_MESSAGE, required = false)
+          byte[] exceptionMessageHeader,
+      Acknowledgment ack) {
+
+    // 헤더가 없으면(직접 발행 등) record의 값으로 최대 보존한다. 원본 토픽은 .DLT 접미사를 떼어 근사한다.
+    String originalTopic = headerToString(originalTopicHeader, stripDltSuffix(record.topic()));
+    int originalPartition = headerToInt(originalPartitionHeader, record.partition());
+    long originalOffset = headerToLong(originalOffsetHeader, record.offset());
+    String exceptionFqcn = headerToString(exceptionFqcnHeader, null);
+    String exceptionMessage = headerToString(exceptionMessageHeader, null);
+
+    String eventId = null;
+    String eventType = null;
+    String payload;
+    Object value = record.value();
+    if (value instanceof DomainEventEnvelope envelope) {
+      eventId = envelope.eventId();
+      eventType = envelope.eventType();
+      payload = envelope.payload();
+    } else {
+      // value가 null이면 역직렬화 실패. springDeserializerExceptionValue 헤더에서 원본 바이트 추출을 시도한다.
+      // null이 아니지만 envelope가 아닌 경우(드문 케이스)는 toString으로 폴백한다.
+      payload = extractRawPayload(record);
+    }
+
+    // #10: 사용자 영향 문자열(Kafka 메시지 유래)의 개행·탭을 sanitize해 로그 인젝션을 방지한다.
+    log.error(
+        "[DLT] 재시도 상한 초과 메시지 수신. 저장 시작. dltTopic={}, originalTopic={}, partition={}, offset={}, "
+            + "eventType={}, eventId={}, exceptionFqcn={}, exceptionMessage={}",
+        record.topic(),
+        originalTopic,
+        originalPartition,
+        originalOffset,
+        sanitize(eventType),
+        sanitize(eventId),
+        sanitize(exceptionFqcn),
+        sanitize(exceptionMessage));
+
+    try {
+      deadLetterRecordRepository.save(
+          DeadLetterRecord.builder()
+              .originalTopic(originalTopic)
+              .originalPartition(originalPartition)
+              .originalOffset(originalOffset)
+              .messageKey(record.key())
+              .eventType(eventType)
+              .eventId(eventId)
+              .payload(payload)
+              .exceptionFqcn(exceptionFqcn)
+              .exceptionMessage(exceptionMessage)
+              .build());
+    } catch (Exception e) {
+      // 저장 실패는 ack하지 않고 예외를 던져 재시도되게 한다(실패 정책은 클래스 Javadoc 참조).
+      log.error(
+          "[DLT] DeadLetterRecord 저장 실패. 재시도를 위해 ack하지 않는다. originalTopic={}, offset={}",
+          originalTopic,
+          originalOffset,
+          e);
+      throw e;
+    }
+
+    // 저장 성공 후 알림. 알림 본문에 자유서식 예외 메시지를 포함하지 않는다(#6 — PII 유출 방지).
+    // 알림 실패는 Notifier 내부에서 삼켜지며, 여기서도 방어적으로 감싼다.
+    try {
+      notifier.send(
+          "[DLT] 재시도 상한 초과 메시지 적재",
+          exceptionFqcn,
+          buildMetadata(originalTopic, originalPartition, originalOffset, eventType, eventId));
+    } catch (Exception e) {
+      log.warn(
+          "[DLT] 알림 전송 중 예외. 저장은 완료됨. originalTopic={}, offset={}",
+          originalTopic,
+          originalOffset,
+          e);
+    }
+
+    ack.acknowledge();
+  }
+
+  /**
+   * 역직렬화 실패(value=null)일 때 {@code springDeserializerExceptionValue} 헤더에서 원본 payload 바이트를 추출한다.
+   *
+   * <p>spring-kafka {@link SerializationUtils#getExceptionFromHeader} 헬퍼를 사용한다. 이 헬퍼는
+   *
+   * <ol>
+   *   <li>헤더가 {@code DeserializationExceptionHeader} 인스턴스인지 검사(외부 조작 헤더 거부, CWE-502 방어)
+   *   <li>{@code ObjectInputStream.resolveClass()}를 오버라이드해 첫 클래스를 {@link
+   *       DeserializationException}으로 강제(가젯 체인 실행 차단)
+   * </ol>
+   *
+   * 헤더 없거나 타입 검사 실패(foreign header) 또는 추출 실패 시, value가 non-null이면 {@code toString()}으로 폴백한다.
+   */
+  private String extractRawPayload(ConsumerRecord<String, Object> record) {
+    DeserializationException deserEx =
+        SerializationUtils.getExceptionFromHeader(
+            record, KafkaUtils.VALUE_DESERIALIZER_EXCEPTION_HEADER, LOG_ACCESSOR);
+    if (deserEx != null && deserEx.getData() != null) {
+      return new String(deserEx.getData(), StandardCharsets.UTF_8);
+    }
+    // 폴백: value가 null이 아닌 경우(역직렬화 성공이지만 envelope 타입이 아닌 경우) toString
+    Object fallback = record.value();
+    return (fallback != null) ? fallback.toString() : null;
+  }
+
+  private Map<String, String> buildMetadata(
+      String originalTopic,
+      int originalPartition,
+      long originalOffset,
+      String eventType,
+      String eventId) {
+    Map<String, String> metadata = new LinkedHashMap<>();
+    metadata.put("originalTopic", originalTopic);
+    metadata.put("partition", String.valueOf(originalPartition));
+    metadata.put("offset", String.valueOf(originalOffset));
+    metadata.put("eventType", String.valueOf(eventType));
+    metadata.put("eventId", String.valueOf(eventId));
+    return metadata;
+  }
+
+  private String stripDltSuffix(String topic) {
+    if (topic != null && topic.endsWith(DLT_SUFFIX)) {
+      return topic.substring(0, topic.length() - DLT_SUFFIX.length());
+    }
+    return topic;
+  }
+
+  /** 로그 인젝션 방지: 개행·탭 문자를 {@code _}로 대체한다. */
+  private static String sanitize(String value) {
+    return (value != null) ? value.replaceAll("[\\r\\n\\t]", "_") : null;
+  }
+
+  /** DLT 헤더는 byte[]로 올 수 있어 UTF-8 문자열로 안전 변환한다. */
+  private String headerToString(byte[] header, String defaultValue) {
+    return (header != null) ? new String(header, StandardCharsets.UTF_8) : defaultValue;
+  }
+
+  /** {@code DLT_ORIGINAL_PARTITION}은 4바이트 정수로 인코딩된다. */
+  private int headerToInt(byte[] header, int defaultValue) {
+    return (header != null && header.length >= Integer.BYTES)
+        ? ByteBuffer.wrap(header).getInt()
+        : defaultValue;
+  }
+
+  /** {@code DLT_ORIGINAL_OFFSET}은 8바이트 정수로 인코딩된다. */
+  private long headerToLong(byte[] header, long defaultValue) {
+    return (header != null && header.length >= Long.BYTES)
+        ? ByteBuffer.wrap(header).getLong()
+        : defaultValue;
+  }
+}

--- a/common/src/main/java/com/ticketrush/global/dlt/DeadLetterRecord.java
+++ b/common/src/main/java/com/ticketrush/global/dlt/DeadLetterRecord.java
@@ -1,0 +1,90 @@
+package com.ticketrush.global.dlt;
+
+import com.ticketrush.global.jpa.entity.AutoIdBaseEntity;
+import jakarta.persistence.AttributeOverride;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 최대 재시도를 초과해 {@code .DLT}로 발행된 실패 메시지를 영구 저장하는 엔티티.
+ *
+ * <p>{@code DeadLetterConsumer}가 DLT 헤더/원본 payload에서 값을 뽑아 저장한다. 실패 원인 추적·운영자 조회·수동 복구의 근거가 된다. 이벤트
+ * 타입별/원본 토픽별 조회를 위해 {@code (event_type, created_at)}, {@code (original_topic, created_at)} 복합 인덱스를
+ * 둔다.
+ *
+ * <p>저장 시각은 {@link com.ticketrush.global.jpa.entity.BaseTimeEntity}가 관리하는 {@code created_at}(JPA
+ * Auditing)으로 기록된다. 별도 {@code occurred_at} 컬럼은 중복이므로 두지 않는다(#9).
+ *
+ * <p>원본 컨슈머가 {@code DeserializationException}으로 실패한 경우 DLT value가 {@code DomainEventEnvelope}로
+ * 역직렬화되지 않을 수 있어, eventType/eventId/payload는 nullable로 두고 최대 보존 저장한다.
+ */
+@Entity
+@Table(
+    name = "dead_letter_record",
+    indexes = {
+      @Index(name = "idx_dlr_event_type_created_at", columnList = "event_type, created_at"),
+      @Index(name = "idx_dlr_original_topic_created_at", columnList = "original_topic, created_at")
+    })
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AttributeOverride(name = "id", column = @Column(name = "dead_letter_record_id"))
+public class DeadLetterRecord extends AutoIdBaseEntity {
+
+  @Column(name = "original_topic", nullable = false, length = 200)
+  private String originalTopic; // 재시도 상한 초과 이전의 원본 토픽(.DLT 접미사 제거)
+
+  @Column(name = "original_partition", nullable = false)
+  private int originalPartition; // 원본 파티션
+
+  @Column(name = "original_offset", nullable = false)
+  private long originalOffset; // 원본 offset
+
+  /* 파티션 키. 키가 없는 이벤트도 있어 nullable. */
+  @Column(name = "message_key", length = 200)
+  private String messageKey;
+
+  /* 이벤트 타입명. 역직렬화 실패 케이스에선 없을 수 있어 nullable. */
+  @Column(name = "event_type", length = 150)
+  private String eventType;
+
+  /* 이벤트 고유 ID(UUID). 역직렬화 실패 케이스에선 없을 수 있어 nullable. */
+  @Column(name = "event_id", length = 36)
+  private String eventId;
+
+  @Column(name = "payload", columnDefinition = "TEXT")
+  private String payload; // 원본 이벤트 JSON 또는 역직렬화 실패 시 raw 문자열
+
+  @Column(name = "exception_fqcn", length = 500)
+  private String exceptionFqcn; // 원본 처리 실패 예외 클래스명(DLT 헤더)
+
+  @Column(name = "exception_message", columnDefinition = "TEXT")
+  private String exceptionMessage; // 원본 처리 실패 예외 메시지(DLT 헤더, 내부 저장 전용)
+
+  @Builder
+  private DeadLetterRecord(
+      String originalTopic,
+      int originalPartition,
+      long originalOffset,
+      String messageKey,
+      String eventType,
+      String eventId,
+      String payload,
+      String exceptionFqcn,
+      String exceptionMessage) {
+    this.originalTopic = originalTopic;
+    this.originalPartition = originalPartition;
+    this.originalOffset = originalOffset;
+    this.messageKey = messageKey;
+    this.eventType = eventType;
+    this.eventId = eventId;
+    this.payload = payload;
+    this.exceptionFqcn = exceptionFqcn;
+    this.exceptionMessage = exceptionMessage;
+  }
+}

--- a/common/src/main/java/com/ticketrush/global/dlt/DeadLetterRecordRepository.java
+++ b/common/src/main/java/com/ticketrush/global/dlt/DeadLetterRecordRepository.java
@@ -1,0 +1,6 @@
+package com.ticketrush.global.dlt;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/** {@link DeadLetterRecord}에 대한 JPA 저장소. */
+public interface DeadLetterRecordRepository extends JpaRepository<DeadLetterRecord, Long> {}

--- a/common/src/main/java/com/ticketrush/global/dlt/DltMonitorProperties.java
+++ b/common/src/main/java/com/ticketrush/global/dlt/DltMonitorProperties.java
@@ -1,0 +1,21 @@
+package com.ticketrush.global.dlt;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+/**
+ * DLT 모니터링 설정.
+ *
+ * <p>모든 {@code .DLT} 토픽을 한 곳에서 소비·저장하기 위해 <b>딱 한 서비스</b>(기본: booking-service)에서만 {@code
+ * enabled=true}로 켠다. 나머지 서비스는 기본 비활성이라 {@link DeadLetterConsumer}가 생성되지 않는다.
+ */
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "app.dlt.monitor")
+public class DltMonitorProperties {
+
+  private boolean enabled = false;
+}

--- a/common/src/main/java/com/ticketrush/global/notification/NoOpNotifier.java
+++ b/common/src/main/java/com/ticketrush/global/notification/NoOpNotifier.java
@@ -1,0 +1,25 @@
+package com.ticketrush.global.notification;
+
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * {@link SlackNotifier}가 비활성일 때({@code app.slack.enabled=false} 또는 미설정) 사용하는 no-op 폴백 {@link
+ * Notifier}.
+ *
+ * <p>주입 측이 항상 non-null {@code Notifier}를 확보하도록 보장한다(빈 없음/NPE 회피). 실제 전송은 하지 않고 {@code debug} 로그만
+ * 남긴다.
+ *
+ * <p>등록은 {@link NotifierConfig}의 {@code @Bean} + {@code @ConditionalOnProperty(prefix="app.slack",
+ * name="enabled", havingValue="false", matchIfMissing=true)}로 한다. {@link SlackNotifier}는 {@code
+ * havingValue="true"}이므로 두 빈이 동시에 등록되는 상황이 발생하지 않는다(순서 의존 제거, #4).
+ */
+@Slf4j
+public class NoOpNotifier implements Notifier {
+
+  @Override
+  public void send(String title, String message, Map<String, String> metadata) {
+    log.debug(
+        "[NOOP-NOTIFIER] 알림 비활성. title={}, message={}, metadata={}", title, message, metadata);
+  }
+}

--- a/common/src/main/java/com/ticketrush/global/notification/Notifier.java
+++ b/common/src/main/java/com/ticketrush/global/notification/Notifier.java
@@ -1,0 +1,23 @@
+package com.ticketrush.global.notification;
+
+import java.util.Map;
+
+/**
+ * 운영 알림 발송 추상화.
+ *
+ * <p>DLT 소비({@code DeadLetterConsumer})와 Outbox DEAD 전환({@code OutboxStatusUpdater}) 등 운영자 인지가 필요한
+ * 실패 지점에서 사용한다. 알림 채널(Slack 등)의 구현 세부는 구현체가 감춘다.
+ *
+ * <p>구현체는 알림 전송 실패가 호출자 흐름을 깨지 않도록 예외를 던지지 않고 내부에서 처리(로깅)해야 한다.
+ */
+public interface Notifier {
+
+  /**
+   * 알림을 발송한다.
+   *
+   * @param title 알림 제목(핵심 요약)
+   * @param message 본문 상세(예: 예외 메시지)
+   * @param metadata 부가 컨텍스트(토픽/offset/eventId 등). {@code null}이면 부가 정보 없이 발송한다.
+   */
+  void send(String title, String message, Map<String, String> metadata);
+}

--- a/common/src/main/java/com/ticketrush/global/notification/NotifierConfig.java
+++ b/common/src/main/java/com/ticketrush/global/notification/NotifierConfig.java
@@ -1,0 +1,32 @@
+package com.ticketrush.global.notification;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * {@link Notifier} 폴백 등록 설정.
+ *
+ * <p>{@link SlackNotifier}와 {@link NoOpNotifier}를 상호배타 {@link ConditionalOnProperty}로 조건을 명시해, 두 빈이
+ * 동시에 등록되는 상황({@code NoUniqueBeanDefinitionException})을 방지한다(#4).
+ *
+ * <ul>
+ *   <li>{@code app.slack.enabled=true} → {@link SlackNotifier}만 등록
+ *   <li>{@code app.slack.enabled=false} 또는 미설정 → {@link NoOpNotifier}만 등록
+ * </ul>
+ *
+ * {@code @ConditionalOnMissingBean}을 사용하면 스캔 순서에 따라 두 빈이 동시에 등록될 수 있어 사용하지 않는다.
+ */
+@Configuration
+public class NotifierConfig {
+
+  @Bean
+  @ConditionalOnProperty(
+      prefix = "app.slack",
+      name = "enabled",
+      havingValue = "false",
+      matchIfMissing = true)
+  public NoOpNotifier noOpNotifier() {
+    return new NoOpNotifier();
+  }
+}

--- a/common/src/main/java/com/ticketrush/global/notification/SlackNotifier.java
+++ b/common/src/main/java/com/ticketrush/global/notification/SlackNotifier.java
@@ -2,7 +2,6 @@ package com.ticketrush.global.notification;
 
 import com.ticketrush.global.config.RestClientFactorySupport;
 import com.ticketrush.global.json.JsonConverter;
-import java.util.LinkedHashMap;
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -60,7 +59,7 @@ public class SlackNotifier implements Notifier {
   @Override
   public void send(String title, String message, Map<String, String> metadata) {
     try {
-      String payload = jsonConverter.serialize(buildBody(buildText(title, message, metadata)));
+      String payload = jsonConverter.serialize(Map.of("text", buildText(title, message, metadata)));
       restClient
           .post()
           .uri(slackProperties.getWebhookUrl())
@@ -72,18 +71,6 @@ public class SlackNotifier implements Notifier {
       // 알림 실패는 본 흐름(저장/상태 전이)을 깨지 않도록 삼키고 로그만 남긴다.
       log.warn("[SLACK] 알림 전송 실패. title={}, error={}", title, e.getMessage());
     }
-  }
-
-  /**
-   * Slack incoming-webhook 페이로드({@code {"text": ..., "channel": ...}})를 구성한다. channel은 설정 시에만 포함한다.
-   */
-  private Map<String, String> buildBody(String text) {
-    Map<String, String> body = new LinkedHashMap<>();
-    body.put("text", text);
-    if (slackProperties.getChannel() != null && !slackProperties.getChannel().isBlank()) {
-      body.put("channel", slackProperties.getChannel());
-    }
-    return body;
   }
 
   /** 제목/본문/메타데이터를 사람이 읽기 좋은 단일 텍스트로 합친다. */

--- a/common/src/main/java/com/ticketrush/global/notification/SlackNotifier.java
+++ b/common/src/main/java/com/ticketrush/global/notification/SlackNotifier.java
@@ -1,0 +1,101 @@
+package com.ticketrush.global.notification;
+
+import com.ticketrush.global.config.RestClientFactorySupport;
+import com.ticketrush.global.json.JsonConverter;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.client.RestClient;
+
+/**
+ * Slack incoming-webhook으로 운영 알림을 발송하는 {@link Notifier} 구현체.
+ *
+ * <p>{@code app.slack.enabled=true}일 때만 활성화된다. {@code webhook-url}이 비어있으면 기동 즉시 {@link
+ * IllegalStateException}으로 실패한다(#5 — 조용한 실패 방지). 웹훅은 외부 엔드포인트이므로 {@link RestClientFactorySupport}로
+ * connect/read 타임아웃을 건 자체 {@link RestClient}를 생성해 호출한다.
+ *
+ * <p>알림은 부가 기능이므로 <b>호출/네트워크 실패는 예외로 전파하지 않고 {@code log.warn}으로만 남긴다</b>. 알림 실패가 DLT 저장이나 Outbox 상태
+ * 전이 같은 본 흐름을 깨서는 안 된다.
+ */
+@Slf4j
+@Component
+@ConditionalOnProperty(prefix = "app.slack", name = "enabled", havingValue = "true")
+public class SlackNotifier implements Notifier {
+
+  private final SlackProperties slackProperties;
+  private final JsonConverter jsonConverter;
+  private final RestClient restClient;
+
+  @Autowired
+  public SlackNotifier(SlackProperties slackProperties, JsonConverter jsonConverter) {
+    this(slackProperties, jsonConverter, buildRestClient(slackProperties));
+  }
+
+  /** RestClient를 주입해 단위 테스트가 실제 HTTP/컨버터 초기화를 우회할 수 있게 하는 생성자. */
+  SlackNotifier(
+      SlackProperties slackProperties, JsonConverter jsonConverter, RestClient restClient) {
+    if (!StringUtils.hasText(slackProperties.getWebhookUrl())) {
+      throw new IllegalStateException(
+          "app.slack.enabled=true 인데 app.slack.webhook-url 이 비어있습니다. "
+              + "SLACK_WEBHOOK_URL 환경변수를 설정하세요.");
+    }
+    this.slackProperties = slackProperties;
+    this.jsonConverter = jsonConverter;
+    this.restClient = restClient;
+  }
+
+  private static RestClient buildRestClient(SlackProperties slackProperties) {
+    return RestClient.builder()
+        .requestFactory(
+            RestClientFactorySupport.withTimeouts(
+                slackProperties.getConnectTimeoutMs(), slackProperties.getReadTimeoutMs()))
+        .build();
+  }
+
+  @Override
+  public void send(String title, String message, Map<String, String> metadata) {
+    try {
+      String payload = jsonConverter.serialize(buildBody(buildText(title, message, metadata)));
+      restClient
+          .post()
+          .uri(slackProperties.getWebhookUrl())
+          .contentType(MediaType.APPLICATION_JSON)
+          .body(payload)
+          .retrieve()
+          .toBodilessEntity();
+    } catch (Exception e) {
+      // 알림 실패는 본 흐름(저장/상태 전이)을 깨지 않도록 삼키고 로그만 남긴다.
+      log.warn("[SLACK] 알림 전송 실패. title={}, error={}", title, e.getMessage());
+    }
+  }
+
+  /**
+   * Slack incoming-webhook 페이로드({@code {"text": ..., "channel": ...}})를 구성한다. channel은 설정 시에만 포함한다.
+   */
+  private Map<String, String> buildBody(String text) {
+    Map<String, String> body = new LinkedHashMap<>();
+    body.put("text", text);
+    if (slackProperties.getChannel() != null && !slackProperties.getChannel().isBlank()) {
+      body.put("channel", slackProperties.getChannel());
+    }
+    return body;
+  }
+
+  /** 제목/본문/메타데이터를 사람이 읽기 좋은 단일 텍스트로 합친다. */
+  private String buildText(String title, String message, Map<String, String> metadata) {
+    StringBuilder sb = new StringBuilder();
+    sb.append(title);
+    if (message != null && !message.isBlank()) {
+      sb.append('\n').append(message);
+    }
+    if (metadata != null) {
+      metadata.forEach((k, v) -> sb.append('\n').append(k).append(": ").append(v));
+    }
+    return sb.toString();
+  }
+}

--- a/common/src/main/java/com/ticketrush/global/notification/SlackProperties.java
+++ b/common/src/main/java/com/ticketrush/global/notification/SlackProperties.java
@@ -19,7 +19,6 @@ public class SlackProperties {
 
   private boolean enabled = false;
   private String webhookUrl;
-  private String channel;
   private long connectTimeoutMs = 3000;
   private long readTimeoutMs = 5000;
 }

--- a/common/src/main/java/com/ticketrush/global/notification/SlackProperties.java
+++ b/common/src/main/java/com/ticketrush/global/notification/SlackProperties.java
@@ -1,0 +1,25 @@
+package com.ticketrush.global.notification;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+/**
+ * Slack incoming-webhook 알림 설정.
+ *
+ * <p>{@code enabled=true}일 때만 {@link SlackNotifier}가 활성화된다. webhook-url은 외부 엔드포인트이므로 환경변수로 주입하고,
+ * connect/read 타임아웃으로 알림 호출이 호출자 흐름을 오래 붙잡지 않게 제한한다.
+ */
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "app.slack")
+public class SlackProperties {
+
+  private boolean enabled = false;
+  private String webhookUrl;
+  private String channel;
+  private long connectTimeoutMs = 3000;
+  private long readTimeoutMs = 5000;
+}

--- a/common/src/main/java/com/ticketrush/global/outbox/OutboxStatusTransition.java
+++ b/common/src/main/java/com/ticketrush/global/outbox/OutboxStatusTransition.java
@@ -1,0 +1,64 @@
+package com.ticketrush.global.outbox;
+
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Outbox row 상태 전이를 독립 트랜잭션({@link Propagation#REQUIRES_NEW})으로 수행하는 빈.
+ *
+ * <p>{@link OutboxStatusUpdater}가 트랜잭션 완료 후 외부 알림을 발송할 수 있도록, 상태 전이 로직을 별도 스프링 빈으로 분리했다. 같은 클래스의
+ * private 메서드로 분리하면 Spring 프록시를 우회해 트랜잭션이 적용되지 않는(self-invocation) 문제를 이 구조로 회피한다.
+ */
+@Slf4j
+@Component
+@ConditionalOnExpression("'${app.event-publisher.type}' == 'outbox'")
+@RequiredArgsConstructor
+public class OutboxStatusTransition {
+
+  private final OutboxRepository outboxRepository;
+  private final OutboxProperties outboxProperties;
+
+  /** 발행 성공을 SENT로 전이한다. */
+  @Transactional(propagation = Propagation.REQUIRES_NEW)
+  public void markSuccess(Long id) {
+    outboxRepository.findById(id).ifPresent(row -> row.markSent(LocalDateTime.now()));
+  }
+
+  /**
+   * 발행 실패를 기록하고 DEAD로 전이됐으면 {@link DeadInfo}를 반환한다. DEAD가 아니거나 row가 없으면 null을 반환한다.
+   *
+   * <p>반환값이 null이 아닌 경우 이 메서드의 트랜잭션은 이미 커밋된 상태이므로, 호출자는 DB 커넥션을 점유하지 않고 알림을 발송할 수 있다.
+   */
+  @Transactional(propagation = Propagation.REQUIRES_NEW)
+  public DeadInfo markFail(Long id, String lastError) {
+    return outboxRepository
+        .findById(id)
+        .map(
+            row -> {
+              row.markFailed(lastError, outboxProperties.getMaxRetries());
+              if (row.getStatus() == OutboxStatus.DEAD) {
+                log.error(
+                    "[CRITICAL] Outbox 이벤트가 재시도 상한({})을 초과해 DEAD 처리되었습니다. eventId={}, lastError={}",
+                    outboxProperties.getMaxRetries(),
+                    row.getEventId(),
+                    sanitize(lastError));
+                return new DeadInfo(row.getEventId(), outboxProperties.getMaxRetries());
+              }
+              return null;
+            })
+        .orElse(null);
+  }
+
+  /** 로그 인젝션 방지: 개행·탭 문자를 {@code _}로 대체한다. */
+  private static String sanitize(String value) {
+    return (value != null) ? value.replaceAll("[\\r\\n\\t]", "_") : null;
+  }
+
+  /** DEAD 전이 시 알림 발송에 필요한 정보를 담는 값 객체. */
+  public record DeadInfo(String eventId, int maxRetries) {}
+}

--- a/common/src/main/java/com/ticketrush/global/outbox/OutboxStatusUpdater.java
+++ b/common/src/main/java/com/ticketrush/global/outbox/OutboxStatusUpdater.java
@@ -1,18 +1,21 @@
 package com.ticketrush.global.outbox;
 
-import java.time.LocalDateTime;
+import com.ticketrush.global.notification.Notifier;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Propagation;
-import org.springframework.transaction.annotation.Transactional;
 
 /**
  * Kafka 비동기 발행 콜백에서 Outbox row의 상태를 전이한다.
  *
- * <p>콜백은 프로듀서 IO 스레드(relay 트랜잭션 밖)에서 실행되므로, 각 전이는 {@link Propagation#REQUIRES_NEW}로 독립 트랜잭션에서 수행해
- * 커밋한다. 콜백 사이에 row가 삭제/변경됐을 수 있어 조회 실패는 조용히 무시한다.
+ * <p>콜백은 프로듀서 IO 스레드(relay 트랜잭션 밖)에서 실행된다. 상태 전이는 {@link OutboxStatusTransition}(별도 스프링 빈)의 {@code
+ * REQUIRES_NEW} 메서드로 위임하고, 트랜잭션 커밋 이후에 {@link Notifier#send}를 호출한다. 이로써 외부 HTTP 지연(최대 8초)이 DB
+ * 커넥션·row 락을 점유하지 않는다.
+ *
+ * <p><b>self-invocation 주의:</b> 알림 호출을 같은 클래스의 private 메서드로 분리하면 Spring 프록시를 우회해 트랜잭션이 적용되지 않는다. 별도
+ * 빈({@link OutboxStatusTransition})으로 분리해 이 문제를 회피한다.
  */
 @Slf4j
 @Component
@@ -20,29 +23,24 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class OutboxStatusUpdater {
 
-  private final OutboxRepository outboxRepository;
-  private final OutboxProperties outboxProperties;
+  private final OutboxStatusTransition transition;
+  private final Notifier notifier;
 
-  @Transactional(propagation = Propagation.REQUIRES_NEW)
   public void markSuccess(Long id) {
-    outboxRepository.findById(id).ifPresent(row -> row.markSent(LocalDateTime.now()));
+    transition.markSuccess(id);
   }
 
-  @Transactional(propagation = Propagation.REQUIRES_NEW)
   public void markFail(Long id, String lastError) {
-    outboxRepository
-        .findById(id)
-        .ifPresent(
-            row -> {
-              row.markFailed(lastError, outboxProperties.getMaxRetries());
-              if (row.getStatus() == OutboxStatus.DEAD) {
-                // SlackNotifier(#50) 도입 전까지 CRITICAL 로그로 대체한다.
-                log.error(
-                    "[CRITICAL] Outbox 이벤트가 재시도 상한({})을 초과해 DEAD 처리되었습니다. eventId={}, lastError={}",
-                    outboxProperties.getMaxRetries(),
-                    row.getEventId(),
-                    lastError);
-              }
-            });
+    OutboxStatusTransition.DeadInfo deadInfo = transition.markFail(id, lastError);
+    if (deadInfo != null) {
+      // 트랜잭션 커밋 후 알림. 외부 HTTP 지연이 DB 커넥션을 점유하지 않는다(#1 결정).
+      // 알림 본문에 자유서식 오류 메시지를 포함하지 않는다(#6 결정 — PII 유출 방지).
+      notifier.send(
+          "[Outbox DEAD] 이벤트 발행 재시도 상한 초과",
+          "상세는 outbox 테이블 eventId=" + deadInfo.eventId() + " 조회",
+          Map.of(
+              "eventId", deadInfo.eventId(),
+              "maxRetries", String.valueOf(deadInfo.maxRetries())));
+    }
   }
 }

--- a/common/src/test/java/com/ticketrush/CommonTestApplication.java
+++ b/common/src/test/java/com/ticketrush/CommonTestApplication.java
@@ -1,0 +1,14 @@
+package com.ticketrush;
+
+import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+
+/**
+ * common 모듈 슬라이스 테스트(@DataJpaTest 등)용 부트스트랩 설정.
+ *
+ * <p>common은 실행형 애플리케이션이 아니라 라이브러리라 {@code @SpringBootApplication}이 없다. 슬라이스 테스트가
+ * {@code @SpringBootConfiguration}을 찾을 수 있도록 테스트 전용으로만 둔다.
+ */
+@SpringBootConfiguration
+@EnableAutoConfiguration
+public class CommonTestApplication {}

--- a/common/src/test/java/com/ticketrush/global/dlt/DeadLetterConsumerTest.java
+++ b/common/src/test/java/com/ticketrush/global/dlt/DeadLetterConsumerTest.java
@@ -1,0 +1,169 @@
+package com.ticketrush.global.dlt;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import com.ticketrush.global.event.DomainEventEnvelope;
+import com.ticketrush.global.notification.Notifier;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.Map;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.kafka.support.serializer.SerializationUtils;
+
+@ExtendWith(MockitoExtension.class)
+class DeadLetterConsumerTest {
+
+  @InjectMocks private DeadLetterConsumer deadLetterConsumer;
+
+  @Mock private DeadLetterRecordRepository deadLetterRecordRepository;
+  @Mock private Notifier notifier;
+  @Mock private Acknowledgment ack;
+
+  private static byte[] intBytes(int value) {
+    return ByteBuffer.allocate(Integer.BYTES).putInt(value).array();
+  }
+
+  private static byte[] longBytes(long value) {
+    return ByteBuffer.allocate(Long.BYTES).putLong(value).array();
+  }
+
+  private static byte[] str(String value) {
+    return value.getBytes(StandardCharsets.UTF_8);
+  }
+
+  @Test
+  @DisplayName("envelope 값이면 DLT 헤더와 envelope에서 레코드를 매핑해 저장하고, 알림/ack를 호출한다")
+  void consume_maps_envelope_and_saves() {
+    // given
+    DomainEventEnvelope envelope =
+        new DomainEventEnvelope(
+            "evt-1",
+            "BookingCreatedEvent",
+            Instant.parse("2026-05-27T06:00:00Z"),
+            "booking-created-topic",
+            "{\"booking_id\":100}",
+            "trace-1");
+    ConsumerRecord<String, Object> record =
+        new ConsumerRecord<>("booking-created-topic.DLT", 0, 42L, "100", envelope);
+
+    given(deadLetterRecordRepository.save(any(DeadLetterRecord.class)))
+        .willAnswer(invocation -> invocation.getArgument(0));
+
+    // when
+    deadLetterConsumer.consume(
+        record,
+        str("booking-created-topic"),
+        intBytes(3),
+        longBytes(99L),
+        str("java.lang.IllegalStateException"),
+        str("boom"),
+        ack);
+
+    // then
+    ArgumentCaptor<DeadLetterRecord> captor = ArgumentCaptor.forClass(DeadLetterRecord.class);
+    verify(deadLetterRecordRepository).save(captor.capture());
+    DeadLetterRecord saved = captor.getValue();
+
+    assertThat(saved.getOriginalTopic()).isEqualTo("booking-created-topic");
+    assertThat(saved.getOriginalPartition()).isEqualTo(3);
+    assertThat(saved.getOriginalOffset()).isEqualTo(99L);
+    assertThat(saved.getMessageKey()).isEqualTo("100");
+    assertThat(saved.getEventType()).isEqualTo("BookingCreatedEvent");
+    assertThat(saved.getEventId()).isEqualTo("evt-1");
+    assertThat(saved.getPayload()).isEqualTo("{\"booking_id\":100}");
+    assertThat(saved.getExceptionFqcn()).isEqualTo("java.lang.IllegalStateException");
+    assertThat(saved.getExceptionMessage()).isEqualTo("boom");
+    // occurredAt 제거됨(#9) — 저장 시각은 created_at(JPA Auditing)으로 관리
+
+    // 알림에는 자유서식 예외 메시지 대신 exceptionFqcn(예외 타입)을 전달한다(#6).
+    verify(notifier).send(any(), eq("java.lang.IllegalStateException"), any());
+    verify(ack).acknowledge();
+  }
+
+  @Test
+  @DisplayName("역직렬화 실패(value=null)일 때 springDeserializerExceptionValue 헤더에서 원본 payload를 추출한다")
+  void consume_extracts_raw_payload_from_deserialization_exception_header() {
+    // given: ErrorHandlingDeserializer가 실제로 생성하는 헤더와 동일한 형식으로 구성한다.
+    // SerializationUtils.deserializationException()은 DeserializationExceptionHeader(타입-안전)를 추가하며,
+    // 이것이 프로덕션 getExceptionFromHeader() 타입 검사를 통과하는 유일한 헤더 형태다(자기-인코딩→자기-디코딩 왕복 금지, #B).
+    byte[] rawBytes = "raw-broken-payload".getBytes(StandardCharsets.UTF_8);
+    ConsumerRecord<String, Object> record =
+        new ConsumerRecord<>("some-topic.DLT", 0, 7L, null, null);
+    SerializationUtils.deserializationException(
+        record.headers(), rawBytes, new RuntimeException("codec error"), false);
+
+    given(deadLetterRecordRepository.save(any(DeadLetterRecord.class)))
+        .willAnswer(invocation -> invocation.getArgument(0));
+
+    // when
+    deadLetterConsumer.consume(record, null, null, null, null, null, ack);
+
+    // then
+    ArgumentCaptor<DeadLetterRecord> captor = ArgumentCaptor.forClass(DeadLetterRecord.class);
+    verify(deadLetterRecordRepository).save(captor.capture());
+    DeadLetterRecord saved = captor.getValue();
+
+    assertThat(saved.getOriginalTopic()).isEqualTo("some-topic");
+    assertThat(saved.getOriginalPartition()).isZero();
+    assertThat(saved.getOriginalOffset()).isEqualTo(7L);
+    assertThat(saved.getEventType()).isNull();
+    assertThat(saved.getEventId()).isNull();
+    // getExceptionFromHeader()가 DeserializationExceptionHeader를 타입-안전하게 역직렬화해 원본 payload를 복원한다.
+    assertThat(saved.getPayload()).isEqualTo("raw-broken-payload");
+
+    verify(notifier).send(any(), any(), any());
+    verify(ack).acknowledge();
+  }
+
+  @Test
+  @DisplayName("알림 전송이 실패해도 예외를 삼키고 저장 후 ack한다")
+  void consume_acks_even_when_notify_fails() {
+    // given
+    ConsumerRecord<String, Object> record =
+        new ConsumerRecord<>("some-topic.DLT", 0, 1L, null, "payload");
+    given(deadLetterRecordRepository.save(any(DeadLetterRecord.class)))
+        .willAnswer(invocation -> invocation.getArgument(0));
+    org.mockito.BDDMockito.willThrow(new RuntimeException("slack down"))
+        .given(notifier)
+        .send(any(), any(), any());
+
+    // when
+    deadLetterConsumer.consume(record, null, null, null, null, null, ack);
+
+    // then
+    verify(deadLetterRecordRepository).save(any(DeadLetterRecord.class));
+    verify(ack).acknowledge();
+  }
+
+  @Test
+  @DisplayName("DB 저장이 실패하면 ack하지 않고 예외를 전파해 재시도되게 한다")
+  void consume_does_not_ack_when_save_fails() {
+    // given
+    ConsumerRecord<String, Object> record =
+        new ConsumerRecord<>("some-topic.DLT", 0, 1L, null, "payload");
+    given(deadLetterRecordRepository.save(any(DeadLetterRecord.class)))
+        .willThrow(new RuntimeException("db down"));
+
+    // when & then
+    org.assertj.core.api.Assertions.assertThatThrownBy(
+            () -> deadLetterConsumer.consume(record, null, null, null, null, null, ack))
+        .isInstanceOf(RuntimeException.class);
+
+    org.mockito.Mockito.verify(ack, org.mockito.Mockito.never()).acknowledge();
+    org.mockito.Mockito.verify(notifier, org.mockito.Mockito.never())
+        .send(any(), any(), any(Map.class));
+  }
+}

--- a/common/src/test/java/com/ticketrush/global/dlt/DeadLetterRecordRepositoryTest.java
+++ b/common/src/test/java/com/ticketrush/global/dlt/DeadLetterRecordRepositoryTest.java
@@ -1,0 +1,77 @@
+package com.ticketrush.global.dlt;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.ticketrush.global.jpa.config.JpaConfig;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+/** {@link JpaConfig}를 임포트해 {@code @EnableJpaAuditing}을 활성화한 뒤 {@code createdAt} 필드 단언을 포함한다. */
+@DataJpaTest
+@Import(JpaConfig.class)
+class DeadLetterRecordRepositoryTest {
+
+  @Autowired private DeadLetterRecordRepository deadLetterRecordRepository;
+
+  @Test
+  @DisplayName("DeadLetterRecord를 저장하고 ID로 조회하면 모든 필드가 보존된다")
+  void save_and_find_preserves_fields() {
+    // given
+    DeadLetterRecord record =
+        DeadLetterRecord.builder()
+            .originalTopic("booking-created-topic")
+            .originalPartition(2)
+            .originalOffset(123L)
+            .messageKey("100")
+            .eventType("BookingCreatedEvent")
+            .eventId("evt-1")
+            .payload("{\"booking_id\":100}")
+            .exceptionFqcn("java.lang.IllegalStateException")
+            .exceptionMessage("boom")
+            .build();
+    // 저장 시각은 created_at(JPA Auditing)으로 자동 기록된다. occurredAt 컬럼은 #9에서 제거됨.
+
+    // when
+    DeadLetterRecord saved = deadLetterRecordRepository.save(record);
+    DeadLetterRecord found = deadLetterRecordRepository.findById(saved.getId()).orElseThrow();
+
+    // then
+    assertThat(found.getOriginalTopic()).isEqualTo("booking-created-topic");
+    assertThat(found.getOriginalPartition()).isEqualTo(2);
+    assertThat(found.getOriginalOffset()).isEqualTo(123L);
+    assertThat(found.getMessageKey()).isEqualTo("100");
+    assertThat(found.getEventType()).isEqualTo("BookingCreatedEvent");
+    assertThat(found.getEventId()).isEqualTo("evt-1");
+    assertThat(found.getPayload()).isEqualTo("{\"booking_id\":100}");
+    assertThat(found.getExceptionFqcn()).isEqualTo("java.lang.IllegalStateException");
+    assertThat(found.getExceptionMessage()).isEqualTo("boom");
+    // #9: occurredAt 제거 후 저장시각은 JPA Auditing createdAt으로 관리됨을 검증한다.
+    assertThat(found.getCreatedAt()).isNotNull();
+  }
+
+  @Test
+  @DisplayName("역직렬화 실패 케이스처럼 eventType/eventId가 없어도 저장된다")
+  void save_allows_null_event_metadata() {
+    // given
+    DeadLetterRecord record =
+        DeadLetterRecord.builder()
+            .originalTopic("some-topic")
+            .originalPartition(0)
+            .originalOffset(7L)
+            .payload("raw-broken-payload")
+            .build();
+
+    // when
+    DeadLetterRecord saved = deadLetterRecordRepository.save(record);
+    DeadLetterRecord found = deadLetterRecordRepository.findById(saved.getId()).orElseThrow();
+
+    // then
+    assertThat(found.getEventType()).isNull();
+    assertThat(found.getEventId()).isNull();
+    assertThat(found.getMessageKey()).isNull();
+    assertThat(found.getPayload()).isEqualTo("raw-broken-payload");
+  }
+}

--- a/common/src/test/java/com/ticketrush/global/notification/SlackNotifierTest.java
+++ b/common/src/test/java/com/ticketrush/global/notification/SlackNotifierTest.java
@@ -1,0 +1,124 @@
+package com.ticketrush.global.notification;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import com.ticketrush.global.json.JsonConverter;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.client.RestClient;
+
+/**
+ * {@link SlackNotifier} 단위 테스트.
+ *
+ * <p>{@link RestClient} 플루언트 체인을 Mockito로 모킹해 실제 HTTP/컨버터 초기화 없이 순수 단위 검증한다({@link SlackNotifier}의
+ * RestClient 주입 생성자 사용).
+ */
+@ExtendWith(MockitoExtension.class)
+class SlackNotifierTest {
+
+  private static final String WEBHOOK_URL = "https://hooks.slack.test/services/webhook";
+
+  @Mock private JsonConverter jsonConverter;
+  @Mock private RestClient restClient;
+  @Mock private RestClient.RequestBodyUriSpec requestBodyUriSpec;
+  @Mock private RestClient.RequestBodySpec requestBodySpec;
+  @Mock private RestClient.ResponseSpec responseSpec;
+
+  private SlackNotifier slackNotifier;
+
+  @BeforeEach
+  void setUp() {
+    SlackProperties properties = new SlackProperties();
+    properties.setWebhookUrl(WEBHOOK_URL);
+
+    slackNotifier = new SlackNotifier(properties, jsonConverter, restClient);
+  }
+
+  private void givenPostChain() {
+    given(restClient.post()).willReturn(requestBodyUriSpec);
+    given(requestBodyUriSpec.uri(WEBHOOK_URL)).willReturn(requestBodySpec);
+    given(requestBodySpec.contentType(any())).willReturn(requestBodySpec);
+    given(requestBodySpec.body(anyString())).willReturn(requestBodySpec);
+    given(requestBodySpec.retrieve()).willReturn(responseSpec);
+  }
+
+  @Test
+  @DisplayName("send: webhook URL로 직렬화한 JSON 페이로드를 POST한다")
+  void send_posts_payload_to_webhook() {
+    given(jsonConverter.serialize(any())).willReturn("{\"text\":\"hello\"}");
+    givenPostChain();
+
+    slackNotifier.send("제목", "본문", Map.of("eventId", "evt-1"));
+
+    verify(requestBodyUriSpec).uri(WEBHOOK_URL);
+    verify(requestBodySpec).body("{\"text\":\"hello\"}");
+    verify(responseSpec).toBodilessEntity();
+  }
+
+  @Test
+  @DisplayName("send: webhook 호출이 실패해도 예외를 삼키고 전파하지 않는다")
+  void send_swallows_exception_on_failure() {
+    given(jsonConverter.serialize(any())).willReturn("{\"text\":\"hello\"}");
+    given(restClient.post()).willReturn(requestBodyUriSpec);
+    given(requestBodyUriSpec.uri(WEBHOOK_URL)).willReturn(requestBodySpec);
+    given(requestBodySpec.contentType(any())).willReturn(requestBodySpec);
+    given(requestBodySpec.body(anyString())).willReturn(requestBodySpec);
+    given(requestBodySpec.retrieve()).willThrow(new RuntimeException("slack down"));
+
+    assertThatCode(() -> slackNotifier.send("제목", "본문", Map.of())).doesNotThrowAnyException();
+  }
+
+  @Test
+  @DisplayName("NoOpNotifier: 아무 것도 하지 않고 예외 없이 반환한다")
+  void noop_notifier_does_nothing() {
+    NoOpNotifier noOpNotifier = new NoOpNotifier();
+
+    assertThatCode(() -> noOpNotifier.send("제목", "본문", Map.of("k", "v")))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  @DisplayName("send: 제목/본문/메타데이터를 합친 text로 페이로드를 직렬화한다")
+  void send_serializes_combined_text() {
+    given(jsonConverter.serialize(any())).willReturn("{\"text\":\"hello\"}");
+    givenPostChain();
+
+    slackNotifier.send("제목", "본문", Map.of("eventId", "evt-1"));
+
+    // text에 제목/본문/메타데이터가 모두 포함된 body가 직렬화 대상으로 넘어간다.
+    verify(jsonConverter)
+        .serialize(
+            org.mockito.ArgumentMatchers.argThat(
+                body -> {
+                  @SuppressWarnings("unchecked")
+                  Map<String, String> map = (Map<String, String>) body;
+                  String text = map.get("text");
+                  return text.contains("제목")
+                      && text.contains("본문")
+                      && text.contains("eventId: evt-1");
+                }));
+    verify(requestBodyUriSpec).uri(eq(WEBHOOK_URL));
+  }
+
+  @Test
+  @DisplayName("생성자: webhook-url이 비어있으면 IllegalStateException으로 즉시 실패한다(#5)")
+  void constructor_throws_when_webhook_url_is_blank() {
+    SlackProperties emptyProps = new SlackProperties();
+    // webhookUrl 미설정 → null
+
+    assertThatThrownBy(() -> new SlackNotifier(emptyProps, jsonConverter, restClient))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("webhook-url");
+  }
+}

--- a/common/src/test/java/com/ticketrush/global/outbox/OutboxStatusTransitionTest.java
+++ b/common/src/test/java/com/ticketrush/global/outbox/OutboxStatusTransitionTest.java
@@ -1,0 +1,102 @@
+package com.ticketrush.global.outbox;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+import com.ticketrush.global.event.DomainEventEnvelope;
+import java.time.Instant;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class OutboxStatusTransitionTest {
+
+  @InjectMocks private OutboxStatusTransition outboxStatusTransition;
+
+  @Mock private OutboxRepository outboxRepository;
+  @Mock private OutboxProperties outboxProperties;
+
+  private OutboxEntity row() {
+    DomainEventEnvelope envelope =
+        new DomainEventEnvelope(
+            "evt-1",
+            "BookingCreatedEvent",
+            Instant.parse("2026-05-27T06:00:00Z"),
+            "booking-created-topic",
+            "{}",
+            "trace-1");
+    return OutboxEntity.from(envelope, "Booking", "100", "100");
+  }
+
+  @Test
+  @DisplayName("markSuccess: SENT로 전이하고 publishedAt을 기록한다")
+  void markSuccess_transitions_to_sent() {
+    OutboxEntity row = row();
+    given(outboxRepository.findById(1L)).willReturn(Optional.of(row));
+
+    outboxStatusTransition.markSuccess(1L);
+
+    assertThat(row.getStatus()).isEqualTo(OutboxStatus.SENT);
+    assertThat(row.getPublishedAt()).isNotNull();
+  }
+
+  @Test
+  @DisplayName("markFail: 재시도 상한 미만이면 FAILED로 전이하고 null을 반환한다")
+  void markFail_transitions_to_failed_below_cap() {
+    OutboxEntity row = row();
+    given(outboxRepository.findById(1L)).willReturn(Optional.of(row));
+    given(outboxProperties.getMaxRetries()).willReturn(3);
+
+    OutboxStatusTransition.DeadInfo result = outboxStatusTransition.markFail(1L, "boom");
+
+    assertThat(row.getStatus()).isEqualTo(OutboxStatus.FAILED);
+    assertThat(row.getRetryCount()).isEqualTo(1);
+    assertThat(row.getLastError()).isEqualTo("boom");
+    assertThat(result).isNull();
+  }
+
+  @Test
+  @DisplayName("markFail: 재시도 상한에 도달하면 DEAD로 전이하고 DeadInfo를 반환한다")
+  void markFail_transitions_to_dead_at_cap() {
+    OutboxEntity row = row();
+    given(outboxRepository.findById(1L)).willReturn(Optional.of(row));
+    given(outboxProperties.getMaxRetries()).willReturn(1);
+
+    OutboxStatusTransition.DeadInfo result = outboxStatusTransition.markFail(1L, "boom");
+
+    assertThat(row.getStatus()).isEqualTo(OutboxStatus.DEAD);
+    assertThat(row.getRetryCount()).isEqualTo(1);
+    assertThat(result).isNotNull();
+    assertThat(result.eventId()).isEqualTo("evt-1");
+    assertThat(result.maxRetries()).isEqualTo(1);
+  }
+
+  @Test
+  @DisplayName("이미 SENT면 늦게 도착한 실패 콜백이 상태를 역전시키지 않고 null을 반환한다")
+  void markFail_does_not_revert_already_sent_row() {
+    OutboxEntity row = row();
+    given(outboxRepository.findById(1L)).willReturn(Optional.of(row));
+    given(outboxProperties.getMaxRetries()).willReturn(1);
+
+    outboxStatusTransition.markSuccess(1L);
+    OutboxStatusTransition.DeadInfo result = outboxStatusTransition.markFail(1L, "late failure");
+
+    assertThat(row.getStatus()).isEqualTo(OutboxStatus.SENT);
+    assertThat(result).isNull();
+  }
+
+  @Test
+  @DisplayName("row가 없으면 예외 없이 null을 반환한다")
+  void ignores_when_row_not_found() {
+    given(outboxRepository.findById(99L)).willReturn(Optional.empty());
+
+    OutboxStatusTransition.DeadInfo result = outboxStatusTransition.markFail(99L, "err");
+
+    assertThat(result).isNull();
+  }
+}

--- a/common/src/test/java/com/ticketrush/global/outbox/OutboxStatusUpdaterTest.java
+++ b/common/src/test/java/com/ticketrush/global/outbox/OutboxStatusUpdaterTest.java
@@ -1,11 +1,13 @@
 package com.ticketrush.global.outbox;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
-import com.ticketrush.global.event.DomainEventEnvelope;
-import java.time.Instant;
-import java.util.Optional;
+import com.ticketrush.global.notification.Notifier;
+import java.util.Map;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -13,83 +15,48 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+/**
+ * {@link OutboxStatusUpdater} 단위 테스트.
+ *
+ * <p>상태 전이 로직은 {@link OutboxStatusTransition}에 위임하므로 여기서는 위임 후 알림 발송 여부만 검증한다. 전이 로직 자체의 단위 테스트는
+ * {@link OutboxStatusTransitionTest}에서 다룬다.
+ */
 @ExtendWith(MockitoExtension.class)
 class OutboxStatusUpdaterTest {
 
   @InjectMocks private OutboxStatusUpdater outboxStatusUpdater;
 
-  @Mock private OutboxRepository outboxRepository;
-  @Mock private OutboxProperties outboxProperties;
-
-  private OutboxEntity row() {
-    DomainEventEnvelope envelope =
-        new DomainEventEnvelope(
-            "evt-1",
-            "BookingCreatedEvent",
-            Instant.parse("2026-05-27T06:00:00Z"),
-            "booking-created-topic",
-            "{}",
-            "trace-1");
-    return OutboxEntity.from(envelope, "Booking", "100", "100");
-  }
+  @Mock private OutboxStatusTransition transition;
+  @Mock private Notifier notifier;
 
   @Test
-  @DisplayName("markSuccess: SENT로 전이하고 publishedAt을 기록한다")
-  void markSuccess_transitions_to_sent() {
-    OutboxEntity row = row();
-    given(outboxRepository.findById(1L)).willReturn(Optional.of(row));
-
+  @DisplayName("markSuccess: transition.markSuccess를 위임한다")
+  void markSuccess_delegates_to_transition() {
     outboxStatusUpdater.markSuccess(1L);
 
-    assertThat(row.getStatus()).isEqualTo(OutboxStatus.SENT);
-    assertThat(row.getPublishedAt()).isNotNull();
+    verify(transition).markSuccess(1L);
+    verify(notifier, never()).send(any(), any(), any());
   }
 
   @Test
-  @DisplayName("markFail: 재시도 상한 미만이면 FAILED로 전이하고 retryCount를 올린다")
-  void markFail_transitions_to_failed_below_cap() {
-    OutboxEntity row = row();
-    given(outboxRepository.findById(1L)).willReturn(Optional.of(row));
-    given(outboxProperties.getMaxRetries()).willReturn(3);
+  @DisplayName("markFail: transition이 null을 반환하면(DEAD 아님) 알림을 발송하지 않는다")
+  void markFail_does_not_notify_when_not_dead() {
+    given(transition.markFail(1L, "boom")).willReturn(null);
 
     outboxStatusUpdater.markFail(1L, "boom");
 
-    assertThat(row.getStatus()).isEqualTo(OutboxStatus.FAILED);
-    assertThat(row.getRetryCount()).isEqualTo(1);
-    assertThat(row.getLastError()).isEqualTo("boom");
+    verify(notifier, never()).send(any(), any(), any());
   }
 
   @Test
-  @DisplayName("markFail: 재시도 상한에 도달하면 DEAD로 전이한다")
-  void markFail_transitions_to_dead_at_cap() {
-    OutboxEntity row = row();
-    given(outboxRepository.findById(1L)).willReturn(Optional.of(row));
-    given(outboxProperties.getMaxRetries()).willReturn(1);
+  @DisplayName("markFail: transition이 DeadInfo를 반환하면(DEAD) 제목·식별자 포함 알림을 발송한다(#6 — lastError 미포함)")
+  void markFail_notifies_when_dead() {
+    given(transition.markFail(1L, "boom"))
+        .willReturn(new OutboxStatusTransition.DeadInfo("evt-1", 1));
 
     outboxStatusUpdater.markFail(1L, "boom");
 
-    assertThat(row.getStatus()).isEqualTo(OutboxStatus.DEAD);
-    assertThat(row.getRetryCount()).isEqualTo(1);
-  }
-
-  @Test
-  @DisplayName("이미 SENT면 늦게 도착한 실패 콜백이 상태를 역전시키지 않는다")
-  void markFail_does_not_revert_already_sent_row() {
-    OutboxEntity row = row();
-    given(outboxRepository.findById(1L)).willReturn(Optional.of(row));
-
-    outboxStatusUpdater.markSuccess(1L);
-    outboxStatusUpdater.markFail(1L, "late failure");
-
-    assertThat(row.getStatus()).isEqualTo(OutboxStatus.SENT);
-    assertThat(row.getRetryCount()).isZero();
-  }
-
-  @Test
-  @DisplayName("row가 없으면 예외 없이 무시한다")
-  void ignores_when_row_not_found() {
-    given(outboxRepository.findById(99L)).willReturn(Optional.empty());
-
-    outboxStatusUpdater.markSuccess(99L);
+    // 알림 본문에 자유서식 오류 메시지(lastError) 대신 안전한 식별자 참조 문자열이 전달된다(#6).
+    verify(notifier).send(eq("[Outbox DEAD] 이벤트 발행 재시도 상한 초과"), any(String.class), any(Map.class));
   }
 }


### PR DESCRIPTION
## 🔗 관련 이슈

- close #50

---

## 📌 주요 변경 사항

- 최대 재시도 초과로 `.DLT` 토픽에 분리된 실패 메시지를 소비→영구 저장→운영 알림하는 계층 신규 추가 (발행 인프라는 기존 `DeadLetterPublishingRecoverer` 재사용)
- Slack 알림 추상화(`Notifier`) 도입 및 Outbox DEAD 전환 알림 연동
- 알림/저장 전 구간을 `@ConditionalOnProperty` 토글 뒤에 배치(기본 비활성, 운영 단일 서비스에서만 활성)

---

## 🛠 상세 구현 내용

- **DLT 소비/저장** (`global/dlt`)
  - `DeadLetterConsumer`: `@KafkaListener(topicPattern=".*(?<!\.DLT)\.DLT")`로 `.DLT` 구독(`.DLT.DLT` 재소비 방지), `@ConditionalOnProperty(app.dlt.monitor.enabled)`로 단일 서비스만 활성. 에러 로그 → `DeadLetterRecord` 저장 → 알림 → 수동 ack
  - 역직렬화 실패 payload는 spring-kafka `SerializationUtils.getExceptionFromHeader`로 안전 복원(무제한 Java 역직렬화(CWE-502) 회피)
  - `DeadLetterRecord`(원본 토픽/파티션/오프셋/키/eventType/eventId/payload/예외정보, 저장시각은 JPA Auditing `createdAt`)
- **Slack 알림** (`global/notification`)
  - `Notifier` 인터페이스 + `SlackNotifier`(webhook POST, `@ConditionalOnProperty(app.slack.enabled)`, webhook-url 빈값 fail-fast) + `NoOpNotifier`(상호배타 폴백) + `SlackProperties`
  - 알림 본문에는 예외 타입·식별자만 노출(자유서식 예외 메시지·PII 제외), 로그 인젝션 sanitize 적용
- **Outbox DEAD 알림 연동**
  - `OutboxStatusUpdater`의 상태 전이를 `OutboxStatusTransition`(별도 빈)으로 분리 → 트랜잭션 커밋 이후 알림 발송(외부 HTTP가 DB 커넥션·row 락 점유 방지, self-invocation 회피)
- **설정**: `booking-service` 기본 모니터로 지정(`DLT_MONITOR_ENABLED`/`SLACK_*` 환경변수, local/test 비활성)

---

## ✅ 테스트

### 테스트 방법

- `./gradlew :common:test` (단위 테스트)
- 작성한 테스트:
  - `SlackNotifierTest` — webhook POST 호출·실패 삼킴·webhook-url 빈값 fail-fast·NoOp no-op
  - `DeadLetterConsumerTest` — DLT 헤더 파싱, 역직렬화 실패 시 헤더에서 원본 payload 복원, 저장·알림·ack
  - `DeadLetterRecordRepositoryTest` — `@DataJpaTest`+Auditing, 필드 보존·`createdAt` 기록
  - `OutboxStatusTransitionTest` — FAILED/DEAD/SENT 역전 방지 전이
  - `OutboxStatusUpdaterTest` — DEAD 시에만 트랜잭션 밖 알림 발송
- `./gradlew :common:spotlessCheck :booking-service:spotlessCheck`

### 테스트 결과

- `./gradlew :common:test` → BUILD SUCCESSFUL, 전체 통과
- `spotlessCheck` → PASS, `:booking-service:compileJava` → PASS
<!--
### 📸 스크린샷

- (수동 시연/스크린샷 필요 시 작성)
-->
---

## 👀 리뷰 요청 사항

- `DeadLetterConsumer`의 저장 실패 시 예외 전파(재시도) vs ack 정책, `.DLT.DLT` 확산 억제 근거(클래스 Javadoc) 검토
- 알림/DB 저장 데이터 최소화 방향 적절성

---

## ⚠️ 배포 시 주의사항

- **DLT 모니터는 단일 서비스에서만 활성화**할 것(`DLT_MONITOR_ENABLED=true`를 여러 서비스에 켜면 같은 `dlt-monitor-group`으로 레코드가 여러 DB에 분산됨). 현재 기본 모니터는 booking-service
- `SLACK_WEBHOOK_URL`은 시크릿 — 환경변수로만 주입(코드/yml 하드코딩 금지)
- 후속 과제(별도 이슈 예정): `dead_letter_record` 보존/purge 정책 + payload 민감정보 마스킹, DLT 레코드 멱등 제약
