### PR TITLE
[Refactor] #269 Kafka 컨슈머 에러 처리 정책 표준화

### DIFF
--- a/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/in/eventlistener/PaymentConfirmedEventListener.java
+++ b/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/in/eventlistener/PaymentConfirmedEventListener.java
@@ -3,14 +3,18 @@ package com.ticketrush.boundedcontext.booking.in.eventlistener;
 import com.ticketrush.boundedcontext.booking.app.usecase.BookingConfirmUseCase;
 import com.ticketrush.boundedcontext.booking.out.apiclient.SeatRestClient;
 import com.ticketrush.global.event.DomainEventEnvelope;
+import com.ticketrush.global.event.KafkaConsumerErrorPolicy;
+import com.ticketrush.global.event.KafkaConsumerGroup;
 import com.ticketrush.global.json.JsonConverter;
 import com.ticketrush.shared.payment.event.PaymentConfirmedEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.kafka.support.Acknowledgment;
 import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.stereotype.Component;
+import org.springframework.web.client.HttpClientErrorException;
 
 @Slf4j
 @Component
@@ -21,7 +25,7 @@ public class PaymentConfirmedEventListener {
   private final SeatRestClient seatRestClient;
   private final JsonConverter jsonConverter;
 
-  @KafkaListener(topics = PaymentConfirmedEvent.TOPIC, groupId = "booking-group")
+  @KafkaListener(topics = PaymentConfirmedEvent.TOPIC, groupId = KafkaConsumerGroup.BOOKING)
   public void handlePaymentConfirmed(@Payload DomainEventEnvelope envelope, Acknowledgment ack) {
 
     PaymentConfirmedEvent event = null;
@@ -38,44 +42,68 @@ public class PaymentConfirmedEventListener {
           bookingConfirmUseCase.execute(event.bookingId(), event.paidAt(), event.seatId());
 
       // 예매 확정 트랜잭션 커밋 후 좌석 SOLD 확정을 동기 호출한다.
-      // SOLD 호출 실패는 예매 확정과 분리해 처리한다(예매는 확정됐으나 좌석만 미확정인 상태를 구분 추적).
+      // 크로스서비스 HTTP 호출이므로 BusinessException이 아닌 RestClient 예외로 도착한다 → isPermanent 미적용, HTTP 상태로 분기.
       try {
         seatRestClient.confirmSold(bookingNumber, event.seatId());
-      } catch (Exception e) {
-        // SOLD 호출 실패 종류를 구분하지 않고 모두 swallow한다(파티션 블로킹 방지).
-        // - 중복 수신으로 이미 SOLD된 좌석: seat-service가 409(SEAT_NOT_AVAILABLE)를 반환하며 이는 정상 상태다.
-        // - 네트워크/5xx 실패: 예매는 확정됐으나 좌석은 미확정인 불일치 상태로, 수동 복구가 필요할 수 있다.
-        // 현재는 두 경우를 같은 [CRITICAL] 로그로 남긴다. 실패 종류 구분과 자동 보정은 후속 고도화 대상이다.
-        log.error(
-            "[CRITICAL] 예매는 확정됐으나 좌석 SOLD 확정에 실패했습니다. 확인이 필요합니다. "
-                + "eventId: {}, bookingId: {}, seatId: {}, bookingNumber: {}",
-            envelope.eventId(),
-            event.bookingId(),
-            event.seatId(),
-            bookingNumber,
-            e);
-
-        // TODO: 추후 고도화 시, 좌석 미확정 상태를 DLT/아웃박스로 재처리해 정합성을 보정
+      } catch (HttpClientErrorException e) {
+        // 4xx는 재시도해도 결과가 바뀌지 않는 결정적 응답이므로 삼키고 진행(ack)한다.
+        // 단 409(이미 SOLD된 중복)만 정상 상태로 보고, 그 외 4xx(401 토큰 오류·404 등)는 설정/요청 오류일 수 있어 CRITICAL로 가시화한다.
+        if (e.getStatusCode().value() == HttpStatus.CONFLICT.value()) {
+          log.warn(
+              "[좌석 SOLD 409] 이미 확정된 좌석(중복 수신). 재시도하지 않는다. "
+                  + "eventId: {}, bookingId: {}, seatId: {}, bookingNumber: {}",
+              envelope.eventId(),
+              event.bookingId(),
+              event.seatId(),
+              bookingNumber);
+        } else {
+          log.error(
+              "[CRITICAL] 좌석 SOLD 확정이 4xx로 거부됨(설정/요청 오류 의심). 예매는 확정됐으나 좌석 미확정. 확인이 필요합니다. "
+                  + "eventId: {}, bookingId: {}, seatId: {}, bookingNumber: {}, status: {}",
+              envelope.eventId(),
+              event.bookingId(),
+              event.seatId(),
+              bookingNumber,
+              e.getStatusCode(),
+              e);
+        }
       }
+      // 5xx/네트워크(ResourceAccessException 등) 일시 오류는 여기서 잡지 않는다.
+      // → 바깥 catch로 전파되어 transient로 분류되고 re-throw → 재시도(멱등)→DLT로 보존된다.
+
+      // 예매 확정 + SOLD(성공 또는 4xx) 완료 시에만 오프셋을 커밋한다(#269 표준).
+      ack.acknowledge();
 
     } catch (Exception e) {
-      // 결제는 이미 완료된 상태라 재시도해도 예매 상태가 바뀌지 않는다.
-      // 무한 재시도/파티션 블로킹을 피하고, 강한 로그를 남겨 수동 복구가 가능하도록 조치한다.
+      // #269 표준: 영구(비즈니스/결정적) 실패는 로그 후 ack, 일시(인프라/SOLD 5xx·네트워크) 실패는 re-throw 하여 재시도→DLT로 보존.
       // 역직렬화 실패 시 event가 null이라 bookingId를 못 얻으므로, 항상 살아있는
       // envelope.eventId()를 함께 남겨 어떤 메시지가 실패했는지 추적할 수 있게 한다.
       Long failedBookingId = (event != null) ? event.bookingId() : null;
-      log.error(
-          "[CRITICAL] 결제 완료 이벤트로 예매 확정 중 치명적 오류 발생! "
-              + "결제는 완료되었으나 예매 확정에 실패했습니다. 확인이 필요합니다. eventId: {}, bookingId: {}",
-          envelope.eventId(),
-          failedBookingId,
-          e);
 
-      // TODO: 추후 고도화 시, 이 위치에서 DLT로 실패한 이벤트를 재발행
-
-    } finally {
-      // 카프카 메시지가 무한 반복되며 파티션을 막는 현상 방지
-      ack.acknowledge();
+      if (KafkaConsumerErrorPolicy.isPermanent(e)) {
+        if (KafkaConsumerErrorPolicy.isExpectedConflict(e)) {
+          log.warn(
+              "결제 완료 이벤트 처리 중 예상된 상태충돌(멱등 처리). eventId: {}, bookingId: {}",
+              envelope.eventId(),
+              failedBookingId,
+              e);
+        } else {
+          log.error(
+              "[CRITICAL] 결제 완료 이벤트로 예매 확정 중 치명적 오류 발생! "
+                  + "결제는 완료되었으나 예매 확정에 실패했습니다. 확인이 필요합니다. eventId: {}, bookingId: {}",
+              envelope.eventId(),
+              failedBookingId,
+              e);
+        }
+        ack.acknowledge();
+      } else {
+        log.warn(
+            "결제 완료 이벤트 처리 중 일시적 오류. 재시도합니다. eventId: {}, bookingId: {}",
+            envelope.eventId(),
+            failedBookingId,
+            e);
+        throw e;
+      }
     }
   }
 }

--- a/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/in/eventlistener/SeatHoldFailedEventListener.java
+++ b/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/in/eventlistener/SeatHoldFailedEventListener.java
@@ -2,6 +2,8 @@ package com.ticketrush.boundedcontext.booking.in.eventlistener;
 
 import com.ticketrush.boundedcontext.booking.app.usecase.BookingCancelUseCase;
 import com.ticketrush.global.event.DomainEventEnvelope;
+import com.ticketrush.global.event.KafkaConsumerErrorPolicy;
+import com.ticketrush.global.event.KafkaConsumerGroup;
 import com.ticketrush.global.json.JsonConverter;
 import com.ticketrush.shared.seat.event.SeatHoldFailedEvent;
 import lombok.RequiredArgsConstructor;
@@ -19,7 +21,7 @@ public class SeatHoldFailedEventListener {
   private final BookingCancelUseCase bookingCancelUseCase;
   private final JsonConverter jsonConverter;
 
-  @KafkaListener(topics = "seat-hold-failed-topic", groupId = "booking-group")
+  @KafkaListener(topics = SeatHoldFailedEvent.TOPIC, groupId = KafkaConsumerGroup.BOOKING)
   public void handleSeatHoldFailed(@Payload DomainEventEnvelope envelope, Acknowledgment ack) {
 
     SeatHoldFailedEvent event = null;
@@ -32,20 +34,28 @@ public class SeatHoldFailedEventListener {
 
       bookingCancelUseCase.execute(event.bookingId());
 
-    } catch (Exception e) {
-      // 에러가 났을 때 로그를 강하게 남겨 수동 복구가 가능하도록 조치
-      Long failedBookingId = (event != null) ? event.bookingId() : null;
-      log.error(
-          "[CRITICAL] 좌석 선점 실패에 대한 예매 취소 중 치명적 오류 발생! "
-              + "데이터 정합성이 깨졌습니다. 확인이 필요합니다. bookingId: {}",
-          failedBookingId,
-          e);
-
-      // TODO: 추후 고도화 시, 이 위치에서 DLT로 실패한 이벤트를 재발행
-
-    } finally {
-      // 카프카 메시지가 무한 반복되며 파티션을 막는 현상 방지
+      // 성공 시에만 오프셋을 커밋한다(#269 표준).
       ack.acknowledge();
+
+    } catch (Exception e) {
+      // #269 표준: 영구(비즈니스/결정적) 실패는 로그 후 ack, 일시(인프라) 실패는 re-throw 하여 재시도→DLT로 보존.
+      Long failedBookingId = (event != null) ? event.bookingId() : null;
+
+      if (KafkaConsumerErrorPolicy.isPermanent(e)) {
+        if (KafkaConsumerErrorPolicy.isExpectedConflict(e)) {
+          log.warn("좌석 선점 실패 보상 처리 중 예상된 상태충돌(멱등 처리). bookingId: {}", failedBookingId, e);
+        } else {
+          log.error(
+              "[CRITICAL] 좌석 선점 실패에 대한 예매 취소 중 치명적 오류 발생! "
+                  + "데이터 정합성이 깨졌습니다. 확인이 필요합니다. bookingId: {}",
+              failedBookingId,
+              e);
+        }
+        ack.acknowledge();
+      } else {
+        log.warn("좌석 선점 실패 보상 처리 중 일시적 오류. 재시도합니다. bookingId: {}", failedBookingId, e);
+        throw e;
+      }
     }
   }
 }

--- a/booking-service/src/test/java/com/ticketrush/boundedcontext/booking/in/eventlistener/PaymentConfirmedEventListenerTest.java
+++ b/booking-service/src/test/java/com/ticketrush/boundedcontext/booking/in/eventlistener/PaymentConfirmedEventListenerTest.java
@@ -1,6 +1,7 @@
 package com.ticketrush.boundedcontext.booking.in.eventlistener;
 
 import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
