### PR TITLE
[Feat] #49 Saga 환불 성공 시 좌석/예매 정합 (consumer 측)

### DIFF
--- a/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/app/usecase/BookingMarkRefundedUseCase.java
+++ b/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/app/usecase/BookingMarkRefundedUseCase.java
@@ -1,0 +1,43 @@
+package com.ticketrush.boundedcontext.booking.app.usecase;
+
+import com.ticketrush.boundedcontext.booking.domain.entity.Booking;
+import com.ticketrush.boundedcontext.booking.out.repository.BookingRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 환불 성공(결제 취소) 이벤트를 받아 예매를 REFUNDED로 종결한다 (#49).
+ *
+ * <p>환불 성공({@code PaymentCanceledEvent})에만 매달려 있어 refund-first 정합성을 지킨다. 존재하지 않는 예매나 이미 종결된 상태는
+ * 멱등하게 처리한다({@link Booking#markRefunded()}).
+ */
+@Slf4j
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class BookingMarkRefundedUseCase {
+
+  private final BookingRepository bookingRepository;
+
+  public void execute(Long bookingId) {
+    Booking booking = bookingRepository.findById(bookingId).orElse(null);
+
+    if (booking == null) {
+      log.warn("환불 예매 종결 스킵. 존재하지 않는 bookingId={}", bookingId);
+      return;
+    }
+
+    boolean refunded = booking.markRefunded();
+    if (refunded) {
+      log.debug("환불 예매 종결 처리. bookingId: {}", bookingId);
+    } else {
+      // 환불은 됐으나 예매가 종결 불가 상태(CANCELED/PENDING/EXPIRED). 이상 상황이므로 가시화한다.
+      log.warn(
+          "환불 예매 종결 스킵: 종결 불가 상태입니다. bookingId: {}, status: {}",
+          bookingId,
+          booking.getBookingStatus());
+    }
+  }
+}

--- a/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/domain/entity/Booking.java
+++ b/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/domain/entity/Booking.java
@@ -91,4 +91,25 @@ public class Booking extends AutoIdBaseEntity {
     this.bookingStatus = BookingStatus.CONFIRMED;
     this.confirmedAt = confirmedAt;
   }
+
+  /**
+   * 환불 성공(결제 취소) 시 예매를 REFUNDED로 종결한다 (#49).
+   *
+   * <p>이미 REFUNDED면 멱등 처리(전이 없이 {@code true}). CONFIRMED/REFUNDING에서만 REFUNDED로 전이한다. 그 외
+   * 상태(CANCELED/PENDING/EXPIRED)는 교차 경로/비정상이므로 전이하지 않고 {@code false}를 반환한다(예외는 던지지 않아 호출 측이 ack
+   * 하도록).
+   *
+   * @return 종결(또는 이미 종결)됐으면 {@code true}, 종결 불가 상태라 전이하지 않았으면 {@code false}
+   */
+  public boolean markRefunded() {
+    if (this.bookingStatus == BookingStatus.REFUNDED) {
+      return true;
+    }
+    if (this.bookingStatus == BookingStatus.CONFIRMED
+        || this.bookingStatus == BookingStatus.REFUNDING) {
+      this.bookingStatus = BookingStatus.REFUNDED;
+      return true;
+    }
+    return false;
+  }
 }

--- a/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/in/eventlistener/PaymentCanceledEventListener.java
+++ b/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/in/eventlistener/PaymentCanceledEventListener.java
@@ -1,0 +1,79 @@
+package com.ticketrush.boundedcontext.booking.in.eventlistener;
+
+import com.ticketrush.boundedcontext.booking.app.usecase.BookingMarkRefundedUseCase;
+import com.ticketrush.global.event.DomainEventEnvelope;
+import com.ticketrush.global.event.KafkaConsumerErrorPolicy;
+import com.ticketrush.global.event.KafkaConsumerGroup;
+import com.ticketrush.global.inbox.DuplicateEventException;
+import com.ticketrush.global.inbox.InboxService;
+import com.ticketrush.global.json.JsonConverter;
+import com.ticketrush.shared.payment.event.PaymentCanceledEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.stereotype.Component;
+
+/**
+ * 결제 취소(환불 성공) 이벤트를 수신해 예매를 REFUNDED로 종결한다 (#49).
+ *
+ * <p>환불 성공을 뜻하는 {@code PaymentCanceledEvent}에만 종결을 매달아 refund-first 정합성을 지킨다. 환불됐는데 예매가 CONFIRMED로
+ * 남는 역방향 정합성 공백을 닫는다.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PaymentCanceledEventListener {
+
+  private final BookingMarkRefundedUseCase bookingMarkRefundedUseCase;
+  private final JsonConverter jsonConverter;
+  private final InboxService inboxService;
+
+  @KafkaListener(topics = PaymentCanceledEvent.TOPIC, groupId = KafkaConsumerGroup.BOOKING)
+  public void handlePaymentCanceled(@Payload DomainEventEnvelope envelope, Acknowledgment ack) {
+    PaymentCanceledEvent event = null;
+
+    try {
+      event = jsonConverter.deserialize(envelope.payload(), PaymentCanceledEvent.class);
+      final Long bookingId = event.bookingId();
+
+      // Inbox로 중복 처리를 방지한다(#110). 최초 수신일 때만 종결을 수행하고 처리와 Inbox 기록을 한 트랜잭션으로 묶는다.
+      boolean processed =
+          inboxService.runIfFirst(
+              KafkaConsumerGroup.BOOKING,
+              envelope,
+              () -> bookingMarkRefundedUseCase.execute(bookingId));
+
+      if (!processed) {
+        log.info(
+            "이미 처리된 결제 취소 이벤트(inbox 중복 스킵). eventId: {}, bookingId: {}",
+            envelope.eventId(),
+            bookingId);
+      }
+
+      // 성공 시에만 오프셋을 커밋한다(#269 표준).
+      ack.acknowledge();
+
+    } catch (DuplicateEventException e) {
+      // 동시 중복 수신으로 inbox unique가 경합함 → 멱등(중복) 정상으로 간주하고 커밋한다(#110).
+      log.info("동시 중복 수신(inbox unique 경합). eventId: {}", envelope.eventId());
+      ack.acknowledge();
+    } catch (Exception e) {
+      // #269 표준: 영구(비즈니스/결정적) 실패는 로그 후 ack, 일시(인프라) 실패는 re-throw 하여 재시도→DLT로 보존.
+      Long bookingId = event != null ? event.bookingId() : null;
+
+      if (KafkaConsumerErrorPolicy.isPermanent(e)) {
+        if (KafkaConsumerErrorPolicy.isExpectedConflict(e)) {
+          log.warn("결제 취소 예매 종결 이벤트 처리 중 예상된 상태충돌(멱등 처리). bookingId: {}", bookingId, e);
+        } else {
+          log.error("[CRITICAL] 결제 취소 예매 종결 이벤트 처리 실패! 확인이 필요합니다. bookingId: {}", bookingId, e);
+        }
+        ack.acknowledge();
+      } else {
+        log.warn("결제 취소 예매 종결 이벤트 처리 중 일시적 오류. 재시도합니다. bookingId: {}", bookingId, e);
+        throw e;
+      }
+    }
+  }
+}

--- a/booking-service/src/test/java/com/ticketrush/boundedcontext/booking/app/usecase/BookingMarkRefundedUseCaseTest.java
+++ b/booking-service/src/test/java/com/ticketrush/boundedcontext/booking/app/usecase/BookingMarkRefundedUseCaseTest.java
@@ -1,0 +1,107 @@
+package com.ticketrush.boundedcontext.booking.app.usecase;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import com.ticketrush.boundedcontext.booking.domain.entity.Booking;
+import com.ticketrush.boundedcontext.booking.domain.types.BookingStatus;
+import com.ticketrush.boundedcontext.booking.out.repository.BookingRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class BookingMarkRefundedUseCaseTest {
+
+  @InjectMocks private BookingMarkRefundedUseCase bookingMarkRefundedUseCase;
+
+  @Mock private BookingRepository bookingRepository;
+
+  private static final Long BOOKING_ID = 1L;
+
+  private Booking bookingWithStatus(BookingStatus status) {
+    return Booking.builder()
+        .bookingNumber("BOOK-1234")
+        .userId(10L)
+        .performanceId(2L)
+        .seatId(3L)
+        .bookingStatus(status)
+        .build();
+  }
+
+  @Test
+  @DisplayName("성공: CONFIRMED 예매를 REFUNDED로 종결한다")
+  void execute_marks_confirmed_as_refunded() {
+    // given
+    Booking booking = bookingWithStatus(BookingStatus.CONFIRMED);
+    given(bookingRepository.findById(BOOKING_ID)).willReturn(Optional.of(booking));
+
+    // when
+    bookingMarkRefundedUseCase.execute(BOOKING_ID);
+
+    // then
+    assertThat(booking.getBookingStatus()).isEqualTo(BookingStatus.REFUNDED);
+  }
+
+  @Test
+  @DisplayName("성공: REFUNDING 예매를 REFUNDED로 종결한다")
+  void execute_marks_refunding_as_refunded() {
+    // given: 후속(#91) 환불-선행 흐름에서 booking이 REFUNDING을 거친 경우
+    Booking booking = bookingWithStatus(BookingStatus.REFUNDING);
+    given(bookingRepository.findById(BOOKING_ID)).willReturn(Optional.of(booking));
+
+    // when
+    bookingMarkRefundedUseCase.execute(BOOKING_ID);
+
+    // then
+    assertThat(booking.getBookingStatus()).isEqualTo(BookingStatus.REFUNDED);
+  }
+
+  @Test
+  @DisplayName("멱등: 이미 REFUNDED면 상태를 유지한다")
+  void execute_is_idempotent_when_already_refunded() {
+    // given
+    Booking booking = bookingWithStatus(BookingStatus.REFUNDED);
+    given(bookingRepository.findById(BOOKING_ID)).willReturn(Optional.of(booking));
+
+    // when
+    bookingMarkRefundedUseCase.execute(BOOKING_ID);
+
+    // then
+    assertThat(booking.getBookingStatus()).isEqualTo(BookingStatus.REFUNDED);
+  }
+
+  @Test
+  @DisplayName("교차 경로: 이미 CANCELED된 예매는 전이하지 않는다(예외 없이)")
+  void execute_no_op_when_canceled() {
+    // given
+    Booking booking = bookingWithStatus(BookingStatus.CANCELED);
+    given(bookingRepository.findById(BOOKING_ID)).willReturn(Optional.of(booking));
+
+    // when
+    bookingMarkRefundedUseCase.execute(BOOKING_ID);
+
+    // then
+    assertThat(booking.getBookingStatus()).isEqualTo(BookingStatus.CANCELED);
+  }
+
+  @Test
+  @DisplayName("스킵: 예매 내역이 없으면 예외 없이 종료된다")
+  void execute_skip_when_booking_not_found() {
+    // given
+    given(bookingRepository.findById(BOOKING_ID)).willReturn(Optional.empty());
+
+    // when
+    bookingMarkRefundedUseCase.execute(BOOKING_ID);
+
+    // then
+    verify(bookingRepository).findById(BOOKING_ID);
+    verifyNoMoreInteractions(bookingRepository);
+  }
+}

--- a/booking-service/src/test/java/com/ticketrush/boundedcontext/booking/in/eventlistener/PaymentCanceledEventListenerTest.java
+++ b/booking-service/src/test/java/com/ticketrush/boundedcontext/booking/in/eventlistener/PaymentCanceledEventListenerTest.java
@@ -1,0 +1,169 @@
+package com.ticketrush.boundedcontext.booking.in.eventlistener;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.ticketrush.boundedcontext.booking.app.usecase.BookingMarkRefundedUseCase;
+import com.ticketrush.global.event.DomainEventEnvelope;
+import com.ticketrush.global.event.KafkaConsumerGroup;
+import com.ticketrush.global.exception.BusinessException;
+import com.ticketrush.global.inbox.DuplicateEventException;
+import com.ticketrush.global.inbox.InboxService;
+import com.ticketrush.global.json.JsonConverter;
+import com.ticketrush.global.status.ErrorStatus;
+import com.ticketrush.shared.payment.event.PaymentCanceledEvent;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.kafka.support.Acknowledgment;
+
+@ExtendWith(MockitoExtension.class)
+class PaymentCanceledEventListenerTest {
+
+  @InjectMocks private PaymentCanceledEventListener listener;
+
+  @Mock private BookingMarkRefundedUseCase bookingMarkRefundedUseCase;
+
+  @Mock private JsonConverter jsonConverter;
+
+  @Mock private InboxService inboxService;
+
+  @Mock private Acknowledgment acknowledgment;
+
+  private static final String PAYLOAD = "payload";
+  private static final Long BOOKING_ID = 10L;
+
+  private DomainEventEnvelope envelope() {
+    return new DomainEventEnvelope(
+        "event-id",
+        PaymentCanceledEvent.EVENT_NAME,
+        Instant.now(),
+        PaymentCanceledEvent.TOPIC,
+        PAYLOAD,
+        null);
+  }
+
+  private PaymentCanceledEvent event() {
+    return new PaymentCanceledEvent(
+        1L, BOOKING_ID, 3L, 5L, 50000L, "단순 변심", LocalDateTime.of(2026, 5, 22, 10, 30));
+  }
+
+  /** Inbox가 최초 수신으로 판정해 비즈니스 콜백을 실행하고 true를 반환하도록 스텁한다. */
+  private void givenInboxProcessesFirst() {
+    given(
+            inboxService.runIfFirst(
+                eq(KafkaConsumerGroup.BOOKING),
+                any(DomainEventEnvelope.class),
+                any(Runnable.class)))
+        .willAnswer(
+            invocation -> {
+              invocation.getArgument(2, Runnable.class).run();
+              return true;
+            });
+  }
+
+  @Test
+  @DisplayName("최초 수신이면 예매를 REFUNDED로 종결하고 오프셋을 커밋한다")
+  void handlePaymentCanceled() {
+    // given
+    given(jsonConverter.deserialize(PAYLOAD, PaymentCanceledEvent.class)).willReturn(event());
+    givenInboxProcessesFirst();
+
+    // when
+    listener.handlePaymentCanceled(envelope(), acknowledgment);
+
+    // then
+    verify(bookingMarkRefundedUseCase).execute(BOOKING_ID);
+    verify(acknowledgment).acknowledge();
+  }
+
+  @Test
+  @DisplayName("이미 처리된 이벤트(inbox 중복)면 종결을 실행하지 않고 오프셋만 커밋한다")
+  void handlePaymentCanceledSkipsDuplicate() {
+    // given
+    given(jsonConverter.deserialize(PAYLOAD, PaymentCanceledEvent.class)).willReturn(event());
+    given(
+            inboxService.runIfFirst(
+                eq(KafkaConsumerGroup.BOOKING),
+                any(DomainEventEnvelope.class),
+                any(Runnable.class)))
+        .willReturn(false);
+
+    // when
+    listener.handlePaymentCanceled(envelope(), acknowledgment);
+
+    // then
+    verify(bookingMarkRefundedUseCase, never()).execute(anyLong());
+    verify(acknowledgment).acknowledge();
+  }
+
+  @Test
+  @DisplayName("동시 중복 수신으로 inbox unique가 경합하면(DuplicateEventException) 예외를 전파하지 않고 오프셋을 커밋한다")
+  void handlePaymentCanceledAcksOnInboxRace() {
+    // given
+    given(jsonConverter.deserialize(PAYLOAD, PaymentCanceledEvent.class)).willReturn(event());
+    given(
+            inboxService.runIfFirst(
+                eq(KafkaConsumerGroup.BOOKING),
+                any(DomainEventEnvelope.class),
+                any(Runnable.class)))
+        .willThrow(
+            new DuplicateEventException(
+                KafkaConsumerGroup.BOOKING,
+                "event-id",
+                new DataIntegrityViolationException("duplicate")));
+
+    // when & then
+    assertThatCode(() -> listener.handlePaymentCanceled(envelope(), acknowledgment))
+        .doesNotThrowAnyException();
+
+    verify(acknowledgment).acknowledge();
+  }
+
+  @Test
+  @DisplayName("일시적(인프라) 예외가 발생하면 예외를 전파하고 오프셋을 커밋하지 않는다(재시도→DLT 위임)")
+  void handlePaymentCanceledRethrowsTransientFailure() {
+    // given
+    given(jsonConverter.deserialize(PAYLOAD, PaymentCanceledEvent.class)).willReturn(event());
+    givenInboxProcessesFirst();
+    willThrow(new RuntimeException("DB 일시 장애"))
+        .given(bookingMarkRefundedUseCase)
+        .execute(BOOKING_ID);
+
+    // when & then
+    assertThatThrownBy(() -> listener.handlePaymentCanceled(envelope(), acknowledgment))
+        .isInstanceOf(RuntimeException.class);
+
+    verify(acknowledgment, never()).acknowledge();
+  }
+
+  @Test
+  @DisplayName("영구(비즈니스) 예외가 발생하면 예외를 전파하지 않고 오프셋을 커밋한다")
+  void handlePaymentCanceledAcksPermanentFailure() {
+    // given
+    given(jsonConverter.deserialize(PAYLOAD, PaymentCanceledEvent.class)).willReturn(event());
+    givenInboxProcessesFirst();
+    willThrow(new BusinessException(ErrorStatus.BOOKING_NOT_FOUND))
+        .given(bookingMarkRefundedUseCase)
+        .execute(BOOKING_ID);
+
+    // when & then
+    assertThatCode(() -> listener.handlePaymentCanceled(envelope(), acknowledgment))
+        .doesNotThrowAnyException();
+
+    verify(acknowledgment).acknowledge();
+  }
+}

--- a/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/app/usecase/SeatReleaseSoldSeatUseCase.java
+++ b/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/app/usecase/SeatReleaseSoldSeatUseCase.java
@@ -1,0 +1,49 @@
+package com.ticketrush.boundedcontext.seat.app.usecase;
+
+import com.ticketrush.boundedcontext.seat.app.support.SeatStatusEventPublisher;
+import com.ticketrush.boundedcontext.seat.out.repository.SeatRepository;
+import com.ticketrush.global.types.SeatStatus;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 환불 성공({@code PaymentCanceledEvent}) 시 결제 완료(SOLD) 좌석을 AVAILABLE로 반환한다 (#49).
+ *
+ * <p>환불은 결제 완료(SOLD) 좌석 대상이므로 <b>SOLD일 때만</b> 반환한다. HOLD(진행 중 선점)나 이미 AVAILABLE인 좌석은 멱등 스킵한다.
+ *
+ * <p><b>한계(→ #91 조율)</b>: {@code PaymentCanceledEvent}에는 예매 번호(bookingNumber)가 없어 좌석이 실제로 그 환불 예매의
+ * 것인지 교차검증할 수 없다. 좌석 id 재사용 + 이벤트 지연이 겹치면 다른 예매의 좌석을 반환할 수 있으므로(ABA), payment 측 이벤트에 bookingNumber를
+ * 포함해 {@code SeatReleaseBookedSeatUseCase}처럼 교차검증하도록 후속 조율이 필요하다. 현재는 SOLD 한정 가드로 blast radius를
+ * 좁힌다.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class SeatReleaseSoldSeatUseCase {
+
+  private final SeatRepository seatRepository;
+  private final SeatStatusEventPublisher seatStatusEventPublisher;
+
+  @Transactional
+  public void execute(Long seatId) {
+    var seat = seatRepository.findById(seatId).orElse(null);
+
+    if (seat == null) {
+      // 결제는 취소됐으나 대상 좌석이 없다. 재전달로도 나타날 수 없으므로 예외 대신 정상 종료(멱등 기록 유지).
+      log.warn("환불 좌석 반환 스킵: 좌석이 존재하지 않습니다. seatId: {}", seatId);
+      return;
+    }
+
+    if (seat.getSeatStatus() != SeatStatus.SOLD) {
+      // 환불 대상은 SOLD 좌석뿐이다. HOLD/AVAILABLE는 대상이 아니므로 멱등 스킵한다.
+      log.info("환불 좌석 반환 스킵: SOLD 상태가 아닙니다. seatId: {}, status: {}", seatId, seat.getSeatStatus());
+      return;
+    }
+
+    seat.releaseBooking(); // SOLD → AVAILABLE
+    seatStatusEventPublisher.publishAfterCommit(seat);
+    log.info("환불 좌석 반환 완료. seatId: {}", seatId);
+  }
+}

--- a/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/in/eventlistener/PaymentCanceledEventListener.java
+++ b/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/in/eventlistener/PaymentCanceledEventListener.java
@@ -1,0 +1,75 @@
+package com.ticketrush.boundedcontext.seat.in.eventlistener;
+
+import com.ticketrush.boundedcontext.seat.app.usecase.SeatReleaseSoldSeatUseCase;
+import com.ticketrush.global.event.DomainEventEnvelope;
+import com.ticketrush.global.event.KafkaConsumerErrorPolicy;
+import com.ticketrush.global.event.KafkaConsumerGroup;
+import com.ticketrush.global.inbox.DuplicateEventException;
+import com.ticketrush.global.inbox.InboxService;
+import com.ticketrush.global.json.JsonConverter;
+import com.ticketrush.shared.payment.event.PaymentCanceledEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.stereotype.Component;
+
+/**
+ * 결제 취소(환불 성공) 이벤트를 수신해 좌석을 반환한다 (#49).
+ *
+ * <p>환불 성공을 뜻하는 {@code PaymentCanceledEvent}에만 좌석 반환을 매달아, "환불 성공 이후에만 좌석 반환"(refund-first)을 보장한다.
+ * 이로써 환불됐는데 좌석이 SOLD로 남는 역방향 정합성 공백을 닫는다.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PaymentCanceledEventListener {
+
+  private final SeatReleaseSoldSeatUseCase seatReleaseSoldSeatUseCase;
+  private final JsonConverter jsonConverter;
+  private final InboxService inboxService;
+
+  @KafkaListener(topics = PaymentCanceledEvent.TOPIC, groupId = KafkaConsumerGroup.SEAT)
+  public void handlePaymentCanceled(@Payload DomainEventEnvelope envelope, Acknowledgment ack) {
+    PaymentCanceledEvent event = null;
+
+    try {
+      event = jsonConverter.deserialize(envelope.payload(), PaymentCanceledEvent.class);
+      final Long seatId = event.seatId();
+
+      // Inbox로 중복 처리를 방지한다(#110). 최초 수신일 때만 좌석 반환을 수행하고 처리와 Inbox 기록을 한 트랜잭션으로 묶는다.
+      boolean processed =
+          inboxService.runIfFirst(
+              KafkaConsumerGroup.SEAT, envelope, () -> seatReleaseSoldSeatUseCase.execute(seatId));
+
+      if (!processed) {
+        log.info(
+            "이미 처리된 결제 취소 이벤트(inbox 중복 스킵). eventId: {}, seatId: {}", envelope.eventId(), seatId);
+      }
+
+      // 성공 시에만 오프셋을 커밋한다(#269 표준).
+      ack.acknowledge();
+
+    } catch (DuplicateEventException e) {
+      // 동시 중복 수신으로 inbox unique가 경합함 → 멱등(중복) 정상으로 간주하고 커밋한다(#110).
+      log.info("동시 중복 수신(inbox unique 경합). eventId: {}", envelope.eventId());
+      ack.acknowledge();
+    } catch (Exception e) {
+      // #269 표준: 영구(비즈니스/결정적) 실패는 로그 후 ack, 일시(인프라) 실패는 re-throw 하여 재시도→DLT로 보존.
+      Long seatId = event != null ? event.seatId() : null;
+
+      if (KafkaConsumerErrorPolicy.isPermanent(e)) {
+        if (KafkaConsumerErrorPolicy.isExpectedConflict(e)) {
+          log.warn("결제 취소 좌석 반환 이벤트 처리 중 예상된 상태충돌(멱등 처리). seatId: {}", seatId, e);
+        } else {
+          log.error("[CRITICAL] 결제 취소 좌석 반환 이벤트 처리 실패! 확인이 필요합니다. seatId: {}", seatId, e);
+        }
+        ack.acknowledge();
+      } else {
+        log.warn("결제 취소 좌석 반환 이벤트 처리 중 일시적 오류. 재시도합니다. seatId: {}", seatId, e);
+        throw e;
+      }
+    }
+  }
+}

--- a/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/app/usecase/SeatReleaseSoldSeatUseCaseTest.java
+++ b/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/app/usecase/SeatReleaseSoldSeatUseCaseTest.java
@@ -1,0 +1,96 @@
+package com.ticketrush.boundedcontext.seat.app.usecase;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import com.ticketrush.boundedcontext.seat.app.support.SeatStatusEventPublisher;
+import com.ticketrush.boundedcontext.seat.domain.entity.Seat;
+import com.ticketrush.boundedcontext.seat.out.repository.SeatRepository;
+import com.ticketrush.global.types.SeatStatus;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class SeatReleaseSoldSeatUseCaseTest {
+
+  @InjectMocks private SeatReleaseSoldSeatUseCase seatReleaseSoldSeatUseCase;
+
+  @Mock private SeatRepository seatRepository;
+  @Mock private SeatStatusEventPublisher seatStatusEventPublisher;
+
+  private static final Long SEAT_ID = 1L;
+
+  private Seat seatWithStatus(SeatStatus status) {
+    return Seat.builder()
+        .performanceId(1L)
+        .seatNumber("A-1")
+        .seatStatus(status)
+        .bookingNumber(status == SeatStatus.AVAILABLE ? null : "BOOK-1234")
+        .build();
+  }
+
+  @Test
+  @DisplayName("성공: SOLD 좌석을 AVAILABLE로 반환하고 상태 변경 이벤트를 발행한다")
+  void execute_success_when_sold() {
+    // given
+    Seat seat = seatWithStatus(SeatStatus.SOLD);
+    given(seatRepository.findById(SEAT_ID)).willReturn(Optional.of(seat));
+
+    // when
+    seatReleaseSoldSeatUseCase.execute(SEAT_ID);
+
+    // then
+    assertThat(seat.getSeatStatus()).isEqualTo(SeatStatus.AVAILABLE);
+    verify(seatStatusEventPublisher).publishAfterCommit(seat);
+  }
+
+  @Test
+  @DisplayName("멱등: 이미 AVAILABLE 좌석이면 스킵한다")
+  void execute_skip_when_already_available() {
+    // given
+    Seat seat = seatWithStatus(SeatStatus.AVAILABLE);
+    given(seatRepository.findById(SEAT_ID)).willReturn(Optional.of(seat));
+
+    // when
+    seatReleaseSoldSeatUseCase.execute(SEAT_ID);
+
+    // then
+    assertThat(seat.getSeatStatus()).isEqualTo(SeatStatus.AVAILABLE);
+    verifyNoInteractions(seatStatusEventPublisher);
+  }
+
+  @Test
+  @DisplayName("안전: HOLD(진행 중 선점) 좌석은 환불 대상이 아니므로 반환하지 않는다")
+  void execute_skip_when_hold() {
+    // given: 좌석 id 재사용으로 다른 예매가 선점 중일 수 있어, 환불이 활성 HOLD를 깨지 않아야 한다
+    Seat seat = seatWithStatus(SeatStatus.HOLD);
+    given(seatRepository.findById(SEAT_ID)).willReturn(Optional.of(seat));
+
+    // when
+    seatReleaseSoldSeatUseCase.execute(SEAT_ID);
+
+    // then
+    assertThat(seat.getSeatStatus()).isEqualTo(SeatStatus.HOLD);
+    verifyNoInteractions(seatStatusEventPublisher);
+  }
+
+  @Test
+  @DisplayName("멱등: 좌석이 없으면 예외 없이 스킵한다")
+  void execute_skip_when_seat_not_found() {
+    // given
+    given(seatRepository.findById(SEAT_ID)).willReturn(Optional.empty());
+
+    // when
+    seatReleaseSoldSeatUseCase.execute(SEAT_ID);
+
+    // then
+    verifyNoInteractions(seatStatusEventPublisher);
+  }
+}

--- a/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/in/eventlistener/PaymentCanceledEventListenerTest.java
+++ b/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/in/eventlistener/PaymentCanceledEventListenerTest.java
@@ -1,0 +1,178 @@
+package com.ticketrush.boundedcontext.seat.in.eventlistener;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.ticketrush.boundedcontext.seat.app.usecase.SeatReleaseSoldSeatUseCase;
+import com.ticketrush.global.event.DomainEventEnvelope;
+import com.ticketrush.global.event.KafkaConsumerGroup;
+import com.ticketrush.global.exception.BusinessException;
+import com.ticketrush.global.inbox.DuplicateEventException;
+import com.ticketrush.global.inbox.InboxService;
+import com.ticketrush.global.json.JsonConverter;
+import com.ticketrush.global.status.ErrorStatus;
+import com.ticketrush.shared.payment.event.PaymentCanceledEvent;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.kafka.support.Acknowledgment;
+
+@ExtendWith(MockitoExtension.class)
+class PaymentCanceledEventListenerTest {
+
+  @InjectMocks private PaymentCanceledEventListener listener;
+
+  @Mock private SeatReleaseSoldSeatUseCase seatReleaseSoldSeatUseCase;
+
+  @Mock private JsonConverter jsonConverter;
+
+  @Mock private InboxService inboxService;
+
+  @Mock private Acknowledgment acknowledgment;
+
+  private static final String PAYLOAD = "payload";
+  private static final Long SEAT_ID = 3L;
+
+  private DomainEventEnvelope envelope() {
+    return new DomainEventEnvelope(
+        "event-id",
+        PaymentCanceledEvent.EVENT_NAME,
+        Instant.now(),
+        PaymentCanceledEvent.TOPIC,
+        PAYLOAD,
+        null);
+  }
+
+  private PaymentCanceledEvent event() {
+    return new PaymentCanceledEvent(
+        1L, 10L, SEAT_ID, 5L, 50000L, "단순 변심", LocalDateTime.of(2026, 5, 22, 10, 30));
+  }
+
+  /** Inbox가 최초 수신으로 판정해 비즈니스 콜백을 실행하고 true를 반환하도록 스텁한다. */
+  private void givenInboxProcessesFirst() {
+    given(
+            inboxService.runIfFirst(
+                eq(KafkaConsumerGroup.SEAT), any(DomainEventEnvelope.class), any(Runnable.class)))
+        .willAnswer(
+            invocation -> {
+              invocation.getArgument(2, Runnable.class).run();
+              return true;
+            });
+  }
+
+  @Test
+  @DisplayName("최초 수신이면 좌석을 반환하고 오프셋을 커밋한다")
+  void handlePaymentCanceled() {
+    // given
+    given(jsonConverter.deserialize(PAYLOAD, PaymentCanceledEvent.class)).willReturn(event());
+    givenInboxProcessesFirst();
+
+    // when
+    listener.handlePaymentCanceled(envelope(), acknowledgment);
+
+    // then
+    verify(seatReleaseSoldSeatUseCase).execute(SEAT_ID);
+    verify(acknowledgment).acknowledge();
+  }
+
+  @Test
+  @DisplayName("이미 처리된 이벤트(inbox 중복)면 좌석 반환을 실행하지 않고 오프셋만 커밋한다")
+  void handlePaymentCanceledSkipsDuplicate() {
+    // given
+    given(jsonConverter.deserialize(PAYLOAD, PaymentCanceledEvent.class)).willReturn(event());
+    given(
+            inboxService.runIfFirst(
+                eq(KafkaConsumerGroup.SEAT), any(DomainEventEnvelope.class), any(Runnable.class)))
+        .willReturn(false);
+
+    // when
+    listener.handlePaymentCanceled(envelope(), acknowledgment);
+
+    // then
+    verify(seatReleaseSoldSeatUseCase, never()).execute(anyLong());
+    verify(acknowledgment).acknowledge();
+  }
+
+  @Test
+  @DisplayName("동시 중복 수신으로 inbox unique가 경합하면(DuplicateEventException) 예외를 전파하지 않고 오프셋을 커밋한다")
+  void handlePaymentCanceledAcksOnInboxRace() {
+    // given
+    given(jsonConverter.deserialize(PAYLOAD, PaymentCanceledEvent.class)).willReturn(event());
+    given(
+            inboxService.runIfFirst(
+                eq(KafkaConsumerGroup.SEAT), any(DomainEventEnvelope.class), any(Runnable.class)))
+        .willThrow(
+            new DuplicateEventException(
+                KafkaConsumerGroup.SEAT,
+                "event-id",
+                new DataIntegrityViolationException("duplicate")));
+
+    // when & then
+    assertThatCode(() -> listener.handlePaymentCanceled(envelope(), acknowledgment))
+        .doesNotThrowAnyException();
+
+    verify(acknowledgment).acknowledge();
+  }
+
+  @Test
+  @DisplayName("일시적(인프라) 예외가 발생하면 예외를 전파하고 오프셋을 커밋하지 않는다(재시도→DLT 위임)")
+  void handlePaymentCanceledRethrowsTransientFailure() {
+    // given
+    given(jsonConverter.deserialize(PAYLOAD, PaymentCanceledEvent.class)).willReturn(event());
+    givenInboxProcessesFirst();
+    willThrow(new RuntimeException("DB 일시 장애")).given(seatReleaseSoldSeatUseCase).execute(SEAT_ID);
+
+    // when & then
+    assertThatThrownBy(() -> listener.handlePaymentCanceled(envelope(), acknowledgment))
+        .isInstanceOf(RuntimeException.class);
+
+    verify(acknowledgment, never()).acknowledge();
+  }
+
+  @Test
+  @DisplayName("예상된 상태충돌(화이트리스트 409)은 warn 후 오프셋을 커밋한다")
+  void handlePaymentCanceledAcksExpectedConflict() {
+    // given: SEAT_NOT_AVAILABLE(409)은 EXPECTED_CONFLICTS라 warn+ack 분기로 간다
+    given(jsonConverter.deserialize(PAYLOAD, PaymentCanceledEvent.class)).willReturn(event());
+    givenInboxProcessesFirst();
+    willThrow(new BusinessException(ErrorStatus.SEAT_NOT_AVAILABLE))
+        .given(seatReleaseSoldSeatUseCase)
+        .execute(SEAT_ID);
+
+    // when & then
+    assertThatCode(() -> listener.handlePaymentCanceled(envelope(), acknowledgment))
+        .doesNotThrowAnyException();
+
+    verify(acknowledgment).acknowledge();
+  }
+
+  @Test
+  @DisplayName("영구(비즈니스) 예외가 발생하면 예외를 전파하지 않고 오프셋을 커밋한다")
+  void handlePaymentCanceledAcksPermanentFailure() {
+    // given
+    given(jsonConverter.deserialize(PAYLOAD, PaymentCanceledEvent.class)).willReturn(event());
+    givenInboxProcessesFirst();
+    willThrow(new BusinessException(ErrorStatus.SEAT_NOT_FOUND))
+        .given(seatReleaseSoldSeatUseCase)
+        .execute(SEAT_ID);
+
+    // when & then
+    assertThatCode(() -> listener.handlePaymentCanceled(envelope(), acknowledgment))
+        .doesNotThrowAnyException();
+
+    verify(acknowledgment).acknowledge();
+  }
+}


### PR DESCRIPTION
## 🔗 관련 이슈

- close #49 (부분 구현 — 환불 성공 시 좌석/예매 정합, consumer 측)

---

## 📌 주요 변경 사항

- payment가 발행하는 `PaymentCanceledEvent`를 **seat·booking도 구독**(기존 ticket만) → 환불 성공 시 좌석 반환 + 예매 REFUNDED 종결
- **refund-first**: 좌석 반환·예매 종결을 환불 성공 이벤트에만 매달아 "좌석은 잃고 환불 못 받는" 역방향 정합성 공백을 구조적으로 차단
- 담당 모듈(seat/booking/ticket)의 **consumer 측만** — payment 무변경

---

## 🛠 상세 구현 내용

- **seat**: 신규 `PaymentCanceledEventListener`(groupId SEAT) + `SeatReleaseSoldSeatUseCase`. `PaymentCanceledEvent`에 bookingNumber가 없어 기존 `SeatReleaseBookedSeatUseCase` 재사용 불가 → seatId 기반, **SOLD 한정** 멱등 반환(HOLD/AVAILABLE skip).
- **booking**: 신규 `PaymentCanceledEventListener`(groupId BOOKING) + `BookingMarkRefundedUseCase` + `Booking.markRefunded()`(죽어있던 `REFUNDED` 부활, CONFIRMED/REFUNDING→REFUNDED, 그 외 no-op+warn).
- 두 신규 리스너 모두 **#110 Inbox**(`runIfFirst`, `DuplicateEventException`→ack) + **#269 에러정책**(isPermanent→ack / transient→re-throw) 표준.
- payment-canceled-topic을 ticket·seat·booking 3그룹이 소비하나 #110 복합키 `(consumer_group, event_id)`로 그룹별 독립 멱등.

---

## ✅ 테스트

### 테스트 방법

- 신규: seat/booking `PaymentCanceledEventListenerTest`(최초→처리+ack, inbox 중복→skip, 경합→ack, 일시→re-throw, 영구/예상충돌→ack), `SeatReleaseSoldSeatUseCaseTest`(SOLD 반환·AVAILABLE/HOLD/미존재 skip), `BookingMarkRefundedUseCaseTest`(CONFIRMED·REFUNDING→REFUNDED, REFUNDED 멱등, CANCELED no-op, 미존재 skip).
- 실행: `./gradlew :seat-service:test :booking-service:test spotlessCheck checkstyleMain checkstyleTest`

### 테스트 결과

- seat·booking `test` + `spotlessCheck` + `checkstyle` **BUILD SUCCESSFUL**
<!--
### 📸 스크린샷

- 
-->
---

## 👀 리뷰 요청 사항

- 좌석 반환을 SOLD 한정으로 좁혀 blast radius를 줄였으나, `PaymentCanceledEvent`에 bookingNumber가 없어 좌석 소유 교차검증(ABA 방지)이 불가합니다. **payment 이벤트에 bookingNumber 포함**을 #91과 조율해야 합니다(후속).
- `Booking.REFUNDED` 부활 및 markRefunded 상태전이 가드 검토 부탁드립니다.
- **후속(#91 조율)**: 예매취소→REFUNDING + `RefundRequestedEvent` 트리거(정방향), `RefundFailedEvent` 롤백, Outbox 활성화, `@Version` 낙관적 락.

---

## ⚠️ 배포 시 주의사항

- payment-canceled-topic에 seat/booking 컨슈머 그룹이 새로 붙습니다. 신규 그룹은 `auto-offset-reset: latest`라 배포 이전 과거 환불 이벤트는 소비하지 않습니다(과거분 정합 필요 시 별도 확인).
- `inbox`·기존 이벤트 흐름과 동일한 at-least-once/재시도→DLT 특성.
