### PR TITLE
[Infra] #45 Grafana 대시보드 구축 및 시스템 메트릭 시각화

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -76,10 +76,30 @@ services:
     networks:
       - ticketrush-net
 
+  grafana:
+    image: grafana/grafana:11.1.0
+    container_name: grafana
+    ports:
+      - "127.0.0.1:3000:3000"
+    environment:
+      GF_SECURITY_ADMIN_USER: ${GRAFANA_ADMIN_USER:-admin}
+      GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_ADMIN_PASSWORD:-admin}
+      GF_USERS_ALLOW_SIGN_UP: "false"
+    volumes:
+      # 데이터소스·대시보드 프로비저닝(자동 연결/임포트)과 대시보드 JSON 번들
+      - ./monitoring/grafana/provisioning:/etc/grafana/provisioning:ro
+      - ./monitoring/grafana/dashboards:/var/lib/grafana/dashboards:ro
+      - grafana_data:/var/lib/grafana
+    depends_on:
+      - prometheus
+    networks:
+      - ticketrush-net
+
 volumes:
   redis_data:
   kafka-data:
   prometheus_data:
+  grafana_data:
 
 networks:
   ticketrush-net:

--- a/monitoring/grafana/dashboards/ticketrush-gateway.json
+++ b/monitoring/grafana/dashboards/ticketrush-gateway.json
@@ -1,0 +1,97 @@
+{
+  "annotations": { "list": [] },
+  "editable": true,
+  "graphTooltip": 1,
+  "schemaVersion": 39,
+  "tags": ["ticketrush", "gateway", "webflux"],
+  "title": "TicketRush - Gateway (WebFlux)",
+  "uid": "ticketrush-gateway",
+  "time": { "from": "now-1h", "to": "now" },
+  "refresh": "30s",
+  "templating": {
+    "list": [
+      {
+        "name": "instance",
+        "label": "Instance",
+        "type": "query",
+        "datasource": { "type": "prometheus", "uid": "prometheus" },
+        "query": { "query": "label_values(jvm_memory_used_bytes{job=\"gateway\"}, instance)", "refId": "vars" },
+        "refresh": 2,
+        "includeAll": true,
+        "multi": true,
+        "sort": 1,
+        "current": { "text": "All", "value": "$__all" }
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "title": "JVM Heap Used",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "fieldConfig": { "defaults": { "unit": "bytes" }, "overrides": [] },
+      "targets": [
+        { "refId": "A", "expr": "sum by (instance) (jvm_memory_used_bytes{job=\"gateway\", area=\"heap\", instance=~\"$instance\"})", "legendFormat": "{{instance}}" }
+      ]
+    },
+    {
+      "id": 2,
+      "title": "GC Pause (rate)",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "fieldConfig": { "defaults": { "unit": "s" }, "overrides": [] },
+      "targets": [
+        { "refId": "A", "expr": "sum by (instance) (rate(jvm_gc_pause_seconds_sum{job=\"gateway\", instance=~\"$instance\"}[5m]))", "legendFormat": "{{instance}}" }
+      ]
+    },
+    {
+      "id": 3,
+      "title": "HTTP Request Rate (WebFlux)",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+      "fieldConfig": { "defaults": { "unit": "reqps" }, "overrides": [] },
+      "targets": [
+        { "refId": "A", "expr": "sum by (instance) (rate(http_server_requests_seconds_count{job=\"gateway\", instance=~\"$instance\"}[5m]))", "legendFormat": "{{instance}}" }
+      ]
+    },
+    {
+      "id": 4,
+      "title": "HTTP Avg Latency (WebFlux)",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
+      "fieldConfig": { "defaults": { "unit": "s" }, "overrides": [] },
+      "targets": [
+        { "refId": "A", "expr": "sum by (instance) (rate(http_server_requests_seconds_sum{job=\"gateway\", instance=~\"$instance\"}[5m])) / sum by (instance) (rate(http_server_requests_seconds_count{job=\"gateway\", instance=~\"$instance\"}[5m]))", "legendFormat": "{{instance}}" }
+      ]
+    },
+    {
+      "id": 5,
+      "title": "HTTP Responses by Status",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 16 },
+      "fieldConfig": { "defaults": { "unit": "reqps" }, "overrides": [] },
+      "targets": [
+        { "refId": "A", "expr": "sum by (status) (rate(http_server_requests_seconds_count{job=\"gateway\", instance=~\"$instance\"}[5m]))", "legendFormat": "{{status}}" }
+      ]
+    },
+    {
+      "id": 6,
+      "title": "Reactive Executor Threads",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 16 },
+      "fieldConfig": { "defaults": { "unit": "short" }, "overrides": [] },
+      "targets": [
+        { "refId": "A", "expr": "sum by (instance) (executor_active_threads{job=\"gateway\", instance=~\"$instance\"})", "legendFormat": "active {{instance}}" },
+        { "refId": "B", "expr": "sum by (instance) (executor_pool_size_threads{job=\"gateway\", instance=~\"$instance\"})", "legendFormat": "pool size {{instance}}" },
+        { "refId": "C", "expr": "sum by (instance) (executor_queued_tasks{job=\"gateway\", instance=~\"$instance\"})", "legendFormat": "queued {{instance}}" }
+      ]
+    }
+  ]
+}

