### PR TITLE
[Infra] #44 Prometheus + Micrometer 메트릭 수집 환경 구축

### DIFF
--- a/auth-service/build.gradle
+++ b/auth-service/build.gradle
@@ -32,6 +32,7 @@ dependencies {
 	implementation project(":common")
 
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+	runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-webmvc'

--- a/auth-service/src/main/resources/application.yml
+++ b/auth-service/src/main/resources/application.yml
@@ -53,3 +53,12 @@ springdoc:
 
 gateway:
   internal-token: ${GATEWAY_INTERNAL_TOKEN:test-token}
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health, info, prometheus
+  endpoint:
+    health:
+      show-details: never

--- a/booking-service/build.gradle
+++ b/booking-service/build.gradle
@@ -32,6 +32,7 @@ dependencies {
     implementation project(":common")
 
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-webmvc'

--- a/booking-service/src/main/resources/application.yml
+++ b/booking-service/src/main/resources/application.yml
@@ -54,3 +54,12 @@ app:
       # 청크 삭제 배치 크기와 1회 실행당 배치 수 상한. 대용량 단일 트랜잭션 삭제를 피하고 최초 활성화 시 완만히 정리한다.
       batch-size: ${INBOX_RETENTION_BATCH_SIZE:1000}
       max-batches-per-run: ${INBOX_RETENTION_MAX_BATCHES_PER_RUN:100}
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health, info, prometheus
+  endpoint:
+    health:
+      show-details: never

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,9 +62,24 @@ services:
     networks:
       - ticketrush-net
 
+  prometheus:
+    image: prom/prometheus:v2.53.0
+    container_name: prometheus
+    ports:
+      - "127.0.0.1:9090:9090"
+    volumes:
+      - ./monitoring/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - prometheus_data:/prometheus
+    extra_hosts:
+      # Linux에서 host.docker.internal을 호스트 게이트웨이로 매핑(macOS/Windows는 기본 지원).
+      - "host.docker.internal:host-gateway"
+    networks:
+      - ticketrush-net
+
 volumes:
   redis_data:
   kafka-data:
+  prometheus_data:
 
 networks:
   ticketrush-net:

--- a/gateway-service/build.gradle
+++ b/gateway-service/build.gradle
@@ -30,6 +30,7 @@ ext {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'

--- a/gateway-service/src/main/resources/application.yml
+++ b/gateway-service/src/main/resources/application.yml
@@ -102,3 +102,12 @@ jwt:
 
 gateway:
   internal-token: ${GATEWAY_INTERNAL_TOKEN:test-token}
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health, info, prometheus
+  endpoint:
+    health:
+      show-details: never

--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -1,0 +1,18 @@
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: 'ticketrush-services'
+    metrics_path: /actuator/prometheus
+    static_configs:
+      # 앱은 docker-compose 밖 호스트에서 직접 실행되므로 host.docker.internal로 스크랩한다.
+      # 컨테이너화(#245, ECR 배포) 이후에는 타겟을 서비스명 기반(예: user-service:8081)으로 전환한다.
+      - targets:
+          - 'host.docker.internal:8080'  # gateway-service (WebFlux)
+          - 'host.docker.internal:8081'  # user-service
+          - 'host.docker.internal:8082'  # auth-service
+          - 'host.docker.internal:8083'  # performance-service
+          - 'host.docker.internal:8084'  # booking-service
+          - 'host.docker.internal:8085'  # payment-service
+          - 'host.docker.internal:8086'  # seat-service
+          - 'host.docker.internal:8087'  # ticket-service

--- a/payment-service/build.gradle
+++ b/payment-service/build.gradle
@@ -32,6 +32,7 @@ dependencies {
 	implementation project(":common")
 
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+	runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-webmvc'

--- a/payment-service/src/main/resources/application.yml
+++ b/payment-service/src/main/resources/application.yml
@@ -35,3 +35,12 @@ payment:
       webhook-secret: ${TOSS_PAYMENTS_WEBHOOK_SECRET:}
       connect-timeout-ms: ${TOSS_PAYMENTS_CONNECT_TIMEOUT_MS:3000}
       read-timeout-ms: ${TOSS_PAYMENTS_READ_TIMEOUT_MS:10000}
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health, info, prometheus
+  endpoint:
+    health:
+      show-details: never

--- a/performance-service/build.gradle
+++ b/performance-service/build.gradle
@@ -36,6 +36,7 @@ dependencies {
 
     implementation 'org.springframework.data:spring-data-commons'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-webmvc'

--- a/performance-service/src/main/resources/application.yml
+++ b/performance-service/src/main/resources/application.yml
@@ -22,3 +22,12 @@ springdoc:
 
 gateway:
   internal-token: ${GATEWAY_INTERNAL_TOKEN:test-token}
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health, info, prometheus
+  endpoint:
+    health:
+      show-details: never

--- a/seat-service/build.gradle
+++ b/seat-service/build.gradle
@@ -31,6 +31,7 @@ ext {
 dependencies {
     implementation project(":common")
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-webmvc'

--- a/seat-service/src/main/resources/application.yml
+++ b/seat-service/src/main/resources/application.yml
@@ -22,3 +22,12 @@ springdoc:
 
 gateway:
   internal-token: ${GATEWAY_INTERNAL_TOKEN:test-token}
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health, info, prometheus
+  endpoint:
+    health:
+      show-details: never

--- a/ticket-service/build.gradle
+++ b/ticket-service/build.gradle
@@ -31,6 +31,7 @@ ext {
 dependencies {
 	implementation project(":common")
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+	runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-webmvc'

--- a/ticket-service/src/main/resources/application.yml
+++ b/ticket-service/src/main/resources/application.yml
@@ -35,3 +35,12 @@ ticket:
     # QR 토큰 서명 시크릿. 기본값을 두지 않아 미주입 시 기동을 실패시킨다(공개 시크릿으로 서명되는 사고 방지).
     secret: ${TICKET_QR_SECRET}
     ttl-millis: ${TICKET_QR_TTL_MILLIS:300000}
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health, info, prometheus
+  endpoint:
+    health:
+      show-details: never

--- a/user-service/build.gradle
+++ b/user-service/build.gradle
@@ -32,6 +32,7 @@ dependencies {
 	implementation project(":common")
 
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+	runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-webmvc'

--- a/user-service/src/main/resources/application.yml
+++ b/user-service/src/main/resources/application.yml
@@ -29,3 +29,12 @@ springdoc:
 
 gateway:
   internal-token: ${GATEWAY_INTERNAL_TOKEN:test-token}
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health, info, prometheus
+  endpoint:
+    health:
+      show-details: never


### PR DESCRIPTION
## 🔗 관련 이슈

- close #44

---

## 📌 주요 변경 사항

- 8개 서비스에 Prometheus 레지스트리(`micrometer-registry-prometheus`) 의존성 추가
- 8개 서비스 Actuator `/actuator/prometheus` 엔드포인트 노출 설정 추가
- Prometheus 스크랩 설정(`monitoring/prometheus.yml`) 및 `docker-compose` 컨테이너(9090) 추가

---

## 🛠 상세 구현 내용

- **의존성 (`build.gradle` × 8)**: gateway/user/auth/performance/booking/payment/seat/ticket에 `runtimeOnly 'io.micrometer:micrometer-registry-prometheus'` 추가. 버전은 Spring Boot BOM이 관리하므로 미명시. 기존 actuator 개별선언 컨벤션과 일치시켰고, 실행 앱이 아닌 `common`은 제외.
- **노출 설정 (`application.yml` × 8)**: `management.endpoints.web.exposure.include`를 `health, info, prometheus`로 화이트리스트해 env/beans 등 민감 엔드포인트는 비노출. `health.show-details: never`로 상세 정보도 차단.
- **스크랩 설정 (`monitoring/prometheus.yml` 신규)**: 앱이 compose 밖 호스트에서 실행되므로 `host.docker.internal:8080~8087`을 타겟으로, `metrics_path: /actuator/prometheus`, `scrape_interval: 15s`. 컨테이너화(#245) 이후 서비스명 기반 전환 예정을 주석으로 명시.
- **Prometheus 컨테이너 (`docker-compose.yml`)**: `prom/prometheus:v2.53.0`, `127.0.0.1:9090` 바인딩, 설정 파일 `:ro` 마운트, `prometheus_data` named volume, Linux 호환용 `extra_hosts: host.docker.internal:host-gateway`.

---

## ✅ 테스트

### 테스트 방법

- 별도 단위/통합 테스트는 추가하지 않음(설정·인프라 변경). 아래 검증을 실제 실행함:
- `./gradlew compileJava -x test` — 전 모듈 의존성 해석·컴파일
- `SPRING_PROFILES_ACTIVE=local ./gradlew :gateway-service:bootRun` 기동 후 `curl`로 엔드포인트 확인
- `docker compose config` / `./gradlew spotlessCheck`

### 테스트 결과

- `compileJava` → **BUILD SUCCESSFUL** (micrometer 아티팩트 정상 해석)
- gateway `/actuator/prometheus` → **200**, 메트릭 텍스트 출력(jvm·reactor_netty·http_server 등 WebFlux 스택 106개 라인)
- `/actuator/health` → **UP** / `/actuator/env`·`/actuator/beans` → **404** (비노출 차단 확인)
- `docker compose config` 통과, `spotlessCheck` 통과
<!--
### 📸 스크린샷

- (Prometheus UI `/targets` UP 확인 등 로컬 시연은 직접 첨부 필요)
-->
---

## 👀 리뷰 요청 사항

- 의존성 배치를 기존 컨벤션대로 **8개 서비스 개별 추가**로 결정했습니다(common `api` 상속 미채택). 이 방향이 팀 컨벤션과 맞는지 확인 부탁드립니다.

---

## ⚠️ 배포 시 주의사항

- **로컬 포트 충돌**: `kafka-ui`가 host 포트 **8085**를 점유 → payment-service(8085)와 동시 구동 시 충돌. 함께 띄우려면 kafka-ui 호스트 포트 조정 필요.
- **actuator 외부 노출 주의**: gateway(8080)가 배포 환경에서 외부에 열릴 경우 `/actuator/*`도 인증 없이 접근 가능. 내부 네트워크 제한 또는 `management.server.port` 분리는 후속 관측성 확장 과제로 분리.
