### PR TITLE
[Feat] #314 Inbox retention 스케줄러 도입

### DIFF
--- a/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/app/scheduler/InboxRetentionScheduler.java
+++ b/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/app/scheduler/InboxRetentionScheduler.java
@@ -1,0 +1,28 @@
+package com.ticketrush.boundedcontext.booking.app.scheduler;
+
+import com.ticketrush.global.inbox.InboxRetentionService;
+import lombok.RequiredArgsConstructor;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/**
+ * booking-service의 Inbox retention 스케줄러(#314).
+ *
+ * <p>{@code app.inbox.retention.enabled=true}일 때만 등록되며, 보존 기간이 지난 {@code inbox} row를 주기적으로 삭제한다.
+ * {@code inbox}는 전역 공유 테이블이므로 이 단일 서비스에서만 정리하며, 다중 인스턴스 중복 실행은 ShedLock으로 방지한다.
+ */
+@Component
+@ConditionalOnProperty(prefix = "app.inbox.retention", name = "enabled", havingValue = "true")
+@RequiredArgsConstructor
+public class InboxRetentionScheduler {
+
+  private final InboxRetentionService inboxRetentionService;
+
+  @Scheduled(fixedDelay = 3600000) // 1시간
+  @SchedulerLock(name = "inboxRetention-booking", lockAtLeastFor = "10s", lockAtMostFor = "5m")
+  public void purge() {
+    inboxRetentionService.purgeExpired();
+  }
+}

--- a/booking-service/src/main/resources/application-test.yml
+++ b/booking-service/src/main/resources/application-test.yml
@@ -1,9 +1,12 @@
 app:
   event-publisher:
     type: kafka
-  # 테스트 환경에서는 DLT 모니터/Slack 알림을 명시적으로 비활성화한다.
+  # 테스트 환경에서는 DLT 모니터/Slack 알림, inbox retention을 명시적으로 비활성화한다.
   dlt:
     monitor:
       enabled: false
   slack:
     enabled: false
+  inbox:
+    retention:
+      enabled: false

--- a/booking-service/src/main/resources/application.yml
+++ b/booking-service/src/main/resources/application.yml
@@ -42,3 +42,15 @@ app:
   slack:
     enabled: ${SLACK_ENABLED:false}
     webhook-url: ${SLACK_WEBHOOK_URL:}
+  # inbox(멱등 기록) retention(#314). inbox는 전 서비스가 공유하는 전역 테이블이라 이 서비스 한 곳에서만 정리한다.
+  # 기본은 비활성이며, 운영 환경에서 INBOX_RETENTION_ENABLED=true로 켠다. local/test는 미설정(기본 false)으로 비활성.
+  inbox:
+    retention:
+      enabled: ${INBOX_RETENTION_ENABLED:false}
+      # inbox 보존 기간(일). Kafka 재전송/replay 윈도우보다 길게 둬 윈도우 내 재전달도 계속 중복 제거되게 한다.
+      retention-days: ${INBOX_RETENTION_DAYS:30}
+      # 보존 하한(일) = Kafka replay 윈도우. retention-days가 이보다 짧으면 중복 재처리 위험이 있어 purge를 건너뛴다.
+      min-retention-days: ${INBOX_MIN_RETENTION_DAYS:7}
+      # 청크 삭제 배치 크기와 1회 실행당 배치 수 상한. 대용량 단일 트랜잭션 삭제를 피하고 최초 활성화 시 완만히 정리한다.
+      batch-size: ${INBOX_RETENTION_BATCH_SIZE:1000}
+      max-batches-per-run: ${INBOX_RETENTION_MAX_BATCHES_PER_RUN:100}

