### PR TITLE
[Feat] #110 Inbox 패턴 도입 (중복 이벤트 처리 방지)

### DIFF
--- a/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/in/eventlistener/SeatHoldFailedEventListener.java
+++ b/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/in/eventlistener/SeatHoldFailedEventListener.java
@@ -4,6 +4,8 @@ import com.ticketrush.boundedcontext.booking.app.usecase.BookingCancelUseCase;
 import com.ticketrush.global.event.DomainEventEnvelope;
 import com.ticketrush.global.event.KafkaConsumerErrorPolicy;
 import com.ticketrush.global.event.KafkaConsumerGroup;
+import com.ticketrush.global.inbox.DuplicateEventException;
+import com.ticketrush.global.inbox.InboxService;
 import com.ticketrush.global.json.JsonConverter;
 import com.ticketrush.shared.seat.event.SeatHoldFailedEvent;
 import lombok.RequiredArgsConstructor;
@@ -20,6 +22,7 @@ public class SeatHoldFailedEventListener {
 
   private final BookingCancelUseCase bookingCancelUseCase;
   private final JsonConverter jsonConverter;
+  private final InboxService inboxService;
 
   @KafkaListener(topics = SeatHoldFailedEvent.TOPIC, groupId = KafkaConsumerGroup.BOOKING)
   public void handleSeatHoldFailed(@Payload DomainEventEnvelope envelope, Acknowledgment ack) {
@@ -28,15 +31,29 @@ public class SeatHoldFailedEventListener {
 
     try {
       event = jsonConverter.deserialize(envelope.payload(), SeatHoldFailedEvent.class);
+      final Long bookingId = event.bookingId();
 
-      log.warn(
-          "좌석 선점 실패 이벤트 수신. 보상 트랜잭션 실행. bookingId: {}, 사유: {}", event.bookingId(), event.reason());
+      log.warn("좌석 선점 실패 이벤트 수신. 보상 트랜잭션 실행. bookingId: {}, 사유: {}", bookingId, event.reason());
 
-      bookingCancelUseCase.execute(event.bookingId());
+      // Inbox로 중복 처리를 방지한다(#110). 최초 수신일 때만 예매 취소를 수행하고 처리와 Inbox 기록을 한 트랜잭션으로 묶는다.
+      boolean processed =
+          inboxService.runIfFirst(
+              KafkaConsumerGroup.BOOKING, envelope, () -> bookingCancelUseCase.execute(bookingId));
+
+      if (!processed) {
+        log.info(
+            "이미 처리된 좌석 선점 실패 이벤트(inbox 중복 스킵). eventId: {}, bookingId: {}",
+            envelope.eventId(),
+            bookingId);
+      }
 
       // 성공 시에만 오프셋을 커밋한다(#269 표준).
       ack.acknowledge();
 
+    } catch (DuplicateEventException e) {
+      // 동시 중복 수신으로 inbox unique가 경합함 → 멱등(중복) 정상으로 간주하고 커밋한다(#110).
+      log.info("동시 중복 수신(inbox unique 경합). eventId: {}", envelope.eventId());
+      ack.acknowledge();
     } catch (Exception e) {
       // #269 표준: 영구(비즈니스/결정적) 실패는 로그 후 ack, 일시(인프라) 실패는 re-throw 하여 재시도→DLT로 보존.
       Long failedBookingId = (event != null) ? event.bookingId() : null;

--- a/booking-service/src/test/java/com/ticketrush/boundedcontext/booking/in/eventlistener/SeatHoldFailedEventListenerTest.java
+++ b/booking-service/src/test/java/com/ticketrush/boundedcontext/booking/in/eventlistener/SeatHoldFailedEventListenerTest.java
@@ -2,6 +2,9 @@ package com.ticketrush.boundedcontext.booking.in.eventlistener;
 
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.never;
@@ -9,7 +12,10 @@ import static org.mockito.Mockito.verify;
 
 import com.ticketrush.boundedcontext.booking.app.usecase.BookingCancelUseCase;
 import com.ticketrush.global.event.DomainEventEnvelope;
+import com.ticketrush.global.event.KafkaConsumerGroup;
 import com.ticketrush.global.exception.BusinessException;
+import com.ticketrush.global.inbox.DuplicateEventException;
+import com.ticketrush.global.inbox.InboxService;
 import com.ticketrush.global.json.JsonConverter;
 import com.ticketrush.global.status.ErrorStatus;
 import com.ticketrush.shared.seat.event.SeatHoldFailedEvent;
@@ -20,6 +26,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.kafka.support.Acknowledgment;
 
 @ExtendWith(MockitoExtension.class)
@@ -30,6 +37,8 @@ class SeatHoldFailedEventListenerTest {
   @Mock private BookingCancelUseCase bookingCancelUseCase;
 
   @Mock private JsonConverter jsonConverter;
+
+  @Mock private InboxService inboxService;
 
   @Mock private Acknowledgment acknowledgment;
 
@@ -50,12 +59,27 @@ class SeatHoldFailedEventListenerTest {
     return new SeatHoldFailedEvent(BOOKING_ID, 3L, "좌석 선점 실패");
   }
 
+  /** Inbox가 최초 수신으로 판정해 비즈니스 콜백을 실행하고 true를 반환하도록 스텁한다. */
+  private void givenInboxProcessesFirst() {
+    given(
+            inboxService.runIfFirst(
+                eq(KafkaConsumerGroup.BOOKING),
+                any(DomainEventEnvelope.class),
+                any(Runnable.class)))
+        .willAnswer(
+            invocation -> {
+              invocation.getArgument(2, Runnable.class).run();
+              return true;
+            });
+  }
+
   @Test
-  @DisplayName("좌석 선점 실패 이벤트를 수신하면 예매를 취소하고 오프셋을 커밋한다")
+  @DisplayName("최초 수신이면 예매를 취소하고 오프셋을 커밋한다")
   void handleSeatHoldFailed() {
     // given
-    DomainEventEnvelope envelope = envelope();
+    final DomainEventEnvelope envelope = envelope();
     given(jsonConverter.deserialize(PAYLOAD, SeatHoldFailedEvent.class)).willReturn(event());
+    givenInboxProcessesFirst();
 
     // when
     listener.handleSeatHoldFailed(envelope, acknowledgment);
@@ -66,11 +90,57 @@ class SeatHoldFailedEventListenerTest {
   }
 
   @Test
+  @DisplayName("이미 처리된 이벤트(inbox 중복)면 예매 취소를 실행하지 않고 오프셋만 커밋한다")
+  void handleSeatHoldFailedSkipsDuplicate() {
+    // given
+    final DomainEventEnvelope envelope = envelope();
+    given(jsonConverter.deserialize(PAYLOAD, SeatHoldFailedEvent.class)).willReturn(event());
+    given(
+            inboxService.runIfFirst(
+                eq(KafkaConsumerGroup.BOOKING),
+                any(DomainEventEnvelope.class),
+                any(Runnable.class)))
+        .willReturn(false);
+
+    // when
+    listener.handleSeatHoldFailed(envelope, acknowledgment);
+
+    // then
+    verify(bookingCancelUseCase, never()).execute(anyLong());
+    verify(acknowledgment).acknowledge();
+  }
+
+  @Test
+  @DisplayName("동시 중복 수신으로 inbox unique가 경합하면(DIVE) 예외를 전파하지 않고 오프셋을 커밋한다")
+  void handleSeatHoldFailedAcksOnInboxRace() {
+    // given
+    final DomainEventEnvelope envelope = envelope();
+    given(jsonConverter.deserialize(PAYLOAD, SeatHoldFailedEvent.class)).willReturn(event());
+    given(
+            inboxService.runIfFirst(
+                eq(KafkaConsumerGroup.BOOKING),
+                any(DomainEventEnvelope.class),
+                any(Runnable.class)))
+        .willThrow(
+            new DuplicateEventException(
+                KafkaConsumerGroup.BOOKING,
+                "event-id",
+                new DataIntegrityViolationException("duplicate")));
+
+    // when & then
+    assertThatCode(() -> listener.handleSeatHoldFailed(envelope, acknowledgment))
+        .doesNotThrowAnyException();
+
+    verify(acknowledgment).acknowledge();
+  }
+
+  @Test
   @DisplayName("일시적(인프라) 예외가 발생하면 예외를 전파하고 오프셋을 커밋하지 않는다(재시도→DLT 위임)")
   void handleSeatHoldFailedRethrowsTransientFailure() {
     // given
-    DomainEventEnvelope envelope = envelope();
+    final DomainEventEnvelope envelope = envelope();
     given(jsonConverter.deserialize(PAYLOAD, SeatHoldFailedEvent.class)).willReturn(event());
+    givenInboxProcessesFirst();
     willThrow(new RuntimeException("DB 일시 장애")).given(bookingCancelUseCase).execute(BOOKING_ID);
 
     // when & then
@@ -84,8 +154,9 @@ class SeatHoldFailedEventListenerTest {
   @DisplayName("영구(비즈니스) 예외가 발생하면 예외를 전파하지 않고 오프셋을 커밋한다")
   void handleSeatHoldFailedAcksPermanentFailure() {
     // given: 이미 취소된 예매 등 상태충돌은 영구 실패로 분류되어 커밋된다
-    DomainEventEnvelope envelope = envelope();
+    final DomainEventEnvelope envelope = envelope();
     given(jsonConverter.deserialize(PAYLOAD, SeatHoldFailedEvent.class)).willReturn(event());
+    givenInboxProcessesFirst();
     willThrow(new BusinessException(ErrorStatus.BOOKING_CANCEL_NOT_ALLOWED))
         .given(bookingCancelUseCase)
         .execute(BOOKING_ID);

--- a/common/src/main/java/com/ticketrush/global/inbox/DuplicateEventException.java
+++ b/common/src/main/java/com/ticketrush/global/inbox/DuplicateEventException.java
@@ -1,0 +1,18 @@
+package com.ticketrush.global.inbox;
+
+/**
+ * 동시 중복 수신으로 Inbox의 {@code (consumer_group, event_id)} unique가 경합했음을 알리는 신호 예외 (#110).
+ *
+ * <p>{@link InboxService#runIfFirst}가 inbox 기록({@code saveAndFlush}) 중 {@code
+ * DataIntegrityViolationException}을 만나면 트랜잭션을 깨끗이 롤백시키기 위해 이 예외로 변환해 던진다(롤백-only 상태에서 정상 반환하면 커밋
+ * 시점에 {@code UnexpectedRollbackException}이 나기 때문).
+ *
+ * <p>리스너는 이 예외만 "멱등(중복) 정상"으로 간주해 ack 한다. 비즈니스 로직이 던진 일반 {@code DataIntegrityViolationException}은 이
+ * 예외로 감싸지 않으므로 #269 표준 분기(일시→재시도→DLT)로 흘러 보존된다.
+ */
+public class DuplicateEventException extends RuntimeException {
+
+  public DuplicateEventException(String consumerGroup, String eventId, Throwable cause) {
+    super("Duplicate event: consumerGroup=" + consumerGroup + ", eventId=" + eventId, cause);
+  }
+}

--- a/common/src/main/java/com/ticketrush/global/inbox/InboxEntity.java
+++ b/common/src/main/java/com/ticketrush/global/inbox/InboxEntity.java
@@ -1,0 +1,70 @@
+package com.ticketrush.global.inbox;
+
+import com.ticketrush.global.jpa.entity.AutoIdBaseEntity;
+import jakarta.persistence.AttributeOverride;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 수신 이벤트의 중복 처리를 막는 Inbox 패턴 엔티티 (#110).
+ *
+ * <p>at-least-once delivery 환경에서 동일 이벤트가 여러 번 전달되어도 한 번만 처리되도록, 처리 성공 시 {@code (consumer_group,
+ * event_id)}를 이 테이블에 기록한다. {@code InboxService.runIfFirst}가 비즈니스 로직과 <b>동일 트랜잭션</b>에서 이 row를 저장해
+ * "처리"와 "기록"의 원자성을 보장한다.
+ *
+ * <p><b>복합 키 {@code (consumer_group, event_id)}</b>: 하나의 이벤트를 여러 컨슈머 그룹이 소비할 수 있고(예: {@code
+ * PaymentConfirmedEvent}를 ticket-group·booking-group이 모두 소비), 로컬은 전 서비스가 단일 스키마를 공유한다. {@code
+ * event_id} 단독 unique이면 한 그룹이 처리한 뒤 다른 그룹이 중복으로 오인해 스킵되므로, 컨슈머 그룹까지 묶어 그룹별로 독립 멱등을 보장한다.
+ *
+ * <p>처리 시각은 {@link com.ticketrush.global.jpa.entity.BaseTimeEntity}가 관리하는 {@code created_at}(JPA
+ * Auditing)으로 기록된다. row는 처리 시점에 저장되므로 별도 {@code processed_at} 컬럼은 중복이라 두지 않는다(#9·Outbox·DLT와 동일
+ * 컨벤션).
+ *
+ * <p>retention 범위 삭제({@code created_at} 기준)를 위해 {@code (created_at)} 단독 인덱스를 둔다.
+ */
+@Entity
+@Table(
+    name = "inbox",
+    indexes = {@Index(name = "idx_inbox_created_at", columnList = "created_at")},
+    uniqueConstraints = {
+      @UniqueConstraint(
+          name = "uk_inbox_group_event",
+          columnNames = {"consumer_group", "event_id"})
+    })
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AttributeOverride(name = "id", column = @Column(name = "inbox_id"))
+public class InboxEntity extends AutoIdBaseEntity {
+
+  @Column(name = "consumer_group", nullable = false, length = 100)
+  private String consumerGroup; // 이벤트를 처리한 컨슈머 그룹 (KafkaConsumerGroup 상수)
+
+  @Column(name = "event_id", nullable = false, length = 36)
+  private String eventId; // DomainEventEnvelope.eventId (UUID). 멱등 식별자
+
+  @Column(name = "event_type", length = 150)
+  private String eventType; // 이벤트 타입명. 관측/디버깅용이라 nullable
+
+  @Builder(access = AccessLevel.PRIVATE)
+  private InboxEntity(String consumerGroup, String eventId, String eventType) {
+    this.consumerGroup = consumerGroup;
+    this.eventId = eventId;
+    this.eventType = eventType;
+  }
+
+  /** 처리 완료를 기록할 Inbox row를 생성한다. */
+  public static InboxEntity of(String consumerGroup, String eventId, String eventType) {
+    return InboxEntity.builder()
+        .consumerGroup(consumerGroup)
+        .eventId(eventId)
+        .eventType(eventType)
+        .build();
+  }
+}

--- a/common/src/main/java/com/ticketrush/global/inbox/InboxRepository.java
+++ b/common/src/main/java/com/ticketrush/global/inbox/InboxRepository.java
@@ -1,0 +1,29 @@
+package com.ticketrush.global.inbox;
+
+import java.time.LocalDateTime;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+/** {@link InboxEntity}에 대한 JPA 저장소. */
+public interface InboxRepository extends JpaRepository<InboxEntity, Long> {
+
+  /**
+   * 해당 컨슈머 그룹이 이미 처리한 {@code eventId}인지 확인한다(멱등 fast-path).
+   *
+   * <p>동시 중복 수신 시에는 두 스레드가 모두 {@code false}를 받을 수 있으나, 저장 시점의 {@code (consumer_group, event_id)}
+   * unique 제약이 하나만 커밋되도록 보장한다.
+   */
+  boolean existsByConsumerGroupAndEventId(String consumerGroup, String eventId);
+
+  /**
+   * retention 대상 row를 벌크 삭제한다. {@code threshold} 이전에 저장(createdAt)된 row만 지운다.
+   *
+   * <p>스케줄러/서비스 배선은 후속 작업이다({@code DltRetentionService} 패턴 참고). 이 메서드와 {@code idx_inbox_created_at}
+   * 인덱스는 그 배선을 위해 미리 준비해 둔 것으로, 배선 전까지 {@code inbox} 테이블은 무한 증가할 수 있다.
+   */
+  @Modifying(clearAutomatically = true)
+  @Query("DELETE FROM InboxEntity i WHERE i.createdAt < :threshold")
+  int deleteCreatedBefore(@Param("threshold") LocalDateTime threshold);
+}

--- a/common/src/main/java/com/ticketrush/global/inbox/InboxService.java
+++ b/common/src/main/java/com/ticketrush/global/inbox/InboxService.java
@@ -1,0 +1,59 @@
+package com.ticketrush.global.inbox;
+
+import com.ticketrush.global.event.DomainEventEnvelope;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Inbox 패턴 기반 중복 이벤트 처리 방지 진입점 (#110).
+ *
+ * <p>컨슈머(리스너)에는 트랜잭션이 없고 비즈니스 트랜잭션은 usecase에서 시작하므로, 이 서비스가 {@link Transactional}로 트랜잭션을 열고 비즈니스
+ * 로직을 콜백으로 받아 <b>같은 트랜잭션(REQUIRED)에 조인</b>시킨다. 그 결과 "비즈니스 처리"와 "Inbox 기록"이 하나의 원자 단위로 커밋/롤백된다.
+ */
+@Service
+@RequiredArgsConstructor
+public class InboxService {
+
+  private final InboxRepository inboxRepository;
+
+  /**
+   * 해당 컨슈머 그룹이 처음 보는 이벤트이면 {@code business}를 실행하고 Inbox에 기록한 뒤 {@code true}를, 이미 처리한 이벤트이면 아무것도 하지
+   * 않고 {@code false}를 반환한다.
+   *
+   * <ul>
+   *   <li>{@code business}가 던진 예외는 잡지 않고 전파한다 → 트랜잭션 롤백(Inbox 미기록)되어 호출자(리스너)의 #269 에러 분기가 그대로
+   *       동작한다. 실패한 처리는 기록되지 않으므로 재전달 시 재처리된다. 비즈니스가 던진 일반 {@code DataIntegrityViolationException}도
+   *       그대로 전파돼 #269 분기(일시→재시도→DLT)로 보존된다.
+   *   <li>동시 중복 수신으로 {@code (consumer_group, event_id)} unique가 충돌하면 {@code saveAndFlush}의 {@code
+   *       DataIntegrityViolationException}을 {@link DuplicateEventException}으로 변환해 던진다. 이 예외만 호출자가
+   *       멱등(중복) 정상으로 간주해 ack 하고, 그 외 무결성 위반과는 구분된다.
+   * </ul>
+   *
+   * @param consumerGroup 처리 주체 컨슈머 그룹({@code KafkaConsumerGroup} 상수)
+   * @param envelope 수신 이벤트 봉투(멱등 식별자 {@code eventId} 제공)
+   * @param business 최초 수신일 때만 실행할 비즈니스 로직(같은 트랜잭션에 조인)
+   * @return 이번에 처리했으면 {@code true}, 이미 처리된 중복이면 {@code false}
+   * @throws DuplicateEventException 동시 중복 수신으로 inbox unique가 경합했을 때
+   */
+  @Transactional
+  public boolean runIfFirst(String consumerGroup, DomainEventEnvelope envelope, Runnable business) {
+    if (inboxRepository.existsByConsumerGroupAndEventId(consumerGroup, envelope.eventId())) {
+      return false;
+    }
+
+    business.run();
+
+    try {
+      // saveAndFlush로 unique 위반을 트랜잭션 안에서 즉시 표면화해, 동시 중복의 패자가 커밋 전에 롤백되도록 한다.
+      inboxRepository.saveAndFlush(
+          InboxEntity.of(consumerGroup, envelope.eventId(), envelope.eventType()));
+    } catch (DataIntegrityViolationException e) {
+      // inbox unique 경합(동시 중복)만 전용 예외로 변환한다. 비즈니스가 던진 DIVE는 여기 오지 않고 그대로 전파된다.
+      // 롤백-only 상태에서 정상 반환하면 커밋 시 UnexpectedRollbackException이 나므로 반드시 예외로 롤백시킨다.
+      throw new DuplicateEventException(consumerGroup, envelope.eventId(), e);
+    }
+    return true;
+  }
+}

--- a/common/src/test/java/com/ticketrush/global/inbox/InboxRepositoryTest.java
+++ b/common/src/test/java/com/ticketrush/global/inbox/InboxRepositoryTest.java
@@ -1,0 +1,95 @@
+package com.ticketrush.global.inbox;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.ticketrush.global.jpa.config.JpaConfig;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.dao.DataIntegrityViolationException;
+
+/** {@link JpaConfig}를 임포트해 {@code @EnableJpaAuditing}을 활성화한 뒤 {@code createdAt} 단언을 포함한다. */
+@DataJpaTest
+@Import(JpaConfig.class)
+class InboxRepositoryTest {
+
+  @Autowired private InboxRepository inboxRepository;
+
+  @Test
+  @DisplayName("InboxEntity를 저장하면 필드가 보존되고 createdAt이 JPA Auditing으로 기록된다")
+  void save_and_find_preserves_fields() {
+    // when
+    InboxEntity saved =
+        inboxRepository.save(InboxEntity.of("seat-group", "evt-1", "BookingCanceledEvent"));
+    InboxEntity found = inboxRepository.findById(saved.getId()).orElseThrow();
+
+    // then
+    assertThat(found.getConsumerGroup()).isEqualTo("seat-group");
+    assertThat(found.getEventId()).isEqualTo("evt-1");
+    assertThat(found.getEventType()).isEqualTo("BookingCanceledEvent");
+    assertThat(found.getCreatedAt()).isNotNull(); // 처리 시각 = createdAt (processed_at 컬럼 없음)
+  }
+
+  @Test
+  @DisplayName("같은 (consumer_group, event_id)를 두 번 저장하면 복합 unique 제약 위반이 발생한다")
+  void duplicate_group_event_violates_unique() {
+    // given
+    inboxRepository.saveAndFlush(InboxEntity.of("ticket-group", "evt-dup", "PaymentCanceledEvent"));
+
+    // when & then
+    assertThatThrownBy(
+            () ->
+                inboxRepository.saveAndFlush(
+                    InboxEntity.of("ticket-group", "evt-dup", "PaymentCanceledEvent")))
+        .isInstanceOf(DataIntegrityViolationException.class);
+  }
+
+  @Test
+  @DisplayName("서로 다른 consumer_group은 동일 event_id라도 각각 저장된다(멀티컨슈머 독립 멱등)")
+  void same_event_id_different_group_both_saved() {
+    // given: PaymentConfirmedEvent를 ticket-group과 booking-group이 같은 eventId로 소비하는 상황
+    String eventId = "evt-shared";
+
+    // when
+    inboxRepository.saveAndFlush(InboxEntity.of("ticket-group", eventId, "PaymentConfirmed"));
+    inboxRepository.saveAndFlush(InboxEntity.of("booking-group", eventId, "PaymentConfirmed"));
+
+    // then: 두 그룹 모두 저장되어 서로의 처리를 막지 않는다
+    assertThat(inboxRepository.existsByConsumerGroupAndEventId("ticket-group", eventId)).isTrue();
+    assertThat(inboxRepository.existsByConsumerGroupAndEventId("booking-group", eventId)).isTrue();
+  }
+
+  @Test
+  @DisplayName("existsByConsumerGroupAndEventId는 저장된 (group, eventId)에만 true를 반환한다")
+  void existsBy_group_and_event_id() {
+    // given
+    inboxRepository.saveAndFlush(InboxEntity.of("payment-group", "evt-x", "BookingExpiredEvent"));
+
+    // then
+    assertThat(inboxRepository.existsByConsumerGroupAndEventId("payment-group", "evt-x")).isTrue();
+    assertThat(inboxRepository.existsByConsumerGroupAndEventId("payment-group", "evt-y")).isFalse();
+    assertThat(inboxRepository.existsByConsumerGroupAndEventId("seat-group", "evt-x")).isFalse();
+  }
+
+  @Test
+  @DisplayName("deleteCreatedBefore는 threshold 이전에 저장된 row만 삭제한다")
+  void delete_created_before_threshold() {
+    // given
+    inboxRepository.saveAndFlush(
+        InboxEntity.of("seat-group", "evt-old", "PerformanceCreatedEvent"));
+
+    // when & then: 과거 threshold면 아무것도 삭제되지 않는다
+    int deletedByPast = inboxRepository.deleteCreatedBefore(LocalDateTime.now().minusMinutes(1));
+    assertThat(deletedByPast).isZero();
+    assertThat(inboxRepository.existsByConsumerGroupAndEventId("seat-group", "evt-old")).isTrue();
+
+    // 미래 threshold면 방금 저장된 row가 삭제된다
+    int deletedByFuture = inboxRepository.deleteCreatedBefore(LocalDateTime.now().plusMinutes(1));
+    assertThat(deletedByFuture).isEqualTo(1);
+    assertThat(inboxRepository.existsByConsumerGroupAndEventId("seat-group", "evt-old")).isFalse();
+  }
+}

--- a/common/src/test/java/com/ticketrush/global/inbox/InboxServiceIntegrationTest.java
+++ b/common/src/test/java/com/ticketrush/global/inbox/InboxServiceIntegrationTest.java
@@ -1,0 +1,82 @@
+package com.ticketrush.global.inbox;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.ticketrush.global.event.DomainEventEnvelope;
+import com.ticketrush.global.jpa.config.JpaConfig;
+import java.time.Instant;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+/**
+ * 실제 트랜잭션·리포지토리로 {@link InboxService#runIfFirst}를 검증한다(mock이 아닌 실동작). 원자성 seam(비즈니스 콜백 + inbox 기록이
+ * 한 트랜잭션)을 실제 DB에서 확인한다.
+ */
+@DataJpaTest
+@Import({JpaConfig.class, InboxService.class})
+class InboxServiceIntegrationTest {
+
+  @Autowired private InboxService inboxService;
+
+  @Autowired private InboxRepository inboxRepository;
+
+  private static final String GROUP = "seat-group";
+
+  private DomainEventEnvelope envelope(String eventId) {
+    return new DomainEventEnvelope(
+        eventId, "BookingCanceledEvent", Instant.now(), "booking-canceled-topic", "payload", null);
+  }
+
+  @Test
+  @DisplayName("최초 수신이면 실제 트랜잭션에서 비즈니스를 실행하고 inbox row를 남기며 true를 반환한다")
+  void runIfFirst_processes_and_records_in_real_tx() {
+    // given
+    AtomicInteger runs = new AtomicInteger();
+
+    // when
+    boolean processed = inboxService.runIfFirst(GROUP, envelope("evt-1"), runs::incrementAndGet);
+
+    // then
+    assertThat(processed).isTrue();
+    assertThat(runs.get()).isEqualTo(1);
+    assertThat(inboxRepository.existsByConsumerGroupAndEventId(GROUP, "evt-1")).isTrue();
+  }
+
+  @Test
+  @DisplayName("같은 (group, eventId)를 다시 처리하면 inbox 기록으로 인해 비즈니스를 실행하지 않고 false를 반환한다")
+  void runIfFirst_skips_already_recorded() {
+    // given: 최초 처리로 inbox에 기록해 둔다
+    AtomicInteger runs = new AtomicInteger();
+    inboxService.runIfFirst(GROUP, envelope("evt-2"), runs::incrementAndGet);
+
+    // when: 동일 (group, eventId) 재처리
+    boolean processed = inboxService.runIfFirst(GROUP, envelope("evt-2"), runs::incrementAndGet);
+
+    // then: 두 번째는 스킵되어 비즈니스가 다시 실행되지 않는다
+    assertThat(processed).isFalse();
+    assertThat(runs.get()).isEqualTo(1);
+  }
+
+  @Test
+  @DisplayName("비즈니스가 예외를 던지면 예외가 전파되고 inbox에 기록되지 않는다")
+  void runIfFirst_does_not_record_when_business_fails() {
+    // when & then
+    assertThatThrownBy(
+            () ->
+                inboxService.runIfFirst(
+                    GROUP,
+                    envelope("evt-3"),
+                    () -> {
+                      throw new IllegalStateException("business 실패");
+                    }))
+        .isInstanceOf(IllegalStateException.class);
+
+    // then: 실패한 처리는 inbox에 남지 않아 재전달 시 재처리될 수 있다
+    assertThat(inboxRepository.existsByConsumerGroupAndEventId(GROUP, "evt-3")).isFalse();
+  }
+}

--- a/common/src/test/java/com/ticketrush/global/inbox/InboxServiceTest.java
+++ b/common/src/test/java/com/ticketrush/global/inbox/InboxServiceTest.java
@@ -1,0 +1,114 @@
+package com.ticketrush.global.inbox;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.ticketrush.global.event.DomainEventEnvelope;
+import java.time.Instant;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
+
+@ExtendWith(MockitoExtension.class)
+class InboxServiceTest {
+
+  @InjectMocks private InboxService inboxService;
+
+  @Mock private InboxRepository inboxRepository;
+
+  private static final String GROUP = "seat-group";
+
+  private DomainEventEnvelope envelope() {
+    return new DomainEventEnvelope(
+        "evt-1", "BookingCanceledEvent", Instant.now(), "booking-canceled-topic", "payload", null);
+  }
+
+  @Test
+  @DisplayName("최초 수신이면 business를 실행하고 inbox에 기록한 뒤 true를 반환한다")
+  void runIfFirst_processes_when_new() {
+    // given
+    given(inboxRepository.existsByConsumerGroupAndEventId(GROUP, "evt-1")).willReturn(false);
+    AtomicBoolean ran = new AtomicBoolean(false);
+
+    // when
+    boolean processed = inboxService.runIfFirst(GROUP, envelope(), () -> ran.set(true));
+
+    // then
+    assertThat(processed).isTrue();
+    assertThat(ran).isTrue();
+    verify(inboxRepository).saveAndFlush(any(InboxEntity.class));
+  }
+
+  @Test
+  @DisplayName("이미 처리된 이벤트면 business를 실행하지 않고 기록도 하지 않으며 false를 반환한다")
+  void runIfFirst_skips_when_duplicate() {
+    // given
+    given(inboxRepository.existsByConsumerGroupAndEventId(GROUP, "evt-1")).willReturn(true);
+    AtomicBoolean ran = new AtomicBoolean(false);
+
+    // when
+    boolean processed = inboxService.runIfFirst(GROUP, envelope(), () -> ran.set(true));
+
+    // then
+    assertThat(processed).isFalse();
+    assertThat(ran).isFalse();
+    verify(inboxRepository, never()).saveAndFlush(any());
+  }
+
+  @Test
+  @DisplayName("business가 예외를 던지면 그대로 전파되고 inbox에 기록하지 않는다(롤백 유도)")
+  void runIfFirst_propagates_business_exception_without_recording() {
+    // given
+    given(inboxRepository.existsByConsumerGroupAndEventId(GROUP, "evt-1")).willReturn(false);
+
+    // when & then
+    assertThatThrownBy(
+            () ->
+                inboxService.runIfFirst(
+                    GROUP,
+                    envelope(),
+                    () -> {
+                      throw new IllegalStateException("business 실패");
+                    }))
+        .isInstanceOf(IllegalStateException.class);
+
+    verify(inboxRepository, never()).saveAndFlush(any());
+  }
+
+  @Test
+  @DisplayName("동시 중복으로 inbox unique가 경합하면 saveAndFlush의 DIVE를 DuplicateEventException으로 변환해 던진다")
+  void runIfFirst_translates_unique_violation_to_duplicate_event() {
+    // given
+    given(inboxRepository.existsByConsumerGroupAndEventId(GROUP, "evt-1")).willReturn(false);
+    given(inboxRepository.saveAndFlush(any(InboxEntity.class)))
+        .willThrow(new DataIntegrityViolationException("duplicate (group,event_id)"));
+
+    // when & then: 리스너가 비즈니스 무결성 위반과 구분해 멱등 처리할 수 있도록 전용 예외로 변환한다
+    assertThatThrownBy(() -> inboxService.runIfFirst(GROUP, envelope(), () -> {}))
+        .isInstanceOf(DuplicateEventException.class);
+  }
+
+  @Test
+  @DisplayName("consumer_group과 eventId로 중복 여부를 조회한다")
+  void runIfFirst_checks_by_group_and_event_id() {
+    // given
+    given(inboxRepository.existsByConsumerGroupAndEventId(anyString(), anyString()))
+        .willReturn(false);
+
+    // when
+    inboxService.runIfFirst(GROUP, envelope(), () -> {});
+
+    // then
+    verify(inboxRepository).existsByConsumerGroupAndEventId(GROUP, "evt-1");
+  }
+}

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/in/eventlistener/BookingExpiredEventListener.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/in/eventlistener/BookingExpiredEventListener.java
@@ -4,8 +4,11 @@ import com.ticketrush.boundedcontext.payment.app.facade.PaymentFacade;
 import com.ticketrush.global.event.DomainEventEnvelope;
 import com.ticketrush.global.event.KafkaConsumerErrorPolicy;
 import com.ticketrush.global.event.KafkaConsumerGroup;
+import com.ticketrush.global.inbox.DuplicateEventException;
+import com.ticketrush.global.inbox.InboxService;
 import com.ticketrush.global.json.JsonConverter;
 import com.ticketrush.shared.booking.event.BookingExpiredEvent;
+import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -25,6 +28,7 @@ public class BookingExpiredEventListener {
 
   private final PaymentFacade paymentFacade;
   private final JsonConverter jsonConverter;
+  private final InboxService inboxService;
 
   @KafkaListener(topics = BookingExpiredEvent.TOPIC, groupId = KafkaConsumerGroup.PAYMENT)
   public void handleBookingExpired(@Payload DomainEventEnvelope envelope, Acknowledgment ack) {
@@ -32,15 +36,35 @@ public class BookingExpiredEventListener {
 
     try {
       event = jsonConverter.deserialize(envelope.payload(), BookingExpiredEvent.class);
-      paymentFacade.registerExpiredBooking(event.bookingId(), event.expiredAt());
+      final Long bookingId = event.bookingId();
+      final LocalDateTime expiredAt = event.expiredAt();
+
+      // Inbox로 중복 처리를 방지한다(#110). 최초 수신일 때만 등록하고 처리와 Inbox 기록을 한 트랜잭션으로 묶는다.
+      boolean processed =
+          inboxService.runIfFirst(
+              KafkaConsumerGroup.PAYMENT,
+              envelope,
+              () -> paymentFacade.registerExpiredBooking(bookingId, expiredAt));
+
+      if (!processed) {
+        log.info(
+            "이미 처리된 만료 booking 이벤트(inbox 중복 스킵). eventId: {}, bookingId: {}",
+            envelope.eventId(),
+            bookingId);
+      }
 
       // 성공 시에만 오프셋을 커밋한다(#269 표준).
       ack.acknowledge();
+    } catch (DuplicateEventException e) {
+      // inbox unique 경합(동시 중복 수신) → 멱등(중복) 정상으로 간주하고 커밋한다(#110).
+      log.info("동시 중복 수신(inbox unique 경합). eventId: {}", envelope.eventId());
+      ack.acknowledge();
     } catch (DataIntegrityViolationException e) {
-      // bookingId unique 제약 위반 = 이미 등록된 만료 booking의 중복 수신.
-      // 멱등 결과(정상)로 간주하고 ack 하여 불필요한 Kafka 재처리를 막는다.
+      // bookingId unique 위반 = 이미 등록된 만료 booking의 (동시) 중복 수신(#224). 멱등 정상으로 간주하고 ack 한다.
       log.info(
-          "이미 등록된 만료 booking 이벤트(중복 수신). bookingId: {}", event != null ? event.bookingId() : null);
+          "이미 등록된 만료 booking 이벤트(중복 수신). eventId: {}, bookingId: {}",
+          envelope.eventId(),
+          event != null ? event.bookingId() : null);
       ack.acknowledge();
     } catch (Exception e) {
       // #269 표준: 영구(비즈니스/결정적) 실패는 로그 후 ack, 일시(인프라) 실패는 re-throw 하여 재시도→DLT로 보존.

--- a/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/in/eventlistener/BookingExpiredEventListenerTest.java
+++ b/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/in/eventlistener/BookingExpiredEventListenerTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.never;
@@ -11,7 +12,10 @@ import static org.mockito.Mockito.verify;
 
 import com.ticketrush.boundedcontext.payment.app.facade.PaymentFacade;
 import com.ticketrush.global.event.DomainEventEnvelope;
+import com.ticketrush.global.event.KafkaConsumerGroup;
 import com.ticketrush.global.exception.BusinessException;
+import com.ticketrush.global.inbox.DuplicateEventException;
+import com.ticketrush.global.inbox.InboxService;
 import com.ticketrush.global.json.JsonConverter;
 import com.ticketrush.global.status.ErrorStatus;
 import com.ticketrush.shared.booking.event.BookingExpiredEvent;
@@ -35,53 +39,86 @@ class BookingExpiredEventListenerTest {
 
   @Mock private JsonConverter jsonConverter;
 
+  @Mock private InboxService inboxService;
+
   @Mock private Acknowledgment acknowledgment;
 
+  private static final Long BOOKING_ID = 100L;
+  private static final LocalDateTime EXPIRED_AT = LocalDateTime.of(2026, 6, 21, 10, 0);
+  private static final String PAYLOAD = "{\"bookingId\":100,\"expiredAt\":\"2026-06-21T10:00:00\"}";
+
+  private DomainEventEnvelope envelope(String payload) {
+    return new DomainEventEnvelope(
+        "event-id",
+        BookingExpiredEvent.EVENT_NAME,
+        Instant.now(),
+        BookingExpiredEvent.TOPIC,
+        payload,
+        null);
+  }
+
+  private BookingExpiredEvent event() {
+    return new BookingExpiredEvent(BOOKING_ID, EXPIRED_AT);
+  }
+
+  /** Inbox가 최초 수신으로 판정해 비즈니스 콜백을 실행하고 true를 반환하도록 스텁한다. */
+  private void givenInboxProcessesFirst() {
+    given(
+            inboxService.runIfFirst(
+                eq(KafkaConsumerGroup.PAYMENT),
+                any(DomainEventEnvelope.class),
+                any(Runnable.class)))
+        .willAnswer(
+            invocation -> {
+              invocation.getArgument(2, Runnable.class).run();
+              return true;
+            });
+  }
+
   @Test
-  @DisplayName("예매 만료 이벤트를 수신하면 만료 booking 등록을 요청하고 오프셋을 커밋한다")
+  @DisplayName("최초 수신이면 만료 booking 등록을 요청하고 오프셋을 커밋한다")
   void handleBookingExpired() {
     // given
-    Long bookingId = 100L;
-    LocalDateTime expiredAt = LocalDateTime.of(2026, 6, 21, 10, 0);
-    String payload = "{\"bookingId\":100,\"expiredAt\":\"2026-06-21T10:00:00\"}";
-    DomainEventEnvelope envelope =
-        new DomainEventEnvelope(
-            "event-id",
-            BookingExpiredEvent.EVENT_NAME,
-            Instant.now(),
-            BookingExpiredEvent.TOPIC,
-            payload,
-            null);
-    BookingExpiredEvent event = new BookingExpiredEvent(bookingId, expiredAt);
-
-    given(jsonConverter.deserialize(payload, BookingExpiredEvent.class)).willReturn(event);
+    given(jsonConverter.deserialize(PAYLOAD, BookingExpiredEvent.class)).willReturn(event());
+    givenInboxProcessesFirst();
 
     // when
-    listener.handleBookingExpired(envelope, acknowledgment);
+    listener.handleBookingExpired(envelope(PAYLOAD), acknowledgment);
 
     // then
-    verify(paymentFacade).registerExpiredBooking(bookingId, expiredAt);
+    verify(paymentFacade).registerExpiredBooking(BOOKING_ID, EXPIRED_AT);
     verify(acknowledgment).acknowledge();
   }
 
   @Test
-  @DisplayName("처리 중 예외가 발생하면 오프셋을 커밋하지 않고 예외를 전파한다")
-  void handleBookingExpired_propagates_on_error() {
+  @DisplayName("이미 처리된 이벤트(inbox 중복)면 등록을 실행하지 않고 오프셋만 커밋한다")
+  void handleBookingExpired_skips_duplicate() {
     // given
-    String payload = "broken";
-    DomainEventEnvelope envelope =
-        new DomainEventEnvelope(
-            "event-id",
-            BookingExpiredEvent.EVENT_NAME,
-            Instant.now(),
-            BookingExpiredEvent.TOPIC,
-            payload,
-            null);
-    given(jsonConverter.deserialize(payload, BookingExpiredEvent.class))
+    given(jsonConverter.deserialize(PAYLOAD, BookingExpiredEvent.class)).willReturn(event());
+    given(
+            inboxService.runIfFirst(
+                eq(KafkaConsumerGroup.PAYMENT),
+                any(DomainEventEnvelope.class),
+                any(Runnable.class)))
+        .willReturn(false);
+
+    // when
+    listener.handleBookingExpired(envelope(PAYLOAD), acknowledgment);
+
+    // then
+    verify(paymentFacade, never()).registerExpiredBooking(anyLong(), any());
+    verify(acknowledgment).acknowledge();
+  }
+
+  @Test
+  @DisplayName("처리 중 역직렬화 예외(일시)가 발생하면 오프셋을 커밋하지 않고 예외를 전파한다")
+  void handleBookingExpired_propagates_on_error() {
+    // given: 역직렬화는 inbox 이전 단계라 inbox 스텁이 필요 없다
+    given(jsonConverter.deserialize("broken", BookingExpiredEvent.class))
         .willThrow(new RuntimeException("deserialize 실패"));
 
     // when & then
-    assertThatThrownBy(() -> listener.handleBookingExpired(envelope, acknowledgment))
+    assertThatThrownBy(() -> listener.handleBookingExpired(envelope("broken"), acknowledgment))
         .isInstanceOf(RuntimeException.class);
 
     verify(paymentFacade, never()).registerExpiredBooking(anyLong(), any());
@@ -89,29 +126,40 @@ class BookingExpiredEventListenerTest {
   }
 
   @Test
-  @DisplayName("이미 등록된 만료 booking(unique 제약 위반)은 중복으로 간주하고 정상 ack 한다")
+  @DisplayName("이미 등록된 만료 booking(unique 위반, DIVE)은 중복으로 간주하고 정상 ack 한다")
   void handleBookingExpired_acks_on_duplicate() {
-    // given
-    Long bookingId = 100L;
-    LocalDateTime expiredAt = LocalDateTime.of(2026, 6, 21, 10, 0);
-    String payload = "{\"bookingId\":100,\"expiredAt\":\"2026-06-21T10:00:00\"}";
-    DomainEventEnvelope envelope =
-        new DomainEventEnvelope(
-            "event-id",
-            BookingExpiredEvent.EVENT_NAME,
-            Instant.now(),
-            BookingExpiredEvent.TOPIC,
-            payload,
-            null);
-    BookingExpiredEvent event = new BookingExpiredEvent(bookingId, expiredAt);
-
-    given(jsonConverter.deserialize(payload, BookingExpiredEvent.class)).willReturn(event);
+    // given: 등록 시 bookingId unique 위반이 발생(동시 중복)
+    given(jsonConverter.deserialize(PAYLOAD, BookingExpiredEvent.class)).willReturn(event());
+    givenInboxProcessesFirst();
     willThrow(new DataIntegrityViolationException("duplicate bookingId"))
         .given(paymentFacade)
-        .registerExpiredBooking(bookingId, expiredAt);
+        .registerExpiredBooking(BOOKING_ID, EXPIRED_AT);
 
     // when & then
-    assertThatCode(() -> listener.handleBookingExpired(envelope, acknowledgment))
+    assertThatCode(() -> listener.handleBookingExpired(envelope(PAYLOAD), acknowledgment))
+        .doesNotThrowAnyException();
+
+    verify(acknowledgment).acknowledge();
+  }
+
+  @Test
+  @DisplayName("동시 중복 수신으로 inbox unique가 경합하면(DuplicateEventException) 예외를 전파하지 않고 오프셋을 커밋한다")
+  void handleBookingExpired_acks_on_inbox_race() {
+    // given
+    given(jsonConverter.deserialize(PAYLOAD, BookingExpiredEvent.class)).willReturn(event());
+    given(
+            inboxService.runIfFirst(
+                eq(KafkaConsumerGroup.PAYMENT),
+                any(DomainEventEnvelope.class),
+                any(Runnable.class)))
+        .willThrow(
+            new DuplicateEventException(
+                KafkaConsumerGroup.PAYMENT,
+                "event-id",
+                new DataIntegrityViolationException("duplicate")));
+
+    // when & then
+    assertThatCode(() -> listener.handleBookingExpired(envelope(PAYLOAD), acknowledgment))
         .doesNotThrowAnyException();
 
     verify(acknowledgment).acknowledge();
@@ -121,26 +169,14 @@ class BookingExpiredEventListenerTest {
   @DisplayName("영구(비즈니스) 예외가 발생하면 예외를 전파하지 않고 오프셋을 커밋한다")
   void handleBookingExpired_acks_on_permanent_failure() {
     // given: BusinessException은 영구 실패로 분류되어 커밋된다(재시도 무의미)
-    Long bookingId = 100L;
-    LocalDateTime expiredAt = LocalDateTime.of(2026, 6, 21, 10, 0);
-    String payload = "{\"bookingId\":100,\"expiredAt\":\"2026-06-21T10:00:00\"}";
-    DomainEventEnvelope envelope =
-        new DomainEventEnvelope(
-            "event-id",
-            BookingExpiredEvent.EVENT_NAME,
-            Instant.now(),
-            BookingExpiredEvent.TOPIC,
-            payload,
-            null);
-    BookingExpiredEvent event = new BookingExpiredEvent(bookingId, expiredAt);
-
-    given(jsonConverter.deserialize(payload, BookingExpiredEvent.class)).willReturn(event);
+    given(jsonConverter.deserialize(PAYLOAD, BookingExpiredEvent.class)).willReturn(event());
+    givenInboxProcessesFirst();
     willThrow(new BusinessException(ErrorStatus.PAYMENT_NOT_FOUND))
         .given(paymentFacade)
-        .registerExpiredBooking(bookingId, expiredAt);
+        .registerExpiredBooking(BOOKING_ID, EXPIRED_AT);
 
     // when & then
-    assertThatCode(() -> listener.handleBookingExpired(envelope, acknowledgment))
+    assertThatCode(() -> listener.handleBookingExpired(envelope(PAYLOAD), acknowledgment))
         .doesNotThrowAnyException();
 
     verify(acknowledgment).acknowledge();

--- a/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/in/eventlistener/BookingCanceledEventListener.java
+++ b/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/in/eventlistener/BookingCanceledEventListener.java
@@ -4,6 +4,8 @@ import com.ticketrush.boundedcontext.seat.app.facade.SeatFacade;
 import com.ticketrush.global.event.DomainEventEnvelope;
 import com.ticketrush.global.event.KafkaConsumerErrorPolicy;
 import com.ticketrush.global.event.KafkaConsumerGroup;
+import com.ticketrush.global.inbox.DuplicateEventException;
+import com.ticketrush.global.inbox.InboxService;
 import com.ticketrush.global.json.JsonConverter;
 import com.ticketrush.shared.booking.event.BookingCanceledEvent;
 import lombok.RequiredArgsConstructor;
@@ -20,6 +22,7 @@ public class BookingCanceledEventListener {
 
   private final SeatFacade seatFacade;
   private final JsonConverter jsonConverter;
+  private final InboxService inboxService;
 
   @KafkaListener(topics = BookingCanceledEvent.TOPIC, groupId = KafkaConsumerGroup.SEAT)
   public void handleBookingCanceled(@Payload DomainEventEnvelope envelope, Acknowledgment ack) {
@@ -27,11 +30,30 @@ public class BookingCanceledEventListener {
 
     try {
       event = jsonConverter.deserialize(envelope.payload(), BookingCanceledEvent.class);
-      seatFacade.releaseBookedSeat(event.seatId(), event.bookingNumber());
+      final Long seatId = event.seatId();
+      final String bookingNumber = event.bookingNumber();
+
+      // Inbox로 중복 처리를 방지한다(#110). 최초 수신일 때만 좌석 반환을 수행하고 처리와 Inbox 기록을 한 트랜잭션으로 묶는다.
+      boolean processed =
+          inboxService.runIfFirst(
+              KafkaConsumerGroup.SEAT,
+              envelope,
+              () -> seatFacade.releaseBookedSeat(seatId, bookingNumber));
+
+      if (!processed) {
+        log.info(
+            "이미 처리된 예매 취소 이벤트(inbox 중복 스킵). eventId: {}, bookingId: {}",
+            envelope.eventId(),
+            event.bookingId());
+      }
 
       // 성공 시에만 오프셋을 커밋한다(#269 표준).
       ack.acknowledge();
 
+    } catch (DuplicateEventException e) {
+      // 동시 중복 수신으로 inbox unique가 경합함 → 멱등(중복) 정상으로 간주하고 커밋한다(#110).
+      log.info("동시 중복 수신(inbox unique 경합). eventId: {}", envelope.eventId());
+      ack.acknowledge();
     } catch (Exception e) {
       // #269 표준: 영구(비즈니스/결정적) 실패는 로그 후 ack, 일시(인프라) 실패는 re-throw 하여 재시도→DLT로 보존.
       Long bookingId = event != null ? event.bookingId() : null;

--- a/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/in/eventlistener/PerformanceCreatedEventListener.java
+++ b/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/in/eventlistener/PerformanceCreatedEventListener.java
@@ -4,6 +4,8 @@ import com.ticketrush.boundedcontext.seat.app.facade.SeatFacade;
 import com.ticketrush.global.event.DomainEventEnvelope;
 import com.ticketrush.global.event.KafkaConsumerErrorPolicy;
 import com.ticketrush.global.event.KafkaConsumerGroup;
+import com.ticketrush.global.inbox.DuplicateEventException;
+import com.ticketrush.global.inbox.InboxService;
 import com.ticketrush.global.json.JsonConverter;
 import com.ticketrush.shared.performance.event.PerformanceCreatedEvent;
 import lombok.RequiredArgsConstructor;
@@ -20,6 +22,7 @@ public class PerformanceCreatedEventListener {
 
   private final SeatFacade seatFacade;
   private final JsonConverter jsonConverter;
+  private final InboxService inboxService;
 
   @KafkaListener(topics = PerformanceCreatedEvent.TOPIC, groupId = KafkaConsumerGroup.SEAT)
   public void handlePerformanceCreated(@Payload DomainEventEnvelope envelope, Acknowledgment ack) {
@@ -32,10 +35,27 @@ public class PerformanceCreatedEventListener {
 
       PerformanceCreatedEvent event =
           jsonConverter.deserialize(envelope.payload(), PerformanceCreatedEvent.class);
+      final Long performanceId = event.performanceId();
 
-      seatFacade.createDefaultSeats(event.performanceId());
+      // Inbox로 중복 처리를 방지한다(#110). 최초 수신일 때만 기본 좌석을 생성하고 처리와 Inbox 기록을 한 트랜잭션으로 묶는다.
+      boolean processed =
+          inboxService.runIfFirst(
+              KafkaConsumerGroup.SEAT,
+              envelope,
+              () -> seatFacade.createDefaultSeats(performanceId));
+
+      if (!processed) {
+        log.info(
+            "이미 처리된 공연 생성 이벤트(inbox 중복 스킵). eventId: {}, performanceId: {}",
+            envelope.eventId(),
+            performanceId);
+      }
 
       // 성공 시에만 오프셋을 커밋한다(#269 표준).
+      ack.acknowledge();
+    } catch (DuplicateEventException e) {
+      // 동시 중복 수신으로 inbox unique가 경합함 → 멱등(중복) 정상으로 간주하고 커밋한다(#110).
+      log.info("동시 중복 수신(inbox unique 경합). eventId: {}", envelope.eventId());
       ack.acknowledge();
     } catch (Exception e) {
       // #269 표준: 영구(비즈니스/결정적) 실패는 로그 후 ack, 일시(인프라) 실패는 re-throw 하여 재시도→DLT로 보존.

--- a/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/in/eventlistener/BookingCanceledEventListenerTest.java
+++ b/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/in/eventlistener/BookingCanceledEventListenerTest.java
@@ -2,6 +2,10 @@ package com.ticketrush.boundedcontext.seat.in.eventlistener;
 
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.never;
@@ -9,7 +13,10 @@ import static org.mockito.Mockito.verify;
 
 import com.ticketrush.boundedcontext.seat.app.facade.SeatFacade;
 import com.ticketrush.global.event.DomainEventEnvelope;
+import com.ticketrush.global.event.KafkaConsumerGroup;
 import com.ticketrush.global.exception.BusinessException;
+import com.ticketrush.global.inbox.DuplicateEventException;
+import com.ticketrush.global.inbox.InboxService;
 import com.ticketrush.global.json.JsonConverter;
 import com.ticketrush.global.status.ErrorStatus;
 import com.ticketrush.shared.booking.event.BookingCanceledEvent;
@@ -21,6 +28,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.kafka.support.Acknowledgment;
 
 @ExtendWith(MockitoExtension.class)
@@ -31,6 +39,8 @@ class BookingCanceledEventListenerTest {
   @Mock private SeatFacade seatFacade;
 
   @Mock private JsonConverter jsonConverter;
+
+  @Mock private InboxService inboxService;
 
   @Mock private Acknowledgment acknowledgment;
 
@@ -53,12 +63,25 @@ class BookingCanceledEventListenerTest {
         10L, BOOKING_NUMBER, SEAT_ID, 4L, LocalDateTime.of(2026, 5, 22, 10, 30));
   }
 
+  /** Inbox가 최초 수신으로 판정해 비즈니스 콜백을 실행하고 true를 반환하도록 스텁한다. */
+  private void givenInboxProcessesFirst() {
+    given(
+            inboxService.runIfFirst(
+                eq(KafkaConsumerGroup.SEAT), any(DomainEventEnvelope.class), any(Runnable.class)))
+        .willAnswer(
+            invocation -> {
+              invocation.getArgument(2, Runnable.class).run();
+              return true;
+            });
+  }
+
   @Test
-  @DisplayName("예매 취소 이벤트를 수신하면 좌석을 반환하고 오프셋을 커밋한다")
+  @DisplayName("최초 수신이면 좌석을 반환하고 오프셋을 커밋한다")
   void handleBookingCanceled() {
     // given
-    DomainEventEnvelope envelope = envelope();
+    final DomainEventEnvelope envelope = envelope();
     given(jsonConverter.deserialize(PAYLOAD, BookingCanceledEvent.class)).willReturn(event());
+    givenInboxProcessesFirst();
 
     // when
     listener.handleBookingCanceled(envelope, acknowledgment);
@@ -69,11 +92,53 @@ class BookingCanceledEventListenerTest {
   }
 
   @Test
+  @DisplayName("이미 처리된 이벤트(inbox 중복)면 좌석 반환을 실행하지 않고 오프셋만 커밋한다")
+  void handleBookingCanceledSkipsDuplicate() {
+    // given
+    final DomainEventEnvelope envelope = envelope();
+    given(jsonConverter.deserialize(PAYLOAD, BookingCanceledEvent.class)).willReturn(event());
+    given(
+            inboxService.runIfFirst(
+                eq(KafkaConsumerGroup.SEAT), any(DomainEventEnvelope.class), any(Runnable.class)))
+        .willReturn(false);
+
+    // when
+    listener.handleBookingCanceled(envelope, acknowledgment);
+
+    // then
+    verify(seatFacade, never()).releaseBookedSeat(anyLong(), anyString());
+    verify(acknowledgment).acknowledge();
+  }
+
+  @Test
+  @DisplayName("동시 중복 수신으로 inbox unique가 경합하면(DIVE) 예외를 전파하지 않고 오프셋을 커밋한다")
+  void handleBookingCanceledAcksOnInboxRace() {
+    // given
+    final DomainEventEnvelope envelope = envelope();
+    given(jsonConverter.deserialize(PAYLOAD, BookingCanceledEvent.class)).willReturn(event());
+    given(
+            inboxService.runIfFirst(
+                eq(KafkaConsumerGroup.SEAT), any(DomainEventEnvelope.class), any(Runnable.class)))
+        .willThrow(
+            new DuplicateEventException(
+                KafkaConsumerGroup.SEAT,
+                "event-id",
+                new DataIntegrityViolationException("duplicate")));
+
+    // when & then
+    assertThatCode(() -> listener.handleBookingCanceled(envelope, acknowledgment))
+        .doesNotThrowAnyException();
+
+    verify(acknowledgment).acknowledge();
+  }
+
+  @Test
   @DisplayName("일시적(인프라) 예외가 발생하면 예외를 전파하고 오프셋을 커밋하지 않는다(재시도→DLT 위임)")
   void handleBookingCanceledRethrowsTransientFailure() {
     // given
-    DomainEventEnvelope envelope = envelope();
+    final DomainEventEnvelope envelope = envelope();
     given(jsonConverter.deserialize(PAYLOAD, BookingCanceledEvent.class)).willReturn(event());
+    givenInboxProcessesFirst();
     willThrow(new RuntimeException("DB 일시 장애"))
         .given(seatFacade)
         .releaseBookedSeat(SEAT_ID, BOOKING_NUMBER);
@@ -89,8 +154,9 @@ class BookingCanceledEventListenerTest {
   @DisplayName("영구(비즈니스) 예외가 발생하면 예외를 전파하지 않고 오프셋을 커밋한다")
   void handleBookingCanceledAcksPermanentFailure() {
     // given
-    DomainEventEnvelope envelope = envelope();
+    final DomainEventEnvelope envelope = envelope();
     given(jsonConverter.deserialize(PAYLOAD, BookingCanceledEvent.class)).willReturn(event());
+    givenInboxProcessesFirst();
     willThrow(new BusinessException(ErrorStatus.SEAT_NOT_FOUND))
         .given(seatFacade)
         .releaseBookedSeat(SEAT_ID, BOOKING_NUMBER);

--- a/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/in/eventlistener/PerformanceCreatedEventListenerTest.java
+++ b/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/in/eventlistener/PerformanceCreatedEventListenerTest.java
@@ -2,7 +2,9 @@ package com.ticketrush.boundedcontext.seat.in.eventlistener;
 
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.never;
@@ -10,7 +12,10 @@ import static org.mockito.Mockito.verify;
 
 import com.ticketrush.boundedcontext.seat.app.facade.SeatFacade;
 import com.ticketrush.global.event.DomainEventEnvelope;
+import com.ticketrush.global.event.KafkaConsumerGroup;
 import com.ticketrush.global.exception.BusinessException;
+import com.ticketrush.global.inbox.DuplicateEventException;
+import com.ticketrush.global.inbox.InboxService;
 import com.ticketrush.global.json.JsonConverter;
 import com.ticketrush.global.status.ErrorStatus;
 import com.ticketrush.shared.performance.event.PerformanceCreatedEvent;
@@ -23,6 +28,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.kafka.support.Acknowledgment;
 
 @ExtendWith(MockitoExtension.class)
@@ -34,35 +40,54 @@ class PerformanceCreatedEventListenerTest {
 
   @Mock private JsonConverter jsonConverter;
 
+  @Mock private InboxService inboxService;
+
   @Mock private Acknowledgment acknowledgment;
 
+  private static final Long PERFORMANCE_ID = 1L;
+  private static final String PAYLOAD = "{\"performance_id\":1}";
+
+  private DomainEventEnvelope envelope() {
+    return new DomainEventEnvelope(
+        "event-id", "PerformanceCreated", Instant.now(), "performance-events", PAYLOAD, null);
+  }
+
+  private PerformanceCreatedEvent event() {
+    return new PerformanceCreatedEvent(
+        PERFORMANCE_ID, "콘서트", 120, LocalDate.now(), LocalTime.of(19, 0), 50000L);
+  }
+
+  /** Inbox가 최초 수신으로 판정해 비즈니스 콜백을 실행하고 true를 반환하도록 스텁한다. */
+  private void givenInboxProcessesFirst() {
+    given(
+            inboxService.runIfFirst(
+                eq(KafkaConsumerGroup.SEAT), any(DomainEventEnvelope.class), any(Runnable.class)))
+        .willAnswer(
+            invocation -> {
+              invocation.getArgument(2, Runnable.class).run();
+              return true;
+            });
+  }
+
   @Test
-  @DisplayName("공연 생성 이벤트를 수신하면 기본 좌석 생성을 요청하고 오프셋을 커밋한다")
+  @DisplayName("최초 수신이면 기본 좌석 생성을 요청하고 오프셋을 커밋한다")
   void handlePerformanceCreated() {
     // given
-    Long performanceId = 1L;
-    String payload = "{\"performance_id\":1}";
-    DomainEventEnvelope envelope =
-        new DomainEventEnvelope(
-            "event-id", "PerformanceCreated", Instant.now(), "performance-events", payload, null);
-    PerformanceCreatedEvent event =
-        new PerformanceCreatedEvent(
-            performanceId, "콘서트", 120, LocalDate.now(), LocalTime.of(19, 0), 50000L);
-
-    given(jsonConverter.deserialize(payload, PerformanceCreatedEvent.class)).willReturn(event);
+    given(jsonConverter.deserialize(PAYLOAD, PerformanceCreatedEvent.class)).willReturn(event());
+    givenInboxProcessesFirst();
 
     // when
-    listener.handlePerformanceCreated(envelope, acknowledgment);
+    listener.handlePerformanceCreated(envelope(), acknowledgment);
 
     // then
-    verify(seatFacade).createDefaultSeats(performanceId);
+    verify(seatFacade).createDefaultSeats(PERFORMANCE_ID);
     verify(acknowledgment).acknowledge();
   }
 
   @Test
   @DisplayName("공연 생성 이벤트가 아니면 좌석을 생성하지 않고 오프셋만 커밋한다")
   void handlePerformanceCreatedIgnoresOtherEventTypes() {
-    // given
+    // given: eventType 필터에서 걸러지므로 inbox/역직렬화까지 가지 않는다
     DomainEventEnvelope envelope =
         new DomainEventEnvelope(
             "event-id", "PerformanceUpdated", Instant.now(), "performance-events", "{}", null);
@@ -76,22 +101,73 @@ class PerformanceCreatedEventListenerTest {
   }
 
   @Test
+  @DisplayName("이미 처리된 이벤트(inbox 중복)면 좌석 생성을 실행하지 않고 오프셋만 커밋한다")
+  void handlePerformanceCreatedSkipsDuplicate() {
+    // given
+    given(jsonConverter.deserialize(PAYLOAD, PerformanceCreatedEvent.class)).willReturn(event());
+    given(
+            inboxService.runIfFirst(
+                eq(KafkaConsumerGroup.SEAT), any(DomainEventEnvelope.class), any(Runnable.class)))
+        .willReturn(false);
+
+    // when
+    listener.handlePerformanceCreated(envelope(), acknowledgment);
+
+    // then
+    verify(seatFacade, never()).createDefaultSeats(anyLong());
+    verify(acknowledgment).acknowledge();
+  }
+
+  @Test
+  @DisplayName("동시 중복 수신으로 inbox unique가 경합하면(DIVE) 예외를 전파하지 않고 오프셋을 커밋한다")
+  void handlePerformanceCreatedAcksOnInboxRace() {
+    // given
+    given(jsonConverter.deserialize(PAYLOAD, PerformanceCreatedEvent.class)).willReturn(event());
+    given(
+            inboxService.runIfFirst(
+                eq(KafkaConsumerGroup.SEAT), any(DomainEventEnvelope.class), any(Runnable.class)))
+        .willThrow(
+            new DuplicateEventException(
+                KafkaConsumerGroup.SEAT,
+                "event-id",
+                new DataIntegrityViolationException("duplicate")));
+
+    // when & then
+    assertThatCode(() -> listener.handlePerformanceCreated(envelope(), acknowledgment))
+        .doesNotThrowAnyException();
+
+    verify(acknowledgment).acknowledge();
+  }
+
+  @Test
+  @DisplayName("비즈니스 무결성 위반(DIVE)은 inbox 경합이 아니므로 삼키지 않고 전파한다(재시도→DLT 위임)")
+  void handlePerformanceCreatedRethrowsBusinessDataIntegrityViolation() {
+    // given: 비즈니스가 던진 DIVE는 DuplicateEventException이 아니므로 #269 일시 분기로 흘러 보존되어야 한다(유실 금지)
+    given(jsonConverter.deserialize(PAYLOAD, PerformanceCreatedEvent.class)).willReturn(event());
+    givenInboxProcessesFirst();
+    willThrow(new DataIntegrityViolationException("좌석 무결성 위반"))
+        .given(seatFacade)
+        .createDefaultSeats(PERFORMANCE_ID);
+
+    // when & then
+    assertThatThrownBy(() -> listener.handlePerformanceCreated(envelope(), acknowledgment))
+        .isInstanceOf(DataIntegrityViolationException.class);
+
+    verify(acknowledgment, never()).acknowledge();
+  }
+
+  @Test
   @DisplayName("일시적(인프라) 예외가 발생하면 예외를 전파하고 오프셋을 커밋하지 않는다(재시도→DLT 위임)")
   void handlePerformanceCreatedRethrowsTransientFailure() {
     // given
-    Long performanceId = 1L;
-    String payload = "{\"performance_id\":1}";
-    DomainEventEnvelope envelope =
-        new DomainEventEnvelope(
-            "event-id", "PerformanceCreated", Instant.now(), "performance-events", payload, null);
-    PerformanceCreatedEvent event =
-        new PerformanceCreatedEvent(
-            performanceId, "콘서트", 120, LocalDate.now(), LocalTime.of(19, 0), 50000L);
-    given(jsonConverter.deserialize(payload, PerformanceCreatedEvent.class)).willReturn(event);
-    willThrow(new RuntimeException("DB 일시 장애")).given(seatFacade).createDefaultSeats(performanceId);
+    given(jsonConverter.deserialize(PAYLOAD, PerformanceCreatedEvent.class)).willReturn(event());
+    givenInboxProcessesFirst();
+    willThrow(new RuntimeException("DB 일시 장애"))
+        .given(seatFacade)
+        .createDefaultSeats(PERFORMANCE_ID);
 
     // when & then
-    assertThatThrownBy(() -> listener.handlePerformanceCreated(envelope, acknowledgment))
+    assertThatThrownBy(() -> listener.handlePerformanceCreated(envelope(), acknowledgment))
         .isInstanceOf(RuntimeException.class);
 
     verify(acknowledgment, never()).acknowledge();
@@ -101,21 +177,14 @@ class PerformanceCreatedEventListenerTest {
   @DisplayName("영구(비즈니스) 예외가 발생하면 예외를 전파하지 않고 오프셋을 커밋한다")
   void handlePerformanceCreatedAcksPermanentFailure() {
     // given
-    Long performanceId = 1L;
-    String payload = "{\"performance_id\":1}";
-    DomainEventEnvelope envelope =
-        new DomainEventEnvelope(
-            "event-id", "PerformanceCreated", Instant.now(), "performance-events", payload, null);
-    PerformanceCreatedEvent event =
-        new PerformanceCreatedEvent(
-            performanceId, "콘서트", 120, LocalDate.now(), LocalTime.of(19, 0), 50000L);
-    given(jsonConverter.deserialize(payload, PerformanceCreatedEvent.class)).willReturn(event);
+    given(jsonConverter.deserialize(PAYLOAD, PerformanceCreatedEvent.class)).willReturn(event());
+    givenInboxProcessesFirst();
     willThrow(new BusinessException(ErrorStatus.PERFORMANCE_NOT_FOUND))
         .given(seatFacade)
-        .createDefaultSeats(performanceId);
+        .createDefaultSeats(PERFORMANCE_ID);
 
     // when & then
-    assertThatCode(() -> listener.handlePerformanceCreated(envelope, acknowledgment))
+    assertThatCode(() -> listener.handlePerformanceCreated(envelope(), acknowledgment))
         .doesNotThrowAnyException();
 
     verify(acknowledgment).acknowledge();

--- a/ticket-service/src/main/java/com/ticketrush/boundedcontext/ticket/in/eventlistener/PaymentCanceledEventListener.java
+++ b/ticket-service/src/main/java/com/ticketrush/boundedcontext/ticket/in/eventlistener/PaymentCanceledEventListener.java
@@ -4,6 +4,8 @@ import com.ticketrush.boundedcontext.ticket.app.usecase.TicketCancelUseCase;
 import com.ticketrush.global.event.DomainEventEnvelope;
 import com.ticketrush.global.event.KafkaConsumerErrorPolicy;
 import com.ticketrush.global.event.KafkaConsumerGroup;
+import com.ticketrush.global.inbox.DuplicateEventException;
+import com.ticketrush.global.inbox.InboxService;
 import com.ticketrush.global.json.JsonConverter;
 import com.ticketrush.shared.payment.event.PaymentCanceledEvent;
 import lombok.RequiredArgsConstructor;
@@ -20,6 +22,7 @@ public class PaymentCanceledEventListener {
 
   private final TicketCancelUseCase ticketCancelUseCase;
   private final JsonConverter jsonConverter;
+  private final InboxService inboxService;
 
   @KafkaListener(topics = PaymentCanceledEvent.TOPIC, groupId = KafkaConsumerGroup.TICKET)
   public void handlePaymentCanceled(@Payload DomainEventEnvelope envelope, Acknowledgment ack) {
@@ -28,18 +31,32 @@ public class PaymentCanceledEventListener {
 
     try {
       event = jsonConverter.deserialize(envelope.payload(), PaymentCanceledEvent.class);
+      final Long bookingId = event.bookingId();
 
-      log.info("결제 취소 이벤트 수신. 입장권 취소 처리. bookingId: {}", event.bookingId());
+      log.info("결제 취소 이벤트 수신. 입장권 취소 처리. bookingId: {}", bookingId);
 
-      // 입장권 취소에는 bookingId만 사용한다.
-      // 중복 수신/USED 등 비정상 케이스는 TicketCancelUseCase가 멱등하게(로그만) 처리한다.
-      ticketCancelUseCase.execute(event.bookingId());
+      // Inbox로 중복 처리를 방지한다(#110). 최초 수신일 때만 취소를 수행하고 처리와 Inbox 기록을 한 트랜잭션으로 묶는다.
+      // 입장권 취소에는 bookingId만 사용한다. USED 등 비정상 케이스는 TicketCancelUseCase가 멱등하게(로그만) 처리한다.
+      boolean processed =
+          inboxService.runIfFirst(
+              KafkaConsumerGroup.TICKET, envelope, () -> ticketCancelUseCase.execute(bookingId));
 
-      log.info("입장권 취소 처리 완료. bookingId: {}", event.bookingId());
+      if (processed) {
+        log.info("입장권 취소 처리 완료. bookingId: {}", bookingId);
+      } else {
+        log.info(
+            "이미 처리된 결제 취소 이벤트(inbox 중복 스킵). eventId: {}, bookingId: {}",
+            envelope.eventId(),
+            bookingId);
+      }
 
       // 성공 시에만 오프셋을 커밋한다(#269 표준).
       ack.acknowledge();
 
+    } catch (DuplicateEventException e) {
+      // 동시 중복 수신으로 inbox unique가 경합함 → 멱등(중복) 정상으로 간주하고 커밋한다(#110).
+      log.info("동시 중복 수신(inbox unique 경합). eventId: {}", envelope.eventId());
+      ack.acknowledge();
     } catch (Exception e) {
       // #269 표준: 영구(비즈니스/결정적) 실패는 로그 후 ack, 일시(인프라) 실패는 re-throw 하여 재시도→DLT로 보존.
       // 역직렬화 실패 시 event가 null이라 bookingId를 못 얻으므로, 항상 살아있는

--- a/ticket-service/src/test/java/com/ticketrush/boundedcontext/ticket/in/eventlistener/PaymentCanceledEventListenerTest.java
+++ b/ticket-service/src/test/java/com/ticketrush/boundedcontext/ticket/in/eventlistener/PaymentCanceledEventListenerTest.java
@@ -2,14 +2,20 @@ package com.ticketrush.boundedcontext.ticket.in.eventlistener;
 
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 import com.ticketrush.boundedcontext.ticket.app.usecase.TicketCancelUseCase;
 import com.ticketrush.global.event.DomainEventEnvelope;
+import com.ticketrush.global.event.KafkaConsumerGroup;
 import com.ticketrush.global.exception.BusinessException;
+import com.ticketrush.global.inbox.DuplicateEventException;
+import com.ticketrush.global.inbox.InboxService;
 import com.ticketrush.global.json.DeserializationException;
 import com.ticketrush.global.json.JsonConverter;
 import com.ticketrush.global.status.ErrorStatus;
@@ -19,10 +25,10 @@ import java.time.LocalDateTime;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.BDDMockito;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.kafka.support.Acknowledgment;
 
 @ExtendWith(MockitoExtension.class)
@@ -33,6 +39,8 @@ class PaymentCanceledEventListenerTest {
   @Mock private TicketCancelUseCase ticketCancelUseCase;
 
   @Mock private JsonConverter jsonConverter;
+
+  @Mock private InboxService inboxService;
 
   @Mock private Acknowledgment acknowledgment;
 
@@ -55,13 +63,25 @@ class PaymentCanceledEventListenerTest {
         1L, BOOKING_ID, 3L, 4L, 50000L, "단순 변심", LocalDateTime.of(2026, 5, 22, 10, 30));
   }
 
+  /** Inbox가 최초 수신으로 판정해 비즈니스 콜백을 실행하고 true를 반환하도록 스텁한다. */
+  private void givenInboxProcessesFirst() {
+    given(
+            inboxService.runIfFirst(
+                eq(KafkaConsumerGroup.TICKET), any(DomainEventEnvelope.class), any(Runnable.class)))
+        .willAnswer(
+            invocation -> {
+              invocation.getArgument(2, Runnable.class).run();
+              return true;
+            });
+  }
+
   @Test
-  @DisplayName("결제 취소 이벤트를 수신하면 해당 bookingId로 입장권을 취소하고 오프셋을 커밋한다")
+  @DisplayName("최초 수신이면 해당 bookingId로 입장권을 취소하고 오프셋을 커밋한다")
   void handlePaymentCanceled() {
     // given
-    DomainEventEnvelope envelope = envelope();
-    BDDMockito.given(jsonConverter.deserialize(PAYLOAD, PaymentCanceledEvent.class))
-        .willReturn(event());
+    final DomainEventEnvelope envelope = envelope();
+    given(jsonConverter.deserialize(PAYLOAD, PaymentCanceledEvent.class)).willReturn(event());
+    givenInboxProcessesFirst();
 
     // when
     listener.handlePaymentCanceled(envelope, acknowledgment);
@@ -72,12 +92,53 @@ class PaymentCanceledEventListenerTest {
   }
 
   @Test
+  @DisplayName("이미 처리된 이벤트(inbox 중복)면 비즈니스 로직을 실행하지 않고 오프셋만 커밋한다")
+  void handlePaymentCanceledSkipsDuplicate() {
+    // given: Inbox가 이미 처리됨으로 판정 → 콜백 미실행, false 반환
+    final DomainEventEnvelope envelope = envelope();
+    given(jsonConverter.deserialize(PAYLOAD, PaymentCanceledEvent.class)).willReturn(event());
+    given(
+            inboxService.runIfFirst(
+                eq(KafkaConsumerGroup.TICKET), any(DomainEventEnvelope.class), any(Runnable.class)))
+        .willReturn(false);
+
+    // when
+    listener.handlePaymentCanceled(envelope, acknowledgment);
+
+    // then
+    verify(ticketCancelUseCase, never()).execute(anyLong());
+    verify(acknowledgment).acknowledge();
+  }
+
+  @Test
+  @DisplayName("동시 중복 수신으로 inbox unique가 경합하면(DIVE) 예외를 전파하지 않고 오프셋을 커밋한다")
+  void handlePaymentCanceledAcksOnInboxRace() {
+    // given
+    final DomainEventEnvelope envelope = envelope();
+    given(jsonConverter.deserialize(PAYLOAD, PaymentCanceledEvent.class)).willReturn(event());
+    given(
+            inboxService.runIfFirst(
+                eq(KafkaConsumerGroup.TICKET), any(DomainEventEnvelope.class), any(Runnable.class)))
+        .willThrow(
+            new DuplicateEventException(
+                KafkaConsumerGroup.TICKET,
+                "event-id",
+                new DataIntegrityViolationException("duplicate")));
+
+    // when & then
+    assertThatCode(() -> listener.handlePaymentCanceled(envelope, acknowledgment))
+        .doesNotThrowAnyException();
+
+    verify(acknowledgment).acknowledge();
+  }
+
+  @Test
   @DisplayName("일시적(인프라) 예외가 발생하면 예외를 전파하고 오프셋을 커밋하지 않는다(재시도→DLT 위임)")
   void handlePaymentCanceledRethrowsTransientFailure() {
     // given: 일반 RuntimeException은 일시 실패로 분류된다
-    DomainEventEnvelope envelope = envelope();
-    BDDMockito.given(jsonConverter.deserialize(PAYLOAD, PaymentCanceledEvent.class))
-        .willReturn(event());
+    final DomainEventEnvelope envelope = envelope();
+    given(jsonConverter.deserialize(PAYLOAD, PaymentCanceledEvent.class)).willReturn(event());
+    givenInboxProcessesFirst();
     willThrow(new RuntimeException("DB 일시 장애")).given(ticketCancelUseCase).execute(BOOKING_ID);
 
     // when & then: 일시 실패는 리스너 밖으로 전파되어 컨테이너 재시도→DLT 파이프라인을 태운다
@@ -93,9 +154,9 @@ class PaymentCanceledEventListenerTest {
   @DisplayName("영구(비즈니스) 예외가 발생하면 예외를 전파하지 않고 오프셋을 커밋한다")
   void handlePaymentCanceledAcksPermanentFailure() {
     // given: BusinessException은 영구 실패로 분류된다(재시도 무의미)
-    DomainEventEnvelope envelope = envelope();
-    BDDMockito.given(jsonConverter.deserialize(PAYLOAD, PaymentCanceledEvent.class))
-        .willReturn(event());
+    final DomainEventEnvelope envelope = envelope();
+    given(jsonConverter.deserialize(PAYLOAD, PaymentCanceledEvent.class)).willReturn(event());
+    givenInboxProcessesFirst();
     willThrow(new BusinessException(ErrorStatus.TICKET_NOT_FOUND))
         .given(ticketCancelUseCase)
         .execute(BOOKING_ID);
@@ -113,8 +174,8 @@ class PaymentCanceledEventListenerTest {
   @DisplayName("이벤트 역직렬화에 실패해도 예외를 전파하지 않고 오프셋을 커밋한다")
   void handlePaymentCanceledSwallowsDeserializationException() {
     // given: 실제 JsonConverter가 변환 실패 시 던지는 예외 타입으로 스텁한다
-    DomainEventEnvelope envelope = envelope();
-    BDDMockito.given(jsonConverter.deserialize(PAYLOAD, PaymentCanceledEvent.class))
+    final DomainEventEnvelope envelope = envelope();
+    given(jsonConverter.deserialize(PAYLOAD, PaymentCanceledEvent.class))
         .willThrow(new DeserializationException(new RuntimeException("broken payload")));
 
     // when & then: 예외를 리스너 밖으로 전파하지 않는다


### PR DESCRIPTION
## 🔗 관련 이슈

- close #110

---

## 📌 주요 변경 사항

- Kafka `event_id` 기반 **Inbox 패턴**으로 중복 이벤트의 "한 번만 처리" 보장(at-least-once 대응)
- 비즈니스 처리와 Inbox 기록을 **하나의 트랜잭션**으로 원자화
- 멀티컨슈머 공유 스키마 대비 **`(consumer_group, event_id)` 복합 unique**로 그룹별 독립 멱등
- 깨끗한 5개 컨슈머에 적용, 기존 DB-unique 멱등은 유지(방어 심층화)

---

## 🛠 상세 구현 내용

- **공통 신설** `common/global/inbox`: `InboxEntity`(`AutoIdBaseEntity` 상속, `(consumer_group, event_id)` 복합 unique, `processed_at`은 `createdAt`으로 대체 — #9 컨벤션), `InboxRepository`(`existsByConsumerGroupAndEventId`, retention용 `deleteCreatedBefore`), `InboxService.runIfFirst(group, envelope, 비즈니스콜백)`, `DuplicateEventException`.
- **원자성**: 리스너엔 tx가 없고 `runIfFirst`가 `@Transactional`로 tx를 열어 usecase(@Transactional REQUIRED)를 콜백으로 조인 → 처리+기록이 한 커밋/롤백. 동시 중복은 unique 경합→롤백→한쪽만 커밋.
- **복합 키 근거**: `PaymentConfirmedEvent`를 ticket·booking 두 그룹이 같은 `eventId`로 소비 + 로컬 단일 스키마 공유 → `event_id` 단독이면 한 그룹 처리 후 다른 그룹이 스킵되는 버그. 그룹까지 묶어 해결.
- **적용 5개**: ticket `PaymentCanceled`, booking `SeatHoldFailed`, seat `BookingCanceled`·`PerformanceCreated`, payment `BookingExpired`.
- **유실 방지**: inbox 경합만 `DuplicateEventException`으로 ack, 그 외 비즈니스 무결성 위반(DIVE 등)은 삼키지 않고 #269 표준(일시→재시도→DLT)으로 보존.
- **제외 3개**(기존 멱등 유지 + 후속 이슈): ticket/booking `PaymentConfirmed`(REQUIRES_NEW·커밋 후 SOLD HTTP), seat `BookingCreated`(Redis/Redisson 혼합).

---

## ✅ 테스트

### 테스트 방법

- 신규: `InboxRepositoryTest`(복합 unique 위반·다른 group 동일 eventId 둘 다 저장·`existsBy`·retention), `InboxServiceTest`(mock: 최초/중복/business 예외/경합→DuplicateEventException), `InboxServiceIntegrationTest`(`@DataJpaTest` 실 트랜잭션: 처리+기록, 중복 스킵, 실패 시 미기록).
- 리스너 5개 테스트 갱신: 최초→처리+ack, inbox 중복→미처리+ack, 경합(DuplicateEventException)→ack, 비즈니스 DIVE→전파(유실 금지), #269 일시/영구 분기 유지.
- 실행: `./gradlew :common:test :ticket-service:test :booking-service:test :seat-service:test :payment-service:test spotlessCheck checkstyleMain checkstyleTest`

### 테스트 결과

- 5개 모듈 `test` + `spotlessCheck` + `checkstyle` **BUILD SUCCESSFUL**
<!--
### 📸 스크린샷

- 
-->
---

## 👀 리뷰 요청 사항

- `(consumer_group, event_id)` 복합 키 결정(멀티컨슈머 대응)과 `processed_at`→`createdAt` 대체가 팀 컨벤션과 맞는지 확인 부탁드립니다.
- `InboxService.runIfFirst` 콜백-트랜잭션 조인 방식(리스너 tx 없음 전제) 검토 부탁드립니다.
- 후속(별도 이슈 제안): 제외 3개 리스너 Inbox 이관(seat는 Outbox 도입 후) / Inbox retention 스케줄러(공유 스키마 무한 증가 대비, `deleteCreatedBefore`는 준비됨).

---

## ⚠️ 배포 시 주의사항

- `inbox` 테이블이 ddl-auto=update로 전 서비스에 자동 생성됩니다(Flyway 미사용, `DeadLetterRecord`·`OutboxEntity`와 동일). 운영 스키마 정책 확인 필요.
- retention 스케줄러 미배선 상태라 장기적으로 `inbox` 증가 → 후속 이슈에서 처리 예정.
