### PR TITLE
[Infra] #132 ticket-service에 MapStruct 기반 Mapper 구조 도입

### DIFF
--- a/ticket-service/build.gradle
+++ b/ticket-service/build.gradle
@@ -34,17 +34,23 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-webmvc'
+	// MapStruct
+	implementation 'org.mapstruct:mapstruct:1.5.5.Final'
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
 	annotationProcessor 'org.projectlombok:lombok'
+	// Lombok과 MapStruct의 순서 및 바인딩을 위한 필수 설정
+	annotationProcessor 'org.projectlombok:lombok-mapstruct-binding:0.2.0'
+	annotationProcessor 'org.mapstruct:mapstruct-processor:1.5.5.Final'
 	testImplementation 'com.h2database:h2'
 	testImplementation 'org.springframework.boot:spring-boot-starter-actuator-test'
 	testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
 	testImplementation 'org.springframework.boot:spring-boot-starter-security-test'
 	testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	testAnnotationProcessor 'org.mapstruct:mapstruct-processor:1.5.5.Final'
 
 	// swagger
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.1'

--- a/ticket-service/src/main/java/com/ticketrush/boundedcontext/ticket/app/dto/response/EntryVerifyResponse.java
+++ b/ticket-service/src/main/java/com/ticketrush/boundedcontext/ticket/app/dto/response/EntryVerifyResponse.java
@@ -1,6 +1,5 @@
 package com.ticketrush.boundedcontext.ticket.app.dto.response;
 
-import com.ticketrush.boundedcontext.ticket.domain.entity.Ticket;
 import com.ticketrush.boundedcontext.ticket.domain.types.TicketStatus;
 import io.swagger.v3.oas.annotations.media.Schema;
 
@@ -8,9 +7,4 @@ import io.swagger.v3.oas.annotations.media.Schema;
 public record EntryVerifyResponse(
     @Schema(description = "입장권 ID", example = "1") Long ticketId,
     @Schema(description = "예매 ID", example = "100") Long bookingId,
-    @Schema(description = "입장권 상태", example = "UNUSED") TicketStatus ticketStatus) {
-
-  public static EntryVerifyResponse of(Ticket ticket) {
-    return new EntryVerifyResponse(ticket.getId(), ticket.getBookingId(), ticket.getTicketStatus());
-  }
-}
+    @Schema(description = "입장권 상태", example = "UNUSED") TicketStatus ticketStatus) {}

--- a/ticket-service/src/main/java/com/ticketrush/boundedcontext/ticket/app/dto/response/TicketQrResponse.java
+++ b/ticket-service/src/main/java/com/ticketrush/boundedcontext/ticket/app/dto/response/TicketQrResponse.java
@@ -1,6 +1,5 @@
 package com.ticketrush.boundedcontext.ticket.app.dto.response;
 
-import com.ticketrush.boundedcontext.ticket.domain.entity.Ticket;
 import com.ticketrush.boundedcontext.ticket.domain.types.TicketStatus;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
@@ -14,10 +13,4 @@ public record TicketQrResponse(
     @Schema(description = "입장권 상태", example = "UNUSED") TicketStatus ticketStatus,
     @Schema(description = "입장권 발급 시각", example = "2026-06-25 10:00:00") LocalDateTime issuedAt,
     @Schema(description = "QR payload 만료 시각", example = "2026-06-25 10:05:00")
-        LocalDateTime expiresAt) {
-
-  public static TicketQrResponse of(Ticket ticket, String payload, LocalDateTime expiresAt) {
-    return new TicketQrResponse(
-        payload, ticket.getTicketStatus(), ticket.getCreatedAt(), expiresAt);
-  }
-}
+        LocalDateTime expiresAt) {}

