### PR TITLE
[Infra] #133 seat-service에 MapStruct 기반 Mapper 구조 도입

### DIFF
--- a/seat-service/build.gradle
+++ b/seat-service/build.gradle
@@ -34,11 +34,16 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-webmvc'
+    // MapStruct
+    implementation 'org.mapstruct:mapstruct:1.5.5.Final'
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.springframework.boot:spring-boot-configuration-processor'
     annotationProcessor 'org.projectlombok:lombok'
+    // Lombok과 MapStruct의 순서 및 바인딩을 위한 필수 설정
+    annotationProcessor 'org.projectlombok:lombok-mapstruct-binding:0.2.0'
+    annotationProcessor 'org.mapstruct:mapstruct-processor:1.5.5.Final'
     testImplementation 'com.h2database:h2'
     testImplementation 'org.springframework.boot:spring-boot-starter-actuator-test'
     testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
@@ -46,6 +51,7 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
     testImplementation testFixtures(project(":common"))
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    testAnnotationProcessor 'org.mapstruct:mapstruct-processor:1.5.5.Final'
 
     // swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:3.0.1'

--- a/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/app/mapper/SeatMapper.java
+++ b/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/app/mapper/SeatMapper.java
@@ -1,0 +1,15 @@
+package com.ticketrush.boundedcontext.seat.app.mapper;
+
+import com.ticketrush.boundedcontext.seat.app.dto.response.SeatStatusChangedResponse;
+import com.ticketrush.boundedcontext.seat.domain.entity.Seat;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+@Mapper(componentModel = "spring")
+public interface SeatMapper {
+
+  // 좌석 상태 변경 이벤트 페이로드로 변환한다. DB의 id를 seatId로 매핑하고,
+  // performanceId/seatLayoutId/seatNumber/seatStatus/holdExpiredAt은 동명 자동 매핑된다.
+  @Mapping(source = "id", target = "seatId")
+  SeatStatusChangedResponse toChangedResponse(Seat seat);
+}

--- a/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/app/support/SeatStatusEventPublisher.java
+++ b/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/app/support/SeatStatusEventPublisher.java
@@ -1,6 +1,7 @@
 package com.ticketrush.boundedcontext.seat.app.support;
 
 import com.ticketrush.boundedcontext.seat.app.dto.response.SeatStatusChangedResponse;
+import com.ticketrush.boundedcontext.seat.app.mapper.SeatMapper;
 import com.ticketrush.boundedcontext.seat.domain.entity.Seat;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -12,16 +13,10 @@ import org.springframework.transaction.support.TransactionSynchronizationManager
 public class SeatStatusEventPublisher {
 
   private final SeatStatusEventSender seatStatusEventSender;
+  private final SeatMapper seatMapper;
 
   public void publishAfterCommit(Seat seat) {
-    SeatStatusChangedResponse event =
-        new SeatStatusChangedResponse(
-            seat.getPerformanceId(),
-            seat.getId(),
-            seat.getSeatLayoutId(),
-            seat.getSeatNumber(),
-            seat.getSeatStatus(),
-            seat.getHoldExpiredAt());
+    SeatStatusChangedResponse event = seatMapper.toChangedResponse(seat);
 
     if (!TransactionSynchronizationManager.isSynchronizationActive()) {
       seatStatusEventSender.send(event);

--- a/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/app/support/SeatStatusEventPublisherTest.java
+++ b/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/app/support/SeatStatusEventPublisherTest.java
@@ -3,14 +3,17 @@ package com.ticketrush.boundedcontext.seat.app.support;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.verify;
 
+import com.ticketrush.boundedcontext.seat.app.mapper.SeatMapper;
 import com.ticketrush.boundedcontext.seat.domain.entity.Seat;
 import com.ticketrush.global.types.SeatStatus;
 import java.time.LocalDateTime;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mapstruct.factory.Mappers;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
@@ -19,6 +22,8 @@ class SeatStatusEventPublisherTest {
   @InjectMocks private SeatStatusEventPublisher seatStatusEventPublisher;
 
   @Mock private SeatStatusEventSender seatStatusEventSender;
+
+  @Spy private SeatMapper seatMapper = Mappers.getMapper(SeatMapper.class);
 
   @Test
   @DisplayName("트랜잭션이 없으면 좌석 상태 변경 이벤트를 즉시 발행한다")


### PR DESCRIPTION
## 🔗 관련 이슈

- close #133

---

## 📌 주요 변경 사항

- seat-service에 MapStruct 기반 Mapper 구조 도입 (도메인 서비스 순차 도입의 일환)
- 유일한 수동 Entity→DTO 변환(`SeatStatusEventPublisher`)을 Mapper로 위임
- Repository Projection 등 가이드 §4상 매퍼 비대상은 현행 유지

---

## 🛠 상세 구현 내용

- **`SeatMapper` 신규**(`app.mapper`, `@Mapper(componentModel = "spring")`)
  - `toChangedResponse(Seat)`: 좌석 상태 변경 이벤트 페이로드로 변환, `id → seatId` 리네임 (나머지 5개 필드 동명 자동 매핑)
- **`SeatStatusEventPublisher` 리팩터링** — `SeatMapper` 주입 후 수동 `new SeatStatusChangedResponse(...)` 조립을 `seatMapper.toChangedResponse(seat)`로 대체
- **build.gradle** — MapStruct `1.5.5.Final` + `lombok-mapstruct-binding 0.2.0` 의존성 추가 (팀 표준 패턴)
- **스코프 판단(가이드 §4 준수)** — 다음은 매퍼 대상에서 제외
  - `SeatRepository`의 JPQL Projection 3건(`SeatStatusCountsResponse`, `List<SeatLayoutResponse>`, `List<SeatNumberResponse>`) — DB에서 DTO 직접 조회
  - `SeatGetNumbersUseCase`의 DTO 재정렬, `SeatCreateDefaultLayoutUseCase`의 프로그램적 엔티티 빌드(요청 DTO 기반 아님)

---

## ✅ 테스트

### 테스트 방법

- `./gradlew :seat-service:compileJava` — MapStruct 구현체(`SeatMapperImpl.java`) 생성 및 매핑 규칙 확인
- `./gradlew :seat-service:test` — 전체 단위 테스트 실행
- `SeatStatusEventPublisherTest`에 실제 매퍼 impl을 `@Spy SeatMapper = Mappers.getMapper(SeatMapper.class)`로 주입해 변환 결과 검증

### 테스트 결과

- ✅ `compileJava` 성공 — `SeatMapperImpl.java` 정상 생성, `id→seatId` 포함 6개 필드 매핑 확인
- ✅ `test` 성공 — 83개 테스트 전부 통과 (failures 0, errors 0)
<!--
### 📸 스크린샷

-
-->
---

## 👀 리뷰 요청 사항

- seat-service는 응답 대부분이 Repository Projection이라 매퍼 이관 대상이 1건뿐입니다. Projection·엔티티 빌드를 매퍼 대상에서 제외한 스코프 판단(가이드 §4)이 팀 컨벤션에 부합하는지 확인 부탁드립니다.

---

## ⚠️ 배포 시 주의사항

- 없음 (컴파일 타임 코드 생성이라 런타임 동작·API 스펙 변경 없음)