--- a/common/src/main/java/com/ticketrush/global/inbox/InboxRepository.java
+++ b/common/src/main/java/com/ticketrush/global/inbox/InboxRepository.java
@@ -26,4 +26,18 @@ public interface InboxRepository extends JpaRepository<InboxEntity, Long> {
   @Modifying(clearAutomatically = true)
   @Query("DELETE FROM InboxEntity i WHERE i.createdAt < :threshold")
   int deleteCreatedBefore(@Param("threshold") LocalDateTime threshold);
+
+  /**
+   * retention 대상 row를 {@code batchSize}개까지만 삭제한다(청크 삭제).
+   *
+   * <p>{@code inbox}는 전 서비스의 처리 이벤트가 쌓이는 고볼륨 테이블이라, 단일 트랜잭션 대용량 DELETE는 긴 락·큰 undo/binlog·리플리케이션
+   * 지연을 유발한다. {@code InboxRetentionService}는 이 메서드를 배치 단위로 반복 호출(각 배치는 독립 트랜잭션)해 락/트랜잭션 크기를 제한한다.
+   * MySQL의 {@code DELETE ... LIMIT}을 사용한다.
+   */
+  @Modifying(clearAutomatically = true)
+  @Query(
+      value = "DELETE FROM inbox WHERE created_at < :threshold LIMIT :batchSize",
+      nativeQuery = true)
+  int deleteCreatedBeforeInBatch(
+      @Param("threshold") LocalDateTime threshold, @Param("batchSize") int batchSize);
 }

--- a/common/src/main/java/com/ticketrush/global/inbox/InboxRetentionBatchDeleter.java
+++ b/common/src/main/java/com/ticketrush/global/inbox/InboxRetentionBatchDeleter.java
@@ -1,0 +1,27 @@
+package com.ticketrush.global.inbox;
+
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Inbox retention의 배치 1개를 <b>독립 트랜잭션</b>으로 삭제한다(#314).
+ *
+ * <p>{@code InboxRetentionService.purgeExpired()}는 트랜잭션을 열지 않고 이 메서드를 배치 단위로 반복 호출한다. 별도 빈으로 분리한
+ * 이유는 같은 빈 내부 호출로는 프록시가 동작하지 않아 배치마다 새 트랜잭션이 열리지 않기 때문이다. 배치 간 커밋으로 락 보유 시간과 트랜잭션(undo/binlog) 크기를
+ * 제한해, 최초 활성화 시 누적 row 대용량 삭제로 인한 긴 락·리플리케이션 지연을 방지한다.
+ */
+@Component
+@ConditionalOnProperty(prefix = "app.inbox.retention", name = "enabled", havingValue = "true")
+@RequiredArgsConstructor
+public class InboxRetentionBatchDeleter {
+
+  private final InboxRepository inboxRepository;
+
+  @Transactional
+  public int deleteBatch(LocalDateTime threshold, int batchSize) {
+    return inboxRepository.deleteCreatedBeforeInBatch(threshold, batchSize);
+  }
+}

--- a/common/src/main/java/com/ticketrush/global/inbox/InboxRetentionProperties.java
+++ b/common/src/main/java/com/ticketrush/global/inbox/InboxRetentionProperties.java
@@ -1,0 +1,34 @@
+package com.ticketrush.global.inbox;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+/**
+ * Inbox retention 설정(#314).
+ *
+ * <p>{@code inbox} 테이블은 전 서비스가 공유하는 전역 단일 테이블이므로, <b>딱 한 서비스</b>(기본: booking-service)에서만 {@code
+ * enabled=true}로 켜 오래된 row를 대표로 정리한다. 나머지 서비스는 기본 비활성이라 retention이 동작하지 않는다.
+ */
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "app.inbox.retention")
+public class InboxRetentionProperties {
+
+  private boolean enabled = false;
+
+  // inbox row를 이 기간 이후 retention 배치가 삭제한다. Kafka 재전송/replay 윈도우보다 길게 설정해 윈도우 내 재전달도 계속 중복 제거되게 한다.
+  private int retentionDays = 30;
+
+  // 보존 하한(일) = Kafka 재전송/replay 윈도우. retentionDays가 이보다 짧으면 윈도우 내 재전달이 중복 제거되지 않아, 안전을 위해 purge를
+  // 건너뛴다.
+  private int minRetentionDays = 7;
+
+  // 청크 삭제 배치 크기. 대용량 단일 트랜잭션 DELETE를 피해 배치마다 독립 트랜잭션으로 삭제한다.
+  private int batchSize = 1000;
+
+  // 1회 실행당 배치 수 상한. 최초 활성화 시 누적분을 여러 주기에 걸쳐 완만히 정리하고, 단일 실행이 스케줄러 락(lockAtMostFor)을 넘기지 않게 한다.
+  private int maxBatchesPerRun = 100;
+}