--- a/ticket-service/src/main/java/com/ticketrush/boundedcontext/ticket/app/mapper/TicketMapper.java
+++ b/ticket-service/src/main/java/com/ticketrush/boundedcontext/ticket/app/mapper/TicketMapper.java
@@ -1,0 +1,27 @@
+package com.ticketrush.boundedcontext.ticket.app.mapper;
+
+import com.ticketrush.boundedcontext.ticket.app.dto.response.EntryVerifyResponse;
+import com.ticketrush.boundedcontext.ticket.app.dto.response.TicketQrResponse;
+import com.ticketrush.boundedcontext.ticket.domain.entity.Ticket;
+import java.time.LocalDateTime;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper(componentModel = "spring")
+public interface TicketMapper {
+
+  // 단일 소스 Entity -> DTO. DB의 id를 DTO의 ticketId로 매핑하고, bookingId/ticketStatus는 동명 자동 매핑한다.
+  @Mapping(source = "id", target = "ticketId")
+  EntryVerifyResponse toEntryVerifyResponse(Ticket ticket);
+
+  // 다중 소스 Entity + 파라미터 -> DTO. 발급 시각(createdAt)을 issuedAt으로, 상태는 ticket에서 매핑한다.
+  // payload/expiresAt 파라미터는 target 필드명과 동일해 자동 매핑된다.
+  @Mapping(source = "ticket.ticketStatus", target = "ticketStatus")
+  @Mapping(source = "ticket.createdAt", target = "issuedAt")
+  TicketQrResponse toTicketQrResponse(Ticket ticket, String payload, LocalDateTime expiresAt);
+
+  // 식별자 + 계산된 토큰 해시 -> Entity. @Builder 대상(bookingId/ticketTokenHash/ticketStatus)만 target이라
+  // id/usedAt은 ignore가 불필요하며, 발급 시 상태는 UNUSED로 고정한다.
+  @Mapping(target = "ticketStatus", constant = "UNUSED")
+  Ticket toEntity(Long bookingId, String ticketTokenHash);
+}

--- a/ticket-service/src/main/java/com/ticketrush/boundedcontext/ticket/app/usecase/EntryVerifyUseCase.java
+++ b/ticket-service/src/main/java/com/ticketrush/boundedcontext/ticket/app/usecase/EntryVerifyUseCase.java
@@ -1,6 +1,7 @@
 package com.ticketrush.boundedcontext.ticket.app.usecase;
 
 import com.ticketrush.boundedcontext.ticket.app.dto.response.EntryVerifyResponse;
+import com.ticketrush.boundedcontext.ticket.app.mapper.TicketMapper;
 import com.ticketrush.boundedcontext.ticket.domain.entity.Ticket;
 import com.ticketrush.boundedcontext.ticket.domain.policy.TicketQrPayloadVerifier;
 import com.ticketrush.boundedcontext.ticket.domain.policy.VerifiedQrClaims;