--- a/monitoring/grafana/dashboards/ticketrush-system.json
+++ b/monitoring/grafana/dashboards/ticketrush-system.json
@@ -1,0 +1,97 @@
+{
+  "annotations": { "list": [] },
+  "editable": true,
+  "graphTooltip": 1,
+  "schemaVersion": 39,
+  "tags": ["ticketrush", "system"],
+  "title": "TicketRush - System (MVC)",
+  "uid": "ticketrush-system",
+  "time": { "from": "now-1h", "to": "now" },
+  "refresh": "30s",
+  "templating": {
+    "list": [
+      {
+        "name": "instance",
+        "label": "Instance",
+        "type": "query",
+        "datasource": { "type": "prometheus", "uid": "prometheus" },
+        "query": { "query": "label_values(jvm_memory_used_bytes{job=\"ticketrush-services\"}, instance)", "refId": "vars" },
+        "refresh": 2,
+        "includeAll": true,
+        "multi": true,
+        "sort": 1,
+        "current": { "text": "All", "value": "$__all" }
+      }
+    ]
+  },
+  "panels": [
+    {
+      "id": 1,
+      "title": "JVM Heap Used",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "fieldConfig": { "defaults": { "unit": "bytes" }, "overrides": [] },
+      "targets": [
+        { "refId": "A", "expr": "sum by (instance) (jvm_memory_used_bytes{job=\"ticketrush-services\", area=\"heap\", instance=~\"$instance\"})", "legendFormat": "{{instance}}" }
+      ]
+    },
+    {
+      "id": 2,
+      "title": "JVM Non-Heap Used",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "fieldConfig": { "defaults": { "unit": "bytes" }, "overrides": [] },
+      "targets": [
+        { "refId": "A", "expr": "sum by (instance) (jvm_memory_used_bytes{job=\"ticketrush-services\", area=\"nonheap\", instance=~\"$instance\"})", "legendFormat": "{{instance}}" }
+      ]
+    },
+    {
+      "id": 3,
+      "title": "GC Pause (rate)",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+      "fieldConfig": { "defaults": { "unit": "s" }, "overrides": [] },
+      "targets": [
+        { "refId": "A", "expr": "sum by (instance) (rate(jvm_gc_pause_seconds_sum{job=\"ticketrush-services\", instance=~\"$instance\"}[5m]))", "legendFormat": "{{instance}}" }
+      ]
+    },
+    {
+      "id": 4,
+      "title": "HTTP Request Rate",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
+      "fieldConfig": { "defaults": { "unit": "reqps" }, "overrides": [] },
+      "targets": [
+        { "refId": "A", "expr": "sum by (instance) (rate(http_server_requests_seconds_count{job=\"ticketrush-services\", instance=~\"$instance\"}[5m]))", "legendFormat": "{{instance}}" }
+      ]
+    },
+    {
+      "id": 5,
+      "title": "HTTP Avg Latency",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 16 },
+      "fieldConfig": { "defaults": { "unit": "s" }, "overrides": [] },
+      "targets": [
+        { "refId": "A", "expr": "sum by (instance) (rate(http_server_requests_seconds_sum{job=\"ticketrush-services\", instance=~\"$instance\"}[5m])) / sum by (instance) (rate(http_server_requests_seconds_count{job=\"ticketrush-services\", instance=~\"$instance\"}[5m]))", "legendFormat": "{{instance}}" }
+      ]
+    },
+    {
+      "id": 6,
+      "title": "HikariCP Connections",
+      "type": "timeseries",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 16 },
+      "fieldConfig": { "defaults": { "unit": "short" }, "overrides": [] },
+      "targets": [
+        { "refId": "A", "expr": "hikaricp_connections_active{job=\"ticketrush-services\", instance=~\"$instance\"}", "legendFormat": "active {{instance}}" },
+        { "refId": "B", "expr": "hikaricp_connections_idle{job=\"ticketrush-services\", instance=~\"$instance\"}", "legendFormat": "idle {{instance}}" },
+        { "refId": "C", "expr": "hikaricp_connections_pending{job=\"ticketrush-services\", instance=~\"$instance\"}", "legendFormat": "pending {{instance}}" }
+      ]
+    }
+  ]
+}