--- a/common/src/main/java/com/ticketrush/global/inbox/InboxRetentionService.java
+++ b/common/src/main/java/com/ticketrush/global/inbox/InboxRetentionService.java
@@ -1,0 +1,77 @@
+package com.ticketrush.global.inbox;
+
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Service;
+
+/**
+ * 보존 기간이 지난 {@code inbox} row를 정리하는 retention 배치(#314, #110 후속).
+ *
+ * <p>배선이 없으면 {@code inbox} 테이블은 무한 증가하므로, 오래된 멱등 기록을 자동 삭제해 상한을 둔다. 전역 공유 테이블이라 단일 서비스(기본:
+ * booking-service)에서만 동작하도록 {@code app.inbox.retention.enabled} 조건을 건다.
+ *
+ * <p>{@code inbox}는 전 서비스 처리 이벤트가 쌓이는 고볼륨 테이블이라, DLT retention과 달리 <b>청크(배치) 삭제</b>로 트랜잭션·락 크기를
+ * 제한한다 ({@link InboxRetentionBatchDeleter}가 배치마다 독립 트랜잭션). 이 메서드 자체는 트랜잭션을 열지 않는다. 또한 보존 기간이 Kafka
+ * 재전송/replay 윈도우({@code minRetentionDays})보다 짧아지면 윈도우 내 재전달의 중복 재처리 사고로 이어지므로, 그 경우 purge를 건너뛴다.
+ */
+@Slf4j
+@Service
+@ConditionalOnProperty(prefix = "app.inbox.retention", name = "enabled", havingValue = "true")
+@RequiredArgsConstructor
+public class InboxRetentionService {
+
+  private final InboxRetentionBatchDeleter batchDeleter;
+  private final InboxRetentionProperties properties;
+
+  public int purgeExpired() {
+    int retentionDays = properties.getRetentionDays();
+    int minRetentionDays = properties.getMinRetentionDays();
+    int batchSize = properties.getBatchSize();
+    int maxBatchesPerRun = properties.getMaxBatchesPerRun();
+
+    if (retentionDays <= 0) {
+      log.warn("Inbox retention: retentionDays({})가 0 이하여서 purge를 건너뜁니다.", retentionDays);
+      return 0;
+    }
+    if (retentionDays < minRetentionDays) {
+      // 보존 기간이 replay 윈도우보다 짧으면 윈도우 내 재전달이 중복 제거되지 않는다(정합성 사고). fail-safe로 삭제하지 않는다.
+      log.error(
+          "Inbox retention: retentionDays({})가 minRetentionDays({}, Kafka replay 윈도우)보다 짧아 "
+              + "윈도우 내 재전달의 중복 재처리 위험이 있어 purge를 건너뜁니다. 설정을 확인하세요.",
+          retentionDays,
+          minRetentionDays);
+      return 0;
+    }
+    if (batchSize <= 0 || maxBatchesPerRun <= 0) {
+      log.warn(
+          "Inbox retention: batchSize({})·maxBatchesPerRun({}) 설정이 유효하지 않아 purge를 건너뜁니다.",
+          batchSize,
+          maxBatchesPerRun);
+      return 0;
+    }
+
+    LocalDateTime threshold = LocalDateTime.now().minusDays(retentionDays);
+    int totalDeleted = 0;
+    for (int batch = 0; batch < maxBatchesPerRun; batch++) {
+      int deleted = batchDeleter.deleteBatch(threshold, batchSize);
+      totalDeleted += deleted;
+      if (deleted < batchSize) {
+        // 남은 대상을 모두 소진했다(정상 종료).
+        if (totalDeleted > 0) {
+          log.info("Inbox retention: inbox {}건 삭제 (threshold={})", totalDeleted, threshold);
+        }
+        return totalDeleted;
+      }
+    }
+
+    // 1회 실행 상한 도달: 남은 대상은 다음 주기에 계속 정리한다(최초 활성화 시 완만한 정리).
+    log.info(
+        "Inbox retention: 상한(maxBatchesPerRun={}) 도달로 {}건 삭제 후 중단(나머지 다음 주기). threshold={}",
+        maxBatchesPerRun,
+        totalDeleted,
+        threshold);
+    return totalDeleted;
+  }
+}