@@ -23,10 +24,11 @@ public class EntryVerifyUseCase {
   private final TicketQrPayloadVerifier ticketQrPayloadVerifier;
   private final TicketRepository ticketRepository;
   private final BookingRestClient bookingRestClient;
+  private final TicketMapper ticketMapper;
 
   /** QR을 검증해 입장 가능 상태를 반환한다(상태 변경 없음). */
   public EntryVerifyResponse execute(String token) {
-    return EntryVerifyResponse.of(verifyAndLoad(token));
+    return ticketMapper.toEntryVerifyResponse(verifyAndLoad(token));
   }
 
   /**

--- a/ticket-service/src/main/java/com/ticketrush/boundedcontext/ticket/app/usecase/TicketIssueUseCase.java
+++ b/ticket-service/src/main/java/com/ticketrush/boundedcontext/ticket/app/usecase/TicketIssueUseCase.java
@@ -1,10 +1,10 @@
 package com.ticketrush.boundedcontext.ticket.app.usecase;
 
 import com.ticketrush.boundedcontext.ticket.app.dto.response.TicketIssueResponse;
+import com.ticketrush.boundedcontext.ticket.app.mapper.TicketMapper;
 import com.ticketrush.boundedcontext.ticket.domain.entity.Ticket;
 import com.ticketrush.boundedcontext.ticket.domain.policy.TicketTokenGenerator;
 import com.ticketrush.boundedcontext.ticket.domain.policy.TicketTokenHasher;
-import com.ticketrush.boundedcontext.ticket.domain.types.TicketStatus;
 import com.ticketrush.boundedcontext.ticket.out.repository.TicketRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -30,6 +30,7 @@ public class TicketIssueUseCase {
   private final TicketRepository ticketRepository;
   private final TicketTokenGenerator ticketTokenGenerator;
   private final TicketTokenHasher ticketTokenHasher;
+  private final TicketMapper ticketMapper;
 
   public TicketIssueResponse execute(Long bookingId) {
     if (ticketRepository.existsByBookingId(bookingId)) {
@@ -37,12 +38,7 @@ public class TicketIssueUseCase {
     }
 
     String token = ticketTokenGenerator.generate();
-    Ticket ticket =
-        Ticket.builder()
-            .bookingId(bookingId)
-            .ticketTokenHash(ticketTokenHasher.hash(token))
-            .ticketStatus(TicketStatus.UNUSED)
-            .build();
+    Ticket ticket = ticketMapper.toEntity(bookingId, ticketTokenHasher.hash(token));
 
     // Inbox 트랜잭션에 조인된 상태로 저장한다. unique(booking_id/ticket_token_hash) 충돌 시 예외를 그대로 전파해
     // 트랜잭션을 롤백시키고(Inbox 미기록) 재소비로 처리한다.

--- a/ticket-service/src/main/java/com/ticketrush/boundedcontext/ticket/app/usecase/TicketQrGetUseCase.java
+++ b/ticket-service/src/main/java/com/ticketrush/boundedcontext/ticket/app/usecase/TicketQrGetUseCase.java
@@ -1,6 +1,7 @@
 package com.ticketrush.boundedcontext.ticket.app.usecase;
 
 import com.ticketrush.boundedcontext.ticket.app.dto.response.TicketQrResponse;
+import com.ticketrush.boundedcontext.ticket.app.mapper.TicketMapper;
 import com.ticketrush.boundedcontext.ticket.domain.entity.Ticket;
 import com.ticketrush.boundedcontext.ticket.domain.policy.QrPayload;
 import com.ticketrush.boundedcontext.ticket.domain.policy.TicketQrPayloadGenerator;
@@ -22,6 +23,7 @@ public class TicketQrGetUseCase {
   private final BookingRestClient bookingRestClient;
   private final TicketRepository ticketRepository;
   private final TicketQrPayloadGenerator ticketQrPayloadGenerator;
+  private final TicketMapper ticketMapper;
 
   /**
    * 외부 동기 호출(booking-service)을 트랜잭션 밖에서 먼저 수행해 DB 커넥션을 장시간 점유하지 않는다. 실제 DB 접근은 findByBookingId
@@ -46,6 +48,6 @@ public class TicketQrGetUseCase {
             .orElseThrow(() -> new BusinessException(ErrorStatus.TICKET_NOT_FOUND));
 
     QrPayload qrPayload = ticketQrPayloadGenerator.generate(ticket);
-    return TicketQrResponse.of(ticket, qrPayload.payload(), qrPayload.expiresAt());
+    return ticketMapper.toTicketQrResponse(ticket, qrPayload.payload(), qrPayload.expiresAt());
   }
 }

--- a/ticket-service/src/test/java/com/ticketrush/boundedcontext/ticket/app/usecase/EntryVerifyUseCaseTest.java
+++ b/ticket-service/src/test/java/com/ticketrush/boundedcontext/ticket/app/usecase/EntryVerifyUseCaseTest.java
@@ -7,6 +7,7 @@ import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.never;
 
 import com.ticketrush.boundedcontext.ticket.app.dto.response.EntryVerifyResponse;
+import com.ticketrush.boundedcontext.ticket.app.mapper.TicketMapper;
 import com.ticketrush.boundedcontext.ticket.domain.entity.Ticket;
 import com.ticketrush.boundedcontext.ticket.domain.policy.TicketQrPayloadVerifier;
 import com.ticketrush.boundedcontext.ticket.domain.policy.VerifiedQrClaims;
@@ -20,8 +21,10 @@ import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mapstruct.factory.Mappers;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
@@ -37,6 +40,8 @@ class EntryVerifyUseCaseTest {
   @Mock private TicketRepository ticketRepository;
 
   @Mock private BookingRestClient bookingRestClient;
+
+  @Spy private TicketMapper ticketMapper = Mappers.getMapper(TicketMapper.class);
 
   private Ticket ticket(Long id, Long bookingId, TicketStatus status) {
     Ticket ticket =

--- a/ticket-service/src/test/java/com/ticketrush/boundedcontext/ticket/app/usecase/TicketIssueUseCaseTest.java
+++ b/ticket-service/src/test/java/com/ticketrush/boundedcontext/ticket/app/usecase/TicketIssueUseCaseTest.java
@@ -9,6 +9,7 @@ import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.never;
 
 import com.ticketrush.boundedcontext.ticket.app.dto.response.TicketIssueResponse;
+import com.ticketrush.boundedcontext.ticket.app.mapper.TicketMapper;
 import com.ticketrush.boundedcontext.ticket.domain.entity.Ticket;
 import com.ticketrush.boundedcontext.ticket.domain.policy.TicketTokenGenerator;
 import com.ticketrush.boundedcontext.ticket.domain.policy.TicketTokenHasher;
@@ -17,9 +18,11 @@ import com.ticketrush.boundedcontext.ticket.out.repository.TicketRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mapstruct.factory.Mappers;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.dao.DataIntegrityViolationException;
 
@@ -33,6 +36,8 @@ class TicketIssueUseCaseTest {
   @Mock private TicketTokenGenerator ticketTokenGenerator;
 
   @Mock private TicketTokenHasher ticketTokenHasher;
+
+  @Spy private TicketMapper ticketMapper = Mappers.getMapper(TicketMapper.class);
 
   @Test
   @DisplayName("성공: 예매 ID 기준으로 티켓 토큰 해시와 UNUSED 상태를 저장한다")

--- a/ticket-service/src/test/java/com/ticketrush/boundedcontext/ticket/app/usecase/TicketQrGetUseCaseTest.java
+++ b/ticket-service/src/test/java/com/ticketrush/boundedcontext/ticket/app/usecase/TicketQrGetUseCaseTest.java
@@ -7,6 +7,7 @@ import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.never;
 
 import com.ticketrush.boundedcontext.ticket.app.dto.response.TicketQrResponse;
+import com.ticketrush.boundedcontext.ticket.app.mapper.TicketMapper;
 import com.ticketrush.boundedcontext.ticket.domain.entity.Ticket;
 import com.ticketrush.boundedcontext.ticket.domain.policy.QrPayload;
 import com.ticketrush.boundedcontext.ticket.domain.policy.TicketQrPayloadGenerator;
@@ -21,8 +22,10 @@ import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mapstruct.factory.Mappers;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
@@ -36,6 +39,8 @@ class TicketQrGetUseCaseTest {
   @Mock private TicketRepository ticketRepository;
 
   @Mock private TicketQrPayloadGenerator ticketQrPayloadGenerator;
+
+  @Spy private TicketMapper ticketMapper = Mappers.getMapper(TicketMapper.class);
 
   private Ticket ticket(Long bookingId, LocalDateTime createdAt) {
     Ticket ticket =


### PR DESCRIPTION
## 🔗 관련 이슈

- close #132

---

## 📌 주요 변경 사항

- ticket-service에 MapStruct 기반 Mapper 구조 도입 (기존 미도입 유일 도메인 서비스 → 팀 표준 정렬)
- Entity ↔ DTO 수동 변환(static factory / UseCase 내 인라인 조립)을 Mapper로 위임
- 서비스 계층의 인라인 객체 생성 코드 제거

---

## 🛠 상세 구현 내용

- **`TicketMapper` 신규**(`app.mapper`, `@Mapper(componentModel = "spring")`) — 매핑 메서드 3개
  - `toEntryVerifyResponse(Ticket)`: 단일 소스, `id → ticketId` 리네임
  - `toTicketQrResponse(Ticket, payload, expiresAt)`: 다중 소스, `createdAt → issuedAt` 리네임
  - `toEntity(bookingId, ticketTokenHash)`: 요청값 → Entity, 상태 상수 `UNUSED`
- **UseCase 3종 리팩터링** — Mapper 주입 후 변환 위임
  - `EntryVerifyUseCase`, `TicketQrGetUseCase`: `of()` 호출 → Mapper 호출
  - `TicketIssueUseCase`: `Ticket.builder()...build()` 인라인 조립 제거 → `ticketMapper.toEntity(...)` (토큰 해싱은 도메인 로직으로 UseCase에 잔류)
- **레거시 정리** — 대체된 `EntryVerifyResponse.of` / `TicketQrResponse.of` static factory 삭제
- **build.gradle** — MapStruct `1.5.5.Final` + `lombok-mapstruct-binding 0.2.0` 의존성 추가 (payment-service 패턴 준수)
- **스코프 판단(가이드 §4 준수)** — 다음은 매퍼 대상에서 제외: `EntryCheckInResponse`(소스 빈 없는 primitive+상수), `TicketIssueResponse.issued/alreadyIssued`(결과 플래그), 도메인 QR policy record(JWT crypto), `BookingRestClient` 언랩(out 어댑터)

---

## ✅ 테스트

### 테스트 방법

- `./gradlew :ticket-service:compileJava` — MapStruct 구현체(`TicketMapperImpl.java`) 생성 및 매핑 규칙 확인
- `./gradlew :ticket-service:test` — 전체 단위 테스트 실행
- 기존 UseCase 테스트 3종(`EntryVerifyUseCaseTest`, `TicketQrGetUseCaseTest`, `TicketIssueUseCaseTest`)에 실제 매퍼 impl을 `@Spy TicketMapper = Mappers.getMapper(TicketMapper.class)`로 주입해 변환 결과 검증

### 테스트 결과

- ✅ `compileJava` 성공 — `TicketMapperImpl.java` 정상 생성, `id→ticketId` / `createdAt→issuedAt` / 상수 `UNUSED` 매핑 확인
- ✅ `test` 성공 — 17개 테스트 클래스 / 68개 테스트 전부 통과 (failures 0, errors 0)
<!--
### 📸 스크린샷

-
-->
---

## 👀 리뷰 요청 사항

- 매퍼 적용 스코프 판단(가이드 §4 기준 EntryCheckIn/TicketIssueResponse 제외)이 팀 컨벤션에 부합하는지 확인 부탁드립니다.

---

## ⚠️ 배포 시 주의사항

- 없음 (컴파일 타임 코드 생성이라 런타임 동작·API 스펙 변경 없음)