--- a/monitoring/grafana/provisioning/dashboards/dashboards.yml
+++ b/monitoring/grafana/provisioning/dashboards/dashboards.yml
@@ -1,0 +1,15 @@
+apiVersion: 1
+
+providers:
+  - name: TicketRush
+    orgId: 1
+    folder: TicketRush
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 30
+    # 대시보드 SSOT는 리포지토리 JSON이며 소스는 :ro로 마운트된다. UI 편집은 파일로 영속되지 않으므로 비허용.
+    allowUiUpdates: false
+    options:
+      # docker-compose에서 ./monitoring/grafana/dashboards 를 이 경로로 마운트한다.
+      path: /var/lib/grafana/dashboards
+      foldersFromFilesStructure: false

--- a/monitoring/grafana/provisioning/datasources/datasource.yml
+++ b/monitoring/grafana/provisioning/datasources/datasource.yml
@@ -1,0 +1,13 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    uid: prometheus
+    access: proxy
+    # compose 네트워크(ticketrush-net) 내부에서 서비스명으로 접근한다.
+    url: http://prometheus:9090
+    isDefault: true
+    editable: false
+    jsonData:
+      httpMethod: POST

--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -1,14 +1,22 @@
 global:
   scrape_interval: 15s
 
+# 앱은 docker-compose 밖 호스트에서 직접 실행되므로 host.docker.internal로 스크랩한다.
+# 컨테이너화(#245, ECR 배포) 이후에는 타겟을 서비스명 기반(예: user-service:8081)으로 전환한다.
+# 스택별 대시보드 분리(#45)를 위해 gateway(WebFlux/리액티브)와 나머지(MVC)를 별도 job으로 나눈다.
 scrape_configs:
+  - job_name: 'gateway'
+    metrics_path: /actuator/prometheus
+    static_configs:
+      - targets:
+          - 'host.docker.internal:8080'  # gateway-service (WebFlux)
+        labels:
+          stack: reactive
+
   - job_name: 'ticketrush-services'
     metrics_path: /actuator/prometheus
     static_configs:
-      # 앱은 docker-compose 밖 호스트에서 직접 실행되므로 host.docker.internal로 스크랩한다.
-      # 컨테이너화(#245, ECR 배포) 이후에는 타겟을 서비스명 기반(예: user-service:8081)으로 전환한다.
       - targets:
-          - 'host.docker.internal:8080'  # gateway-service (WebFlux)
           - 'host.docker.internal:8081'  # user-service
           - 'host.docker.internal:8082'  # auth-service
           - 'host.docker.internal:8083'  # performance-service
@@ -16,3 +24,5 @@ scrape_configs:
           - 'host.docker.internal:8085'  # payment-service
           - 'host.docker.internal:8086'  # seat-service
           - 'host.docker.internal:8087'  # ticket-service
+        labels:
+          stack: mvc


### PR DESCRIPTION
## 🔗 관련 이슈

- close #45

---

## 📌 주요 변경 사항

- Grafana 컨테이너를 `docker-compose`에 추가하고 Prometheus 데이터소스를 자동 연결
- 시스템 메트릭 대시보드(MVC) + gateway(WebFlux) 대시보드를 JSON으로 번들·자동 프로비저닝
- Prometheus 스크랩을 스택별(gateway=reactive / services=mvc) job으로 분리

---

## 🛠 상세 구현 내용