--- a/common/src/test/java/com/ticketrush/global/inbox/InboxRetentionBatchDeleterTest.java
+++ b/common/src/test/java/com/ticketrush/global/inbox/InboxRetentionBatchDeleterTest.java
@@ -1,0 +1,37 @@
+package com.ticketrush.global.inbox;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class InboxRetentionBatchDeleterTest {
+
+  @InjectMocks private InboxRetentionBatchDeleter batchDeleter;
+
+  @Mock private InboxRepository inboxRepository;
+
+  @Test
+  @DisplayName("배치 삭제를 repository의 LIMIT 삭제 쿼리에 위임하고 삭제 수를 반환한다")
+  void deleteBatch_delegates_to_repository() {
+    // given
+    LocalDateTime threshold = LocalDateTime.now().minusDays(30);
+    int batchSize = 1000;
+    given(inboxRepository.deleteCreatedBeforeInBatch(threshold, batchSize)).willReturn(1000);
+
+    // when
+    int deleted = batchDeleter.deleteBatch(threshold, batchSize);
+
+    // then
+    assertThat(deleted).isEqualTo(1000);
+    verify(inboxRepository).deleteCreatedBeforeInBatch(threshold, batchSize);
+  }
+}

--- a/common/src/test/java/com/ticketrush/global/inbox/InboxRetentionServiceTest.java
+++ b/common/src/test/java/com/ticketrush/global/inbox/InboxRetentionServiceTest.java
@@ -1,0 +1,143 @@
+package com.ticketrush.global.inbox;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class InboxRetentionServiceTest {
+
+  @InjectMocks private InboxRetentionService inboxRetentionService;
+
+  @Mock private InboxRetentionBatchDeleter batchDeleter;
+  @Mock private InboxRetentionProperties properties;
+
+  /** 서비스가 시작 시 읽는 4개 설정을 한 번에 스텁한다. */
+  private void givenProps(int retentionDays, int minRetentionDays, int batchSize, int maxBatches) {
+    given(properties.getRetentionDays()).willReturn(retentionDays);
+    given(properties.getMinRetentionDays()).willReturn(minRetentionDays);
+    given(properties.getBatchSize()).willReturn(batchSize);
+    given(properties.getMaxBatchesPerRun()).willReturn(maxBatches);
+  }
+
+  @Test
+  @DisplayName("한 배치로 소진되면(삭제 수 < batchSize) threshold 기준으로 삭제하고 총 삭제 수를 반환한다")
+  void purge_deletes_in_single_batch() {
+    // given
+    givenProps(30, 7, 1000, 100);
+    given(batchDeleter.deleteBatch(any(LocalDateTime.class), anyInt())).willReturn(7);
+
+    // when
+    int deleted = inboxRetentionService.purgeExpired();
+
+    // then
+    assertThat(deleted).isEqualTo(7);
+    ArgumentCaptor<LocalDateTime> thresholdCaptor = ArgumentCaptor.forClass(LocalDateTime.class);
+    verify(batchDeleter).deleteBatch(thresholdCaptor.capture(), eq(1000));
+    // threshold는 대략 now - 30일. 경계 오차를 감안해 [now-31일, now-29일] 범위인지만 확인한다.
+    LocalDateTime threshold = thresholdCaptor.getValue();
+    assertThat(threshold).isBefore(LocalDateTime.now().minusDays(29));
+    assertThat(threshold).isAfter(LocalDateTime.now().minusDays(31));
+  }
+
+  @Test
+  @DisplayName("여러 배치에 걸쳐 반복 삭제하고(각 배치 독립 트랜잭션) 마지막 부분 배치에서 종료한다")
+  void purge_loops_across_batches() {
+    // given: 1000, 1000, 300 → 3번째에서 batchSize 미만이라 종료
+    givenProps(30, 7, 1000, 100);
+    given(batchDeleter.deleteBatch(any(LocalDateTime.class), anyInt())).willReturn(1000, 1000, 300);
+
+    // when
+    int deleted = inboxRetentionService.purgeExpired();
+
+    // then
+    assertThat(deleted).isEqualTo(2300);
+    verify(batchDeleter, times(3)).deleteBatch(any(LocalDateTime.class), anyInt());
+  }
+
+  @Test
+  @DisplayName("1회 실행 배치 수 상한(maxBatchesPerRun)에 도달하면 중단하고, 남은 대상은 다음 주기로 넘긴다")
+  void purge_stops_at_max_batches_per_run() {
+    // given: 항상 batchSize를 꽉 채워 삭제(대량 누적) + 상한 2
+    givenProps(30, 7, 1000, 2);
+    given(batchDeleter.deleteBatch(any(LocalDateTime.class), anyInt())).willReturn(1000);
+
+    // when
+    int deleted = inboxRetentionService.purgeExpired();
+
+    // then: 상한만큼만 삭제하고 중단(2 * 1000)
+    assertThat(deleted).isEqualTo(2000);
+    verify(batchDeleter, times(2)).deleteBatch(any(LocalDateTime.class), anyInt());
+  }
+
+  @Test
+  @DisplayName("삭제 대상이 없으면(첫 배치가 0건) 0을 반환한다")
+  void purge_returns_zero_when_nothing_deleted() {
+    // given
+    givenProps(30, 7, 1000, 100);
+    given(batchDeleter.deleteBatch(any(LocalDateTime.class), anyInt())).willReturn(0);
+
+    // when
+    int deleted = inboxRetentionService.purgeExpired();
+
+    // then
+    assertThat(deleted).isZero();
+    verify(batchDeleter).deleteBatch(any(LocalDateTime.class), anyInt());
+  }
+
+  @Test
+  @DisplayName("retentionDays가 0 이하이면 전량 삭제 사고를 막기 위해 purge를 건너뛰고 0을 반환한다")
+  void purge_skips_when_retention_days_non_positive() {
+    // given
+    givenProps(0, 7, 1000, 100);
+
+    // when
+    int deleted = inboxRetentionService.purgeExpired();
+
+    // then
+    assertThat(deleted).isZero();
+    verify(batchDeleter, never()).deleteBatch(any(), anyInt());
+  }
+
+  @Test
+  @DisplayName("retentionDays가 minRetentionDays(replay 윈도우)보다 짧으면 중복 재처리 위험을 막기 위해 purge를 건너뛴다")
+  void purge_skips_when_below_min_retention() {
+    // given: 보존 3일 < 최소 7일
+    givenProps(3, 7, 1000, 100);
+
+    // when
+    int deleted = inboxRetentionService.purgeExpired();
+
+    // then
+    assertThat(deleted).isZero();
+    verify(batchDeleter, never()).deleteBatch(any(), anyInt());
+  }
+
+  @Test
+  @DisplayName("batchSize·maxBatchesPerRun 설정이 유효하지 않으면 purge를 건너뛴다")
+  void purge_skips_when_batch_config_invalid() {
+    // given: batchSize 0
+    givenProps(30, 7, 0, 100);
+
+    // when
+    int deleted = inboxRetentionService.purgeExpired();
+
+    // then
+    assertThat(deleted).isZero();
+    verify(batchDeleter, never()).deleteBatch(any(), anyInt());
+  }
+}


