### PR TITLE
[Docs] #317 kafka-event-guide에 Outbox/Inbox 발행 전략·중복 수신 방지 문서화

### DIFF
--- a/docs/kafka-event-guide.md
+++ b/docs/kafka-event-guide.md
@@ -28,7 +28,7 @@
 | **영구(permanent)** | cause 체인에 `BusinessException` 존재 (비즈니스 규칙 위반, payload 역직렬화 `json.DeserializationException` 등) | `[CRITICAL]` error | **ack** | 재시도해도 결과 불변 → 커밋해 파티션 블로킹 방지. 복구는 CRITICAL 로그·모니터링(#50)에 위임 |
 | └ 그중 **예상된 상태충돌** | `BusinessException` 이면서 **화이트리스트**(`KafkaConsumerErrorPolicy.EXPECTED_CONFLICTS`: `SEAT_NOT_AVAILABLE`·`SEAT_ALREADY_LOCKED`·`PAYMENT_ALREADY_COMPLETED`·`TICKET_ALREADY_USED`·`TICKET_NOT_USABLE`·`BOOKING_CANCEL_NOT_ALLOWED`)에 속함 | `warn` (CRITICAL 아님) | **ack** | 재수신·순서로 자연 발생하는 멱등 상태 → 알림 피로 방지. **모든 409를 정상으로 보지 않는다** — `BOOKING_SEAT_MISMATCH`·`BOOKING_EXPIRED`·`BOOKING_CONFIRM_NOT_ALLOWED`(결제됐으나 확정 불가)는 화이트리스트에서 제외해 `[CRITICAL]`로 남긴다 |
 | **일시(transient)** | 위에 해당하지 않는 모든 예외 (Spring `DataAccessException`·락 타임아웃, Redis 오류, `RetriableException`, 미분류 `RuntimeException`) | `warn` | **ack 안 함 → re-throw** | 재시도하면 성공할 수 있음 → 재시도 5회 후 DLT로 보존 |
-| **예상된 중복(DAO)** | `DataIntegrityViolationException`(unique 위반=중복 등록) 등 리스너별로 명시 처리 | `info` | **ack** | 멱등 결과(정상). 단 재시도가 필요한 경우(예: 토큰 해시 충돌 재생성)는 리스너 맥락에 맞게 예외 처리 |
+| **예상된 중복(DAO)** | `DataIntegrityViolationException`(unique 위반=중복 등록) 등 리스너별로 명시 처리 | `info` | **ack** | 멱등 결과(정상). Inbox 동시 중복 경합(`DuplicateEventException`)이 대표 사례 → §5.3. 단 재시도가 필요한 경우(예: 토큰 해시 충돌 재생성)는 리스너 맥락에 맞게 예외 처리 |
 
 분류는 공통 헬퍼 **`com.ticketrush.global.event.KafkaConsumerErrorPolicy`** 로 판정한다: `isPermanent(Throwable)`, `isExpectedConflict(Throwable)`.
 
@@ -59,7 +59,7 @@ public void handleXxx(@Payload DomainEventEnvelope envelope, Acknowledgment ack)
 ```
 
 - **ack ⊻ re-throw 상호배타:** `MANUAL_IMMEDIATE`에서 한 경로는 ack 하거나 예외를 전파하거나 **둘 중 하나만** 한다(둘 다 금지). 예전의 `finally`-무조건-ack 패턴은 일시 예외까지 삼켜 유실시키므로 금지한다.
-- **멱등키(Redis SETNX) 사용 리스너**(seat `BookingCreatedEventListener`)는 **일시 실패로 re-throw 하기 직전에 멱등키를 롤백**해 재시도가 다시 처리할 수 있게 한다. 영구 실패로 ack 할 때는 멱등키를 유지한다(처리됨).
+- **중복 수신 방지가 필요한 비멱등 리스너**는 처리를 **Inbox(`runIfFirst`)로 감싼다**(→ **§5**). 동시 중복 경합 시 `DuplicateEventException`을 `ack`로 처리하고, 일시 실패는 전파해 롤백(Inbox 미기록)→재처리한다. (과거 seat `BookingCreatedEventListener`의 Redis SETNX 멱등키 방식은 #313에서 Inbox 표준으로 통합됨.)
 
 ### 2.3. 주의사항
 
@@ -137,7 +137,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class OrderService {
 
-    // KafkaDomainEventPublisher가 자동으로 주입됩니다.
+    // 설정(app.event-publisher.type)에 따라 KafkaDomainEventPublisher 또는 OutboxEventPublisher가 주입됩니다(§4).
     private final EventPublisher eventPublisher;
 
     @Transactional
@@ -206,3 +206,151 @@ public class OrderEventListener {
   }
 }
 ```
+
+> `eventPublisher.publish()`의 **실제 발행 방식은 설정(`app.event-publisher.type`)에 따라 두 모드로 갈린다** — **§4**. 그리고 재전달(at-least-once)에 대비한 **중복 수신 방지**는 **§5(Inbox)** 를 따른다.
+
+---
+
+## 4. 발행 전략: Outbox vs AFTER_COMMIT
+
+§3의 `eventPublisher.publish(event)`는 **동일한 한 줄**이지만, 실제 발행 방식은 `app.event-publisher.type` 설정으로 두 모드 중 하나가 선택된다. 발행 코드는 그대로 두고 배선만 바꾼다.
+
+### 4.1. 두 모드 비교
+
+| 구분 | `outbox` | `kafka` (AFTER_COMMIT) |
+|------|----------|------------------------|
+| 설정값 | `app.event-publisher.type: outbox` | `app.event-publisher.type: kafka` |
+| 구현체 | `OutboxEventPublisher` | `KafkaDomainEventPublisher` |
+| 발행 시점 | 호출부 트랜잭션에 참여해 `outbox` 테이블에 INSERT → 폴링 relay가 나중에 Kafka로 send | 트랜잭션이 있으면 커밋 직후(AFTER_COMMIT) send, 없으면 즉시 send |
+| 원자성 | **비즈니스 변경 + 발행 기록이 한 커밋**(트랜잭셔널 아웃박스) | 커밋 후 send이므로 "커밋됐으나 send 실패"의 유실 창이 존재 |
+| 전달 보장 | at-least-once(relay가 `PENDING`·`FAILED`를 재시도) | fire-and-forget(비동기 send, 실패 시 error 로그만) |
+| 선택 기준 | 발행 유실이 정합성 사고로 이어지는 흐름(Saga 보상 등) | 유실 허용 가능한 알림·통계성 발행 |
+
+두 구현체는 `@ConditionalOnExpression`으로 상호배타 활성화된다(`'${app.event-publisher.type}' == 'outbox'` / `== 'kafka'`). 서비스는 `EventPublisher` 인터페이스만 주입받으므로(§3 Step 2) 어느 모드든 발행 코드는 동일하다.
+
+> ⚠️ `OutboxEventPublisher.publish()`는 **활성 트랜잭션이 필수**다. 트랜잭션 밖에서 호출하면 `IllegalStateException`을 던진다(*"…비즈니스 변경과 Outbox 저장의 원자성을 보장하려면 호출부를 @Transactional 등으로 감싸세요."*). outbox 모드 서비스는 발행부를 반드시 `@Transactional` 안에서 호출한다.
+
+**현재 배선:** outbox 모드는 **seat-service**만 사용한다. 나머지 서비스(booking·user·performance·payment·ticket·auth)는 `kafka` 모드다. booking-service는 outbox 인프라(relay·retention 스케줄러·`app.outbox` 설정)를 갖추고 있으나 프로파일이 `kafka`라 휴면 상태다.
+
+### 4.2. Outbox 모드 배선
+
+outbox 모드를 켜면(`app.event-publisher.type: outbox`) 두 스케줄러가 함께 동작한다(둘 다 `@ConditionalOnExpression`로 outbox일 때만 등록).
+
+| 스케줄러 | 주기 | ShedLock 이름 | 역할 |
+|----------|------|---------------|------|
+| `OutboxRelayScheduler` | `fixedDelay=5s` | `outboxRelay-{service}` | `PENDING`·`FAILED` row를 배치로 Kafka에 send |
+| `OutboxRetentionScheduler` | `fixedDelay=1h` | `outboxRetention-{service}` | 보존기간 지난 `SENT` row 삭제 |
+
+ShedLock 이름은 서비스별로 유일해야 한다(예: `outboxRelay-seat`, `outboxRelay-booking`) — 다중 인스턴스 중복 실행 방지.
+
+**`app.outbox.*` 설정 키**
+
+| 키 | 기본값 | 의미 |
+|----|--------|------|
+| `aggregate-types` | `[]` (빈 값이면 relay가 아무것도 안 함) | 이 서비스가 relay·정리할 애그리거트 타입 목록(예: `[Seat]`) |
+| `batch-size` | `100` | relay 1회 배치 크기 |
+| `max-retries` | `3` | 발행 재시도 상한. 초과 시 `DEAD` 전이 |
+| `retention-hours` | `72` | `SENT` row 보존 시간 |
+
+> **여러 서비스가 하나의 `outbox` 테이블을 공유**한다. 각 서비스는 `aggregate-types`로 **자기 소유 row만** relay·정리한다. `aggregateType`은 이벤트 패키지 `com.ticketrush.shared.<aggregate>.event`에서 유도되어 첫 글자가 대문자화된다(`booking` → `Booking`). 따라서 `aggregate-types` 값이 발행 이벤트의 aggregateType과 일치해야 한다.
+
+**상태 흐름 (`OutboxStatus`)**
+
+`PENDING`(발행 대기) → relay send 성공 시 `SENT`(발행 완료) / 실패 시 `FAILED`(발행 실패, `retryCount++`) → 재시도가 `max-retries`에 도달하면 `DEAD`(최종 실패). relay는 `PENDING`·`FAILED`만 대상으로 재시도하고, `SENT`·`DEAD`는 종결 상태다.
+
+> `DEAD` 전이 시 **Slack 알림**이 발송된다(제목 `[Outbox DEAD] 이벤트 발행 재시도 상한 초과`). 알림 본문에는 PII 방지를 위해 원문 에러를 넣지 않고 `eventId`만 담아 outbox 테이블 조회를 유도한다. 상세 원인은 `[CRITICAL]` 로그에 남는다.
+
+### 4.3. 발행 코드는 두 모드가 동일
+
+§3 Step 2의 `eventPublisher.publish(event)`가 그대로다. 모드에 따라 달라지는 것은 배선(설정·스케줄러)뿐이다. outbox 모드에서는 위 콜아웃대로 **호출부를 `@Transactional`로 감싸는 것**만 지키면 된다.
+
+---
+
+## 5. 중복 수신 방지: Inbox 패턴 (#110)
+
+Kafka는 at-least-once라 같은 이벤트가 재전달될 수 있다. **비멱등 소비**(상태 전이·좌석 선점·보상 처리 등)는 재처리되면 사고가 나므로 Inbox로 감싸 한 번만 처리한다.
+
+### 5.1. 언제 쓰나
+
+- **비즈니스 컨슈머는 기본적으로 Inbox로 감싼다.** 현재 모든 도메인 `@KafkaListener`가 `InboxService.runIfFirst`를 거친다(§5.5 목록). Inbox를 쓰지 않는 유일한 `@KafkaListener`는 DLT 모니터(`DeadLetterConsumer`, groupId `dlt-monitor-group`)로, 이는 멱등 처리 대상이 아니라 실패 메시지 적재용이다.
+- **도메인 멱등은 2차 방어(방어 심층화)로 유지한다.** 예: `TicketIssueUseCase`의 `alreadyIssued`, 좌석 SOLD 확정의 409 응답. Inbox가 1차 중복 차단을, 도메인 멱등이 2차 안전망을 담당한다.
+
+### 5.2. 사용법
+
+리스너에는 트랜잭션이 없고 비즈니스 트랜잭션은 usecase에서 시작한다. `InboxService.runIfFirst`가 `@Transactional`(REQUIRED)로 트랜잭션을 열고, business 콜백을 **같은 트랜잭션에 조인**시켜 "처리 + Inbox 기록"을 원자적으로 커밋한다.
+
+```java
+boolean processed =
+    inboxService.runIfFirst(
+        KafkaConsumerGroup.SEAT, envelope, () -> seatFacade.releaseBookedSeat(seatId, bookingNumber));
+
+if (processed) {
+  // 최초 수신 → 이번에 처리함
+} else {
+  // 이미 처리된 이벤트 → 스킵(중복 수신)
+}
+```
+
+- `runIfFirst`는 최초 수신이면 business를 실행하고 Inbox에 기록한 뒤 `true`, 이미 처리한 이벤트면 아무것도 하지 않고 `false`를 반환한다.
+- business가 던진 예외는 잡지 않고 전파한다 → 트랜잭션 롤백(Inbox 미기록) → 재전달 시 재처리.
+
+### 5.3. §2 에러 표준과의 결합
+
+`runIfFirst`를 §2.2 표준 템플릿 위에 얹는다. 결과별 대응:
+
+| 상황 | 처리 |
+|------|------|
+| 정상 처리(`processed=true`) 또는 스킵(`false`) | `ack` |
+| `DuplicateEventException`(동시 중복 수신으로 inbox unique 경합) | **`ack`**(멱등 정상) — 전용 catch 블록 |
+| business의 비즈니스 예외(영구) | §2 표준대로 `[CRITICAL]`/`warn` 후 `ack` |
+| business의 일시(인프라) 예외 | 전파(re-throw) → 롤백(Inbox 미기록) → §2의 재시도→DLT. 재전달 시 재처리 |
+
+```java
+try {
+  boolean processed =
+      inboxService.runIfFirst(KafkaConsumerGroup.XXX, envelope, () -> usecase.execute(...));
+  // processed 여부 로깅
+  ack.acknowledge();
+} catch (DuplicateEventException e) {
+  ack.acknowledge();                        // 동시 중복 → 멱등 정상
+} catch (Exception e) {
+  // §2.2 표준 분기(영구 → ack / 일시 → re-throw)
+}
+```
+
+### 5.4. 멱등 키
+
+Inbox 중복 판정은 복합 unique **`uk_inbox_group_event (consumer_group, event_id)`** 로 한다(`inbox` 테이블). **컨슈머 그룹별로** 키가 갈리므로, 같은 이벤트라도 여러 컨슈머 그룹(예: `seat-group`·`booking-group`·`ticket-group`)이 **각자 한 번씩** 소비한다. `created_at`에는 retention용 인덱스 `idx_inbox_created_at`가 있다.
+
+### 5.5. 적용 리스너 목록
+
+`inboxService.runIfFirst`를 사용하는 리스너(10개):
+
+| 서비스 | 리스너 | groupId | 감싸는 처리 |
+|--------|--------|---------|-------------|
+| seat | `BookingCreatedEventListener` | `seat-group` | `seatFacade.tryLockSeat(...)` |
+| seat | `BookingCanceledEventListener` | `seat-group` | `seatFacade.releaseBookedSeat(...)` |
+| seat | `PaymentCanceledEventListener` | `seat-group` | `seatReleaseSoldSeatUseCase.execute(...)` |
+| seat | `PerformanceCreatedEventListener` | `seat-group` | `seatFacade.createDefaultSeats(...)` |
+| booking | `PaymentConfirmedEventListener` | `booking-group` | `bookingConfirmUseCase.execute(...)` (확정만; SOLD HTTP는 Inbox 밖) |
+| booking | `PaymentCanceledEventListener` | `booking-group` | `bookingMarkRefundedUseCase.execute(...)` |
+| booking | `SeatHoldFailedEventListener` | `booking-group` | `bookingCancelUseCase.execute(...)` |
+| ticket | `PaymentConfirmedEventListener` | `ticket-group` | `ticketIssueUseCase.execute(...)` |
+| ticket | `PaymentCanceledEventListener` | `ticket-group` | `ticketCancelUseCase.execute(...)` |
+| payment | `BookingExpiredEventListener` | `payment-group` | `paymentFacade.registerExpiredBooking(...)` |
+
+> booking `PaymentConfirmedEventListener`는 **확정(DB 상태 전이)만 Inbox로 감싸고**, 커밋 후 좌석 SOLD 확정 HTTP 호출은 Inbox 밖에서 수행한다(재소비 시에도 `bookingNumber`를 재조회해 SOLD를 멱등하게 재호출). 크로스서비스 호출은 트랜잭셔널 원자 단위에 포함할 수 없기 때문이다.
+
+### 5.6. Inbox retention (#314)
+
+`inbox` 테이블은 방치하면 무한 증가하므로, 보존기간이 지난 row를 **booking-service 단독**에서 정리한다(전역 공유 테이블이라 한 서비스가 대표로 정리). `app.inbox.retention.enabled=true`일 때만 동작하며 기본 비활성이다.
+
+| 키 | 기본값 | 의미 |
+|----|--------|------|
+| `enabled` | `false` | 운영에서 단일 서비스(booking)만 `true` |
+| `retention-days` | `30` | 보존기간 |
+| `min-retention-days` | `7` | 보존 하한 = Kafka replay 윈도우. `retention-days`가 이보다 짧으면 중복 재처리 위험이 있어 purge를 건너뛴다(fail-safe) |
+| `batch-size` | `1000` | 청크 삭제 배치 크기(배치마다 독립 트랜잭션 → 대용량 단일 삭제 회피) |
+| `max-batches-per-run` | `100` | 1회 실행당 배치 수 상한 |
+
+`InboxRetentionScheduler`(booking, `@Scheduled` 1h + `@SchedulerLock inboxRetention-booking`)가 청크 단위로 삭제한다.


### PR DESCRIPTION
## 🔗 관련 이슈

- close #317

---

## 📌 주요 변경 사항

- `common`에 구현된 **Outbox / Inbox 패턴**을 이벤트·메시징 SSOT인 `docs/kafka-event-guide.md`에 문서화(기존 문서에 §4·§5 섹션 추가)
- **#313·#314 머지 후 최신 구현 기준**으로 작성(문서만 변경, 프로덕션 코드 무변경)

---

## 🛠 상세 구현 내용

- **신규 §4 발행 전략: Outbox vs AFTER_COMMIT** — 두 모드 비교표(구현체·발행시점·원자성·전달보장·선택기준), Outbox 배선(`OutboxRelayScheduler`/`OutboxRetentionScheduler` 주기·ShedLock명, `app.outbox.*` 키·기본값), 상태 흐름 `PENDING→SENT/FAILED→DEAD`(DEAD→Slack 알림), `OutboxEventPublisher` 활성 트랜잭션 필수 콜아웃, 현재 배선(seat만 outbox)
- **신규 §5 중복 수신 방지: Inbox 패턴** — 언제 쓰나(비즈니스 컨슈머 기본 Inbox·도메인 멱등은 2차 방어), `InboxService.runIfFirst` 사용법·§2 에러 표준 결합 표, 멱등키 `uk_inbox_group_event (consumer_group, event_id)`, **적용 리스너 10개 census(groupId 포함)**, §5.6 Inbox retention(#314 반영)
- **기존 §1~§3 정합화** — §2.2의 낡은 "Redis SETNX 멱등키" 서술을 Inbox(§5)로 교체(#313 반영), §2.1 `DuplicateEventException` 상호참조, §3 Step2 주입 주석에 §4 참조, §3 말미 §4·§5 콜아웃

---

## ✅ 테스트

### 테스트 방법

- 문서 변경이라 자동화 테스트 없음. 대신 **인용 정확성**을 코드로 직접 검증: 적용 리스너 10개 census(`runIfFirst` grep으로 groupId·감싸는 usecase 확인), `OutboxStatus` enum(PENDING/SENT/FAILED/DEAD), `OutboxRelayScheduler` 주기(5s)·ShedLock명, DEAD Slack 제목, `app.outbox.*`·`app.inbox.retention.*` 키·기본값

### 테스트 결과

- 인용한 클래스·설정 키·기본값·경로·리스너 groupId가 실제 구현과 일치함을 확인
<!--
### 📸 스크린샷

- 
-->
---

## 👀 리뷰 요청 사항

- 이슈 본문이 상정한 "PaymentConfirmed류는 inbox 없이 도메인 멱등 의존"·"retention 미배선"은 #313·#314로 낡아, **최신 구현 기준**(모든 비즈니스 리스너 Inbox 표준·retention 배선됨)으로 작성했습니다. 이 방향이 맞는지 확인 부탁드립니다.
- §5.5 적용 리스너 census(10개) 누락 여부 검토 요청

---

## ⚠️ 배포 시 주의사항

- 없음(문서 변경).
