### PR TITLE
[Feat] #308 DeadLetterRecord 멱등 제약으로 중복 적재 방지

### DIFF
--- a/common/src/main/java/com/ticketrush/global/dlt/DeadLetterConsumer.java
+++ b/common/src/main/java/com/ticketrush/global/dlt/DeadLetterConsumer.java
@@ -11,6 +11,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.core.log.LogAccessor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.kafka.support.Acknowledgment;
 import org.springframework.kafka.support.KafkaHeaders;
@@ -131,6 +132,33 @@ public class DeadLetterConsumer {
               .exceptionFqcn(exceptionFqcn)
               .exceptionMessage(DltPayloadMasker.mask(exceptionMessage))
               .build());
+    } catch (DataIntegrityViolationException e) {
+      // #308: DIVE가 unique 위반(중복 수신)인지 다른 무결성 위반(길이초과 등)인지 구분한다.
+      // existsBy 조회는 save가 자체 트랜잭션에서 롤백된 후 새 쿼리로 실행되므로 안전하다.
+      boolean isDuplicate =
+          deadLetterRecordRepository.existsByOriginalTopicAndOriginalPartitionAndOriginalOffset(
+              originalTopic, originalPartition, originalOffset);
+      if (!isDuplicate) {
+        // unique 위반이 아닌 다른 무결성 위반(길이초과 등) = 실제 저장 실패. 유실 방지 위해 재시도.
+        log.error(
+            "[DLT] DeadLetterRecord 저장 실패(비중복 무결성 위반). 재시도한다. originalTopic={}, offset={}",
+            originalTopic,
+            originalOffset,
+            e);
+        throw e;
+      }
+      // 진짜 중복(멱등). 최초 수신 시 이미 저장했고 알림을 시도했으므로 재저장/재알림 없이 ack만 한다.
+      // (최초 알림 실패 시 유실 가능은 수용된 트레이드오프 — #308)
+      log.info(
+          "[DLT] 중복 DeadLetterRecord 수신(멱등 스킵). originalTopic={}, partition={}, offset={},"
+              + " eventType={}, eventId={}",
+          originalTopic,
+          originalPartition,
+          originalOffset,
+          eventType,
+          eventId);
+      ack.acknowledge();
+      return;
     } catch (Exception e) {
       // 저장 실패는 ack하지 않고 예외를 던져 재시도되게 한다(실패 정책은 클래스 Javadoc 참조).
       log.error(

--- a/common/src/main/java/com/ticketrush/global/dlt/DeadLetterRecord.java
+++ b/common/src/main/java/com/ticketrush/global/dlt/DeadLetterRecord.java
@@ -6,6 +6,7 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Index;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -23,6 +24,9 @@ import lombok.NoArgsConstructor;
  *
  * <p>원본 컨슈머가 {@code DeserializationException}으로 실패한 경우 DLT value가 {@code DomainEventEnvelope}로
  * 역직렬화되지 않을 수 있어, eventType/eventId/payload는 nullable로 두고 최대 보존 저장한다.
+ *
+ * <p>{@code (original_topic, original_partition, original_offset)}는 DLT 메시지의 멱등 키로, 재전달 시 중복 적재를
+ * 막는다(#308).
  */
 @Entity
 @Table(
@@ -31,6 +35,11 @@ import lombok.NoArgsConstructor;
       @Index(name = "idx_dlr_event_type_created_at", columnList = "event_type, created_at"),
       @Index(name = "idx_dlr_original_topic_created_at", columnList = "original_topic, created_at"),
       @Index(name = "idx_dlr_created_at", columnList = "created_at")
+    },
+    uniqueConstraints = {
+      @UniqueConstraint(
+          name = "uk_dlr_topic_partition_offset",
+          columnNames = {"original_topic", "original_partition", "original_offset"})
     })
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/common/src/main/java/com/ticketrush/global/dlt/DeadLetterRecordRepository.java
+++ b/common/src/main/java/com/ticketrush/global/dlt/DeadLetterRecordRepository.java
@@ -13,4 +13,13 @@ public interface DeadLetterRecordRepository extends JpaRepository<DeadLetterReco
   @Modifying(clearAutomatically = true)
   @Query("DELETE FROM DeadLetterRecord d WHERE d.createdAt < :threshold")
   int deleteCreatedBefore(@Param("threshold") LocalDateTime threshold);
+
+  /**
+   * 동일 DLT 원본 좌표 {@code (originalTopic, originalPartition, originalOffset)}로 저장된 레코드가 있는지 확인한다.
+   *
+   * <p>{@link com.ticketrush.global.dlt.DeadLetterConsumer}가 {@code
+   * DataIntegrityViolationException} 발생 시 unique 위반(중복 수신)인지 다른 무결성 위반인지 구분하는 데 사용한다(#308).
+   */
+  boolean existsByOriginalTopicAndOriginalPartitionAndOriginalOffset(
+      String originalTopic, int originalPartition, long originalOffset);
 }

--- a/common/src/test/java/com/ticketrush/global/dlt/DeadLetterConsumerTest.java
+++ b/common/src/test/java/com/ticketrush/global/dlt/DeadLetterConsumerTest.java
@@ -205,4 +205,49 @@ class DeadLetterConsumerTest {
     org.mockito.Mockito.verify(notifier, org.mockito.Mockito.never())
         .send(any(), any(), any(Map.class));
   }
+
+  @Test
+  @DisplayName("중복 수신(save가 DIVE, existsBy=true)이면 예외 없이 ack하고 재알림하지 않는다(#308 멱등)")
+  void consume_skips_notify_and_acks_on_duplicate() {
+    // given: 동일 DLT 메시지 재전달 → unique 제약 위반으로 save가 DIVE를 던지고, existsBy는 true를 반환한다.
+    ConsumerRecord<String, Object> record =
+        new ConsumerRecord<>("some-topic.DLT", 0, 1L, null, "payload");
+    given(deadLetterRecordRepository.save(any(DeadLetterRecord.class)))
+        .willThrow(new org.springframework.dao.DataIntegrityViolationException("duplicate key"));
+    given(
+            deadLetterRecordRepository.existsByOriginalTopicAndOriginalPartitionAndOriginalOffset(
+                "some-topic", 0, 1L))
+        .willReturn(true);
+
+    // when: 예외가 밖으로 전파되지 않아야 한다.
+    deadLetterConsumer.consume(record, null, null, null, null, null, ack);
+
+    // then: 중복은 멱등 스킵 → ack만 하고 재알림하지 않는다.
+    verify(deadLetterRecordRepository).save(any(DeadLetterRecord.class));
+    verify(ack).acknowledge();
+    org.mockito.Mockito.verify(notifier, org.mockito.Mockito.never()).send(any(), any(), any());
+  }
+
+  @Test
+  @DisplayName("save가 DIVE인데 existsBy=false(비중복 무결성 위반)이면 예외를 rethrow하고 ack하지 않는다(#308)")
+  void consume_rethrows_on_non_duplicate_integrity_violation() {
+    // given: 길이초과 등 unique 위반이 아닌 DIVE → save가 DIVE를 던지고, existsBy는 false를 반환한다.
+    ConsumerRecord<String, Object> record =
+        new ConsumerRecord<>("some-topic.DLT", 0, 1L, null, "payload");
+    org.springframework.dao.DataIntegrityViolationException dive =
+        new org.springframework.dao.DataIntegrityViolationException("column too long");
+    given(deadLetterRecordRepository.save(any(DeadLetterRecord.class))).willThrow(dive);
+    given(
+            deadLetterRecordRepository.existsByOriginalTopicAndOriginalPartitionAndOriginalOffset(
+                "some-topic", 0, 1L))
+        .willReturn(false);
+
+    // when & then: 예외가 밖으로 전파되어야 한다(재시도).
+    org.assertj.core.api.Assertions.assertThatThrownBy(
+            () -> deadLetterConsumer.consume(record, null, null, null, null, null, ack))
+        .isInstanceOf(org.springframework.dao.DataIntegrityViolationException.class);
+
+    org.mockito.Mockito.verify(ack, org.mockito.Mockito.never()).acknowledge();
+    org.mockito.Mockito.verify(notifier, org.mockito.Mockito.never()).send(any(), any(), any());
+  }
 }