@@ -24,7 +25,10 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
 import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.HttpServerErrorException;
 
 @ExtendWith(MockitoExtension.class)
 class PaymentConfirmedEventListenerTest {
@@ -103,9 +107,9 @@ class PaymentConfirmedEventListenerTest {
   }
 
   @Test
-  @DisplayName("좌석 SOLD 확정 호출이 실패해도 예외를 전파하지 않고 오프셋을 커밋한다")
-  void handlePaymentConfirmedSwallowsSoldFailure() {
-    // given
+  @DisplayName("좌석 SOLD 확정이 4xx(예: 409 중복)로 실패하면 재시도하지 않고 오프셋을 커밋한다")
+  void handlePaymentConfirmedAcksWhenSoldReturns4xx() {
+    // given: 이미 SOLD된 좌석에 대한 409 등 4xx는 결정적 응답이라 재시도해도 결과가 같다
     Long bookingId = 10L;
     LocalDateTime paidAt = LocalDateTime.of(2026, 5, 22, 10, 30);
     DomainEventEnvelope envelope = envelope();
@@ -114,18 +118,92 @@ class PaymentConfirmedEventListenerTest {
 
     given(jsonConverter.deserialize(PAYLOAD, PaymentConfirmedEvent.class)).willReturn(event);
     given(bookingConfirmUseCase.execute(bookingId, paidAt, SEAT_ID)).willReturn(BOOKING_NUMBER);
-    willThrow(new RuntimeException("seat-service 호출 실패"))
+    willThrow(HttpClientErrorException.create(HttpStatus.CONFLICT, "Conflict", null, null, null))
         .given(seatRestClient)
         .confirmSold(BOOKING_NUMBER, SEAT_ID);
 
-    // when & then: 좌석 SOLD 호출 실패가 리스너 밖으로 전파되지 않는다
+    // when & then: 4xx는 삼키고 예매 확정을 유지하며 커밋한다
     assertThatCode(() -> listener.handlePaymentConfirmed(envelope, acknowledgment))
         .doesNotThrowAnyException();
 
-    // then: 예매 확정과 SOLD 호출은 시도되었고, 실패와 무관하게 오프셋은 커밋된다
+    // then
     verify(bookingConfirmUseCase).execute(bookingId, paidAt, SEAT_ID);
     verify(seatRestClient).confirmSold(BOOKING_NUMBER, SEAT_ID);
     verify(acknowledgment).acknowledge();
+  }
+
+  @Test
+  @DisplayName("좌석 SOLD 확정이 409가 아닌 4xx(예: 404)로 실패해도 결정적 응답이라 재시도하지 않고 오프셋을 커밋한다")
+  void handlePaymentConfirmedAcksWhenSoldReturnsNon409_4xx() {
+    // given: 404 등 409가 아닌 4xx도 결정적이라 재시도 무의미 → CRITICAL 로그 후 커밋
+    Long bookingId = 10L;
+    LocalDateTime paidAt = LocalDateTime.of(2026, 5, 22, 10, 30);
+    DomainEventEnvelope envelope = envelope();
+    PaymentConfirmedEvent event =
+        new PaymentConfirmedEvent(1L, bookingId, SEAT_ID, 4L, 50000L, paidAt);
+
+    given(jsonConverter.deserialize(PAYLOAD, PaymentConfirmedEvent.class)).willReturn(event);
+    given(bookingConfirmUseCase.execute(bookingId, paidAt, SEAT_ID)).willReturn(BOOKING_NUMBER);
+    willThrow(HttpClientErrorException.create(HttpStatus.NOT_FOUND, "Not Found", null, null, null))
+        .given(seatRestClient)
+        .confirmSold(BOOKING_NUMBER, SEAT_ID);
+
+    // when & then
+    assertThatCode(() -> listener.handlePaymentConfirmed(envelope, acknowledgment))
+        .doesNotThrowAnyException();
+
+    verify(acknowledgment).acknowledge();
+  }
+
+  @Test
+  @DisplayName("좌석 SOLD 확정이 5xx(일시 인프라 오류)로 실패하면 예외를 전파하고 오프셋을 커밋하지 않는다(재시도→DLT 위임)")
+  void handlePaymentConfirmedRethrowsWhenSoldReturns5xx() {
+    // given: 5xx는 일시 오류라 재시도하면 성공할 수 있다
+    Long bookingId = 10L;
+    LocalDateTime paidAt = LocalDateTime.of(2026, 5, 22, 10, 30);
+    DomainEventEnvelope envelope = envelope();
+    PaymentConfirmedEvent event =
+        new PaymentConfirmedEvent(1L, bookingId, SEAT_ID, 4L, 50000L, paidAt);
+
+    given(jsonConverter.deserialize(PAYLOAD, PaymentConfirmedEvent.class)).willReturn(event);
+    given(bookingConfirmUseCase.execute(bookingId, paidAt, SEAT_ID)).willReturn(BOOKING_NUMBER);
+    willThrow(
+            HttpServerErrorException.create(
+                HttpStatus.INTERNAL_SERVER_ERROR, "error", null, null, null))
+        .given(seatRestClient)
+        .confirmSold(BOOKING_NUMBER, SEAT_ID);
+
+    // when & then: 5xx는 리스너 밖으로 전파되어 컨테이너 재시도→DLT 파이프라인을 태운다
+    assertThatThrownBy(() -> listener.handlePaymentConfirmed(envelope, acknowledgment))
+        .isInstanceOf(HttpServerErrorException.class);
+
+    // then: 오프셋은 커밋되지 않는다
+    verify(seatRestClient).confirmSold(BOOKING_NUMBER, SEAT_ID);
+    verify(acknowledgment, never()).acknowledge();
+  }
+
+  @Test
+  @DisplayName("확정 유스케이스가 일시적(인프라) 예외를 던지면 예외를 전파하고 오프셋을 커밋하지 않는다")
+  void handlePaymentConfirmedRethrowsTransientConfirmFailure() {
+    // given: 일반 RuntimeException은 일시 실패로 분류된다
+    Long bookingId = 10L;
+    LocalDateTime paidAt = LocalDateTime.of(2026, 5, 22, 10, 30);
+    DomainEventEnvelope envelope = envelope();
+    PaymentConfirmedEvent event =
+        new PaymentConfirmedEvent(1L, bookingId, SEAT_ID, 4L, 50000L, paidAt);
+
+    given(jsonConverter.deserialize(PAYLOAD, PaymentConfirmedEvent.class)).willReturn(event);
+    willThrow(new RuntimeException("DB 일시 장애"))
+        .given(bookingConfirmUseCase)
+        .execute(bookingId, paidAt, SEAT_ID);
+
+    // when & then
+    assertThatThrownBy(() -> listener.handlePaymentConfirmed(envelope, acknowledgment))
+        .isInstanceOf(RuntimeException.class);
+
+    // then: SOLD는 호출되지 않고 오프셋도 커밋되지 않는다
+    verify(seatRestClient, never()).confirmSold(any(), anyLong());
+    verify(acknowledgment, never()).acknowledge();
   }
 
   @Test

--- a/booking-service/src/test/java/com/ticketrush/boundedcontext/booking/in/eventlistener/SeatHoldFailedEventListenerTest.java
+++ b/booking-service/src/test/java/com/ticketrush/boundedcontext/booking/in/eventlistener/SeatHoldFailedEventListenerTest.java
@@ -1,0 +1,99 @@
+package com.ticketrush.boundedcontext.booking.in.eventlistener;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.ticketrush.boundedcontext.booking.app.usecase.BookingCancelUseCase;
+import com.ticketrush.global.event.DomainEventEnvelope;
+import com.ticketrush.global.exception.BusinessException;
+import com.ticketrush.global.json.JsonConverter;
+import com.ticketrush.global.status.ErrorStatus;
+import com.ticketrush.shared.seat.event.SeatHoldFailedEvent;
+import java.time.Instant;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.kafka.support.Acknowledgment;
+
+@ExtendWith(MockitoExtension.class)
+class SeatHoldFailedEventListenerTest {
+
+  @InjectMocks private SeatHoldFailedEventListener listener;
+
+  @Mock private BookingCancelUseCase bookingCancelUseCase;
+
+  @Mock private JsonConverter jsonConverter;
+
+  @Mock private Acknowledgment acknowledgment;
+
+  private static final String PAYLOAD = "payload";
+  private static final Long BOOKING_ID = 10L;
+
+  private DomainEventEnvelope envelope() {
+    return new DomainEventEnvelope(
+        "event-id",
+        SeatHoldFailedEvent.class.getSimpleName(),
+        Instant.now(),
+        SeatHoldFailedEvent.TOPIC,
+        PAYLOAD,
+        null);
+  }
+
+  private SeatHoldFailedEvent event() {
+    return new SeatHoldFailedEvent(BOOKING_ID, 3L, "좌석 선점 실패");
+  }
+
+  @Test
+  @DisplayName("좌석 선점 실패 이벤트를 수신하면 예매를 취소하고 오프셋을 커밋한다")
+  void handleSeatHoldFailed() {
+    // given
+    DomainEventEnvelope envelope = envelope();
+    given(jsonConverter.deserialize(PAYLOAD, SeatHoldFailedEvent.class)).willReturn(event());
+
+    // when
+    listener.handleSeatHoldFailed(envelope, acknowledgment);
+
+    // then
+    verify(bookingCancelUseCase).execute(BOOKING_ID);
+    verify(acknowledgment).acknowledge();
+  }
+
+  @Test
+  @DisplayName("일시적(인프라) 예외가 발생하면 예외를 전파하고 오프셋을 커밋하지 않는다(재시도→DLT 위임)")
+  void handleSeatHoldFailedRethrowsTransientFailure() {
+    // given
+    DomainEventEnvelope envelope = envelope();
+    given(jsonConverter.deserialize(PAYLOAD, SeatHoldFailedEvent.class)).willReturn(event());
+    willThrow(new RuntimeException("DB 일시 장애")).given(bookingCancelUseCase).execute(BOOKING_ID);
+
+    // when & then
+    assertThatThrownBy(() -> listener.handleSeatHoldFailed(envelope, acknowledgment))
+        .isInstanceOf(RuntimeException.class);
+
+    verify(acknowledgment, never()).acknowledge();
+  }
+
+  @Test
+  @DisplayName("영구(비즈니스) 예외가 발생하면 예외를 전파하지 않고 오프셋을 커밋한다")
+  void handleSeatHoldFailedAcksPermanentFailure() {
+    // given: 이미 취소된 예매 등 상태충돌은 영구 실패로 분류되어 커밋된다
+    DomainEventEnvelope envelope = envelope();
+    given(jsonConverter.deserialize(PAYLOAD, SeatHoldFailedEvent.class)).willReturn(event());
+    willThrow(new BusinessException(ErrorStatus.BOOKING_CANCEL_NOT_ALLOWED))
+        .given(bookingCancelUseCase)
+        .execute(BOOKING_ID);
+
+    // when & then
+    assertThatCode(() -> listener.handleSeatHoldFailed(envelope, acknowledgment))
+        .doesNotThrowAnyException();
+
+    verify(acknowledgment).acknowledge();
+  }
+}

--- a/common/src/main/java/com/ticketrush/global/dlt/DeadLetterConsumer.java
+++ b/common/src/main/java/com/ticketrush/global/dlt/DeadLetterConsumer.java
@@ -1,6 +1,7 @@
 package com.ticketrush.global.dlt;
 
 import com.ticketrush.global.event.DomainEventEnvelope;
+import com.ticketrush.global.event.KafkaConsumerGroup;
 import com.ticketrush.global.notification.Notifier;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
@@ -70,7 +71,7 @@ public class DeadLetterConsumer {
    * <p>검증: {@code "X.DLT".matches(".*(?<!\\.DLT)\\.DLT")} → true, {@code
    * "X.DLT.DLT".matches(".*(?<!\\.DLT)\\.DLT")} → false.
    */
-  @KafkaListener(topicPattern = ".*(?<!\\.DLT)\\.DLT", groupId = "dlt-monitor-group")
+  @KafkaListener(topicPattern = ".*(?<!\\.DLT)\\.DLT", groupId = KafkaConsumerGroup.DLT_MONITOR)
   public void consume(
       ConsumerRecord<String, Object> record,
       @Header(name = KafkaHeaders.DLT_ORIGINAL_TOPIC, required = false) byte[] originalTopicHeader,

--- a/common/src/main/java/com/ticketrush/global/event/KafkaConsumerErrorPolicy.java
+++ b/common/src/main/java/com/ticketrush/global/event/KafkaConsumerErrorPolicy.java
@@ -1,0 +1,76 @@
+package com.ticketrush.global.event;
+
+import com.ticketrush.global.exception.BusinessException;
+import com.ticketrush.global.status.ErrorStatus;
+import java.util.EnumSet;
+import java.util.Set;
+
+/**
+ * Kafka 컨슈머의 예외 처리 표준 정책(#269).
+ *
+ * <p>일시(transient/인프라) vs 영구(permanent/비즈니스) 예외를 구분해, 리스너가 ack(커밋) 할지 re-throw(재시도→DLT 위임) 할지 결정하도록
+ * 돕는다. 대원칙은 fail-safe = 메시지 보존이다. 애매하면 transient로 간주해 re-throw 하여 기존 재시도→DLT 파이프라인으로 보존한다.
+ *
+ * <p>2계층 분류의 리스너 레벨 판정을 담당한다. 컨테이너 레벨(재시도 횟수 vs 즉시 DLT)은 {@code KafkaConfig}의 not-retryable 목록이
+ * 담당하며 상보적으로 동작한다. 자세한 표준은 {@code docs/kafka-event-guide.md} 참고.
+ *
+ * <p><b>주의</b>: 크로스서비스 HTTP 호출(예: RestClient) 실패는 {@code BusinessException}이 아니라 {@code
+ * RestClientResponseException}으로 도착하므로 이 헬퍼로 분류하지 않는다. 그런 호출은 HTTP 상태코드 기반으로 직접 분기해야 한다.
+ */
+public final class KafkaConsumerErrorPolicy {
+
+  /** 자기참조 cause 체인으로 인한 무한 루프를 막는 순회 깊이 상한. */
+  private static final int MAX_CAUSE_DEPTH = 20;
+
+  /**
+   * 재수신·순서로 자연스럽게 발생하는 "정상 상태충돌"로 취급할 {@link ErrorStatus} 화이트리스트.
+   *
+   * <p>모든 409를 정상으로 보면 결제는 됐으나 확정 불가 같은 정합성 위반({@code BOOKING_SEAT_MISMATCH}, {@code
+   * BOOKING_EXPIRED}, {@code BOOKING_CONFIRM_NOT_ALLOWED} 등)까지 WARN으로 묻히므로, 재처리 시 결과가 동일한 멱등 상태만
+   * 명시적으로 열거한다. 여기 없는 영구 실패는 {@code [CRITICAL]}로 남긴다.
+   */
+  private static final Set<ErrorStatus> EXPECTED_CONFLICTS =
+      EnumSet.of(
+          ErrorStatus.SEAT_NOT_AVAILABLE,
+          ErrorStatus.SEAT_ALREADY_LOCKED,
+          ErrorStatus.PAYMENT_ALREADY_COMPLETED,
+          ErrorStatus.TICKET_ALREADY_USED,
+          ErrorStatus.TICKET_NOT_USABLE,
+          ErrorStatus.BOOKING_CANCEL_NOT_ALLOWED);
+
+  private KafkaConsumerErrorPolicy() {}
+
+  /**
+   * 재시도해도 결과가 바뀌지 않는 영구(비즈니스/결정적) 실패이면 {@code true}.
+   *
+   * <p>cause 체인에 {@link BusinessException}이 있으면 영구로 본다. 비즈니스 규칙 위반(SEAT_NOT_AVAILABLE 등)과 결정적
+   * 실패(payload 역직렬화 {@code json.DeserializationException} 등)가 모두 여기 해당한다. 인프라
+   * 실패(DataAccess/Redis/네트워크)는 {@code BusinessException}이 아니므로 일시(re-throw 대상)로 분류된다.
+   */
+  public static boolean isPermanent(Throwable e) {
+    return findBusinessException(e) != null;
+  }
+
+  /**
+   * 재수신·순서 등으로 자연스럽게 발생하는 "정상 상태충돌"({@link #EXPECTED_CONFLICTS})이면 {@code true}.
+   *
+   * <p>영구 실패이지만 재처리해도 결과가 같은 멱등 상태충돌이므로, 리스너는 {@code [CRITICAL]} 대신 info/warn 수준으로 로그하고 ack 한다.
+   * {@code [CRITICAL]}은 화이트리스트에 없는 예상 밖 영구 실패(정합성 위반 등)에만 남겨 알림 피로를 줄인다.
+   */
+  public static boolean isExpectedConflict(Throwable e) {
+    BusinessException businessException = findBusinessException(e);
+    return businessException != null
+        && EXPECTED_CONFLICTS.contains(businessException.getErrorStatus());
+  }
+
+  private static BusinessException findBusinessException(Throwable e) {
+    Throwable current = e;
+    for (int depth = 0; current != null && depth < MAX_CAUSE_DEPTH; depth++) {
+      if (current instanceof BusinessException businessException) {
+        return businessException;
+      }
+      current = current.getCause();
+    }
+    return null;
+  }
+}

--- a/common/src/main/java/com/ticketrush/global/event/KafkaConsumerGroup.java
+++ b/common/src/main/java/com/ticketrush/global/event/KafkaConsumerGroup.java
@@ -1,0 +1,20 @@
+package com.ticketrush.global.event;
+
+/**
+ * Kafka 컨슈머 groupId의 단일 정의처(SSOT) (#269).
+ *
+ * <p>서비스별 groupId 리터럴이 리스너마다 흩어져 오타·불일치를 유발하던 것을 이 클래스로 통일한다.
+ *
+ * <p>{@code @KafkaListener(groupId = ...)}는 컴파일 타임 상수 String을 요구하므로 반드시 {@code public static final
+ * String} 리터럴로 둔다(enum은 어노테이션 값으로 컴파일되지 않는다).
+ */
+public final class KafkaConsumerGroup {
+
+  public static final String BOOKING = "booking-group";
+  public static final String SEAT = "seat-group";
+  public static final String TICKET = "ticket-group";
+  public static final String PAYMENT = "payment-group";
+  public static final String DLT_MONITOR = "dlt-monitor-group";
+
+  private KafkaConsumerGroup() {}
+}

--- a/common/src/main/java/com/ticketrush/shared/booking/event/BookingCreatedEvent.java
+++ b/common/src/main/java/com/ticketrush/shared/booking/event/BookingCreatedEvent.java
@@ -7,9 +7,11 @@ public record BookingCreatedEvent(
     Long bookingId, String bookingNumber, Long seatId, Long performanceId, Long userId)
     implements DomainEvent {
 
+  public static final String TOPIC = "booking-created-topic";
+
   @Override
   public String topic() {
-    return "booking-created-topic";
+    return TOPIC;
   }
 
   @Override

--- a/common/src/main/java/com/ticketrush/shared/seat/event/SeatHoldFailedEvent.java
+++ b/common/src/main/java/com/ticketrush/shared/seat/event/SeatHoldFailedEvent.java
@@ -6,9 +6,11 @@ import com.ticketrush.global.event.EventUtils;
 public record SeatHoldFailedEvent(Long bookingId, Long seatId, String reason)
     implements DomainEvent {
 
+  public static final String TOPIC = "seat-hold-failed-topic";
+
   @Override
   public String topic() {
-    return "seat-hold-failed-topic";
+    return TOPIC;
   }
 
   @Override

--- a/common/src/test/java/com/ticketrush/global/event/KafkaConsumerErrorPolicyTest.java
+++ b/common/src/test/java/com/ticketrush/global/event/KafkaConsumerErrorPolicyTest.java
@@ -1,0 +1,111 @@
+package com.ticketrush.global.event;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.ticketrush.global.exception.BusinessException;
+import com.ticketrush.global.json.DeserializationException;
+import com.ticketrush.global.status.ErrorStatus;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.HttpServerErrorException;
+
+class KafkaConsumerErrorPolicyTest {
+
+  @Nested
+  @DisplayName("isPermanent: 재시도해도 결과가 바뀌지 않는 영구 실패 판정")
+  class IsPermanent {
+
+    @Test
+    @DisplayName("BusinessException은 영구 실패다")
+    void businessExceptionIsPermanent() {
+      BusinessException e = new BusinessException(ErrorStatus.SEAT_NOT_AVAILABLE);
+
+      assertThat(KafkaConsumerErrorPolicy.isPermanent(e)).isTrue();
+    }
+
+    @Test
+    @DisplayName("cause 체인 깊은 곳에 BusinessException이 있어도 영구 실패로 판정한다")
+    void nestedBusinessExceptionIsPermanent() {
+      Throwable e =
+          new RuntimeException(
+              "wrapper",
+              new IllegalStateException(new BusinessException(ErrorStatus.BOOKING_EXPIRED)));
+
+      assertThat(KafkaConsumerErrorPolicy.isPermanent(e)).isTrue();
+    }
+
+    @Test
+    @DisplayName("payload 역직렬화 실패(DeserializationException)는 BusinessException 하위라 영구 실패다")
+    void deserializationExceptionIsPermanent() {
+      DeserializationException e = new DeserializationException(new RuntimeException("broken"));
+
+      assertThat(KafkaConsumerErrorPolicy.isPermanent(e)).isTrue();
+    }
+
+    @Test
+    @DisplayName("일반 RuntimeException(인프라 오류 대용)은 일시 실패다")
+    void plainRuntimeExceptionIsTransient() {
+      RuntimeException e = new RuntimeException("DB 일시 장애");
+
+      assertThat(KafkaConsumerErrorPolicy.isPermanent(e)).isFalse();
+    }
+
+    @Test
+    @DisplayName("크로스서비스 HTTP 4xx는 BusinessException이 아니라 일시로 분류된다(SOLD 오분류 리스크 고정)")
+    void httpClientErrorExceptionIsNotPermanent() {
+      HttpClientErrorException e =
+          HttpClientErrorException.create(HttpStatus.CONFLICT, "Conflict", null, null, null);
+
+      // 이 헬퍼로는 HTTP 예외를 영구로 구분할 수 없다 → 크로스서비스 호출은 상태코드 기반으로 별도 처리해야 한다.
+      assertThat(KafkaConsumerErrorPolicy.isPermanent(e)).isFalse();
+    }
+
+    @Test
+    @DisplayName("null이면 일시로 간주한다")
+    void nullIsTransient() {
+      assertThat(KafkaConsumerErrorPolicy.isPermanent(null)).isFalse();
+    }
+  }
+
+  @Nested
+  @DisplayName("isExpectedConflict: 재수신 등으로 자연 발생하는 상태충돌(409) 판정")
+  class IsExpectedConflict {
+
+    @Test
+    @DisplayName("화이트리스트에 등록된 멱등 상태충돌(예: SEAT_NOT_AVAILABLE)은 예상된 상태충돌이다")
+    void whitelistedConflictIsExpectedConflict() {
+      BusinessException e = new BusinessException(ErrorStatus.SEAT_NOT_AVAILABLE);
+
+      assertThat(KafkaConsumerErrorPolicy.isExpectedConflict(e)).isTrue();
+    }
+
+    @Test
+    @DisplayName("화이트리스트에 없는 409 정합성 위반(예: BOOKING_SEAT_MISMATCH)은 예상된 상태충돌이 아니다(CRITICAL 대상)")
+    void non409NotWhitelistedConflictIsNotExpectedConflict() {
+      BusinessException mismatch = new BusinessException(ErrorStatus.BOOKING_SEAT_MISMATCH);
+
+      assertThat(KafkaConsumerErrorPolicy.isExpectedConflict(mismatch)).isFalse();
+    }
+
+    @Test
+    @DisplayName("409가 아닌 BusinessException(예: 500 역직렬화)은 예상된 상태충돌이 아니다")
+    void non409BusinessExceptionIsNotExpectedConflict() {
+      DeserializationException e = new DeserializationException(new RuntimeException("broken"));
+
+      assertThat(KafkaConsumerErrorPolicy.isExpectedConflict(e)).isFalse();
+    }
+
+    @Test
+    @DisplayName("BusinessException이 아니면 예상된 상태충돌이 아니다")
+    void nonBusinessExceptionIsNotExpectedConflict() {
+      HttpServerErrorException e =
+          HttpServerErrorException.create(
+              HttpStatus.INTERNAL_SERVER_ERROR, "error", null, null, null);
+
+      assertThat(KafkaConsumerErrorPolicy.isExpectedConflict(e)).isFalse();
+    }
+  }
+}

--- a/docs/backend-convention.md
+++ b/docs/backend-convention.md
@@ -291,6 +291,10 @@ class SeatControllerTest {
 }
 ```
 
+### 📨 Kafka 컨슈머 에러 처리 · 상수화
+
+* **컨슈머 에러 처리 정책(일시/영구 예외 구분, ack vs re-throw)과 groupId/topic 상수화 컨벤션의 SSOT는 [`kafka-event-guide.md`](kafka-event-guide.md) §2**입니다. `@KafkaListener` 리스너를 추가·수정할 때 그 표준(영구→ack, 일시→re-throw→DLT, `KafkaConsumerErrorPolicy`·`KafkaConsumerGroup` 상수)을 따릅니다. 여기에 재기술하지 않습니다.
+
 ### 🔐 이벤트 payload · DLT 보안 규칙
 
 * **이벤트 payload에 PII(이메일·카드번호·개인정보) 금지** — 이벤트에는 식별자(ID)·금액·시간 등 최소 정보만 담습니다. **payload에 PII를 넣지 않는 것이 1차 통제**이며 마스킹은 보조 수단입니다.

--- a/docs/kafka-event-guide.md
+++ b/docs/kafka-event-guide.md
@@ -15,7 +15,63 @@
 
 ---
 
-## 2. 사용 가이드 (How to Use)
+## 2. 컨슈머 에러 처리 표준 (#269)
+
+`@KafkaListener` 리스너가 예외를 만났을 때 **커밋(ack)** 할지 **재시도→DLT에 위임(re-throw)** 할지를 통일한 규약이다. §1.2의 인프라(재시도→DLT) 정책은 **리스너가 예외를 다시 던져야만** 작동하므로, 이 표준이 그 진입 조건을 정의한다.
+
+**대원칙 — fail-safe = 메시지 보존.** 애매하면 re-throw 하여 재시도→DLT로 보존한다. 예외를 삼켜 유실시키지 않는다.
+
+### 2.1. 예외 분류와 처리 (ack vs re-throw 결정표)
+
+| 분류 | 판정 기준 | 로그 | 오프셋 | 근거 |
+|------|-----------|------|--------|------|
+| **영구(permanent)** | cause 체인에 `BusinessException` 존재 (비즈니스 규칙 위반, payload 역직렬화 `json.DeserializationException` 등) | `[CRITICAL]` error | **ack** | 재시도해도 결과 불변 → 커밋해 파티션 블로킹 방지. 복구는 CRITICAL 로그·모니터링(#50)에 위임 |
+| └ 그중 **예상된 상태충돌** | `BusinessException` 이면서 **화이트리스트**(`KafkaConsumerErrorPolicy.EXPECTED_CONFLICTS`: `SEAT_NOT_AVAILABLE`·`SEAT_ALREADY_LOCKED`·`PAYMENT_ALREADY_COMPLETED`·`TICKET_ALREADY_USED`·`TICKET_NOT_USABLE`·`BOOKING_CANCEL_NOT_ALLOWED`)에 속함 | `warn` (CRITICAL 아님) | **ack** | 재수신·순서로 자연 발생하는 멱등 상태 → 알림 피로 방지. **모든 409를 정상으로 보지 않는다** — `BOOKING_SEAT_MISMATCH`·`BOOKING_EXPIRED`·`BOOKING_CONFIRM_NOT_ALLOWED`(결제됐으나 확정 불가)는 화이트리스트에서 제외해 `[CRITICAL]`로 남긴다 |
+| **일시(transient)** | 위에 해당하지 않는 모든 예외 (Spring `DataAccessException`·락 타임아웃, Redis 오류, `RetriableException`, 미분류 `RuntimeException`) | `warn` | **ack 안 함 → re-throw** | 재시도하면 성공할 수 있음 → 재시도 5회 후 DLT로 보존 |
+| **예상된 중복(DAO)** | `DataIntegrityViolationException`(unique 위반=중복 등록) 등 리스너별로 명시 처리 | `info` | **ack** | 멱등 결과(정상). 단 재시도가 필요한 경우(예: 토큰 해시 충돌 재생성)는 리스너 맥락에 맞게 예외 처리 |
+
+분류는 공통 헬퍼 **`com.ticketrush.global.event.KafkaConsumerErrorPolicy`** 로 판정한다: `isPermanent(Throwable)`, `isExpectedConflict(Throwable)`.
+
+### 2.2. 표준 리스너 템플릿
+
+```java
+@KafkaListener(topics = XxxEvent.TOPIC, groupId = KafkaConsumerGroup.XXX)
+public void handleXxx(@Payload DomainEventEnvelope envelope, Acknowledgment ack) {
+  XxxEvent event = null;
+  try {
+    event = jsonConverter.deserialize(envelope.payload(), XxxEvent.class);
+    usecase.execute(...);
+    ack.acknowledge();                       // 성공 시에만 커밋
+  } catch (Exception e) {
+    if (KafkaConsumerErrorPolicy.isPermanent(e)) {
+      if (KafkaConsumerErrorPolicy.isExpectedConflict(e)) {
+        log.warn("... 예상된 상태충돌(멱등 처리). eventId: {}", envelope.eventId(), e);
+      } else {
+        log.error("[CRITICAL] ... 확인이 필요합니다. eventId: {}", envelope.eventId(), e);
+      }
+      ack.acknowledge();                     // 영구 실패: 재시도 무의미 → 커밋
+    } else {
+      log.warn("... 일시적 오류. 재시도합니다. eventId: {}", envelope.eventId(), e);
+      throw e;                               // 일시 실패: 재시도→DLT 위임 (ack 안 함)
+    }
+  }
+}
+```
+
+- **ack ⊻ re-throw 상호배타:** `MANUAL_IMMEDIATE`에서 한 경로는 ack 하거나 예외를 전파하거나 **둘 중 하나만** 한다(둘 다 금지). 예전의 `finally`-무조건-ack 패턴은 일시 예외까지 삼켜 유실시키므로 금지한다.
+- **멱등키(Redis SETNX) 사용 리스너**(seat `BookingCreatedEventListener`)는 **일시 실패로 re-throw 하기 직전에 멱등키를 롤백**해 재시도가 다시 처리할 수 있게 한다. 영구 실패로 ack 할 때는 멱등키를 유지한다(처리됨).
+
+### 2.3. 주의사항
+
+- **크로스서비스 HTTP 호출은 `isPermanent`로 분류하지 않는다.** RestClient 호출 실패는 `BusinessException`이 아니라 `HttpClientErrorException`(4xx)/`HttpServerErrorException`(5xx)/`ResourceAccessException`(네트워크)으로 도착한다. **HTTP 상태코드 기반으로 직접 분기**한다: 4xx(결정적)→진행(ack)하되 **409(이미 처리된 중복)만 warn, 그 외 4xx(401·404 등 설정/요청 오류)는 `[CRITICAL]`**, 5xx/네트워크(일시)→re-throw. 예) booking `PaymentConfirmedEventListener`의 `seatRestClient.confirmSold()`.
+- **2계층 분류(상보적):** 리스너 레벨(`isPermanent`)은 **ack vs 전파**를 결정하고, 컨테이너 레벨(`KafkaConfig`의 `addNotRetryableExceptions`)은 전파된 예외의 **재시도 횟수 vs 즉시 DLT**를 결정한다.
+- **동명 `DeserializationException` 2종 구분:** ① envelope(외부) 역직렬화 = spring-kafka `org.springframework.kafka.support.serializer.DeserializationException` → 컨테이너 not-retryable로 **즉시 DLT**(리스너 실행 안 됨). ② payload(내부) 역직렬화 = `com.ticketrush.global.json.DeserializationException`(`BusinessException` 하위) → 리스너 catch에서 **영구→ack**. 이름만 같고 경로가 다르다.
+- **groupId/topic 상수화:** topic은 각 이벤트의 `*Event.TOPIC` 상수를, groupId는 `com.ticketrush.global.event.KafkaConsumerGroup`의 상수를 참조한다(리터럴 하드코딩 금지). `@KafkaListener`는 컴파일 타임 상수 String을 요구하므로 상수는 `public static final String`으로 둔다(enum 불가).
+- **파티션 블로킹:** 일시 실패 재시도(5회, 1→2→4→8→16s ≈ 31초)는 `MAX_POLL_INTERVAL_MS`(300초)보다 훨씬 짧아 리밸런싱을 유발하지 않는다. 다만 재시도 동안 컨슈머 스레드가 점유되고 같은 배치의 후속 레코드가 대기하므로, 현 트래픽 수준에서만 허용된다.
+
+---
+
+## 3. 사용 가이드 (How to Use)
 
 새로운 비즈니스 로직에서 카프카로 이벤트를 발행하려면 다음 **2가지 단계**만 거치면 됩니다. 카프카 인프라 기술에 종속되지 않고 비즈니스 로직에만 집중할 수 있습니다.
 
@@ -37,10 +93,12 @@ public record OrderCompletedEvent(
     int totalAmount
 ) implements DomainEvent {
 
+    // 토픽명은 리터럴을 하드코딩하지 말고 상수로 노출해 컨슈머가 재사용한다(#269).
+    public static final String TOPIC = "order-events";
+
     @Override
     public String topic() {
-        // 이 이벤트가 전송될 카프카 토픽명
-        return "order-events"; 
+        return TOPIC;
     }
 
     @Override
@@ -97,15 +155,19 @@ public class OrderService {
 ```
 
 ### (참고) 발행된 이벤트를 수신하는 방법 (Consumer)
-발행된 데이터는 `DomainEventEnvelope` 형태로 수신됩니다. 수신 후 `payload` 필드를 역직렬화하여 사용합니다.
+발행된 데이터는 `DomainEventEnvelope` 형태로 수신됩니다. 수신 후 `payload` 필드를 역직렬화하여 사용합니다. 에러 처리는 **§2 컨슈머 에러 처리 표준**을 따릅니다(topic/groupId 상수, 수동 ack, 영구→ack / 일시→re-throw).
 
 ```java
 import com.ticketrush.domain.order.event.OrderCompletedEvent;
 import com.ticketrush.global.event.DomainEventEnvelope;
-import com.ticketrush.global.json;
+import com.ticketrush.global.event.KafkaConsumerErrorPolicy;
+import com.ticketrush.global.event.KafkaConsumerGroup;
+import com.ticketrush.global.json.JsonConverter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.stereotype.Component;
 
 @Slf4j
@@ -116,25 +178,28 @@ public class OrderEventListener {
   // Publisher에서 직렬화할 때 썼던 동일한 JsonConverter를 주입받습니다.
   private final JsonConverter jsonConverter;
 
-  @KafkaListener(topics = "order-events", groupId = "notification-group")
-  public void handleOrderEvent(DomainEventEnvelope envelope) {
+  // topic/groupId는 리터럴이 아니라 상수를 참조합니다(§2.3).
+  @KafkaListener(topics = OrderCompletedEvent.TOPIC, groupId = KafkaConsumerGroup.TICKET)
+  public void handleOrderEvent(@Payload DomainEventEnvelope envelope, Acknowledgment ack) {
+    try {
+      // String 형태의 payload를 실제 객체로 역직렬화 후 비즈니스 로직 처리
+      OrderCompletedEvent event =
+          jsonConverter.deserialize(envelope.payload(), OrderCompletedEvent.class);
 
-    // 1. 봉투(Envelope)의 메타데이터를 확인하여 처리할 이벤트인지 검증
-    if ("OrderCompleted".equals(envelope.eventType())) {
+      // ... 유저 알림 발송, 통계 적재 등 필요한 로직 수행 ...
 
-      try {
-        // 2. String 형태의 payload를 실제 객체(OrderCompletedEvent)로 역직렬화
-        OrderCompletedEvent event = jsonConverter.deserialize(
-          envelope.payload(),
-          OrderCompletedEvent.class
-        );
-
-        // 3. 역직렬화된 객체의 필드값들을 활용하여 비즈니스 로직 처리
-        // 유저에게 카카오톡 알림 발송, 통계 데이터 적재 등 필요한 로직 수행
-
-      } catch (Exception e) {
-        // 필요시 예외를 던져서 KafkaConfig에 설정해둔 DLT로 넘어가게 할 수 있습니다.
-        log.error("이벤트 역직렬화 또는 처리 중 에러 발생: eventId={}", envelope.eventId(), e);
+      ack.acknowledge(); // 성공 시에만 커밋
+    } catch (Exception e) {
+      // §2 표준: 영구(비즈니스/결정적) 실패는 로그 후 ack, 일시(인프라) 실패는 re-throw 하여 재시도→DLT로 보존.
+      if (KafkaConsumerErrorPolicy.isPermanent(e)) {
+        if (KafkaConsumerErrorPolicy.isExpectedConflict(e)) {
+          log.warn("주문 이벤트 처리 중 예상된 상태충돌(멱등 처리). eventId: {}", envelope.eventId(), e);
+        } else {
+          log.error("[CRITICAL] 주문 이벤트 처리 실패! 확인이 필요합니다. eventId: {}", envelope.eventId(), e);
+        }
+        ack.acknowledge();
+      } else {
+        log.warn("주문 이벤트 처리 중 일시적 오류. 재시도합니다. eventId: {}", envelope.eventId(), e);
         throw e;
       }
     }

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/in/eventlistener/BookingExpiredEventListener.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/in/eventlistener/BookingExpiredEventListener.java
@@ -2,6 +2,8 @@ package com.ticketrush.boundedcontext.payment.in.eventlistener;
 
 import com.ticketrush.boundedcontext.payment.app.facade.PaymentFacade;
 import com.ticketrush.global.event.DomainEventEnvelope;
+import com.ticketrush.global.event.KafkaConsumerErrorPolicy;
+import com.ticketrush.global.event.KafkaConsumerGroup;
 import com.ticketrush.global.json.JsonConverter;
 import com.ticketrush.shared.booking.event.BookingExpiredEvent;
 import lombok.RequiredArgsConstructor;
@@ -24,23 +26,37 @@ public class BookingExpiredEventListener {
   private final PaymentFacade paymentFacade;
   private final JsonConverter jsonConverter;
 
-  @KafkaListener(topics = BookingExpiredEvent.TOPIC, groupId = "payment-group")
+  @KafkaListener(topics = BookingExpiredEvent.TOPIC, groupId = KafkaConsumerGroup.PAYMENT)
   public void handleBookingExpired(@Payload DomainEventEnvelope envelope, Acknowledgment ack) {
     BookingExpiredEvent event = null;
 
     try {
       event = jsonConverter.deserialize(envelope.payload(), BookingExpiredEvent.class);
       paymentFacade.registerExpiredBooking(event.bookingId(), event.expiredAt());
+
+      // 성공 시에만 오프셋을 커밋한다(#269 표준).
+      ack.acknowledge();
     } catch (DataIntegrityViolationException e) {
       // bookingId unique 제약 위반 = 이미 등록된 만료 booking의 중복 수신.
       // 멱등 결과(정상)로 간주하고 ack 하여 불필요한 Kafka 재처리를 막는다.
-      log.info("이미 등록된 만료 booking 이벤트(중복 수신). bookingId: {}", event.bookingId());
+      log.info(
+          "이미 등록된 만료 booking 이벤트(중복 수신). bookingId: {}", event != null ? event.bookingId() : null);
+      ack.acknowledge();
     } catch (Exception e) {
+      // #269 표준: 영구(비즈니스/결정적) 실패는 로그 후 ack, 일시(인프라) 실패는 re-throw 하여 재시도→DLT로 보존.
       Long bookingId = event != null ? event.bookingId() : null;
-      log.error("예매 만료 이벤트 처리 실패. bookingId: {}", bookingId, e);
-      throw e;
-    }
 
-    ack.acknowledge();
+      if (KafkaConsumerErrorPolicy.isPermanent(e)) {
+        if (KafkaConsumerErrorPolicy.isExpectedConflict(e)) {
+          log.warn("예매 만료 이벤트 처리 중 예상된 상태충돌(멱등 처리). bookingId: {}", bookingId, e);
+        } else {
+          log.error("[CRITICAL] 예매 만료 이벤트 처리 실패! 확인이 필요합니다. bookingId: {}", bookingId, e);
+        }
+        ack.acknowledge();
+      } else {
+        log.warn("예매 만료 이벤트 처리 중 일시적 오류. 재시도합니다. bookingId: {}", bookingId, e);
+        throw e;
+      }
+    }
   }
 }

--- a/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/in/eventlistener/BookingExpiredEventListenerTest.java
+++ b/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/in/eventlistener/BookingExpiredEventListenerTest.java
@@ -11,7 +11,9 @@ import static org.mockito.Mockito.verify;
 
 import com.ticketrush.boundedcontext.payment.app.facade.PaymentFacade;
 import com.ticketrush.global.event.DomainEventEnvelope;
+import com.ticketrush.global.exception.BusinessException;
 import com.ticketrush.global.json.JsonConverter;
+import com.ticketrush.global.status.ErrorStatus;
 import com.ticketrush.shared.booking.event.BookingExpiredEvent;
 import java.time.Instant;
 import java.time.LocalDateTime;
@@ -105,6 +107,35 @@ class BookingExpiredEventListenerTest {
 
     given(jsonConverter.deserialize(payload, BookingExpiredEvent.class)).willReturn(event);
     willThrow(new DataIntegrityViolationException("duplicate bookingId"))
+        .given(paymentFacade)
+        .registerExpiredBooking(bookingId, expiredAt);
+
+    // when & then
+    assertThatCode(() -> listener.handleBookingExpired(envelope, acknowledgment))
+        .doesNotThrowAnyException();
+
+    verify(acknowledgment).acknowledge();
+  }
+
+  @Test
+  @DisplayName("영구(비즈니스) 예외가 발생하면 예외를 전파하지 않고 오프셋을 커밋한다")
+  void handleBookingExpired_acks_on_permanent_failure() {
+    // given: BusinessException은 영구 실패로 분류되어 커밋된다(재시도 무의미)
+    Long bookingId = 100L;
+    LocalDateTime expiredAt = LocalDateTime.of(2026, 6, 21, 10, 0);
+    String payload = "{\"bookingId\":100,\"expiredAt\":\"2026-06-21T10:00:00\"}";
+    DomainEventEnvelope envelope =
+        new DomainEventEnvelope(
+            "event-id",
+            BookingExpiredEvent.EVENT_NAME,
+            Instant.now(),
+            BookingExpiredEvent.TOPIC,
+            payload,
+            null);
+    BookingExpiredEvent event = new BookingExpiredEvent(bookingId, expiredAt);
+
+    given(jsonConverter.deserialize(payload, BookingExpiredEvent.class)).willReturn(event);
+    willThrow(new BusinessException(ErrorStatus.PAYMENT_NOT_FOUND))
         .given(paymentFacade)
         .registerExpiredBooking(bookingId, expiredAt);
 

--- a/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/in/eventlistener/BookingCanceledEventListener.java
+++ b/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/in/eventlistener/BookingCanceledEventListener.java
@@ -2,6 +2,8 @@ package com.ticketrush.boundedcontext.seat.in.eventlistener;
 
 import com.ticketrush.boundedcontext.seat.app.facade.SeatFacade;
 import com.ticketrush.global.event.DomainEventEnvelope;
+import com.ticketrush.global.event.KafkaConsumerErrorPolicy;
+import com.ticketrush.global.event.KafkaConsumerGroup;
 import com.ticketrush.global.json.JsonConverter;
 import com.ticketrush.shared.booking.event.BookingCanceledEvent;
 import lombok.RequiredArgsConstructor;
@@ -19,19 +21,32 @@ public class BookingCanceledEventListener {
   private final SeatFacade seatFacade;
   private final JsonConverter jsonConverter;
 
-  @KafkaListener(topics = BookingCanceledEvent.TOPIC, groupId = "seat-group")
+  @KafkaListener(topics = BookingCanceledEvent.TOPIC, groupId = KafkaConsumerGroup.SEAT)
   public void handleBookingCanceled(@Payload DomainEventEnvelope envelope, Acknowledgment ack) {
     BookingCanceledEvent event = null;
 
     try {
       event = jsonConverter.deserialize(envelope.payload(), BookingCanceledEvent.class);
       seatFacade.releaseBookedSeat(event.seatId(), event.bookingNumber());
-    } catch (Exception e) {
-      Long bookingId = event != null ? event.bookingId() : null;
-      log.error("예매 취소 좌석 반환 이벤트 처리 실패. bookingId: {}", bookingId, e);
-      throw e;
-    }
 
-    ack.acknowledge();
+      // 성공 시에만 오프셋을 커밋한다(#269 표준).
+      ack.acknowledge();
+
+    } catch (Exception e) {
+      // #269 표준: 영구(비즈니스/결정적) 실패는 로그 후 ack, 일시(인프라) 실패는 re-throw 하여 재시도→DLT로 보존.
+      Long bookingId = event != null ? event.bookingId() : null;
+
+      if (KafkaConsumerErrorPolicy.isPermanent(e)) {
+        if (KafkaConsumerErrorPolicy.isExpectedConflict(e)) {
+          log.warn("예매 취소 좌석 반환 이벤트 처리 중 예상된 상태충돌(멱등 처리). bookingId: {}", bookingId, e);
+        } else {
+          log.error("[CRITICAL] 예매 취소 좌석 반환 이벤트 처리 실패! 확인이 필요합니다. bookingId: {}", bookingId, e);
+        }
+        ack.acknowledge();
+      } else {
+        log.warn("예매 취소 좌석 반환 이벤트 처리 중 일시적 오류. 재시도합니다. bookingId: {}", bookingId, e);
+        throw e;
+      }
+    }
   }
 }

--- a/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/in/eventlistener/BookingCreatedEventListener.java
+++ b/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/in/eventlistener/BookingCreatedEventListener.java
@@ -2,6 +2,8 @@ package com.ticketrush.boundedcontext.seat.in.eventlistener;
 
 import com.ticketrush.boundedcontext.seat.app.facade.SeatFacade;
 import com.ticketrush.global.event.DomainEventEnvelope;
+import com.ticketrush.global.event.KafkaConsumerErrorPolicy;
+import com.ticketrush.global.event.KafkaConsumerGroup;
 import com.ticketrush.global.json.JsonConverter;
 import com.ticketrush.shared.booking.event.BookingCreatedEvent;
 import java.time.Duration;
@@ -26,7 +28,7 @@ public class BookingCreatedEventListener {
   // 이벤트 중복을 방어할 유효 기간
   private static final int IDEMPOTENCY_TTL_HOURS = 24;
 
-  @KafkaListener(topics = "booking-created-topic", groupId = "seat-group")
+  @KafkaListener(topics = BookingCreatedEvent.TOPIC, groupId = KafkaConsumerGroup.SEAT)
   public void handleBookingCreated(@Payload DomainEventEnvelope envelope, Acknowledgment ack) {
 
     // 1. 멱등성 키 생성
@@ -53,13 +55,25 @@ public class BookingCreatedEventListener {
       seatFacade.tryLockSeat(
           event.bookingId(), event.bookingNumber(), event.seatId(), event.userId());
 
-    } catch (Exception e) {
-      log.error("이벤트 처리 중 에러 발생. 재시도를 위해 멱등성 키를 롤백합니다. eventId: {}", eventId, e);
-      redisTemplate.delete(idempotencyKey);
-      throw e; // 예외를 다시 던져 스프링 카프카의 재시도(Retry) 정책을 태움
-    }
+      // 4. 예외 없이 성공적으로 완료되었을 때만 오프셋 수동 커밋
+      ack.acknowledge();
 
-    // 4. 예외 없이 성공적으로 완료되었을 때만 오프셋 수동 커밋
-    ack.acknowledge();
+    } catch (Exception e) {
+      // #269 표준: 영구(비즈니스/결정적) 실패는 로그 후 ack, 일시(인프라) 실패는 멱등키 롤백 후 re-throw 하여 재시도→DLT로 보존.
+      if (KafkaConsumerErrorPolicy.isPermanent(e)) {
+        if (KafkaConsumerErrorPolicy.isExpectedConflict(e)) {
+          log.warn("좌석 선점 이벤트 처리 중 예상된 상태충돌(멱등 처리). eventId: {}", eventId, e);
+        } else {
+          log.error("[CRITICAL] 좌석 선점 이벤트 처리 중 치명적 오류 발생! 확인이 필요합니다. eventId: {}", eventId, e);
+        }
+        // 영구 실패는 재처리해도 결과가 같으므로 멱등키를 유지(처리됨)하고 커밋한다.
+        ack.acknowledge();
+      } else {
+        // 일시 실패는 재시도가 다시 처리할 수 있도록 멱등키를 롤백한 뒤 예외를 다시 던진다.
+        log.warn("좌석 선점 이벤트 처리 중 일시적 오류. 멱등키를 롤백하고 재시도합니다. eventId: {}", eventId, e);
+        redisTemplate.delete(idempotencyKey);
+        throw e;
+      }
+    }
   }
 }

--- a/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/in/eventlistener/PerformanceCreatedEventListener.java
+++ b/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/in/eventlistener/PerformanceCreatedEventListener.java
@@ -2,6 +2,8 @@ package com.ticketrush.boundedcontext.seat.in.eventlistener;
 
 import com.ticketrush.boundedcontext.seat.app.facade.SeatFacade;
 import com.ticketrush.global.event.DomainEventEnvelope;
+import com.ticketrush.global.event.KafkaConsumerErrorPolicy;
+import com.ticketrush.global.event.KafkaConsumerGroup;
 import com.ticketrush.global.json.JsonConverter;
 import com.ticketrush.shared.performance.event.PerformanceCreatedEvent;
 import lombok.RequiredArgsConstructor;
@@ -16,12 +18,10 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class PerformanceCreatedEventListener {
 
-  private static final String SEAT_GROUP_ID = "seat-group";
-
   private final SeatFacade seatFacade;
   private final JsonConverter jsonConverter;
 
-  @KafkaListener(topics = PerformanceCreatedEvent.TOPIC, groupId = SEAT_GROUP_ID)
+  @KafkaListener(topics = PerformanceCreatedEvent.TOPIC, groupId = KafkaConsumerGroup.SEAT)
   public void handlePerformanceCreated(@Payload DomainEventEnvelope envelope, Acknowledgment ack) {
     try {
       if (!PerformanceCreatedEvent.EVENT_NAME.equals(envelope.eventType())) {
@@ -34,10 +34,23 @@ public class PerformanceCreatedEventListener {
           jsonConverter.deserialize(envelope.payload(), PerformanceCreatedEvent.class);
 
       seatFacade.createDefaultSeats(event.performanceId());
+
+      // 성공 시에만 오프셋을 커밋한다(#269 표준).
       ack.acknowledge();
     } catch (Exception e) {
-      log.error("공연 생성 이벤트 처리 중 에러가 발생했습니다. eventId: {}", envelope.eventId(), e);
-      throw e;
+      // #269 표준: 영구(비즈니스/결정적) 실패는 로그 후 ack, 일시(인프라) 실패는 re-throw 하여 재시도→DLT로 보존.
+      if (KafkaConsumerErrorPolicy.isPermanent(e)) {
+        if (KafkaConsumerErrorPolicy.isExpectedConflict(e)) {
+          log.warn("공연 생성 이벤트 처리 중 예상된 상태충돌(멱등 처리). eventId: {}", envelope.eventId(), e);
+        } else {
+          log.error(
+              "[CRITICAL] 공연 생성 이벤트 처리 중 치명적 오류 발생! 확인이 필요합니다. eventId: {}", envelope.eventId(), e);
+        }
+        ack.acknowledge();
+      } else {
+        log.warn("공연 생성 이벤트 처리 중 일시적 오류. 재시도합니다. eventId: {}", envelope.eventId(), e);
+        throw e;
+      }
     }
   }
 }

--- a/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/in/eventlistener/BookingCanceledEventListenerTest.java
+++ b/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/in/eventlistener/BookingCanceledEventListenerTest.java
@@ -1,0 +1,104 @@
+package com.ticketrush.boundedcontext.seat.in.eventlistener;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.ticketrush.boundedcontext.seat.app.facade.SeatFacade;
+import com.ticketrush.global.event.DomainEventEnvelope;
+import com.ticketrush.global.exception.BusinessException;
+import com.ticketrush.global.json.JsonConverter;
+import com.ticketrush.global.status.ErrorStatus;
+import com.ticketrush.shared.booking.event.BookingCanceledEvent;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.kafka.support.Acknowledgment;
+
+@ExtendWith(MockitoExtension.class)
+class BookingCanceledEventListenerTest {
+
+  @InjectMocks private BookingCanceledEventListener listener;
+
+  @Mock private SeatFacade seatFacade;
+
+  @Mock private JsonConverter jsonConverter;
+
+  @Mock private Acknowledgment acknowledgment;
+
+  private static final String PAYLOAD = "payload";
+  private static final Long SEAT_ID = 3L;
+  private static final String BOOKING_NUMBER = "BOOK-1234";
+
+  private DomainEventEnvelope envelope() {
+    return new DomainEventEnvelope(
+        "event-id",
+        BookingCanceledEvent.EVENT_NAME,
+        Instant.now(),
+        BookingCanceledEvent.TOPIC,
+        PAYLOAD,
+        null);
+  }
+
+  private BookingCanceledEvent event() {
+    return new BookingCanceledEvent(
+        10L, BOOKING_NUMBER, SEAT_ID, 4L, LocalDateTime.of(2026, 5, 22, 10, 30));
+  }
+
+  @Test
+  @DisplayName("예매 취소 이벤트를 수신하면 좌석을 반환하고 오프셋을 커밋한다")
+  void handleBookingCanceled() {
+    // given
+    DomainEventEnvelope envelope = envelope();
+    given(jsonConverter.deserialize(PAYLOAD, BookingCanceledEvent.class)).willReturn(event());
+
+    // when
+    listener.handleBookingCanceled(envelope, acknowledgment);
+
+    // then
+    verify(seatFacade).releaseBookedSeat(SEAT_ID, BOOKING_NUMBER);
+    verify(acknowledgment).acknowledge();
+  }
+
+  @Test
+  @DisplayName("일시적(인프라) 예외가 발생하면 예외를 전파하고 오프셋을 커밋하지 않는다(재시도→DLT 위임)")
+  void handleBookingCanceledRethrowsTransientFailure() {
+    // given
+    DomainEventEnvelope envelope = envelope();
+    given(jsonConverter.deserialize(PAYLOAD, BookingCanceledEvent.class)).willReturn(event());
+    willThrow(new RuntimeException("DB 일시 장애"))
+        .given(seatFacade)
+        .releaseBookedSeat(SEAT_ID, BOOKING_NUMBER);
+
+    // when & then
+    assertThatThrownBy(() -> listener.handleBookingCanceled(envelope, acknowledgment))
+        .isInstanceOf(RuntimeException.class);
+
+    verify(acknowledgment, never()).acknowledge();
+  }
+
+  @Test
+  @DisplayName("영구(비즈니스) 예외가 발생하면 예외를 전파하지 않고 오프셋을 커밋한다")
+  void handleBookingCanceledAcksPermanentFailure() {
+    // given
+    DomainEventEnvelope envelope = envelope();
+    given(jsonConverter.deserialize(PAYLOAD, BookingCanceledEvent.class)).willReturn(event());
+    willThrow(new BusinessException(ErrorStatus.SEAT_NOT_FOUND))
+        .given(seatFacade)
+        .releaseBookedSeat(SEAT_ID, BOOKING_NUMBER);
+
+    // when & then
+    assertThatCode(() -> listener.handleBookingCanceled(envelope, acknowledgment))
+        .doesNotThrowAnyException();
+
+    verify(acknowledgment).acknowledge();
+  }
+}

--- a/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/in/eventlistener/BookingCreatedEventListenerTest.java
+++ b/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/in/eventlistener/BookingCreatedEventListenerTest.java
@@ -1,0 +1,141 @@
+package com.ticketrush.boundedcontext.seat.in.eventlistener;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.ticketrush.boundedcontext.seat.app.facade.SeatFacade;
+import com.ticketrush.global.event.DomainEventEnvelope;
+import com.ticketrush.global.exception.BusinessException;
+import com.ticketrush.global.json.JsonConverter;
+import com.ticketrush.global.status.ErrorStatus;
+import com.ticketrush.shared.booking.event.BookingCreatedEvent;
+import java.time.Duration;
+import java.time.Instant;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.kafka.support.Acknowledgment;
+
+@ExtendWith(MockitoExtension.class)
+class BookingCreatedEventListenerTest {
+
+  @InjectMocks private BookingCreatedEventListener listener;
+
+  @Mock private SeatFacade seatFacade;
+
+  @Mock private JsonConverter jsonConverter;
+
+  @Mock private StringRedisTemplate redisTemplate;
+
+  @Mock private ValueOperations<String, String> valueOperations;
+
+  @Mock private Acknowledgment acknowledgment;
+
+  private static final String PAYLOAD = "payload";
+  private static final String EVENT_ID = "event-id";
+  private static final String IDEMPOTENCY_KEY = "idempotency:event:" + EVENT_ID;
+  private static final Long BOOKING_ID = 10L;
+  private static final String BOOKING_NUMBER = "BOOK-1234";
+  private static final Long SEAT_ID = 3L;
+  private static final Long USER_ID = 4L;
+
+  private DomainEventEnvelope envelope() {
+    return new DomainEventEnvelope(
+        EVENT_ID, "BookingCreatedEvent", Instant.now(), BookingCreatedEvent.TOPIC, PAYLOAD, null);
+  }
+
+  private BookingCreatedEvent event() {
+    return new BookingCreatedEvent(BOOKING_ID, BOOKING_NUMBER, SEAT_ID, 5L, USER_ID);
+  }
+
+  private void givenFirstMessage() {
+    given(redisTemplate.opsForValue()).willReturn(valueOperations);
+    given(valueOperations.setIfAbsent(anyString(), anyString(), any(Duration.class)))
+        .willReturn(true);
+  }
+
+  @Test
+  @DisplayName("최초 수신 이벤트는 좌석 선점을 시도하고 오프셋을 커밋한다")
+  void handleBookingCreated() {
+    // given
+    givenFirstMessage();
+    DomainEventEnvelope envelope = envelope();
+    given(jsonConverter.deserialize(PAYLOAD, BookingCreatedEvent.class)).willReturn(event());
+
+    // when
+    listener.handleBookingCreated(envelope, acknowledgment);
+
+    // then
+    verify(seatFacade).tryLockSeat(BOOKING_ID, BOOKING_NUMBER, SEAT_ID, USER_ID);
+    verify(acknowledgment).acknowledge();
+  }
+
+  @Test
+  @DisplayName("이미 처리된(멱등키 존재) 이벤트는 스킵하고 오프셋만 커밋한다")
+  void handleBookingCreatedSkipsDuplicate() {
+    // given: SETNX가 false(이미 존재)를 반환
+    given(redisTemplate.opsForValue()).willReturn(valueOperations);
+    given(valueOperations.setIfAbsent(anyString(), anyString(), any(Duration.class)))
+        .willReturn(false);
+    DomainEventEnvelope envelope = envelope();
+
+    // when
+    listener.handleBookingCreated(envelope, acknowledgment);
+
+    // then: 비즈니스 로직은 실행되지 않고 커밋만 한다
+    verify(seatFacade, never()).tryLockSeat(anyLong(), anyString(), anyLong(), anyLong());
+    verify(acknowledgment).acknowledge();
+  }
+
+  @Test
+  @DisplayName("일시적(인프라) 예외가 발생하면 멱등키를 롤백하고 예외를 전파하며 커밋하지 않는다")
+  void handleBookingCreatedRollsBackAndRethrowsTransientFailure() {
+    // given
+    givenFirstMessage();
+    DomainEventEnvelope envelope = envelope();
+    given(jsonConverter.deserialize(PAYLOAD, BookingCreatedEvent.class)).willReturn(event());
+    willThrow(new RuntimeException("DB 일시 장애"))
+        .given(seatFacade)
+        .tryLockSeat(BOOKING_ID, BOOKING_NUMBER, SEAT_ID, USER_ID);
+
+    // when & then
+    assertThatThrownBy(() -> listener.handleBookingCreated(envelope, acknowledgment))
+        .isInstanceOf(RuntimeException.class);
+
+    // then: 재시도가 다시 처리할 수 있도록 멱등키를 롤백하고, 오프셋은 커밋하지 않는다
+    verify(redisTemplate).delete(IDEMPOTENCY_KEY);
+    verify(acknowledgment, never()).acknowledge();
+  }
+
+  @Test
+  @DisplayName("영구(비즈니스) 예외가 발생하면 멱등키를 유지하고 예외를 전파하지 않으며 커밋한다")
+  void handleBookingCreatedAcksPermanentFailure() {
+    // given
+    givenFirstMessage();
+    DomainEventEnvelope envelope = envelope();
+    given(jsonConverter.deserialize(PAYLOAD, BookingCreatedEvent.class)).willReturn(event());
+    willThrow(new BusinessException(ErrorStatus.SEAT_NOT_AVAILABLE))
+        .given(seatFacade)
+        .tryLockSeat(BOOKING_ID, BOOKING_NUMBER, SEAT_ID, USER_ID);
+
+    // when & then
+    assertThatCode(() -> listener.handleBookingCreated(envelope, acknowledgment))
+        .doesNotThrowAnyException();
+
+    // then: 영구 실패는 재처리해도 같으므로 멱등키를 롤백하지 않고 커밋한다
+    verify(redisTemplate, never()).delete(anyString());
+    verify(acknowledgment).acknowledge();
+  }
+}

--- a/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/in/eventlistener/PerformanceCreatedEventListenerTest.java
+++ b/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/in/eventlistener/PerformanceCreatedEventListenerTest.java
@@ -1,13 +1,18 @@
 package com.ticketrush.boundedcontext.seat.in.eventlistener;
 
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 import com.ticketrush.boundedcontext.seat.app.facade.SeatFacade;
 import com.ticketrush.global.event.DomainEventEnvelope;
+import com.ticketrush.global.exception.BusinessException;
 import com.ticketrush.global.json.JsonConverter;
+import com.ticketrush.global.status.ErrorStatus;
 import com.ticketrush.shared.performance.event.PerformanceCreatedEvent;
 import java.time.Instant;
 import java.time.LocalDate;
@@ -67,6 +72,52 @@ class PerformanceCreatedEventListenerTest {
 
     // then
     verify(seatFacade, never()).createDefaultSeats(anyLong());
+    verify(acknowledgment).acknowledge();
+  }
+
+  @Test
+  @DisplayName("일시적(인프라) 예외가 발생하면 예외를 전파하고 오프셋을 커밋하지 않는다(재시도→DLT 위임)")
+  void handlePerformanceCreatedRethrowsTransientFailure() {
+    // given
+    Long performanceId = 1L;
+    String payload = "{\"performance_id\":1}";
+    DomainEventEnvelope envelope =
+        new DomainEventEnvelope(
+            "event-id", "PerformanceCreated", Instant.now(), "performance-events", payload, null);
+    PerformanceCreatedEvent event =
+        new PerformanceCreatedEvent(
+            performanceId, "콘서트", 120, LocalDate.now(), LocalTime.of(19, 0), 50000L);
+    given(jsonConverter.deserialize(payload, PerformanceCreatedEvent.class)).willReturn(event);
+    willThrow(new RuntimeException("DB 일시 장애")).given(seatFacade).createDefaultSeats(performanceId);
+
+    // when & then
+    assertThatThrownBy(() -> listener.handlePerformanceCreated(envelope, acknowledgment))
+        .isInstanceOf(RuntimeException.class);
+
+    verify(acknowledgment, never()).acknowledge();
+  }
+
+  @Test
+  @DisplayName("영구(비즈니스) 예외가 발생하면 예외를 전파하지 않고 오프셋을 커밋한다")
+  void handlePerformanceCreatedAcksPermanentFailure() {
+    // given
+    Long performanceId = 1L;
+    String payload = "{\"performance_id\":1}";
+    DomainEventEnvelope envelope =
+        new DomainEventEnvelope(
+            "event-id", "PerformanceCreated", Instant.now(), "performance-events", payload, null);
+    PerformanceCreatedEvent event =
+        new PerformanceCreatedEvent(
+            performanceId, "콘서트", 120, LocalDate.now(), LocalTime.of(19, 0), 50000L);
+    given(jsonConverter.deserialize(payload, PerformanceCreatedEvent.class)).willReturn(event);
+    willThrow(new BusinessException(ErrorStatus.PERFORMANCE_NOT_FOUND))
+        .given(seatFacade)
+        .createDefaultSeats(performanceId);
+
+    // when & then
+    assertThatCode(() -> listener.handlePerformanceCreated(envelope, acknowledgment))
+        .doesNotThrowAnyException();
+
     verify(acknowledgment).acknowledge();
   }
 }

--- a/ticket-service/src/main/java/com/ticketrush/boundedcontext/ticket/in/eventlistener/PaymentCanceledEventListener.java
+++ b/ticket-service/src/main/java/com/ticketrush/boundedcontext/ticket/in/eventlistener/PaymentCanceledEventListener.java
@@ -2,6 +2,8 @@ package com.ticketrush.boundedcontext.ticket.in.eventlistener;
 
 import com.ticketrush.boundedcontext.ticket.app.usecase.TicketCancelUseCase;
 import com.ticketrush.global.event.DomainEventEnvelope;
+import com.ticketrush.global.event.KafkaConsumerErrorPolicy;
+import com.ticketrush.global.event.KafkaConsumerGroup;
 import com.ticketrush.global.json.JsonConverter;
 import com.ticketrush.shared.payment.event.PaymentCanceledEvent;
 import lombok.RequiredArgsConstructor;
@@ -19,7 +21,7 @@ public class PaymentCanceledEventListener {
   private final TicketCancelUseCase ticketCancelUseCase;
   private final JsonConverter jsonConverter;
 
-  @KafkaListener(topics = PaymentCanceledEvent.TOPIC, groupId = "ticket-group")
+  @KafkaListener(topics = PaymentCanceledEvent.TOPIC, groupId = KafkaConsumerGroup.TICKET)
   public void handlePaymentCanceled(@Payload DomainEventEnvelope envelope, Acknowledgment ack) {
 
     PaymentCanceledEvent event = null;
@@ -35,24 +37,39 @@ public class PaymentCanceledEventListener {
 
       log.info("입장권 취소 처리 완료. bookingId: {}", event.bookingId());
 
+      // 성공 시에만 오프셋을 커밋한다(#269 표준).
+      ack.acknowledge();
+
     } catch (Exception e) {
-      // 결제는 이미 취소된 상태라 재시도해도 결과가 바뀌지 않는다.
-      // 무한 재시도/파티션 블로킹을 피하고, 강한 로그를 남겨 수동 복구가 가능하도록 조치한다.
+      // #269 표준: 영구(비즈니스/결정적) 실패는 로그 후 ack, 일시(인프라) 실패는 re-throw 하여 재시도→DLT로 보존.
       // 역직렬화 실패 시 event가 null이라 bookingId를 못 얻으므로, 항상 살아있는
       // envelope.eventId()를 함께 남겨 어떤 메시지가 실패했는지 추적할 수 있게 한다.
       Long failedBookingId = (event != null) ? event.bookingId() : null;
-      log.error(
-          "[CRITICAL] 결제 취소 이벤트로 입장권 취소 중 치명적 오류 발생! "
-              + "결제는 취소되었으나 입장권 취소에 실패했습니다. 확인이 필요합니다. eventId: {}, bookingId: {}",
-          envelope.eventId(),
-          failedBookingId,
-          e);
 
-      // TODO: 추후 고도화 시, 이 위치에서 DLT로 실패한 이벤트를 재발행
-
-    } finally {
-      // 카프카 메시지가 무한 반복되며 파티션을 막는 현상 방지
-      ack.acknowledge();
+      if (KafkaConsumerErrorPolicy.isPermanent(e)) {
+        if (KafkaConsumerErrorPolicy.isExpectedConflict(e)) {
+          log.warn(
+              "결제 취소 이벤트 처리 중 예상된 상태충돌(멱등 처리). eventId: {}, bookingId: {}",
+              envelope.eventId(),
+              failedBookingId,
+              e);
+        } else {
+          log.error(
+              "[CRITICAL] 결제 취소 이벤트로 입장권 취소 중 치명적 오류 발생! "
+                  + "결제는 취소되었으나 입장권 취소에 실패했습니다. 확인이 필요합니다. eventId: {}, bookingId: {}",
+              envelope.eventId(),
+              failedBookingId,
+              e);
+        }
+        ack.acknowledge();
+      } else {
+        log.warn(
+            "결제 취소 이벤트 처리 중 일시적 오류. 재시도합니다. eventId: {}, bookingId: {}",
+            envelope.eventId(),
+            failedBookingId,
+            e);
+        throw e;
+      }
     }
   }
 }

--- a/ticket-service/src/main/java/com/ticketrush/boundedcontext/ticket/in/eventlistener/PaymentConfirmedEventListener.java
+++ b/ticket-service/src/main/java/com/ticketrush/boundedcontext/ticket/in/eventlistener/PaymentConfirmedEventListener.java
@@ -3,6 +3,8 @@ package com.ticketrush.boundedcontext.ticket.in.eventlistener;
 import com.ticketrush.boundedcontext.ticket.app.dto.response.TicketIssueResponse;
 import com.ticketrush.boundedcontext.ticket.app.usecase.TicketIssueUseCase;
 import com.ticketrush.global.event.DomainEventEnvelope;
+import com.ticketrush.global.event.KafkaConsumerErrorPolicy;
+import com.ticketrush.global.event.KafkaConsumerGroup;
 import com.ticketrush.global.json.JsonConverter;
 import com.ticketrush.shared.payment.event.PaymentConfirmedEvent;
 import lombok.RequiredArgsConstructor;
@@ -20,7 +22,7 @@ public class PaymentConfirmedEventListener {
   private final TicketIssueUseCase ticketIssueUseCase;
   private final JsonConverter jsonConverter;
 
-  @KafkaListener(topics = PaymentConfirmedEvent.TOPIC, groupId = "ticket-group")
+  @KafkaListener(topics = PaymentConfirmedEvent.TOPIC, groupId = KafkaConsumerGroup.TICKET)
   public void handlePaymentConfirmed(@Payload DomainEventEnvelope envelope, Acknowledgment ack) {
 
     PaymentConfirmedEvent event = null;
@@ -37,24 +39,42 @@ public class PaymentConfirmedEventListener {
       // 신규 발급/이미 발급 여부를 남겨 멱등 동작을 추적할 수 있게 한다.
       log.info("티켓 발급 처리 완료. bookingId: {}, issued: {}", event.bookingId(), response.issued());
 
+      // 성공 시에만 오프셋을 커밋한다(#269 표준).
+      ack.acknowledge();
+
     } catch (Exception e) {
-      // 결제는 이미 완료된 상태라 재시도해도 결과가 바뀌지 않는다.
-      // 무한 재시도/파티션 블로킹을 피하고, 강한 로그를 남겨 수동 복구가 가능하도록 조치한다.
+      // #269 표준: 영구(비즈니스/결정적) 실패는 로그 후 ack, 일시(인프라) 실패는 re-throw 하여 재시도→DLT로 보존.
       // 역직렬화 실패 시 event가 null이라 bookingId를 못 얻으므로, 항상 살아있는
       // envelope.eventId()를 함께 남겨 어떤 메시지가 실패했는지 추적할 수 있게 한다.
       Long failedBookingId = (event != null) ? event.bookingId() : null;
-      log.error(
-          "[CRITICAL] 결제 완료 이벤트로 티켓 발급 중 치명적 오류 발생! "
-              + "결제는 완료되었으나 티켓 발급에 실패했습니다. 확인이 필요합니다. eventId: {}, bookingId: {}",
-          envelope.eventId(),
-          failedBookingId,
-          e);
 
-      // TODO: 추후 고도화 시, 이 위치에서 DLT로 실패한 이벤트를 재발행
-
-    } finally {
-      // 카프카 메시지가 무한 반복되며 파티션을 막는 현상 방지
-      ack.acknowledge();
+      if (KafkaConsumerErrorPolicy.isPermanent(e)) {
+        if (KafkaConsumerErrorPolicy.isExpectedConflict(e)) {
+          // 재수신 등으로 자연 발생하는 상태충돌(멱등). 정상 흐름이므로 낮은 레벨로 남긴다.
+          log.warn(
+              "결제 완료 이벤트 처리 중 예상된 상태충돌(멱등 처리). eventId: {}, bookingId: {}",
+              envelope.eventId(),
+              failedBookingId,
+              e);
+        } else {
+          log.error(
+              "[CRITICAL] 결제 완료 이벤트로 티켓 발급 중 치명적 오류 발생! "
+                  + "결제는 완료되었으나 티켓 발급에 실패했습니다. 확인이 필요합니다. eventId: {}, bookingId: {}",
+              envelope.eventId(),
+              failedBookingId,
+              e);
+        }
+        // 영구 실패는 재시도해도 결과가 바뀌지 않으므로 커밋해 파티션 블로킹을 막는다.
+        ack.acknowledge();
+      } else {
+        // 일시 실패는 ack 하지 않고 예외를 다시 던져 컨테이너의 재시도→DLT 파이프라인에 위임한다.
+        log.warn(
+            "결제 완료 이벤트 처리 중 일시적 오류. 재시도합니다. eventId: {}, bookingId: {}",
+            envelope.eventId(),
+            failedBookingId,
+            e);
+        throw e;
+      }
     }
   }
 }

--- a/ticket-service/src/test/java/com/ticketrush/boundedcontext/ticket/in/eventlistener/PaymentCanceledEventListenerTest.java
+++ b/ticket-service/src/test/java/com/ticketrush/boundedcontext/ticket/in/eventlistener/PaymentCanceledEventListenerTest.java
@@ -1,6 +1,7 @@
 package com.ticketrush.boundedcontext.ticket.in.eventlistener;
 
 import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.never;
@@ -8,8 +9,10 @@ import static org.mockito.Mockito.verify;
 
 import com.ticketrush.boundedcontext.ticket.app.usecase.TicketCancelUseCase;
 import com.ticketrush.global.event.DomainEventEnvelope;
+import com.ticketrush.global.exception.BusinessException;
 import com.ticketrush.global.json.DeserializationException;
 import com.ticketrush.global.json.JsonConverter;
+import com.ticketrush.global.status.ErrorStatus;
 import com.ticketrush.shared.payment.event.PaymentCanceledEvent;
 import java.time.Instant;
 import java.time.LocalDateTime;
@@ -69,19 +72,39 @@ class PaymentCanceledEventListenerTest {
   }
 
   @Test
-  @DisplayName("취소 유스케이스가 예외를 던져도 예외를 전파하지 않고 오프셋을 커밋한다")
-  void handlePaymentCanceledSwallowsCancelFailure() {
-    // given
+  @DisplayName("일시적(인프라) 예외가 발생하면 예외를 전파하고 오프셋을 커밋하지 않는다(재시도→DLT 위임)")
+  void handlePaymentCanceledRethrowsTransientFailure() {
+    // given: 일반 RuntimeException은 일시 실패로 분류된다
     DomainEventEnvelope envelope = envelope();
     BDDMockito.given(jsonConverter.deserialize(PAYLOAD, PaymentCanceledEvent.class))
         .willReturn(event());
-    willThrow(new RuntimeException("입장권 취소 실패")).given(ticketCancelUseCase).execute(BOOKING_ID);
+    willThrow(new RuntimeException("DB 일시 장애")).given(ticketCancelUseCase).execute(BOOKING_ID);
 
-    // when & then: 취소 실패가 리스너 밖으로 전파되지 않는다(파티션 블로킹 방지)
+    // when & then: 일시 실패는 리스너 밖으로 전파되어 컨테이너 재시도→DLT 파이프라인을 태운다
+    assertThatThrownBy(() -> listener.handlePaymentCanceled(envelope, acknowledgment))
+        .isInstanceOf(RuntimeException.class);
+
+    // then: 취소는 시도되었으나 오프셋은 커밋되지 않는다
+    verify(ticketCancelUseCase).execute(BOOKING_ID);
+    verify(acknowledgment, never()).acknowledge();
+  }
+
+  @Test
+  @DisplayName("영구(비즈니스) 예외가 발생하면 예외를 전파하지 않고 오프셋을 커밋한다")
+  void handlePaymentCanceledAcksPermanentFailure() {
+    // given: BusinessException은 영구 실패로 분류된다(재시도 무의미)
+    DomainEventEnvelope envelope = envelope();
+    BDDMockito.given(jsonConverter.deserialize(PAYLOAD, PaymentCanceledEvent.class))
+        .willReturn(event());
+    willThrow(new BusinessException(ErrorStatus.TICKET_NOT_FOUND))
+        .given(ticketCancelUseCase)
+        .execute(BOOKING_ID);
+
+    // when & then: 영구 실패는 로그 후 커밋되어 파티션 블로킹을 막는다
     assertThatCode(() -> listener.handlePaymentCanceled(envelope, acknowledgment))
         .doesNotThrowAnyException();
 
-    // then: 취소는 시도되었고, 실패와 무관하게 오프셋은 커밋된다
+    // then
     verify(ticketCancelUseCase).execute(BOOKING_ID);
     verify(acknowledgment).acknowledge();
   }

--- a/ticket-service/src/test/java/com/ticketrush/boundedcontext/ticket/in/eventlistener/PaymentConfirmedEventListenerTest.java
+++ b/ticket-service/src/test/java/com/ticketrush/boundedcontext/ticket/in/eventlistener/PaymentConfirmedEventListenerTest.java
@@ -1,6 +1,7 @@
 package com.ticketrush.boundedcontext.ticket.in.eventlistener;
 
 import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willThrow;
@@ -10,8 +11,10 @@ import static org.mockito.Mockito.verify;
 import com.ticketrush.boundedcontext.ticket.app.dto.response.TicketIssueResponse;
 import com.ticketrush.boundedcontext.ticket.app.usecase.TicketIssueUseCase;
 import com.ticketrush.global.event.DomainEventEnvelope;
+import com.ticketrush.global.exception.BusinessException;
 import com.ticketrush.global.json.DeserializationException;
 import com.ticketrush.global.json.JsonConverter;
+import com.ticketrush.global.status.ErrorStatus;
 import com.ticketrush.shared.payment.event.PaymentConfirmedEvent;
 import java.time.Instant;
 import java.time.LocalDateTime;
@@ -89,18 +92,37 @@ class PaymentConfirmedEventListenerTest {
   }
 
   @Test
-  @DisplayName("티켓 발급 유스케이스가 예외를 던져도 예외를 전파하지 않고 오프셋을 커밋한다")
-  void handlePaymentConfirmedSwallowsIssueFailure() {
-    // given
+  @DisplayName("일시적(인프라) 예외가 발생하면 예외를 전파하고 오프셋을 커밋하지 않는다(재시도→DLT 위임)")
+  void handlePaymentConfirmedRethrowsTransientFailure() {
+    // given: 일반 RuntimeException은 일시 실패로 분류된다
     DomainEventEnvelope envelope = envelope();
     given(jsonConverter.deserialize(PAYLOAD, PaymentConfirmedEvent.class)).willReturn(event());
-    willThrow(new RuntimeException("티켓 발급 실패")).given(ticketIssueUseCase).execute(BOOKING_ID);
+    willThrow(new RuntimeException("DB 일시 장애")).given(ticketIssueUseCase).execute(BOOKING_ID);
 
-    // when & then: 발급 실패가 리스너 밖으로 전파되지 않는다(파티션 블로킹 방지)
+    // when & then: 일시 실패는 리스너 밖으로 전파되어 컨테이너 재시도→DLT 파이프라인을 태운다
+    assertThatThrownBy(() -> listener.handlePaymentConfirmed(envelope, acknowledgment))
+        .isInstanceOf(RuntimeException.class);
+
+    // then: 발급은 시도되었으나 오프셋은 커밋되지 않는다
+    verify(ticketIssueUseCase).execute(BOOKING_ID);
+    verify(acknowledgment, never()).acknowledge();
+  }
+
+  @Test
+  @DisplayName("영구(비즈니스) 예외가 발생하면 예외를 전파하지 않고 오프셋을 커밋한다")
+  void handlePaymentConfirmedAcksPermanentFailure() {
+    // given: BusinessException은 영구 실패로 분류된다(재시도 무의미)
+    DomainEventEnvelope envelope = envelope();
+    given(jsonConverter.deserialize(PAYLOAD, PaymentConfirmedEvent.class)).willReturn(event());
+    willThrow(new BusinessException(ErrorStatus.BOOKING_NOT_FOUND))
+        .given(ticketIssueUseCase)
+        .execute(BOOKING_ID);
+
+    // when & then: 영구 실패는 로그 후 커밋되어 파티션 블로킹을 막는다
     assertThatCode(() -> listener.handlePaymentConfirmed(envelope, acknowledgment))
         .doesNotThrowAnyException();
 
-    // then: 발급은 시도되었고, 실패와 무관하게 오프셋은 커밋된다
+    // then
     verify(ticketIssueUseCase).execute(BOOKING_ID);
     verify(acknowledgment).acknowledge();
   }


### PR DESCRIPTION
## 🔗 관련 이슈

- close #269

---

## 📌 주요 변경 사항

- 전 서비스 Kafka 컨슈머(`@KafkaListener`)의 예외 처리 정책을 **일시(transient)/영구(permanent) 구분** 표준으로 통일
- 일시(인프라) 실패는 `re-throw`로 기존 재시도→DLT 파이프라인에 위임해 **메시지 유실 방지**, 영구(비즈니스) 실패는 로그 후 `ack`
- `groupId`/`topic` 리터럴을 상수로 통일(SSOT)
- 컨슈머 에러 처리 표준을 `docs/kafka-event-guide.md`에 문서화

---

## 🛠 상세 구현 내용

- **공통 정책 헬퍼 신설** `common/.../global/event/KafkaConsumerErrorPolicy`
  - `isPermanent(Throwable)`: cause 체인에 `BusinessException`이 있으면 영구(재시도 무의미). 인프라 예외(DataAccess/Redis/네트워크)는 일시로 분류.
  - `isExpectedConflict(Throwable)`: 재수신으로 자연 발생하는 멱등 상태충돌 화이트리스트(`SEAT_NOT_AVAILABLE`·`SEAT_ALREADY_LOCKED`·`PAYMENT_ALREADY_COMPLETED`·`TICKET_ALREADY_USED`·`TICKET_NOT_USABLE`·`BOOKING_CANCEL_NOT_ALLOWED`)만 warn+ack. 화이트리스트 밖 409(`BOOKING_SEAT_MISMATCH`·`BOOKING_EXPIRED`·`BOOKING_CONFIRM_NOT_ALLOWED` 등 결제됐으나 확정 불가)는 CRITICAL 유지.
- **groupId SSOT** `KafkaConsumerGroup` 신설, `BookingCreatedEvent`·`SeatHoldFailedEvent`에 `TOPIC` 상수 추가 → 리스너 리터럴 잔존 0.
- **9개 컨슈머 표준 전환**(ticket 2 · booking 2 · seat 3 · payment 1 · common DLT 1): 성공→ack / 영구→로그 후 ack / 일시→re-throw. `finally`-무조건-ack 제거.
- **크로스서비스 SOLD 호출 예외 처리**: booking `PaymentConfirmedEventListener`의 `seatRestClient.confirmSold()`는 `BusinessException`이 아닌 `RestClient` 예외로 도착하므로 `isPermanent` 미적용 → HTTP 상태코드 기반(409→ack, 그 외 4xx→CRITICAL+ack, 5xx/네트워크→re-throw).
- **문서화**: `docs/kafka-event-guide.md` §2 컨슈머 에러 처리 표준(분류 결정표·2계층 분류·동명 `DeserializationException` 2종·파티션 블로킹) 추가, `docs/backend-convention.md` SSOT 포인터.

---

## ✅ 테스트

### 테스트 방법

- 신규/재작성 단위 테스트:
  - `KafkaConsumerErrorPolicyTest` — 영구/일시/상태충돌 분류(중첩 cause·`HttpClientErrorException`→일시·화이트리스트 판정) 검증
  - 리스너별 분기 테스트(일시=re-throw+ack 미호출, 영구=ack): ticket 2, booking 2(SOLD 4xx→ack/5xx→re-throw 포함), seat 3(SETNX 멱등키 롤백 포함), payment 1
- 실행 명령:
  - `./gradlew :common:test :ticket-service:test :booking-service:test :seat-service:test :payment-service:test spotlessCheck`
  - `./gradlew checkstyleMain checkstyleTest`

### 테스트 결과

- 5개 모듈 `test` + `spotlessCheck` + `checkstyle` **BUILD SUCCESSFUL** (전부 통과)
<!--
### 📸 스크린샷

- 
-->
---

## 👀 리뷰 요청 사항

- 상태충돌 화이트리스트(`KafkaConsumerErrorPolicy.EXPECTED_CONFLICTS`) 구성이 도메인 의미와 맞는지 검토 부탁드립니다(warn vs CRITICAL 경계).
- booking SOLD 호출의 상태코드 분기(409/기타 4xx/5xx) 처리 방향 확인 부탁드립니다.
- 후속(범위 밖, 별도 이슈 제안): payment `BookingExpired`의 DIVE를 #308 `existsBy` 패턴으로 정밀화 / SOLD 5xx 소진 후 booking-seat 정합성 reconciliation / seat 멱등키 롤백 시 Redis 장애 취약성.

---

## ⚠️ 배포 시 주의사항

- 동작 변경: 기존 일부 컨슈머가 예외를 삼키던(swallow+ack) 것이, 이제 **일시 예외는 재시도→DLT로 흐릅니다**. DLT 토픽(`*.DLT`) 적재량이 실패 상황에서 증가할 수 있으며, DLT 모니터/알림(#50)과 함께 관찰 필요.
- 재시도가 발생하므로 컨슈머 처리는 멱등해야 합니다(현행 리스너는 도메인 멱등·SETNX·DB unique로 보장).