- **Grafana 컨테이너 (`docker-compose.yml`)**: `grafana/grafana:11.1.0`, `127.0.0.1:3000` 바인딩, `depends_on: prometheus`, 프로비저닝 디렉토리 `:ro` 마운트 + `grafana_data` 볼륨, admin 계정 env override(`GRAFANA_ADMIN_USER/PASSWORD`), 회원가입 비활성.
- **데이터소스 프로비저닝 (`provisioning/datasources/datasource.yml`)**: Prometheus(`uid: prometheus`, `url: http://prometheus:9090`, compose 네트워크 내부 통신), 기본 데이터소스.
- **대시보드 프로비저닝 (`provisioning/dashboards/dashboards.yml`)**: 파일 기반 프로바이더. 소스가 `:ro`+리포지토리 SSOT이므로 `allowUiUpdates: false`.
- **대시보드 JSON 2개 (`dashboards/*.json`)**:
  - `ticketrush-system.json` (MVC): JVM 힙/논힙, GC, HTTP 요청률/평균 Latency, HikariCP 커넥션. 전 패널 `job="ticketrush-services"` 스코프 + `instance` 템플릿 변수.
  - `ticketrush-gateway.json` (WebFlux): JVM/GC, WebFlux HTTP 요청률/Latency, 상태코드별 응답, 리액티브 executor 스레드풀. 전 패널 `job="gateway"` 스코프.
- **스크랩 분리 (`prometheus.yml`)**: 스택별 대시보드 분리를 위해 `gateway`(stack=reactive) / `ticketrush-services`(stack=mvc) 2개 job으로 재구성.

> ⚠️ 계획 대비 조정(런타임 근거): gateway의 `reactor_netty_*`·`spring_cloud_gateway_*` 메트릭은 이 스택에서 기본 미노출(라우팅해도 등록 안 됨)이라, **실제 존재가 확인된 리액티브 메트릭**(WebFlux `http_server_requests`, `executor_*`, JVM)으로 gateway 대시보드를 구성했습니다. 앱 코드는 변경하지 않았습니다.

---

## ✅ 테스트

### 테스트 방법

- 별도 단위/통합 테스트는 추가하지 않음(설정·인프라 변경). 아래 검증을 실제 실행함:
- `docker compose up -d prometheus grafana` 후 Grafana API로 검증
- `docker compose config` / `./gradlew spotlessCheck` / JSON·YAML 문법 검증

### 테스트 결과

- Grafana `/api/health` OK, 데이터소스 헬스 **OK**("Successfully queried the Prometheus API")
- 대시보드 2개(System MVC / Gateway WebFlux) 프로비저닝 확인, 프로비저닝 에러 없음
- Prometheus 타겟: `gateway`(stack=reactive) **UP** / `ticketrush-services`(stack=mvc) 분리 확인
- gateway job 실메트릭 조회 성공: `jvm_memory_used_bytes`(3계열), `executor_active_threads`(1계열), `http_server_requests_seconds` 존재
- system 대시보드 8/8 패널 `job="ticketrush-services"` 스코프 반영 확인
- `docker compose config` / `spotlessCheck` / JSON·YAML 문법 통과
<!--
### 📸 스크린샷

- (Grafana 대시보드 실제 렌더링 화면은 직접 첨부 필요 — http://localhost:3000, admin/admin)
-->
---

## 👀 리뷰 요청 사항

- gateway 리액티브 대시보드를 `reactor_netty`/`spring_cloud_gateway` 대신 확실히 존재하는 메트릭으로 구성한 결정이 적절한지 확인 부탁드립니다. (해당 메트릭 노출은 후속 계측/설정 이슈로 분리 가능)
- MVC 대시보드의 HikariCP 패널은 MVC 서비스 기동 시 채워집니다(이번 검증 시엔 gateway만 기동).

---

## ⚠️ 배포 시 주의사항

- **Grafana admin 비밀번호**: 미설정 시 기본 `admin/admin`. 운영/공유 환경에서는 `GRAFANA_ADMIN_PASSWORD` 환경변수 설정 필요(현재 `127.0.0.1` 바인딩으로 외부 비노출).
- **포트 충돌(선재)**: `kafka-ui`(host 8085) ↔ payment-service(8085) — 로컬 동시 구동 시 payment 스크랩이 kafka-ui로 갈 수 있어 포트 조정 필요.
- 이 대시보드는 **#44(Prometheus 수집)**가 전제이며, 앱 기동 시 시스템 메트릭이 채워집니다.