--- a/common/src/test/java/com/ticketrush/global/dlt/DeadLetterRecordRepositoryTest.java
+++ b/common/src/test/java/com/ticketrush/global/dlt/DeadLetterRecordRepositoryTest.java
@@ -1,6 +1,7 @@
 package com.ticketrush.global.dlt;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.ticketrush.global.jpa.config.JpaConfig;
 import java.time.LocalDateTime;
@@ -9,6 +10,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.dao.DataIntegrityViolationException;
 
 /** {@link JpaConfig}를 임포트해 {@code @EnableJpaAuditing}을 활성화한 뒤 {@code createdAt} 필드 단언을 포함한다. */
 @DataJpaTest
@@ -117,5 +119,82 @@ class DeadLetterRecordRepositoryTest {
     // then
     assertThat(deleted).isZero();
     assertThat(deadLetterRecordRepository.findById(saved.getId())).isPresent();
+  }
+
+  @Test
+  @DisplayName(
+      "동일 (originalTopic, originalPartition, originalOffset)로 두 번 저장하면 멱등 제약 위반 예외가 발생한다(#308)")
+  void duplicate_topic_partition_offset_violates_unique_constraint() {
+    // given: 동일 좌표(booking-created-topic, 2, 123)를 가진 두 레코드
+    deadLetterRecordRepository.saveAndFlush(
+        DeadLetterRecord.builder()
+            .originalTopic("booking-created-topic")
+            .originalPartition(2)
+            .originalOffset(123L)
+            .payload("{\"booking_id\":100}")
+            .build());
+
+    DeadLetterRecord duplicate =
+        DeadLetterRecord.builder()
+            .originalTopic("booking-created-topic")
+            .originalPartition(2)
+            .originalOffset(123L)
+            .payload("{\"booking_id\":100}")
+            .build();
+
+    // when & then: 두 번째 저장(flush)에서 unique 제약 위반이 발생한다.
+    assertThatThrownBy(() -> deadLetterRecordRepository.saveAndFlush(duplicate))
+        .isInstanceOf(DataIntegrityViolationException.class);
+  }
+
+  @Test
+  @DisplayName("좌표 중 하나라도 다르면 동일 토픽이어도 정상 저장된다(#308)")
+  void different_offset_is_saved_normally() {
+    // given
+    deadLetterRecordRepository.saveAndFlush(
+        DeadLetterRecord.builder()
+            .originalTopic("booking-created-topic")
+            .originalPartition(2)
+            .originalOffset(123L)
+            .payload("{\"booking_id\":100}")
+            .build());
+
+    // when: offset만 다른 레코드
+    DeadLetterRecord other =
+        deadLetterRecordRepository.saveAndFlush(
+            DeadLetterRecord.builder()
+                .originalTopic("booking-created-topic")
+                .originalPartition(2)
+                .originalOffset(124L)
+                .payload("{\"booking_id\":101}")
+                .build());
+
+    // then
+    assertThat(deadLetterRecordRepository.findById(other.getId())).isPresent();
+  }
+
+  @Test
+  @DisplayName("저장된 좌표엔 existsBy=true, 없는 좌표엔 false를 반환한다(#308)")
+  void existsByOriginalTopicAndOriginalPartitionAndOriginalOffset_returns_correct_result() {
+    // given
+    deadLetterRecordRepository.saveAndFlush(
+        DeadLetterRecord.builder()
+            .originalTopic("booking-created-topic")
+            .originalPartition(2)
+            .originalOffset(123L)
+            .payload("{\"booking_id\":100}")
+            .build());
+
+    // when & then: 동일 좌표 → true
+    assertThat(
+            deadLetterRecordRepository.existsByOriginalTopicAndOriginalPartitionAndOriginalOffset(
+                "booking-created-topic", 2, 123L))
+        .isTrue();
+
+    // 다른 offset → false
+    assertThat(
+            deadLetterRecordRepository.existsByOriginalTopicAndOriginalPartitionAndOriginalOffset(
+                "booking-created-topic", 2, 999L))
+        .isFalse();
   }
 }


