### PR TITLE
[Feat] #297 결제 confirm 실패 상태(FAILED) 영속화 및 추적

### DIFF
--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentConfirmUseCase.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentConfirmUseCase.java
@@ -13,7 +13,10 @@ import com.ticketrush.boundedcontext.payment.out.repository.ExpiredBookingReposi
 import com.ticketrush.boundedcontext.payment.out.repository.PaymentRepository;
 import com.ticketrush.global.exception.BusinessException;
 import com.ticketrush.global.status.ErrorStatus;
+import java.util.EnumSet;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 /**
@@ -24,9 +27,25 @@ import org.springframework.stereotype.Service;
  * 전파된다. (ID 전략이 IDENTITY라 {@code save}만으로도 INSERT가 즉시 실행되지만, 동시 confirm 시 unique 위반을 이벤트 발행 이전에
  * 표면화한다는 의도를 명시하고 취소 경로({@code PaymentCancelPersister})와 일관성을 맞추기 위해 saveAndFlush를 쓴다, #296.)
  */
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class PaymentConfirmUseCase {
+
+  /**
+   * FAILED 이력으로 기록할 실패 사유 화이트리스트(#297).
+   *
+   * <p>과금이 발생하지 않은 것이 확실하고 결정적인 실패(카드 거절/한도 초과/세션 만료)만 기록한다. 승인 결과가 성공이거나(예: {@code
+   * PAYMENT_ALREADY_COMPLETED} = PG 승인·과금 완료) 불명인 경우(예: {@code PAYMENT_PG_COMMUNICATION_FAILED} 통신
+   * 실패, {@code PAYMENT_APPROVAL_FAILED} 미매핑, {@code PAYMENT_AMOUNT_MISMATCH} = 승인 후 검증 실패라 과금됨), 우리
+   * 키/인증 결함({@code PAYMENT_PG_AUTH_FAILED})은 FAILED로 확정하면 실제 성공·과금 건을 "결제 안 됨"으로 오라벨링하는 고아 청구가 되거나
+   * 사용자 결제실패 통계에 노이즈가 되므로 기록하지 않는다.
+   */
+  private static final Set<ErrorStatus> RECORDABLE_FAILURES =
+      EnumSet.of(
+          ErrorStatus.PAYMENT_METHOD_REJECTED,
+          ErrorStatus.PAYMENT_LIMIT_EXCEEDED,
+          ErrorStatus.PAYMENT_SESSION_NOT_FOUND);
 
   private final PaymentRepository paymentRepository;
   private final PaymentApprovalClientRouter paymentApprovalClientRouter;
@@ -47,17 +66,24 @@ public class PaymentConfirmUseCase {
 
     String orderId = generateOrderId(request.bookingId());
 
-    PaymentApprovalResponse approval =
-        paymentApprovalClientRouter.approve(
-            new PaymentApprovalRequest(
-                request.provider(),
-                request.paymentKey(),
-                orderId,
-                request.bookingId(),
-                request.amount()));
+    // PG 승인·금액 검증 단계에서 결제 실패가 확정되면(PG 거절/금액 불일치) 예외만 던지지 않고 FAILED 이력을 남긴다(#297).
+    PaymentApprovalResponse approval;
+    try {
+      approval =
+          paymentApprovalClientRouter.approve(
+              new PaymentApprovalRequest(
+                  request.provider(),
+                  request.paymentKey(),
+                  orderId,
+                  request.bookingId(),
+                  request.amount()));
 
-    if (!request.amount().equals(approval.approvedAmount())) {
-      throw new BusinessException(ErrorStatus.PAYMENT_AMOUNT_MISMATCH);
+      if (!request.amount().equals(approval.approvedAmount())) {
+        throw new BusinessException(ErrorStatus.PAYMENT_AMOUNT_MISMATCH);
+      }
+    } catch (BusinessException e) {
+      recordFailedPayment(userId, request, e);
+      throw e;
     }
 
     Payment payment =
@@ -102,6 +128,39 @@ public class PaymentConfirmUseCase {
             .findFirstByBookingIdAndStatus(bookingId, PaymentStatus.COMPLETED)
             .orElseThrow(() -> new BusinessException(ErrorStatus.PAYMENT_NOT_FOUND));
     return paymentMapper.toConfirmResponse(payment);
+  }
+
+  /**
+   * 결제 실패가 확정된 시점에 FAILED Payment 이력을 남긴다(#297).
+   *
+   * <p>과금이 발생하지 않은 결정적 거절({@link #RECORDABLE_FAILURES})만 기록한다. 승인 결과가 성공이거나 불명인 사유(통신 실패, 미매핑 승인
+   * 실패, 승인 후 금액 불일치 등)는 실제 성공·과금 건을 FAILED로 오라벨링하는 고아 청구가 되므로 기록하지 않는다. 실패 이력 저장 자체가 실패하더라도 원래의 결제
+   * 실패 예외를 가리지 않도록 예외를 삼키고 로그만 남긴다(호출부에서 원 예외를 재던진다).
+   */
+  private void recordFailedPayment(
+      Long userId, PaymentConfirmRequest request, BusinessException e) {
+    if (!RECORDABLE_FAILURES.contains(e.getErrorStatus())) {
+      return;
+    }
+    try {
+      Payment failed =
+          Payment.failed(
+              request.bookingId(),
+              userId,
+              request.seatId(),
+              request.provider(),
+              request.amount(),
+              e.getErrorStatus().getCode(),
+              e.getErrorStatus().getMessage());
+      paymentRepository.saveAndFlush(failed);
+    } catch (Exception ex) {
+      // 추적이 목적인 기능이라 이력 저장 실패는 집계 누락이다. error 레벨로 올려 알람/메트릭 대상이 되게 한다.
+      log.error(
+          "FAILED 결제 이력 저장에 실패했습니다. bookingId={}, failureCode={}",
+          request.bookingId(),
+          e.getErrorStatus().getCode(),
+          ex);
+    }
   }
 
   /* PG 공통 orderId 규격(6~64자, 영문/숫자/_/-, 현재 Toss 기준)을 만족하기 위해 zero-padding 한다. */

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/domain/entity/Payment.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/domain/entity/Payment.java
@@ -52,6 +52,14 @@ public class Payment extends AutoIdBaseEntity {
 
   private LocalDateTime paidAt; // 결제 완료 시점
 
+  /* 결제 실패(FAILED) 시 실패 코드/사유를 남겨 추적·집계·CS 대응에 쓴다. 성공 결제는 NULL이다(#297). failureCode는
+   * ErrorStatus code(예: PAYMENT_400_003) 문자열이다. */
+  @Column(length = 50)
+  private String failureCode; // 실패 코드 (ErrorStatus code)
+
+  @Column(length = 255)
+  private String failureReason; // 실패 사유 (사람이 읽는 메시지)
+
   /* completedBookingId는 status=COMPLETED일 때만 booking_id 값을 갖는 DB generated 컬럼이다(그 외 NULL). 이 컬럼의
    * unique 제약(uk_payment_completed_booking)으로 동일 booking에 서로 다른 paymentKey를 가진 confirm이 동시에 들어와도
    * COMPLETED 결제가 2건 생성되지 못하게 DB 레벨에서 막는다(#296, TOCTOU 최종 방어선). MySQL은 NULL을 unique 중복으로 보지 않으므로
@@ -80,6 +88,36 @@ public class Payment extends AutoIdBaseEntity {
     this.paymentKey = paymentKey;
     this.approvalNumber = approvalNumber;
     this.paidAt = paidAt;
+  }
+
+  /**
+   * PG 거절·검증 실패 등 결제 실패가 확정된 시점의 이력을 FAILED 상태로 생성한다(#297).
+   *
+   * <p>실패 추적/집계·CS 대응을 위해 실패 코드·사유를 함께 남긴다. 결제가 성립하지 않았으므로 {@code paymentKey}·{@code
+   * approvalNumber}·{@code paidAt}은 비운다. 특히 {@code paymentKey}를 비워 unique 제약과 충돌하지 않게 해 재결제(재시도)를
+   * 막지 않는다. {@code completedBookingId}(generated)도 COMPLETED가 아니므로 NULL이라 동일 booking에 FAILED가 여러 건
+   * 누적될 수 있다(재시도 이력). PG 통신 실패(결과 불명)는 고아 청구 위험이 있어 이 팩토리로 기록하지 않는다(UseCase에서 분기).
+   */
+  public static Payment failed(
+      Long bookingId,
+      Long userId,
+      Long seatId,
+      PaymentProvider provider,
+      Long amount,
+      String failureCode,
+      String failureReason) {
+    Payment payment =
+        Payment.builder()
+            .bookingId(bookingId)
+            .userId(userId)
+            .seatId(seatId)
+            .provider(provider)
+            .amount(amount)
+            .status(PaymentStatus.FAILED)
+            .build();
+    payment.failureCode = failureCode;
+    payment.failureReason = failureReason;
+    return payment;
   }
 
   /**

--- a/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentConfirmUseCaseTest.java
+++ b/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentConfirmUseCaseTest.java
@@ -125,8 +125,8 @@ class PaymentConfirmUseCaseTest {
   }
 
   @Test
-  @DisplayName("PG 승인 금액과 요청 금액이 다르면 PAYMENT_400_001 예외가 발생하고 Payment를 저장하지 않는다")
-  void execute_fail_when_amount_mismatch() {
+  @DisplayName("금액 불일치는 PG 승인 후(과금됨) 검증 실패라 FAILED로 기록하지 않는다")
+  void execute_does_not_record_when_amount_mismatch() {
     // given
     Long userId = 10L;
     Long bookingId = 100L;
@@ -147,6 +147,87 @@ class PaymentConfirmUseCaseTest {
         .isInstanceOf(BusinessException.class)
         .extracting("errorStatus")
         .isEqualTo(ErrorStatus.PAYMENT_AMOUNT_MISMATCH);
+
+    verify(paymentRepository, never()).saveAndFlush(any(Payment.class));
+    verify(paymentEventPublisher, never())
+        .publishConfirmed(any(), any(), any(), any(), any(), any());
+  }
+
+  @Test
+  @DisplayName("PG가 이미 승인·과금 완료한 건(ALREADY_COMPLETED)은 성공 건이라 FAILED로 기록하지 않는다")
+  void execute_does_not_record_when_pg_already_completed() {
+    // given
+    Long userId = 10L;
+    Long bookingId = 100L;
+    PaymentConfirmRequest request =
+        new PaymentConfirmRequest(bookingId, 200L, PaymentProvider.TOSS, 55_000L, "pgKey_xyz");
+
+    given(paymentRepository.existsByBookingIdAndStatus(bookingId, PaymentStatus.COMPLETED))
+        .willReturn(false);
+    given(paymentApprovalClientRouter.approve(any()))
+        .willThrow(new BusinessException(ErrorStatus.PAYMENT_ALREADY_COMPLETED));
+
+    // when & then
+    assertThatThrownBy(() -> paymentConfirmUseCase.execute(userId, request))
+        .isInstanceOf(BusinessException.class)
+        .extracting("errorStatus")
+        .isEqualTo(ErrorStatus.PAYMENT_ALREADY_COMPLETED);
+
+    verify(paymentRepository, never()).saveAndFlush(any(Payment.class));
+    verify(paymentEventPublisher, never())
+        .publishConfirmed(any(), any(), any(), any(), any(), any());
+  }
+
+  @Test
+  @DisplayName("PG가 결제를 거절하면(무과금 거절) 예외가 전파되고 FAILED 이력을 남긴다")
+  void execute_records_failed_when_pg_rejected() {
+    // given
+    Long userId = 10L;
+    Long bookingId = 100L;
+    Long seatId = 200L;
+    Long amount = 55_000L;
+    PaymentConfirmRequest request =
+        new PaymentConfirmRequest(bookingId, seatId, PaymentProvider.TOSS, amount, "pgKey_xyz");
+
+    given(paymentRepository.existsByBookingIdAndStatus(bookingId, PaymentStatus.COMPLETED))
+        .willReturn(false);
+    given(paymentApprovalClientRouter.approve(any()))
+        .willThrow(new BusinessException(ErrorStatus.PAYMENT_METHOD_REJECTED));
+
+    // when & then
+    assertThatThrownBy(() -> paymentConfirmUseCase.execute(userId, request))
+        .isInstanceOf(BusinessException.class)
+        .extracting("errorStatus")
+        .isEqualTo(ErrorStatus.PAYMENT_METHOD_REJECTED);
+
+    ArgumentCaptor<Payment> failedCaptor = ArgumentCaptor.forClass(Payment.class);
+    verify(paymentRepository).saveAndFlush(failedCaptor.capture());
+    Payment failed = failedCaptor.getValue();
+    assertThat(failed.getStatus()).isEqualTo(PaymentStatus.FAILED);
+    assertThat(failed.getFailureCode()).isEqualTo(ErrorStatus.PAYMENT_METHOD_REJECTED.getCode());
+    verify(paymentEventPublisher, never())
+        .publishConfirmed(any(), any(), any(), any(), any(), any());
+  }
+
+  @Test
+  @DisplayName("PG 통신 실패(결과 불명)는 고아 청구 위험이 있어 FAILED 이력을 남기지 않는다")
+  void execute_does_not_record_when_pg_communication_failed() {
+    // given
+    Long userId = 10L;
+    Long bookingId = 100L;
+    PaymentConfirmRequest request =
+        new PaymentConfirmRequest(bookingId, 200L, PaymentProvider.TOSS, 55_000L, "pgKey_xyz");
+
+    given(paymentRepository.existsByBookingIdAndStatus(bookingId, PaymentStatus.COMPLETED))
+        .willReturn(false);
+    given(paymentApprovalClientRouter.approve(any()))
+        .willThrow(new BusinessException(ErrorStatus.PAYMENT_PG_COMMUNICATION_FAILED));
+
+    // when & then
+    assertThatThrownBy(() -> paymentConfirmUseCase.execute(userId, request))
+        .isInstanceOf(BusinessException.class)
+        .extracting("errorStatus")
+        .isEqualTo(ErrorStatus.PAYMENT_PG_COMMUNICATION_FAILED);
 
     verify(paymentRepository, never()).saveAndFlush(any(Payment.class));
     verify(paymentEventPublisher, never())

--- a/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/domain/entity/PaymentTest.java
+++ b/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/domain/entity/PaymentTest.java
@@ -76,4 +76,27 @@ class PaymentTest {
     assertThat(payment(PaymentStatus.CANCELED).isAlreadyProcessed()).isFalse();
     assertThat(payment(PaymentStatus.FAILED).isAlreadyProcessed()).isFalse();
   }
+
+  @Test
+  @DisplayName("failed 팩토리는 FAILED 상태로 실패 코드/사유를 담고 paymentKey는 비운다")
+  void failed_creates_failed_payment_with_meta() {
+    // when
+    Payment failed =
+        Payment.failed(
+            100L, 10L, 200L, PaymentProvider.TOSS, 55_000L, "PAYMENT_400_003", "결제가 거절되었습니다.");
+
+    // then
+    assertThat(failed.getStatus()).isEqualTo(PaymentStatus.FAILED);
+    assertThat(failed.getFailureCode()).isEqualTo("PAYMENT_400_003");
+    assertThat(failed.getFailureReason()).isEqualTo("결제가 거절되었습니다.");
+    assertThat(failed.getBookingId()).isEqualTo(100L);
+    assertThat(failed.getUserId()).isEqualTo(10L);
+    assertThat(failed.getSeatId()).isEqualTo(200L);
+    assertThat(failed.getAmount()).isEqualTo(55_000L);
+    // 결제가 성립하지 않았으므로 결제 성립 관련 필드는 비운다.
+    assertThat(failed.getPaymentKey()).isNull();
+    assertThat(failed.getApprovalNumber()).isNull();
+    assertThat(failed.getPaidAt()).isNull();
+    assertThat(failed.isAlreadyProcessed()).isFalse();
+  }
 }


### PR DESCRIPTION
## 🔗 관련 이슈

- close #297

---

## 📌 주요 변경 사항

- confirm 실패가 확정된 시점에 `PaymentStatus.FAILED` 결제 이력을 실패 사유와 함께 영속화(그동안 예외만 던지고 흔적 없이 사라지던 실패 결제를 추적 가능하게)
- 정의만 되어 있고 미사용이던 `PaymentStatus.FAILED`를 실제 상태에 편입
- 성공/멱등 경로(#296)는 무변경 — 실패 확정 시에만 별도 FAILED row 기록

---

## 🛠 상세 구현 내용

- `Payment` 엔티티: 실패 메타 필드 `failureCode`(len 50) / `failureReason`(len 255, 둘 다 nullable) 추가, `Payment.failed(...)` 정적 팩토리 신설(status=FAILED, `paymentKey`·`approvalNumber`·`paidAt`은 비워 unique 충돌·재시도 차단 방지)
- `PaymentConfirmUseCase`: PG 승인 + 금액 검증 블록을 `try/catch(BusinessException)`로 감싸, 실패 시 `recordFailedPayment`로 FAILED 이력 기록 후 원 예외 재던짐. 성공 경로의 `saveAndFlush`는 try 밖이라 `DataIntegrityViolationException` 멱등 fallback(#296) 무손상
- **화이트리스트 기반 기록**: 과금 위험이 없고 결정적인 실패(`PAYMENT_METHOD_REJECTED`·`PAYMENT_LIMIT_EXCEEDED`·`PAYMENT_SESSION_NOT_FOUND`)만 FAILED로 남김. 승인 성공/불명(`ALREADY_COMPLETED`·`AMOUNT_MISMATCH`·PG 통신 실패·미매핑 승인 실패·PG 인증 결함)은 고아 청구·오라벨링 방지를 위해 미기록
- 실패 이력 저장 자체가 실패해도 원 예외를 가리지 않도록 방어적 처리(`log.error` + 원 예외 재던짐)

---

## ✅ 테스트

### 테스트 방법

- `./gradlew :payment-service:spotlessApply :payment-service:checkstyleMain :payment-service:checkstyleTest :payment-service:compileJava :payment-service:test`
- `PaymentTest`: `failed()` 팩토리가 FAILED 상태·실패 메타를 담고 `paymentKey`/`approvalNumber`/`paidAt`을 비우는지 검증
- `PaymentConfirmUseCaseTest`: PG 거절(무과금)→FAILED 기록, 금액 불일치(과금됨)→미기록, `ALREADY_COMPLETED`→미기록, PG 통신 실패→미기록, 기존 성공/이미완료/만료 경로 회귀

### 테스트 결과

- BUILD SUCCESSFUL — spotless·checkstyle(main+test)·compile·test 전부 통과
<!--

### 📸 스크린샷

- 
-->
---

## 👀 리뷰 요청 사항

- FAILED 기록 화이트리스트 범위(`PAYMENT_SESSION_NOT_FOUND` 포함 여부 등)가 제품 정책과 맞는지 검토 부탁드립니다.
- 실제 PG(Toss) 원본 거절 코드 저장, FAILED row 누적 제약은 이번 범위에서 제외하고 후속 이슈로 다룰 예정입니다.

---

## ⚠️ 배포 시 주의사항

- `payment` 테이블에 `failure_code`/`failure_reason` 컬럼 추가(nullable). 운영 환경 스키마 반영 필요(기존 row 하위호환).