### PR DESCRIPTION
## 🔗 관련 이슈

- close #314

---

## 📌 주요 변경 사항

- #110에서 도입한 `inbox` 테이블의 오래된 row를 주기적으로 정리하는 **retention 스케줄러** 추가 (DLT retention 패턴 미러링)
- `inbox`는 전 서비스가 공유하는 전역 테이블이라 **booking-service 단독**에서만 정리(중복 실행 없음)
- 고볼륨 테이블 특성을 고려해 **청크(배치) 삭제** + **보존기간 하한 가드**로 운영 안전성 보강

---

## 🛠 상세 구현 내용

- **`InboxRetentionService`(common)**: 보존기간이 지난 row를 정리. `@ConditionalOnProperty(app.inbox.retention.enabled=true)`로 단일 서비스에서만 빈 생성. 로직 패턴은 `DltRetentionService`(#307)를 따름.
- **`InboxRetentionScheduler`(booking-service)**: `@Scheduled(fixedDelay=1h)` + `@SchedulerLock(inboxRetention-booking)`로 다중 인스턴스 중복 실행 방지. 기존 `ShedLockConfig`(@EnableScheduling)·ShedLock 인프라 재사용.
- **청크 삭제**: `InboxRepository.deleteCreatedBeforeInBatch`(MySQL `DELETE ... LIMIT`) 추가. `InboxRetentionBatchDeleter`가 배치마다 **독립 트랜잭션**으로 삭제하고, `purgeExpired()`는 트랜잭션 없이 배치를 반복 → 대용량 단일 트랜잭션 삭제(긴 락·큰 undo/binlog)를 회피. `maxBatchesPerRun`으로 1회 실행량을 묶어 최초 활성화 시 여러 주기에 걸쳐 완만히 정리하고 `lockAtMostFor` 초과를 방지.
- **보존 하한 가드**: `retentionDays`가 `minRetentionDays`(기본 7일 = Kafka replay 윈도우)보다 짧으면, 윈도우 내 재전달의 중복 재처리 위험이 있어 **fail-safe로 purge를 건너뛰고 error 로그**를 남김.
- 설정: booking `application.yml`에 `app.inbox.retention.*` 블록(`enabled`, `retention-days=30`, `min-retention-days=7`, `batch-size=1000`, `max-batches-per-run=100`), `application-test.yml`에 `enabled: false`. 기본 비활성이며 운영에서 `INBOX_RETENTION_ENABLED=true`로 켬.

---

## ✅ 테스트

### 테스트 방법

- `InboxRetentionServiceTest`: 단일 배치 소진(임계 시각 검증), 다중 배치 반복, `maxBatchesPerRun` 상한 중단, 삭제 대상 없음(0건), `retentionDays<=0` 스킵, `retentionDays < minRetentionDays` 스킵, 배치 설정 무효 스킵
- `InboxRetentionBatchDeleterTest`: 배치 삭제가 `deleteCreatedBeforeInBatch`에 위임되는지 검증
- 실행:
  ```
  ./gradlew :common:test :booking-service:test \
            :common:spotlessCheck :booking-service:spotlessCheck \
            :common:checkstyleMain :booking-service:checkstyleMain \
            :common:checkstyleTest :booking-service:checkstyleTest
  ```

### 테스트 결과

- common + booking `test` + `spotlessCheck` + `checkstyleMain` + `checkstyleTest` **BUILD SUCCESSFUL** (전부 통과)
<!--
### 📸 스크린샷

- 
-->
---

## 👀 리뷰 요청 사항

- 청크 삭제 구조(`InboxRetentionBatchDeleter` 별도 빈으로 배치별 독립 트랜잭션) 및 `maxBatchesPerRun` 기본값(100)·`batch-size`(1000)의 운영 적정성 검토 요청
- 보존 하한 가드(`minRetentionDays`) 기본 7일이 실제 Kafka replay 윈도우와 맞는지 확인 요청

---

## ⚠️ 배포 시 주의사항

- retention은 기본 비활성입니다. 운영에서 **단 하나의 서비스(booking-service)에서만** `INBOX_RETENTION_ENABLED=true`로 켜야 합니다(inbox는 전역 공유 테이블).
- `INBOX_RETENTION_DAYS`는 반드시 `INBOX_MIN_RETENTION_DAYS`(Kafka replay 윈도우) 이상으로 설정하세요. 미만이면 안전을 위해 purge가 동작하지 않습니다.
- 최초 활성화 시 누적 row가 많으면 `max-batches-per-run` × `batch-size`(기본 10만건/회) 단위로 여러 주기에 걸쳐 정리됩니다.