### PR DESCRIPTION
## 🔗 관련 이슈

- close #308

---

## 📌 주요 변경 사항

- `DeadLetterRecord`에 `(original_topic, original_partition, original_offset)` 복합 unique 제약을 두어 DLT 메시지 중복 적재를 방지
- `DeadLetterConsumer`가 커밋~ack 사이 재전달(리밸런스/재시작)로 같은 메시지를 다시 받아도 멱등하게 처리

---

## 🛠 상세 구현 내용

- **복합 unique 제약**: `@Table(uniqueConstraints=@UniqueConstraint(name="uk_dlr_topic_partition_offset", columnNames={"original_topic","original_partition","original_offset"}))` — DLT 메시지의 원본 좌표를 멱등 키로 사용
- **멱등 처리**(프로젝트 표준 패턴, `BookingExpiredEventListener` 미러):
  - `save`에서 `DataIntegrityViolationException` 발생 시 `existsBy(topic,partition,offset)`로 **실제 중복 여부 확인**
  - 진짜 중복 → 재저장·재알림 없이 `ack`(멱등 스킵)
  - unique 위반이 아닌 다른 무결성 위반(길이 초과 등) → rethrow해 재시도(실패 메시지 무음 유실 방지)
- `DeadLetterConsumer`는 `@Transactional` 없이 `save`가 즉시 flush/commit(IDENTITY PK)되어 DIVE가 `consume()` 내부에서 포착됨

---

## ✅ 테스트

### 테스트 방법

- `./gradlew :common:test`
- 작성/보강 테스트:
  - `DeadLetterRecordRepositoryTest`(7) — 동일 좌표 중복 저장 시 제약 위반, 다른 좌표 정상 저장, `existsBy` 정확성
  - `DeadLetterConsumerTest`(7) — 중복(existsBy=true) 시 멱등 ack + 알림 skip, 비중복 무결성 위반(existsBy=false) 시 rethrow, 정상 저장 시 알림 발송
- `./gradlew :common:spotlessCheck`

### 테스트 결과

- `./gradlew :common:test` → BUILD SUCCESSFUL (Repository 7, Consumer 7, 0 실패)
- `spotlessCheck` → PASS
<!--
### 📸 스크린샷

- (수동 시연 필요 시 작성)
-->
---

## 👀 리뷰 요청 사항

- DIVE 오분류 방지(existsBy 재확인) 방식의 적절성
- 중복 시 알림 skip 정책(최초 알림 실패 시 유실 가능은 수용된 트레이드오프)

---

## ⚠️ 배포 시 주의사항

- **ddl-auto 의존**: unique 제약은 `@Table(uniqueConstraints=...)`로 추가됨. 운영이 `validate`/`none`이면 자동 반영 안 되므로 수동 DDL 필요. **기존 `dead_letter_record`에 이미 중복 행이 있으면 unique 인덱스 생성 실패** — 배포 전 중복 존재 여부 확인 필요(단 #50 신규 테이블이라 영향 적음)
