### PR TITLE
[Feat] #307 dead_letter_record 보존 정책 및 payload PII 마스킹

### DIFF
--- a/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/app/scheduler/DltRetentionScheduler.java
+++ b/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/app/scheduler/DltRetentionScheduler.java
@@ -1,0 +1,28 @@
+package com.ticketrush.boundedcontext.booking.app.scheduler;
+
+import com.ticketrush.global.dlt.DltRetentionService;
+import lombok.RequiredArgsConstructor;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/**
+ * booking-service의 DLT retention 스케줄러.
+ *
+ * <p>{@code app.dlt.monitor.enabled=true}일 때만 등록되며, 보존 기간이 지난 {@code dead_letter_record} row를 주기적으로
+ * 삭제한다. 다중 인스턴스 중복 실행은 ShedLock으로 방지한다.
+ */
+@Component
+@ConditionalOnProperty(prefix = "app.dlt.monitor", name = "enabled", havingValue = "true")
+@RequiredArgsConstructor
+public class DltRetentionScheduler {
+
+  private final DltRetentionService dltRetentionService;
+
+  @Scheduled(fixedDelay = 3600000) // 1시간
+  @SchedulerLock(name = "dltRetention-booking", lockAtLeastFor = "10s", lockAtMostFor = "5m")
+  public void purge() {
+    dltRetentionService.purgeExpired();
+  }
+}

--- a/booking-service/src/main/resources/application.yml
+++ b/booking-service/src/main/resources/application.yml
@@ -37,6 +37,8 @@ app:
   dlt:
     monitor:
       enabled: ${DLT_MONITOR_ENABLED:false}
+      # dead_letter_record 보존 기간(일). 이 기간이 지난 레코드는 retention 배치가 자동 삭제한다(#307).
+      retention-days: ${DLT_RETENTION_DAYS:30}
   slack:
     enabled: ${SLACK_ENABLED:false}
     webhook-url: ${SLACK_WEBHOOK_URL:}

