### PR TITLE
[Docs] #319 README 팀원 GitHub 핸들 수정

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 |                            프로필                            | 이름  |                     GitHub                     | 담당 파트                                      |
 |:---------------------------------------------------------:|:---:|:----------------------------------------------:|--------------------------------------------|
-|   <img src="https://github.com/sohee52.png" width="80">   | 김소희 |     [@sohee52](https://github.com/sohee52)     | 좌석(seat) · 예매(booking) · 티켓(ticket) · 모니터링 |
+|    <img src="https://github.com/50h33.png" width="80">    | 김소희 |       [@50h33](https://github.com/50h33)       | 좌석(seat) · 예매(booking) · 티켓(ticket) · 모니터링 |
 |  <img src="https://github.com/calla1102.png" width="80">  | 민주  |   [@calla1102](https://github.com/calla1102)   | 공연(performance) · 결제(payment) · CI         |
 | <img src="https://github.com/kimhyerim01.png" width="80"> | 김혜림 | [@kimhyerim01](https://github.com/kimhyerim01) | 인증(auth) · 회원(user) · 게이트웨이(gateway) · 배포  |
 


### PR DESCRIPTION
## 🔗 관련 이슈

- close #319

---

## 📌 주요 변경 사항

- README 팀원 소개의 김소희 GitHub 핸들을 `sohee52` → `50h33`으로 정정 (아바타·링크 3곳)

---

## 🛠 상세 구현 내용

- 변경된 실제 계정(`50h33`)에 맞춰 아바타 이미지 URL·링크 텍스트·링크 URL 수정, 표 정렬 유지
<!--
---

## ✅ 테스트

### 테스트 방법

- 문서 변경. `sohee52` 잔여 없음(grep) 확인

### 테스트 결과

- 잔여 0건 / diff 1줄 변경

### 📸 스크린샷

- (작성 필요)

---

## 👀 리뷰 요청 사항

-

---

## ⚠️ 배포 시 주의사항

- 없음 (문서 변경)
-->