--- a/common/src/main/java/com/ticketrush/global/dlt/DeadLetterConsumer.java
+++ b/common/src/main/java/com/ticketrush/global/dlt/DeadLetterConsumer.java
@@ -114,9 +114,11 @@ public class DeadLetterConsumer {
         sanitize(eventType),
         sanitize(eventId),
         sanitize(exceptionFqcn),
-        sanitize(exceptionMessage));
+        // #307: 로그 수집기 경로 PII 유출 방지 — 마스킹 후 로그 인젝션 sanitize 순으로 적용한다.
+        sanitize(DltPayloadMasker.mask(exceptionMessage)));
 
     try {
+      // #307: 저장 직전 PII를 보수적으로 마스킹한다(미래 PII 유입 방어). exceptionFqcn은 클래스명이라 마스킹 대상 아님.
       deadLetterRecordRepository.save(
           DeadLetterRecord.builder()
               .originalTopic(originalTopic)
@@ -125,9 +127,9 @@ public class DeadLetterConsumer {
               .messageKey(record.key())
               .eventType(eventType)
               .eventId(eventId)
-              .payload(payload)
+              .payload(DltPayloadMasker.mask(payload))
               .exceptionFqcn(exceptionFqcn)
-              .exceptionMessage(exceptionMessage)
+              .exceptionMessage(DltPayloadMasker.mask(exceptionMessage))
               .build());
     } catch (Exception e) {
       // 저장 실패는 ack하지 않고 예외를 던져 재시도되게 한다(실패 정책은 클래스 Javadoc 참조).

--- a/common/src/main/java/com/ticketrush/global/dlt/DeadLetterRecord.java
+++ b/common/src/main/java/com/ticketrush/global/dlt/DeadLetterRecord.java
@@ -16,7 +16,7 @@ import lombok.NoArgsConstructor;
  *
  * <p>{@code DeadLetterConsumer}가 DLT 헤더/원본 payload에서 값을 뽑아 저장한다. 실패 원인 추적·운영자 조회·수동 복구의 근거가 된다. 이벤트
  * 타입별/원본 토픽별 조회를 위해 {@code (event_type, created_at)}, {@code (original_topic, created_at)} 복합 인덱스를
- * 둔다.
+ * 두고, retention 배치의 {@code created_at} 범위 삭제를 위해 {@code (created_at)} 단독 인덱스를 둔다.
  *
  * <p>저장 시각은 {@link com.ticketrush.global.jpa.entity.BaseTimeEntity}가 관리하는 {@code created_at}(JPA
  * Auditing)으로 기록된다. 별도 {@code occurred_at} 컬럼은 중복이므로 두지 않는다(#9).
@@ -29,7 +29,8 @@ import lombok.NoArgsConstructor;
     name = "dead_letter_record",
     indexes = {
       @Index(name = "idx_dlr_event_type_created_at", columnList = "event_type, created_at"),
-      @Index(name = "idx_dlr_original_topic_created_at", columnList = "original_topic, created_at")
+      @Index(name = "idx_dlr_original_topic_created_at", columnList = "original_topic, created_at"),
+      @Index(name = "idx_dlr_created_at", columnList = "created_at")
     })
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/common/src/main/java/com/ticketrush/global/dlt/DeadLetterRecordRepository.java
+++ b/common/src/main/java/com/ticketrush/global/dlt/DeadLetterRecordRepository.java
@@ -1,6 +1,16 @@
 package com.ticketrush.global.dlt;
 
+import java.time.LocalDateTime;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 /** {@link DeadLetterRecord}에 대한 JPA 저장소. */
-public interface DeadLetterRecordRepository extends JpaRepository<DeadLetterRecord, Long> {}
+public interface DeadLetterRecordRepository extends JpaRepository<DeadLetterRecord, Long> {
+
+  /** retention 대상 row를 벌크 삭제한다. {@code threshold} 이전에 저장(createdAt)된 row만 지운다. */
+  @Modifying(clearAutomatically = true)
+  @Query("DELETE FROM DeadLetterRecord d WHERE d.createdAt < :threshold")
+  int deleteCreatedBefore(@Param("threshold") LocalDateTime threshold);
+}

--- a/common/src/main/java/com/ticketrush/global/dlt/DltMonitorProperties.java
+++ b/common/src/main/java/com/ticketrush/global/dlt/DltMonitorProperties.java
@@ -18,4 +18,5 @@ import org.springframework.stereotype.Component;
 public class DltMonitorProperties {
 
   private boolean enabled = false;
+  private int retentionDays = 30; // dead_letter_record를 이 기간 이후 retention 배치가 삭제한다.
 }

--- a/common/src/main/java/com/ticketrush/global/dlt/DltPayloadMasker.java
+++ b/common/src/main/java/com/ticketrush/global/dlt/DltPayloadMasker.java
@@ -1,0 +1,68 @@
+package com.ticketrush.global.dlt;
+
+import java.util.regex.Pattern;
+
+/**
+ * {@code dead_letter_record} 저장 직전 payload/exceptionMessage에서 PII를 마스킹하는 경량 유틸(#307).
+ *
+ * <p>키관리 없이 조회·수동복구 가능성을 유지하기 위해 암호화 대신 정규식 마스킹만 적용한다. <b>보수적 패턴만</b> 마스킹해 정상 식별자(예: {@code
+ * bookingId=100}, {@code userId=5} 같은 짧은 숫자열)를 PII로 <b>오탐하지 않도록</b> 한다. 오탐은 실패 원인 추적을 훼손하므로, 카드번호는
+ * 구분자(하이픈·공백)로 나뉜 4-4-4-4 형태처럼 명확한 것만 매칭한다.
+ *
+ * <ul>
+ *   <li>이메일: 로컬파트 첫 글자만 남기고 도메인까지 마스킹({@code user@x.com} → {@code u***@***}).
+ *   <li>카드번호: 구분자로 구분된 4-4-4-4(마지막 그룹 3~4자리) 형태만. 마지막 4자리만 남긴다({@code ****-****-****-1234}).
+ *   <li>한국 휴대폰: {@code 01[016789]} 시작 번호의 가운데를 마스킹({@code 010-****-5678}).
+ *   <li>주민등록번호: {@code YYMMDD-[1-4]NNNNNN} 형태(성별자리 [1-4] 강제)만 매칭해 뒷자리 6개를 마스킹({@code
+ *       900101-1******}).
+ * </ul>
+ */
+public final class DltPayloadMasker {
+
+  private static final Pattern EMAIL =
+      Pattern.compile("([\\w.+-])[\\w.+-]*@[\\w.-]+\\.[A-Za-z]{2,}");
+
+  /** 구분자(하이픈·공백)로 나뉜 4-4-4-4(마지막 3~4자리) 카드 형태만 보수적으로 매칭한다. */
+  private static final Pattern CARD =
+      Pattern.compile("\\b\\d{4}[ -]\\d{4}[ -]\\d{4}[ -]\\d{3,4}\\b");
+
+  /** 한국 휴대폰 번호({@code 01[016789]-3~4자리-4자리}, 구분자 선택). */
+  private static final Pattern PHONE = Pattern.compile("\\b01[016789][ -]?\\d{3,4}[ -]?\\d{4}\\b");
+
+  /**
+   * 주민등록번호: 생년월일 6자리, 하이픈, 성별자리([1-4]) + 6자리.
+   *
+   * <p>성별자리를 {@code [1-4]}로 제한해 임의의 {@code 6자리-7자리} 숫자열을 오탐하지 않는다. 뒷자리 6개를 {@code ******}으로 마스킹하고
+   * 성별자리는 보존({@code 900101-1******}).
+   */
+  private static final Pattern RRN = Pattern.compile("\\b(\\d{6})-([1-4])\\d{6}\\b");
+
+  private DltPayloadMasker() {}
+
+  /**
+   * 입력 문자열에서 이메일·카드번호·휴대폰 번호·주민등록번호를 마스킹한다. null 입력은 null을 반환한다.
+   *
+   * @param input 원본 문자열(payload 또는 예외 메시지)
+   * @return 마스킹된 문자열, 입력이 null이면 null
+   */
+  public static String mask(String input) {
+    if (input == null) {
+      return null;
+    }
+    String result = EMAIL.matcher(input).replaceAll(mr -> mr.group(1) + "***@***");
+    result = CARD.matcher(result).replaceAll(mr -> "****-****-****-" + lastFour(mr.group()));
+    result = PHONE.matcher(result).replaceAll(mr -> maskPhone(mr.group()));
+    result = RRN.matcher(result).replaceAll(mr -> mr.group(1) + "-" + mr.group(2) + "******");
+    return result;
+  }
+
+  private static String lastFour(String matched) {
+    String digits = matched.replaceAll("\\D", "");
+    return digits.substring(digits.length() - 4);
+  }
+
+  private static String maskPhone(String matched) {
+    String digits = matched.replaceAll("\\D", "");
+    return digits.substring(0, 3) + "-****-" + digits.substring(digits.length() - 4);
+  }
+}

--- a/common/src/main/java/com/ticketrush/global/dlt/DltRetentionService.java
+++ b/common/src/main/java/com/ticketrush/global/dlt/DltRetentionService.java
@@ -1,0 +1,40 @@
+package com.ticketrush.global.dlt;
+
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 보존 기간이 지난 {@code dead_letter_record} row를 정리하는 retention 배치.
+ *
+ * <p>유출 시 blast radius가 시간에 비례해 커지므로 오래된 실패 메시지를 자동 삭제해 상한을 둔다(#307). DLT를 소비·저장하는 단일 서비스(기본:
+ * booking-service)에서만 동작하도록 {@link DeadLetterConsumer}와 같은 {@code app.dlt.monitor.enabled} 조건을
+ * 재사용한다.
+ */
+@Slf4j
+@Service
+@ConditionalOnProperty(prefix = "app.dlt.monitor", name = "enabled", havingValue = "true")
+@RequiredArgsConstructor
+public class DltRetentionService {
+
+  private final DeadLetterRecordRepository repository;
+  private final DltMonitorProperties properties;
+
+  @Transactional
+  public int purgeExpired() {
+    int retentionDays = properties.getRetentionDays();
+    if (retentionDays <= 0) {
+      log.warn("DLT retention: retentionDays({})가 0 이하여서 purge를 건너뜁니다.", retentionDays);
+      return 0;
+    }
+    LocalDateTime threshold = LocalDateTime.now().minusDays(retentionDays);
+    int deleted = repository.deleteCreatedBefore(threshold);
+    if (deleted > 0) {
+      log.info("DLT retention: dead_letter_record {}건 삭제 (threshold={})", deleted, threshold);
+    }
+    return deleted;
+  }
+}

--- a/common/src/test/java/com/ticketrush/global/dlt/DeadLetterConsumerTest.java
+++ b/common/src/test/java/com/ticketrush/global/dlt/DeadLetterConsumerTest.java
@@ -94,6 +94,45 @@ class DeadLetterConsumerTest {
   }
 
   @Test
+  @DisplayName("payload에 PII(이메일)가 있으면 마스킹된 값으로 저장한다")
+  void consume_masks_pii_in_payload_before_saving() {
+    // given: payload에 이메일이 포함된 envelope
+    DomainEventEnvelope envelope =
+        new DomainEventEnvelope(
+            "evt-1",
+            "BookingCreatedEvent",
+            Instant.parse("2026-05-27T06:00:00Z"),
+            "booking-created-topic",
+            "{\"email\":\"user@example.com\"}",
+            "trace-1");
+    ConsumerRecord<String, Object> record =
+        new ConsumerRecord<>("booking-created-topic.DLT", 0, 42L, "100", envelope);
+
+    given(deadLetterRecordRepository.save(any(DeadLetterRecord.class)))
+        .willAnswer(invocation -> invocation.getArgument(0));
+
+    // when
+    deadLetterConsumer.consume(
+        record,
+        str("booking-created-topic"),
+        intBytes(3),
+        longBytes(99L),
+        str("java.lang.IllegalStateException"),
+        str("user@example.com 처리 실패"),
+        ack);
+
+    // then
+    ArgumentCaptor<DeadLetterRecord> captor = ArgumentCaptor.forClass(DeadLetterRecord.class);
+    verify(deadLetterRecordRepository).save(captor.capture());
+    DeadLetterRecord saved = captor.getValue();
+
+    assertThat(saved.getPayload()).doesNotContain("user@example.com");
+    assertThat(saved.getPayload()).contains("u***@***");
+    assertThat(saved.getExceptionMessage()).doesNotContain("user@example.com");
+    assertThat(saved.getExceptionMessage()).contains("u***@***");
+  }
+
+  @Test
   @DisplayName("역직렬화 실패(value=null)일 때 springDeserializerExceptionValue 헤더에서 원본 payload를 추출한다")
   void consume_extracts_raw_payload_from_deserialization_exception_header() {
     // given: ErrorHandlingDeserializer가 실제로 생성하는 헤더와 동일한 형식으로 구성한다.

--- a/common/src/test/java/com/ticketrush/global/dlt/DeadLetterRecordRepositoryTest.java
+++ b/common/src/test/java/com/ticketrush/global/dlt/DeadLetterRecordRepositoryTest.java
@@ -3,6 +3,7 @@ package com.ticketrush.global.dlt;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.ticketrush.global.jpa.config.JpaConfig;
+import java.time.LocalDateTime;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -73,5 +74,48 @@ class DeadLetterRecordRepositoryTest {
     assertThat(found.getEventId()).isNull();
     assertThat(found.getMessageKey()).isNull();
     assertThat(found.getPayload()).isEqualTo("raw-broken-payload");
+  }
+
+  @Test
+  @DisplayName("threshold 이전에 저장된 레코드는 deleteCreatedBefore로 삭제된다")
+  void deleteCreatedBefore_removes_records_before_threshold() {
+    // given: createdAt은 Auditing으로 저장 시점(now)에 자동 세팅된다.
+    DeadLetterRecord record =
+        DeadLetterRecord.builder()
+            .originalTopic("some-topic")
+            .originalPartition(0)
+            .originalOffset(1L)
+            .payload("{\"booking_id\":1}")
+            .build();
+    DeadLetterRecord saved = deadLetterRecordRepository.saveAndFlush(record);
+
+    // when: 방금 저장분의 createdAt보다 미래(now+1분) threshold로 삭제
+    int deleted =
+        deadLetterRecordRepository.deleteCreatedBefore(LocalDateTime.now().plusMinutes(1));
+
+    // then
+    assertThat(deleted).isEqualTo(1);
+    assertThat(deadLetterRecordRepository.findById(saved.getId())).isEmpty();
+  }
+
+  @Test
+  @DisplayName("threshold 이후에 저장된 레코드는 deleteCreatedBefore로 삭제되지 않는다")
+  void deleteCreatedBefore_keeps_records_after_threshold() {
+    // given
+    DeadLetterRecord record =
+        DeadLetterRecord.builder()
+            .originalTopic("some-topic")
+            .originalPartition(0)
+            .originalOffset(2L)
+            .payload("{\"booking_id\":2}")
+            .build();
+    DeadLetterRecord saved = deadLetterRecordRepository.saveAndFlush(record);
+
+    // when: 방금 저장분의 createdAt보다 과거(now-1년) threshold로는 삭제되지 않아야 한다.
+    int deleted = deadLetterRecordRepository.deleteCreatedBefore(LocalDateTime.now().minusYears(1));
+
+    // then
+    assertThat(deleted).isZero();
+    assertThat(deadLetterRecordRepository.findById(saved.getId())).isPresent();
   }
 }

--- a/common/src/test/java/com/ticketrush/global/dlt/DltPayloadMaskerTest.java
+++ b/common/src/test/java/com/ticketrush/global/dlt/DltPayloadMaskerTest.java
@@ -1,0 +1,97 @@
+package com.ticketrush.global.dlt;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class DltPayloadMaskerTest {
+
+  @Test
+  @DisplayName("이메일은 로컬파트 첫 글자만 남기고 마스킹한다")
+  void masks_email() {
+    // given
+    String input = "{\"email\":\"user@example.com\"}";
+
+    // when
+    String masked = DltPayloadMasker.mask(input);
+
+    // then
+    assertThat(masked).doesNotContain("user@example.com");
+    assertThat(masked).contains("u***@***");
+  }
+
+  @Test
+  @DisplayName("구분자로 나뉜 카드번호는 마지막 4자리만 남기고 마스킹한다")
+  void masks_card_number() {
+    // given
+    String input = "카드 4111-1111-1111-1234 결제";
+
+    // when
+    String masked = DltPayloadMasker.mask(input);
+
+    // then
+    assertThat(masked).doesNotContain("4111-1111-1111-1234");
+    assertThat(masked).contains("****-****-****-1234");
+  }
+
+  @Test
+  @DisplayName("한국 휴대폰 번호는 가운데를 마스킹한다")
+  void masks_phone_number() {
+    // given
+    String input = "연락처 010-1234-5678 입니다";
+
+    // when
+    String masked = DltPayloadMasker.mask(input);
+
+    // then
+    assertThat(masked).doesNotContain("010-1234-5678");
+    assertThat(masked).contains("010-****-5678");
+  }
+
+  @Test
+  @DisplayName("PII가 없는 정상 JSON은 오탐 없이 원형을 유지한다")
+  void keeps_non_pii_payload_intact() {
+    // given: 짧은 식별자 숫자열을 카드/전화로 오탐하지 않아야 한다.
+    String input = "{\"bookingId\":100,\"userId\":5,\"amount\":25000}";
+
+    // when
+    String masked = DltPayloadMasker.mask(input);
+
+    // then
+    assertThat(masked).isEqualTo(input);
+  }
+
+  @Test
+  @DisplayName("주민등록번호는 뒷자리 6개를 마스킹하고 성별자리만 남긴다")
+  void masks_resident_registration_number() {
+    // given
+    String input = "주민번호 900101-1234567 입니다";
+
+    // when
+    String masked = DltPayloadMasker.mask(input);
+
+    // then
+    assertThat(masked).doesNotContain("900101-1234567");
+    assertThat(masked).contains("900101-1******");
+  }
+
+  @Test
+  @DisplayName("주민번호 패턴([1-4] 성별자리)에 해당하지 않는 6자리-7자리 숫자열은 오탐하지 않는다")
+  void does_not_false_positive_on_non_rrn_number_sequences() {
+    // given: 성별자리가 [1-4] 범위 밖(예: 5로 시작하는 뒷자리)이라 RRN으로 매칭되지 않아야 한다.
+    String input = "{\"refId\":\"123456-5678901\",\"bookingId\":100}";
+
+    // when
+    String masked = DltPayloadMasker.mask(input);
+
+    // then
+    assertThat(masked).isEqualTo(input);
+  }
+
+  @Test
+  @DisplayName("null 입력은 null을 반환한다")
+  void returns_null_for_null_input() {
+    assertThat(DltPayloadMasker.mask(null)).isNull();
+  }
+}

--- a/common/src/test/java/com/ticketrush/global/dlt/DltRetentionServiceTest.java
+++ b/common/src/test/java/com/ticketrush/global/dlt/DltRetentionServiceTest.java
@@ -1,0 +1,73 @@
+package com.ticketrush.global.dlt;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class DltRetentionServiceTest {
+
+  @InjectMocks private DltRetentionService dltRetentionService;
+
+  @Mock private DeadLetterRecordRepository repository;
+  @Mock private DltMonitorProperties properties;
+
+  @Test
+  @DisplayName("보존 기간이 지난 dead_letter_record를 threshold 기준으로 삭제한다")
+  void purge_deletes_expired_records() {
+    // given
+    given(properties.getRetentionDays()).willReturn(30);
+    given(repository.deleteCreatedBefore(any(LocalDateTime.class))).willReturn(7);
+
+    // when
+    int deleted = dltRetentionService.purgeExpired();
+
+    // then
+    assertThat(deleted).isEqualTo(7);
+    ArgumentCaptor<LocalDateTime> thresholdCaptor = ArgumentCaptor.forClass(LocalDateTime.class);
+    verify(repository).deleteCreatedBefore(thresholdCaptor.capture());
+    // threshold는 대략 now - 30일. 경계 오차를 감안해 [now-31일, now-29일] 범위인지만 확인한다.
+    LocalDateTime threshold = thresholdCaptor.getValue();
+    assertThat(threshold).isBefore(LocalDateTime.now().minusDays(29));
+    assertThat(threshold).isAfter(LocalDateTime.now().minusDays(31));
+  }
+
+  @Test
+  @DisplayName("삭제 대상이 없으면 0을 반환한다")
+  void purge_returns_zero_when_nothing_deleted() {
+    // given
+    given(properties.getRetentionDays()).willReturn(30);
+    given(repository.deleteCreatedBefore(any(LocalDateTime.class))).willReturn(0);
+
+    // when
+    int deleted = dltRetentionService.purgeExpired();
+
+    // then
+    assertThat(deleted).isZero();
+  }
+
+  @Test
+  @DisplayName("retentionDays가 0 이하이면 전량 삭제 사고를 막기 위해 purge를 건너뛰고 0을 반환한다")
+  void purge_skips_and_returns_zero_when_retention_days_non_positive() {
+    // given: 0은 사실상 전량 삭제를 의미하므로 스킵
+    given(properties.getRetentionDays()).willReturn(0);
+
+    // when
+    int deleted = dltRetentionService.purgeExpired();
+
+    // then
+    assertThat(deleted).isZero();
+    verify(repository, never()).deleteCreatedBefore(any());
+  }
+}

--- a/docs/backend-convention.md
+++ b/docs/backend-convention.md
@@ -290,3 +290,12 @@ class SeatControllerTest {
   value(8))
 }
 ```
+
+### 🔐 이벤트 payload · DLT 보안 규칙
+
+* **이벤트 payload에 PII(이메일·카드번호·개인정보) 금지** — 이벤트에는 식별자(ID)·금액·시간 등 최소 정보만 담습니다. **payload에 PII를 넣지 않는 것이 1차 통제**이며 마스킹은 보조 수단입니다.
+* **DLT 저장 전 마스킹** — 재시도 상한을 초과해 `dead_letter_record`에 적재되는 실패 메시지는 저장 직전 `DltPayloadMasker`로
+  PII(이메일·카드·전화·주민번호)를 마스킹합니다. **보수적 best-effort 패턴만** 커버하며 전수 보장이 아닙니다(정상 ID 오탐 방지 우선).
+* **DLT 자동 보존/삭제** — `dead_letter_record`는 기본 **30일** 보존 후 retention 배치가 자동 삭제합니다.
+  보존 기간은 `app.dlt.monitor.retention-days`(환경변수 `DLT_RETENTION_DAYS`)로 조정합니다.
+* **Kafka .DLT 토픽 잔존 주의** — DB 저장값은 마스킹되지만 원본 메시지는 Kafka `.DLT` 토픽에 해당 토픽의 retention 기간 동안 잔존합니다. 운영 환경에서는 Kafka 토픽 retention 설정도 함께 관리하세요.


### PR DESCRIPTION
## 🔗 관련 이슈

- close #307

---

## 📌 주요 변경 사항

- `dead_letter_record`를 보존기간(기본 30일) 경과 시 자동 삭제하는 retention 스케줄러 추가 → 유출 시 blast radius를 시간으로 상한
- 저장 직전 payload/exceptionMessage의 PII를 보수적으로 마스킹 → 미래 이벤트에 PII가 섞여도 방어
- #50 리뷰(security-reviewer)에서 후속 분리된 항목 구현

---

## 🛠 상세 구현 내용

- **보존(retention)** — Outbox retention(#103) 패턴 미러
  - `DltRetentionService`(common): `@ConditionalOnProperty(app.dlt.monitor.enabled)`, `createdAt < now-retentionDays` 벌크 삭제. `retentionDays<=0`이면 purge 스킵(전량 삭제 사고 방지)
  - `DltRetentionScheduler`(booking): `@Scheduled(1시간)` + `@SchedulerLock(name="dltRetention-booking")`
  - `DeadLetterRecordRepository.deleteCreatedBefore` 벌크 삭제 쿼리, `DeadLetterRecord`에 `created_at` 인덱스 추가
  - `DltMonitorProperties.retentionDays=30`(기본), `DLT_RETENTION_DAYS` 오버라이드
- **PII 마스킹**
  - `DltPayloadMasker`(common): 보수적 정규식으로 이메일·카드(구분자 4-4-4-4)·한국 휴대폰·주민번호 마스킹. 정상 ID 숫자열 오탐 방지 우선
  - `DeadLetterConsumer`: 저장 값과 **로그 값 모두** 마스킹 적용(로그 경로 우회 차단)
- **문서**: `docs/backend-convention.md`에 payload PII 금지(1차 통제) + DLT 마스킹/30일 보존 정책 명시

---

## ✅ 테스트

### 테스트 방법

- `./gradlew :common:test :booking-service:test`
- 작성/보강 테스트:
  - `DltPayloadMaskerTest`(7) — 이메일/카드/전화/주민번호 마스킹, 정상 JSON 오탐 없음, null 안전
  - `DltRetentionServiceTest`(3) — threshold 계산, retentionDays=0 가드
  - `DeadLetterRecordRepositoryTest`(4) — 삭제 threshold 경계(이전 삭제/이후 보존)
  - `DeadLetterConsumerTest`(5) — 저장 payload 마스킹
- `./gradlew :common:spotlessCheck :booking-service:spotlessCheck`

### 테스트 결과

- `./gradlew :common:test :booking-service:test` → BUILD SUCCESSFUL
- `spotlessCheck` → PASS
<!--
### 📸 스크린샷

- (수동 시연 필요 시 작성)
-->
---

## 👀 리뷰 요청 사항

- 마스킹 정규식의 보수성(오탐 방지) vs 커버리지 트레이드오프 적절성
- retention 기본 30일 값, `app.dlt.monitor.enabled` 활성 조건 재사용

---

## ⚠️ 배포 시 주의사항

- **ddl-auto 의존**: `created_at` 인덱스는 `@Index`로 추가됨. 운영이 `validate`/`none`이면 자동 반영 안 되므로 수동 DDL 확인 필요
- retention은 `app.dlt.monitor.enabled=true`인 서비스(booking)에서만 동작. `DLT_RETENTION_DAYS`로 보존기간 조정
- 마스킹은 보수적 best-effort(전수 보장 아님) — payload에 PII를 넣지 않는 것이 1차 통제. 원본은 Kafka `.DLT` 토픽에 topic-retention 기간 잔존
