### PR TITLE
[Infra] #335 핵심 도메인 비즈니스 메트릭(Micrometer) 계측

### DIFF
--- a/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/app/usecase/BookingCreateUseCase.java
+++ b/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/app/usecase/BookingCreateUseCase.java
@@ -4,8 +4,11 @@ import com.ticketrush.boundedcontext.booking.app.dto.request.BookingCreateReques
 import com.ticketrush.boundedcontext.booking.app.mapper.BookingMapper;
 import com.ticketrush.boundedcontext.booking.domain.entity.Booking;
 import com.ticketrush.boundedcontext.booking.out.repository.BookingRepository;
+import com.ticketrush.global.constants.MetricNames;
 import com.ticketrush.global.eventpublisher.EventPublisher;
 import com.ticketrush.shared.booking.event.BookingCreatedEvent;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -21,9 +24,13 @@ public class BookingCreateUseCase {
   // 비즈니스 트랜잭션 내부에서 직접 발행해 상태 변경과 이벤트 기록의 원자성을 보장한다.
   private final EventPublisher eventPublisher;
 
+  private final MeterRegistry meterRegistry;
+
   public Booking execute(BookingCreateRequest request) {
     Booking booking = bookingMapper.toEntity(request);
     Booking savedBooking = bookingRepository.save(booking);
+
+    Counter.builder(MetricNames.BOOKING_CREATED).register(meterRegistry).increment();
 
     BookingCreatedEvent event =
         new BookingCreatedEvent(

--- a/booking-service/src/test/java/com/ticketrush/boundedcontext/booking/app/usecase/BookingCreateUseCaseTest.java
+++ b/booking-service/src/test/java/com/ticketrush/boundedcontext/booking/app/usecase/BookingCreateUseCaseTest.java
@@ -10,12 +10,14 @@ import com.ticketrush.boundedcontext.booking.app.mapper.BookingMapper;
 import com.ticketrush.boundedcontext.booking.domain.entity.Booking;
 import com.ticketrush.boundedcontext.booking.domain.types.BookingStatus;
 import com.ticketrush.boundedcontext.booking.out.repository.BookingRepository;
+import com.ticketrush.global.constants.MetricNames;
 import com.ticketrush.global.eventpublisher.EventPublisher;
 import com.ticketrush.shared.booking.event.BookingCreatedEvent;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -23,11 +25,20 @@ import org.springframework.test.util.ReflectionTestUtils;
 @ExtendWith(MockitoExtension.class)
 class BookingCreateUseCaseTest {
 
-  @InjectMocks private BookingCreateUseCase bookingCreateUseCase;
+  private BookingCreateUseCase bookingCreateUseCase;
 
   @Mock private BookingRepository bookingRepository;
   @Mock private BookingMapper bookingMapper;
   @Mock private EventPublisher eventPublisher;
+
+  private SimpleMeterRegistry meterRegistry;
+
+  @BeforeEach
+  void setUp() {
+    meterRegistry = new SimpleMeterRegistry();
+    bookingCreateUseCase =
+        new BookingCreateUseCase(bookingRepository, bookingMapper, eventPublisher, meterRegistry);
+  }
 
   @Test
   @DisplayName("성공: 예약 요청을 받아 저장하고 내부 이벤트를 발행한다")
@@ -72,5 +83,8 @@ class BookingCreateUseCaseTest {
 
     // 3. 도메인 이벤트가 트랜잭션 내부에서 정상적으로 발행되었는지 검증
     verify(eventPublisher).publish(any(BookingCreatedEvent.class));
+
+    // 4. 예약 생성 성공 카운터가 1 증가했는지 검증
+    assertThat(meterRegistry.counter(MetricNames.BOOKING_CREATED).count()).isEqualTo(1.0);
   }
 }

--- a/common/src/main/java/com/ticketrush/global/constants/MetricNames.java
+++ b/common/src/main/java/com/ticketrush/global/constants/MetricNames.java
@@ -1,0 +1,56 @@
+package com.ticketrush.global.constants;
+
+/**
+ * 비즈니스 메트릭(Micrometer) 이름·태그 상수(#335). 메트릭 이름은 dot 표기이며 Prometheus에서는 '_'로 변환된다(예:
+ * ticketrush.booking.created → ticketrush_booking_created_total). 태그 값은 카디널리티 폭발을 막기 위해 유한 집합(아래
+ * 상수)만 사용하고 ID류는 태그로 쓰지 않는다.
+ */
+public class MetricNames {
+
+  private MetricNames() {}
+
+  // ===== Metric names =====
+  // booking
+  public static final String BOOKING_CREATED = "ticketrush.booking.created";
+
+  // seat
+  public static final String SEAT_HOLD = "ticketrush.seat.hold";
+  public static final String SEAT_LOCK_CONTENTION = "ticketrush.seat.lock.contention";
+  public static final String SEAT_HELD = "ticketrush.seat.held"; // Gauge (전역 미만료 HOLD 총수)
+
+  // payment
+  public static final String PAYMENT_CONFIRM = "ticketrush.payment.confirm";
+  public static final String PAYMENT_PG_APPROVE = "ticketrush.payment.pg.approve"; // Timer
+  public static final String PAYMENT_REFUND = "ticketrush.payment.refund";
+  public static final String PAYMENT_PG_CANCEL = "ticketrush.payment.pg.cancel"; // Timer
+  public static final String PAYMENT_REFUND_FAILED = "ticketrush.payment.refund.failed";
+
+  // ticket
+  public static final String TICKET_ISSUE = "ticketrush.ticket.issue";
+  public static final String TICKET_ISSUE_CRITICAL_FAILURE =
+      "ticketrush.ticket.issue.critical_failure";
+
+  // kafka / outbox (횡단)
+  public static final String KAFKA_INBOX = "ticketrush.kafka.inbox";
+  public static final String KAFKA_DLT = "ticketrush.kafka.dlt";
+  public static final String OUTBOX_RELAY = "ticketrush.outbox.relay";
+  public static final String OUTBOX_BACKLOG = "ticketrush.outbox.backlog"; // Gauge
+
+  // ===== Tag keys =====
+  public static final String TAG_RESULT = "result";
+  public static final String TAG_REASON = "reason";
+  public static final String TAG_OUTCOME = "outcome";
+  public static final String TAG_CONSUMER_GROUP = "consumer_group";
+  public static final String TAG_AGGREGATE_TYPE = "aggregate_type";
+  public static final String TAG_PROVIDER = "provider";
+
+  // ===== Tag values =====
+  public static final String RESULT_SUCCESS = "success";
+  public static final String RESULT_FAILURE = "failure";
+  public static final String RESULT_UNAVAILABLE = "unavailable";
+  public static final String RESULT_PROCESSED = "processed";
+  public static final String RESULT_DUPLICATE = "duplicate";
+  public static final String RESULT_FAIL = "fail";
+  public static final String RESULT_ISSUED = "issued";
+  public static final String RESULT_ALREADY_ISSUED = "already_issued";
+}

--- a/common/src/main/java/com/ticketrush/global/dlt/DeadLetterConsumer.java
+++ b/common/src/main/java/com/ticketrush/global/dlt/DeadLetterConsumer.java
@@ -1,8 +1,11 @@
 package com.ticketrush.global.dlt;
 
+import com.ticketrush.global.constants.MetricNames;
 import com.ticketrush.global.event.DomainEventEnvelope;
 import com.ticketrush.global.event.KafkaConsumerGroup;
 import com.ticketrush.global.notification.Notifier;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.LinkedHashMap;
@@ -64,6 +67,7 @@ public class DeadLetterConsumer {
 
   private final DeadLetterRecordRepository deadLetterRecordRepository;
   private final Notifier notifier;
+  private final MeterRegistry meterRegistry;
 
   /**
    * topicPattern: 접미사가 정확히 하나인 {@code .DLT} 토픽만 매칭. {@code .DLT.DLT}는 부정형 lookbehind로 제외한다.
@@ -104,6 +108,8 @@ public class DeadLetterConsumer {
       // null이 아니지만 envelope가 아닌 경우(드문 케이스)는 toString으로 폴백한다.
       payload = extractRawPayload(record);
     }
+
+    Counter.builder(MetricNames.KAFKA_DLT).register(meterRegistry).increment();
 
     // #10: 사용자 영향 문자열(Kafka 메시지 유래)의 개행·탭을 sanitize해 로그 인젝션을 방지한다.
     log.error(

--- a/common/src/main/java/com/ticketrush/global/inbox/InboxService.java
+++ b/common/src/main/java/com/ticketrush/global/inbox/InboxService.java
@@ -1,6 +1,9 @@
 package com.ticketrush.global.inbox;
 
+import com.ticketrush.global.constants.MetricNames;
 import com.ticketrush.global.event.DomainEventEnvelope;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
@@ -17,6 +20,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class InboxService {
 
   private final InboxRepository inboxRepository;
+  private final MeterRegistry meterRegistry;
 
   /**
    * 해당 컨슈머 그룹이 처음 보는 이벤트이면 {@code business}를 실행하고 Inbox에 기록한 뒤 {@code true}를, 이미 처리한 이벤트이면 아무것도 하지
@@ -40,6 +44,11 @@ public class InboxService {
   @Transactional
   public boolean runIfFirst(String consumerGroup, DomainEventEnvelope envelope, Runnable business) {
     if (inboxRepository.existsByConsumerGroupAndEventId(consumerGroup, envelope.eventId())) {
+      Counter.builder(MetricNames.KAFKA_INBOX)
+          .tag(MetricNames.TAG_CONSUMER_GROUP, consumerGroup)
+          .tag(MetricNames.TAG_RESULT, MetricNames.RESULT_DUPLICATE)
+          .register(meterRegistry)
+          .increment();
       return false;
     }
 
@@ -54,6 +63,11 @@ public class InboxService {
       // 롤백-only 상태에서 정상 반환하면 커밋 시 UnexpectedRollbackException이 나므로 반드시 예외로 롤백시킨다.
       throw new DuplicateEventException(consumerGroup, envelope.eventId(), e);
     }
+    Counter.builder(MetricNames.KAFKA_INBOX)
+        .tag(MetricNames.TAG_CONSUMER_GROUP, consumerGroup)
+        .tag(MetricNames.TAG_RESULT, MetricNames.RESULT_PROCESSED)
+        .register(meterRegistry)
+        .increment();
     return true;
   }
 }

--- a/common/src/main/java/com/ticketrush/global/outbox/OutboxRelayService.java
+++ b/common/src/main/java/com/ticketrush/global/outbox/OutboxRelayService.java
@@ -1,10 +1,15 @@
 package com.ticketrush.global.outbox;
 
+import com.ticketrush.global.constants.MetricNames;
 import com.ticketrush.global.event.DomainEventEnvelope;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import jakarta.annotation.PostConstruct;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
@@ -37,12 +42,24 @@ public class OutboxRelayService {
   private final KafkaTemplate<String, DomainEventEnvelope> kafkaTemplate;
   private final OutboxProperties outboxProperties;
   private final OutboxStatusUpdater outboxStatusUpdater;
+  private final MeterRegistry meterRegistry;
+
+  private final AtomicLong backlog = new AtomicLong();
+
+  /** 이 서비스가 소유한 aggregateTypes의 적체(PENDING/FAILED) 건수를 노출하는 Gauge를 등록한다(#335). */
+  @PostConstruct
+  public void registerBacklogGauge() {
+    Gauge.builder(MetricNames.OUTBOX_BACKLOG, backlog, AtomicLong::get).register(meterRegistry);
+  }
 
   public void relayBatch() {
     List<String> aggregateTypes = outboxProperties.getAggregateTypes();
     if (aggregateTypes == null || aggregateTypes.isEmpty()) {
       return;
     }
+
+    backlog.set(
+        outboxRepository.countByAggregateTypeInAndStatusIn(aggregateTypes, RELAY_TARGET_STATUSES));
 
     int batchSize = outboxProperties.getBatchSize();
     if (batchSize < 1) {

--- a/common/src/main/java/com/ticketrush/global/outbox/OutboxRepository.java
+++ b/common/src/main/java/com/ticketrush/global/outbox/OutboxRepository.java
@@ -28,6 +28,13 @@ public interface OutboxRepository extends JpaRepository<OutboxEntity, Long> {
       Collection<String> aggregateTypes, Collection<OutboxStatus> statuses, Pageable pageable);
 
   /**
+   * relay 폴링 대상(자기 소유 {@code aggregateTypes} 중 {@code statuses})의 적체 건수를 센다(#335 {@code
+   * OUTBOX_BACKLOG} Gauge용).
+   */
+  long countByAggregateTypeInAndStatusIn(
+      Collection<String> aggregateTypes, Collection<OutboxStatus> statuses);
+
+  /**
    * retention 대상 row를 벌크 삭제한다. 자기 소유 {@code aggregateTypes} 중 {@code status}(보통 {@link
    * OutboxStatus#SENT})이면서 {@code threshold} 이전에 발행된 row만 지운다.
    */

--- a/common/src/main/java/com/ticketrush/global/outbox/OutboxStatusUpdater.java
+++ b/common/src/main/java/com/ticketrush/global/outbox/OutboxStatusUpdater.java
@@ -1,6 +1,9 @@
 package com.ticketrush.global.outbox;
 
+import com.ticketrush.global.constants.MetricNames;
 import com.ticketrush.global.notification.Notifier;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -25,13 +28,22 @@ public class OutboxStatusUpdater {
 
   private final OutboxStatusTransition transition;
   private final Notifier notifier;
+  private final MeterRegistry meterRegistry;
 
   public void markSuccess(Long id) {
     transition.markSuccess(id);
+    Counter.builder(MetricNames.OUTBOX_RELAY)
+        .tag(MetricNames.TAG_RESULT, MetricNames.RESULT_SUCCESS)
+        .register(meterRegistry)
+        .increment();
   }
 
   public void markFail(Long id, String lastError) {
     OutboxStatusTransition.DeadInfo deadInfo = transition.markFail(id, lastError);
+    Counter.builder(MetricNames.OUTBOX_RELAY)
+        .tag(MetricNames.TAG_RESULT, MetricNames.RESULT_FAIL)
+        .register(meterRegistry)
+        .increment();
     if (deadInfo != null) {
       // 트랜잭션 커밋 후 알림. 외부 HTTP 지연이 DB 커넥션을 점유하지 않는다(#1 결정).
       // 알림 본문에 자유서식 오류 메시지를 포함하지 않는다(#6 결정 — PII 유출 방지).

--- a/common/src/test/java/com/ticketrush/global/dlt/DeadLetterConsumerTest.java
+++ b/common/src/test/java/com/ticketrush/global/dlt/DeadLetterConsumerTest.java
@@ -8,16 +8,17 @@ import static org.mockito.Mockito.verify;
 
 import com.ticketrush.global.event.DomainEventEnvelope;
 import com.ticketrush.global.notification.Notifier;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.Map;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.kafka.support.Acknowledgment;
@@ -26,11 +27,20 @@ import org.springframework.kafka.support.serializer.SerializationUtils;
 @ExtendWith(MockitoExtension.class)
 class DeadLetterConsumerTest {
 
-  @InjectMocks private DeadLetterConsumer deadLetterConsumer;
+  private DeadLetterConsumer deadLetterConsumer;
 
   @Mock private DeadLetterRecordRepository deadLetterRecordRepository;
   @Mock private Notifier notifier;
   @Mock private Acknowledgment ack;
+
+  private SimpleMeterRegistry meterRegistry;
+
+  @BeforeEach
+  void setUp() {
+    meterRegistry = new SimpleMeterRegistry();
+    deadLetterConsumer =
+        new DeadLetterConsumer(deadLetterRecordRepository, notifier, meterRegistry);
+  }
 
   private static byte[] intBytes(int value) {
     return ByteBuffer.allocate(Integer.BYTES).putInt(value).array();

--- a/common/src/test/java/com/ticketrush/global/inbox/InboxServiceIntegrationTest.java
+++ b/common/src/test/java/com/ticketrush/global/inbox/InboxServiceIntegrationTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.ticketrush.global.event.DomainEventEnvelope;
 import com.ticketrush.global.jpa.config.JpaConfig;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.time.Instant;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.DisplayName;
@@ -16,9 +17,12 @@ import org.springframework.context.annotation.Import;
 /**
  * 실제 트랜잭션·리포지토리로 {@link InboxService#runIfFirst}를 검증한다(mock이 아닌 실동작). 원자성 seam(비즈니스 콜백 + inbox 기록이
  * 한 트랜잭션)을 실제 DB에서 확인한다.
+ *
+ * <p>{@code @DataJpaTest}는 메트릭 익스포트를 비활성화해 {@link io.micrometer.core.instrument.MeterRegistry} 빈이
+ * 없으므로, {@link InboxService}(#335 계측) 생성을 위해 {@link SimpleMeterRegistry}를 함께 가져온다.
  */
 @DataJpaTest
-@Import({JpaConfig.class, InboxService.class})
+@Import({JpaConfig.class, InboxService.class, SimpleMeterRegistry.class})
 class InboxServiceIntegrationTest {
 
   @Autowired private InboxService inboxService;

--- a/common/src/test/java/com/ticketrush/global/inbox/InboxServiceTest.java
+++ b/common/src/test/java/com/ticketrush/global/inbox/InboxServiceTest.java
@@ -8,13 +8,15 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
+import com.ticketrush.global.constants.MetricNames;
 import com.ticketrush.global.event.DomainEventEnvelope;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.time.Instant;
 import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -22,11 +24,19 @@ import org.springframework.dao.DataIntegrityViolationException;
 @ExtendWith(MockitoExtension.class)
 class InboxServiceTest {
 
-  @InjectMocks private InboxService inboxService;
+  private InboxService inboxService;
+
+  private SimpleMeterRegistry meterRegistry;
 
   @Mock private InboxRepository inboxRepository;
 
   private static final String GROUP = "seat-group";
+
+  @BeforeEach
+  void setUp() {
+    meterRegistry = new SimpleMeterRegistry();
+    inboxService = new InboxService(inboxRepository, meterRegistry);
+  }
 
   private DomainEventEnvelope envelope() {
     return new DomainEventEnvelope(
@@ -110,5 +120,45 @@ class InboxServiceTest {
 
     // then
     verify(inboxRepository).existsByConsumerGroupAndEventId(GROUP, "evt-1");
+  }
+
+  @Test
+  @DisplayName("최초 처리 성공 시 KAFKA_INBOX processed 카운터가 증가한다(#335)")
+  void runIfFirst_increments_processed_counter_when_new() {
+    // given
+    given(inboxRepository.existsByConsumerGroupAndEventId(GROUP, "evt-1")).willReturn(false);
+
+    // when
+    inboxService.runIfFirst(GROUP, envelope(), () -> {});
+
+    // then
+    double count =
+        meterRegistry
+            .get(MetricNames.KAFKA_INBOX)
+            .tag(MetricNames.TAG_CONSUMER_GROUP, GROUP)
+            .tag(MetricNames.TAG_RESULT, MetricNames.RESULT_PROCESSED)
+            .counter()
+            .count();
+    assertThat(count).isEqualTo(1.0);
+  }
+
+  @Test
+  @DisplayName("중복 처리 시 KAFKA_INBOX duplicate 카운터가 증가한다(#335)")
+  void runIfFirst_increments_duplicate_counter_when_already_processed() {
+    // given
+    given(inboxRepository.existsByConsumerGroupAndEventId(GROUP, "evt-1")).willReturn(true);
+
+    // when
+    inboxService.runIfFirst(GROUP, envelope(), () -> {});
+
+    // then
+    double count =
+        meterRegistry
+            .get(MetricNames.KAFKA_INBOX)
+            .tag(MetricNames.TAG_CONSUMER_GROUP, GROUP)
+            .tag(MetricNames.TAG_RESULT, MetricNames.RESULT_DUPLICATE)
+            .counter()
+            .count();
+    assertThat(count).isEqualTo(1.0);
   }
 }

--- a/common/src/test/java/com/ticketrush/global/outbox/OutboxStatusUpdaterTest.java
+++ b/common/src/test/java/com/ticketrush/global/outbox/OutboxStatusUpdaterTest.java
@@ -7,11 +7,12 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 import com.ticketrush.global.notification.Notifier;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -24,10 +25,18 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class OutboxStatusUpdaterTest {
 
-  @InjectMocks private OutboxStatusUpdater outboxStatusUpdater;
+  private OutboxStatusUpdater outboxStatusUpdater;
 
   @Mock private OutboxStatusTransition transition;
   @Mock private Notifier notifier;
+
+  private SimpleMeterRegistry meterRegistry;
+
+  @BeforeEach
+  void setUp() {
+    meterRegistry = new SimpleMeterRegistry();
+    outboxStatusUpdater = new OutboxStatusUpdater(transition, notifier, meterRegistry);
+  }
 
   @Test
   @DisplayName("markSuccess: transition.markSuccess를 위임한다")

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentConfirmUseCase.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentConfirmUseCase.java
@@ -11,8 +11,12 @@ import com.ticketrush.boundedcontext.payment.out.apiclient.PaymentApprovalReques
 import com.ticketrush.boundedcontext.payment.out.apiclient.PaymentApprovalResponse;
 import com.ticketrush.boundedcontext.payment.out.repository.ExpiredBookingRepository;
 import com.ticketrush.boundedcontext.payment.out.repository.PaymentRepository;
+import com.ticketrush.global.constants.MetricNames;
 import com.ticketrush.global.exception.BusinessException;
 import com.ticketrush.global.status.ErrorStatus;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
 import java.util.EnumSet;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
@@ -52,6 +56,7 @@ public class PaymentConfirmUseCase {
   private final PaymentEventPublisher paymentEventPublisher;
   private final ExpiredBookingRepository expiredBookingRepository;
   private final PaymentMapper paymentMapper;
+  private final MeterRegistry meterRegistry;
 
   public PaymentConfirmResponse execute(Long userId, PaymentConfirmRequest request) {
     if (paymentRepository.existsByBookingIdAndStatus(
@@ -69,14 +74,24 @@ public class PaymentConfirmUseCase {
     // PG 승인·금액 검증 단계에서 결제 실패가 확정되면(PG 거절/금액 불일치) 예외만 던지지 않고 FAILED 이력을 남긴다(#297).
     PaymentApprovalResponse approval;
     try {
-      approval =
-          paymentApprovalClientRouter.approve(
-              new PaymentApprovalRequest(
-                  request.provider(),
-                  request.paymentKey(),
-                  orderId,
-                  request.bookingId(),
-                  request.amount()));
+      Timer.Sample sample = Timer.start(meterRegistry);
+      try {
+        approval =
+            paymentApprovalClientRouter.approve(
+                new PaymentApprovalRequest(
+                    request.provider(),
+                    request.paymentKey(),
+                    orderId,
+                    request.bookingId(),
+                    request.amount()));
+      } finally {
+        sample.stop(
+            Timer.builder(MetricNames.PAYMENT_PG_APPROVE)
+                .tag(
+                    MetricNames.TAG_PROVIDER,
+                    request.provider() != null ? request.provider().name() : "unknown")
+                .register(meterRegistry));
+      }
 
       if (!request.amount().equals(approval.approvedAmount())) {
         throw new BusinessException(ErrorStatus.PAYMENT_AMOUNT_MISMATCH);
@@ -111,6 +126,11 @@ public class PaymentConfirmUseCase {
         userId,
         saved.getAmount(),
         saved.getPaidAt());
+
+    Counter.builder(MetricNames.PAYMENT_CONFIRM)
+        .tag(MetricNames.TAG_RESULT, MetricNames.RESULT_SUCCESS)
+        .register(meterRegistry)
+        .increment();
 
     return paymentMapper.toConfirmResponse(saved);
   }
@@ -153,6 +173,11 @@ public class PaymentConfirmUseCase {
               e.getErrorStatus().getCode(),
               e.getErrorStatus().getMessage());
       paymentRepository.saveAndFlush(failed);
+      Counter.builder(MetricNames.PAYMENT_CONFIRM)
+          .tag(MetricNames.TAG_RESULT, MetricNames.RESULT_FAILURE)
+          .tag(MetricNames.TAG_REASON, e.getErrorStatus().getCode())
+          .register(meterRegistry)
+          .increment();
     } catch (Exception ex) {
       // 추적이 목적인 기능이라 이력 저장 실패는 집계 누락이다. error 레벨로 올려 알람/메트릭 대상이 되게 한다.
       log.error(

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentRefundByBookingUseCase.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentRefundByBookingUseCase.java
@@ -11,7 +11,10 @@ import com.ticketrush.boundedcontext.payment.out.apiclient.PaymentCancelCommand;
 import com.ticketrush.boundedcontext.payment.out.apiclient.PaymentCancelResult;
 import com.ticketrush.boundedcontext.payment.out.repository.PaymentRepository;
 import com.ticketrush.boundedcontext.payment.out.repository.RefundRepository;
+import com.ticketrush.global.constants.MetricNames;
 import com.ticketrush.shared.booking.event.RefundRequestedEvent;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
 import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -42,6 +45,7 @@ public class PaymentRefundByBookingUseCase {
   private final PaymentCancelClientRouter paymentCancelClientRouter;
   private final PaymentCancelPersister paymentCancelPersister;
   private final PaymentEventPublisher paymentEventPublisher;
+  private final MeterRegistry meterRegistry;
 
   public enum RefundOutcome {
     /** PG 환불을 실행하고 {@code PaymentCanceledEvent}를 발행했다. */
@@ -64,14 +68,23 @@ public class PaymentRefundByBookingUseCase {
     }
 
     // PG 취소는 트랜잭션 밖에서 호출한다(외부 왕복 동안 DB 커넥션을 점유하지 않기 위함). paymentId 기반 고정 멱등 키로 PG 측 중복 취소를 막는다.
-    PaymentCancelResult result =
-        paymentCancelClientRouter.cancel(
-            new PaymentCancelCommand(
-                payment.getProvider(),
-                payment.getPaymentKey(),
-                payment.getAmount(),
-                REFUND_REASON,
-                generateIdempotencyKey(payment.getId())));
+    Timer.Sample sample = Timer.start(meterRegistry);
+    PaymentCancelResult result;
+    try {
+      result =
+          paymentCancelClientRouter.cancel(
+              new PaymentCancelCommand(
+                  payment.getProvider(),
+                  payment.getPaymentKey(),
+                  payment.getAmount(),
+                  REFUND_REASON,
+                  generateIdempotencyKey(payment.getId())));
+    } finally {
+      sample.stop(
+          Timer.builder(MetricNames.PAYMENT_PG_CANCEL)
+              .tag(MetricNames.TAG_PROVIDER, payment.getProvider().name())
+              .register(meterRegistry));
+    }
 
     Refund refund =
         Refund.builder()

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/in/eventlistener/RefundRequestedEventListener.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/in/eventlistener/RefundRequestedEventListener.java
@@ -3,12 +3,15 @@ package com.ticketrush.boundedcontext.payment.in.eventlistener;
 import com.ticketrush.boundedcontext.payment.app.support.PaymentEventPublisher;
 import com.ticketrush.boundedcontext.payment.app.usecase.PaymentRefundByBookingUseCase;
 import com.ticketrush.boundedcontext.payment.app.usecase.PaymentRefundByBookingUseCase.RefundOutcome;
+import com.ticketrush.global.constants.MetricNames;
 import com.ticketrush.global.event.DomainEventEnvelope;
 import com.ticketrush.global.event.KafkaConsumerGroup;
 import com.ticketrush.global.exception.BusinessException;
 import com.ticketrush.global.json.JsonConverter;
 import com.ticketrush.global.status.ErrorStatus;
 import com.ticketrush.shared.booking.event.RefundRequestedEvent;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
 import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -50,6 +53,7 @@ public class RefundRequestedEventListener {
   private final PaymentRefundByBookingUseCase paymentRefundByBookingUseCase;
   private final PaymentEventPublisher paymentEventPublisher;
   private final JsonConverter jsonConverter;
+  private final MeterRegistry meterRegistry;
 
   @KafkaListener(topics = RefundRequestedEvent.TOPIC, groupId = KafkaConsumerGroup.PAYMENT)
   public void handleRefundRequested(@Payload DomainEventEnvelope envelope, Acknowledgment ack) {
@@ -72,6 +76,11 @@ public class RefundRequestedEventListener {
             event.bookingId());
       }
 
+      Counter.builder(MetricNames.PAYMENT_REFUND)
+          .tag(MetricNames.TAG_OUTCOME, outcome.name().toLowerCase())
+          .register(meterRegistry)
+          .increment();
+
       // 성공(재발행·멱등 스킵 포함) 시에만 오프셋을 커밋한다(#269 표준).
       ack.acknowledge();
     } catch (DataIntegrityViolationException e) {
@@ -90,6 +99,7 @@ public class RefundRequestedEventListener {
             e);
         paymentEventPublisher.publishRefundFailed(
             event.bookingId(), event.bookingNumber(), REASON_REFUND_FAILED, LocalDateTime.now());
+        Counter.builder(MetricNames.PAYMENT_REFUND_FAILED).register(meterRegistry).increment();
         ack.acknowledge();
       } else {
         log.warn(

--- a/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentConfirmUseCaseTest.java
+++ b/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentConfirmUseCaseTest.java
@@ -21,18 +21,20 @@ import com.ticketrush.boundedcontext.payment.out.apiclient.PaymentApprovalReques
 import com.ticketrush.boundedcontext.payment.out.apiclient.PaymentApprovalResponse;
 import com.ticketrush.boundedcontext.payment.out.repository.ExpiredBookingRepository;
 import com.ticketrush.boundedcontext.payment.out.repository.PaymentRepository;
+import com.ticketrush.global.constants.MetricNames;
 import com.ticketrush.global.exception.BusinessException;
 import com.ticketrush.global.status.ErrorStatus;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.lang.reflect.Field;
 import java.time.LocalDateTime;
 import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mapstruct.factory.Mappers;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InOrder;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -47,7 +49,21 @@ class PaymentConfirmUseCaseTest {
 
   @Spy private PaymentMapper paymentMapper = Mappers.getMapper(PaymentMapper.class);
 
-  @InjectMocks private PaymentConfirmUseCase paymentConfirmUseCase;
+  private SimpleMeterRegistry meterRegistry;
+  private PaymentConfirmUseCase paymentConfirmUseCase;
+
+  @BeforeEach
+  void setUp() {
+    meterRegistry = new SimpleMeterRegistry();
+    paymentConfirmUseCase =
+        new PaymentConfirmUseCase(
+            paymentRepository,
+            paymentApprovalClientRouter,
+            paymentEventPublisher,
+            expiredBookingRepository,
+            paymentMapper,
+            meterRegistry);
+  }
 
   @Test
   @DisplayName("PG 승인 성공 시 Payment를 COMPLETED 상태로 저장하고 PaymentConfirmedEvent를 발행한다")
@@ -116,6 +132,19 @@ class PaymentConfirmUseCaseTest {
     inOrder
         .verify(paymentEventPublisher)
         .publishConfirmed(any(), any(), any(), any(), any(), any());
+
+    // 성공 시 result=success 카운터가 증가하고 PG 승인 Latency 타이머가 기록되어야 한다.
+    assertThat(
+            meterRegistry
+                .counter(
+                    MetricNames.PAYMENT_CONFIRM, MetricNames.TAG_RESULT, MetricNames.RESULT_SUCCESS)
+                .count())
+        .isEqualTo(1.0);
+    assertThat(
+            meterRegistry
+                .timer(MetricNames.PAYMENT_PG_APPROVE, MetricNames.TAG_PROVIDER, "TOSS")
+                .count())
+        .isEqualTo(1L);
   }
 
   private void setId(Payment payment, Long id) throws Exception {
@@ -207,6 +236,25 @@ class PaymentConfirmUseCaseTest {
     assertThat(failed.getFailureCode()).isEqualTo(ErrorStatus.PAYMENT_METHOD_REJECTED.getCode());
     verify(paymentEventPublisher, never())
         .publishConfirmed(any(), any(), any(), any(), any(), any());
+
+    // 화이트리스트 실패는 result=failure & reason 태그 카운터가 증가해야 한다.
+    assertThat(
+            meterRegistry
+                .counter(
+                    MetricNames.PAYMENT_CONFIRM,
+                    MetricNames.TAG_RESULT,
+                    MetricNames.RESULT_FAILURE,
+                    MetricNames.TAG_REASON,
+                    ErrorStatus.PAYMENT_METHOD_REJECTED.getCode())
+                .count())
+        .isEqualTo(1.0);
+
+    // approve()가 예외를 던져도 finally에서 PG 승인 Latency 타이머는 기록되어야 한다(예외 안전성).
+    assertThat(
+            meterRegistry
+                .timer(MetricNames.PAYMENT_PG_APPROVE, MetricNames.TAG_PROVIDER, "TOSS")
+                .count())
+        .isEqualTo(1L);
   }
 
   @Test

--- a/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentRefundByBookingUseCaseTest.java
+++ b/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentRefundByBookingUseCaseTest.java
@@ -20,16 +20,18 @@ import com.ticketrush.boundedcontext.payment.out.apiclient.PaymentCancelCommand;
 import com.ticketrush.boundedcontext.payment.out.apiclient.PaymentCancelResult;
 import com.ticketrush.boundedcontext.payment.out.repository.PaymentRepository;
 import com.ticketrush.boundedcontext.payment.out.repository.RefundRepository;
+import com.ticketrush.global.constants.MetricNames;
 import com.ticketrush.shared.booking.event.RefundRequestedEvent;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.lang.reflect.Field;
 import java.time.LocalDateTime;
 import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InOrder;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -42,7 +44,21 @@ class PaymentRefundByBookingUseCaseTest {
   @Mock private PaymentCancelPersister paymentCancelPersister;
   @Mock private PaymentEventPublisher paymentEventPublisher;
 
-  @InjectMocks private PaymentRefundByBookingUseCase paymentRefundByBookingUseCase;
+  private SimpleMeterRegistry meterRegistry;
+  private PaymentRefundByBookingUseCase paymentRefundByBookingUseCase;
+
+  @BeforeEach
+  void setUp() {
+    meterRegistry = new SimpleMeterRegistry();
+    paymentRefundByBookingUseCase =
+        new PaymentRefundByBookingUseCase(
+            paymentRepository,
+            refundRepository,
+            paymentCancelClientRouter,
+            paymentCancelPersister,
+            paymentEventPublisher,
+            meterRegistry);
+  }
 
   private static final Long PAYMENT_ID = 1L;
   private static final Long BOOKING_ID = 100L;
@@ -112,6 +128,13 @@ class PaymentRefundByBookingUseCaseTest {
     inOrder
         .verify(paymentEventPublisher)
         .publishCanceled(any(), any(), any(), any(), any(), any(), any(), any());
+
+    // PG 취소 Latency 타이머가 provider 태그와 함께 기록되어야 한다.
+    assertThat(
+            meterRegistry
+                .timer(MetricNames.PAYMENT_PG_CANCEL, MetricNames.TAG_PROVIDER, "TOSS")
+                .count())
+        .isEqualTo(1L);
   }
 
   @Test

--- a/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/in/eventlistener/RefundRequestedEventListenerTest.java
+++ b/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/in/eventlistener/RefundRequestedEventListenerTest.java
@@ -1,5 +1,6 @@
 package com.ticketrush.boundedcontext.payment.in.eventlistener;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
@@ -12,17 +13,19 @@ import static org.mockito.Mockito.verify;
 import com.ticketrush.boundedcontext.payment.app.support.PaymentEventPublisher;
 import com.ticketrush.boundedcontext.payment.app.usecase.PaymentRefundByBookingUseCase;
 import com.ticketrush.boundedcontext.payment.app.usecase.PaymentRefundByBookingUseCase.RefundOutcome;
+import com.ticketrush.global.constants.MetricNames;
 import com.ticketrush.global.event.DomainEventEnvelope;
 import com.ticketrush.global.exception.BusinessException;
 import com.ticketrush.global.json.JsonConverter;
 import com.ticketrush.global.status.ErrorStatus;
 import com.ticketrush.shared.booking.event.RefundRequestedEvent;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.time.Instant;
 import java.time.LocalDateTime;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -31,12 +34,22 @@ import org.springframework.kafka.support.Acknowledgment;
 @ExtendWith(MockitoExtension.class)
 class RefundRequestedEventListenerTest {
 
-  @InjectMocks private RefundRequestedEventListener listener;
+  private RefundRequestedEventListener listener;
 
   @Mock private PaymentRefundByBookingUseCase paymentRefundByBookingUseCase;
   @Mock private PaymentEventPublisher paymentEventPublisher;
   @Mock private JsonConverter jsonConverter;
   @Mock private Acknowledgment acknowledgment;
+
+  private SimpleMeterRegistry meterRegistry;
+
+  @BeforeEach
+  void setUp() {
+    meterRegistry = new SimpleMeterRegistry();
+    listener =
+        new RefundRequestedEventListener(
+            paymentRefundByBookingUseCase, paymentEventPublisher, jsonConverter, meterRegistry);
+  }
 
   private static final String PAYLOAD = "payload";
   private static final Long BOOKING_ID = 100L;
@@ -71,6 +84,12 @@ class RefundRequestedEventListenerTest {
     // then
     verify(paymentEventPublisher, never()).publishRefundFailed(any(), any(), any(), any());
     verify(acknowledgment).acknowledge();
+
+    assertThat(
+            meterRegistry
+                .counter(MetricNames.PAYMENT_REFUND, MetricNames.TAG_OUTCOME, "refunded")
+                .count())
+        .isEqualTo(1.0);
   }
 
   @Test
@@ -139,6 +158,8 @@ class RefundRequestedEventListenerTest {
         .publishRefundFailed(
             eq(BOOKING_ID), eq(BOOKING_NUMBER), eq("PG 환불 처리 실패"), any(LocalDateTime.class));
     verify(acknowledgment).acknowledge();
+
+    assertThat(meterRegistry.counter(MetricNames.PAYMENT_REFUND_FAILED).count()).isEqualTo(1.0);
   }
 
   @Test

--- a/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/app/scheduler/SeatHeldGaugeMetrics.java
+++ b/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/app/scheduler/SeatHeldGaugeMetrics.java
@@ -1,0 +1,33 @@
+package com.ticketrush.boundedcontext.seat.app.scheduler;
+
+import com.ticketrush.boundedcontext.seat.out.repository.SeatRepository;
+import com.ticketrush.global.constants.MetricNames;
+import com.ticketrush.global.types.SeatStatus;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import jakarta.annotation.PostConstruct;
+import java.time.LocalDateTime;
+import java.util.concurrent.atomic.AtomicLong;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class SeatHeldGaugeMetrics {
+
+  private final MeterRegistry meterRegistry;
+  private final SeatRepository seatRepository;
+
+  private final AtomicLong heldSeats = new AtomicLong(0);
+
+  @PostConstruct
+  public void init() {
+    Gauge.builder(MetricNames.SEAT_HELD, heldSeats, AtomicLong::get).register(meterRegistry);
+  }
+
+  @Scheduled(fixedDelay = 30000)
+  public void refreshHeldSeats() {
+    heldSeats.set(seatRepository.countHeldSeats(SeatStatus.HOLD, LocalDateTime.now()));
+  }
+}

--- a/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/app/usecase/SeatHoldUseCase.java
+++ b/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/app/usecase/SeatHoldUseCase.java
@@ -3,8 +3,11 @@ package com.ticketrush.boundedcontext.seat.app.usecase;
 import com.ticketrush.boundedcontext.seat.app.support.SeatStatusEventPublisher;
 import com.ticketrush.boundedcontext.seat.domain.entity.Seat;
 import com.ticketrush.boundedcontext.seat.out.repository.SeatRepository;
+import com.ticketrush.global.constants.MetricNames;
 import com.ticketrush.global.exception.BusinessException;
 import com.ticketrush.global.status.ErrorStatus;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
 import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -17,6 +20,7 @@ public class SeatHoldUseCase {
 
   private final SeatRepository seatRepository;
   private final SeatStatusEventPublisher seatStatusEventPublisher;
+  private final MeterRegistry meterRegistry;
 
   /**
    * 좌석을 HOLD로 전이한다.
@@ -34,11 +38,19 @@ public class SeatHoldUseCase {
             .orElseThrow(() -> new BusinessException(ErrorStatus.SEAT_NOT_FOUND));
 
     if (!seat.isAvailable()) {
+      Counter.builder(MetricNames.SEAT_HOLD)
+          .tag(MetricNames.TAG_RESULT, MetricNames.RESULT_UNAVAILABLE)
+          .register(meterRegistry)
+          .increment();
       return false;
     }
 
     seat.hold(holdExpiredAt, bookingNumber);
     seatStatusEventPublisher.publishAfterCommit(seat);
+    Counter.builder(MetricNames.SEAT_HOLD)
+        .tag(MetricNames.TAG_RESULT, MetricNames.RESULT_SUCCESS)
+        .register(meterRegistry)
+        .increment();
     return true;
   }
 }

--- a/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/app/usecase/SeatLockUseCase.java
+++ b/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/app/usecase/SeatLockUseCase.java
@@ -1,5 +1,8 @@
 package com.ticketrush.boundedcontext.seat.app.usecase;
 
+import com.ticketrush.global.constants.MetricNames;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
 import java.time.LocalDateTime;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
@@ -15,6 +18,7 @@ import org.springframework.stereotype.Service;
 public class SeatLockUseCase {
 
   private final RedissonClient redissonClient;
+  private final MeterRegistry meterRegistry;
 
   private static final String SEAT_LOCK_PREFIX = "seat:lock:";
   private static final int LOCK_TTL_MINUTES = 5;
@@ -31,12 +35,15 @@ public class SeatLockUseCase {
         // 락 획득 성공 시 만료 시간 반환
         return Optional.of(LocalDateTime.now().plusMinutes(LOCK_TTL_MINUTES));
       }
+
+      // 락 획득 실패 (이미 다른 사용자가 선점 중, 락 경합)
+      Counter.builder(MetricNames.SEAT_LOCK_CONTENTION).register(meterRegistry).increment();
     } catch (InterruptedException e) {
       log.error("Redisson 락 획득 중 인터럽트 발생. seatId: {}", seatId, e);
       Thread.currentThread().interrupt(); // 인터럽트 상태 복구
     }
 
-    // 락 획득 실패 (이미 다른 사용자가 선점 중)
+    // 락 획득 실패
     return Optional.empty();
   }
 }

--- a/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/out/repository/SeatRepository.java
+++ b/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/out/repository/SeatRepository.java
@@ -80,4 +80,7 @@ public interface SeatRepository extends JpaRepository<Seat, Long> {
       @Param("bookingNumber") String bookingNumber,
       @Param("holdStatus") SeatStatus holdStatus,
       @Param("soldStatus") SeatStatus soldStatus);
+
+  @Query("select count(s) from Seat s where s.seatStatus = :hold and s.holdExpiredAt > :now")
+  long countHeldSeats(@Param("hold") SeatStatus hold, @Param("now") LocalDateTime now);
 }

--- a/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/app/usecase/SeatHoldUseCaseTest.java
+++ b/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/app/usecase/SeatHoldUseCaseTest.java
@@ -9,25 +9,35 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import com.ticketrush.boundedcontext.seat.app.support.SeatStatusEventPublisher;
 import com.ticketrush.boundedcontext.seat.domain.entity.Seat;
 import com.ticketrush.boundedcontext.seat.out.repository.SeatRepository;
+import com.ticketrush.global.constants.MetricNames;
 import com.ticketrush.global.exception.BusinessException;
 import com.ticketrush.global.status.ErrorStatus;
 import com.ticketrush.global.types.SeatStatus;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.time.LocalDateTime;
 import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class SeatHoldUseCaseTest {
 
-  @InjectMocks private SeatHoldUseCase seatHoldUseCase;
+  private SeatHoldUseCase seatHoldUseCase;
 
   @Mock private SeatRepository seatRepository;
   @Mock private SeatStatusEventPublisher seatStatusEventPublisher;
+
+  private SimpleMeterRegistry meterRegistry;
+
+  @BeforeEach
+  void setUp() {
+    meterRegistry = new SimpleMeterRegistry();
+    seatHoldUseCase = new SeatHoldUseCase(seatRepository, seatStatusEventPublisher, meterRegistry);
+  }
 
   @Test
   @DisplayName("성공: 좌석이 존재하고 만료 시간이 유효하면 HOLD 상태로 변경된다")
@@ -58,6 +68,11 @@ class SeatHoldUseCaseTest {
     assertThat(seat.getHoldExpiredAt()).isEqualTo(expiredAt);
     assertThat(seat.getBookingNumber()).isEqualTo(bookingNumber);
     verify(seatStatusEventPublisher).publishAfterCommit(seat);
+    assertThat(
+            meterRegistry
+                .counter(MetricNames.SEAT_HOLD, MetricNames.TAG_RESULT, MetricNames.RESULT_SUCCESS)
+                .count())
+        .isEqualTo(1.0);
   }
 
   @Test
@@ -83,6 +98,12 @@ class SeatHoldUseCaseTest {
     assertThat(held).isFalse();
     assertThat(seat.getSeatStatus()).isEqualTo(SeatStatus.SOLD);
     verifyNoInteractions(seatStatusEventPublisher);
+    assertThat(
+            meterRegistry
+                .counter(
+                    MetricNames.SEAT_HOLD, MetricNames.TAG_RESULT, MetricNames.RESULT_UNAVAILABLE)
+                .count())
+        .isEqualTo(1.0);
   }
 
   @Test

--- a/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/app/usecase/SeatLockUseCaseTest.java
+++ b/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/app/usecase/SeatLockUseCaseTest.java
@@ -5,13 +5,15 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
+import com.ticketrush.global.constants.MetricNames;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.time.LocalDateTime;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.redisson.api.RLock;
@@ -20,10 +22,18 @@ import org.redisson.api.RedissonClient;
 @ExtendWith(MockitoExtension.class)
 class SeatLockUseCaseTest {
 
-  @InjectMocks private SeatLockUseCase seatLockUseCase;
+  private SeatLockUseCase seatLockUseCase;
 
   @Mock private RedissonClient redissonClient;
   @Mock private RLock redissonLock;
+
+  private SimpleMeterRegistry meterRegistry;
+
+  @BeforeEach
+  void setUp() {
+    meterRegistry = new SimpleMeterRegistry();
+    seatLockUseCase = new SeatLockUseCase(redissonClient, meterRegistry);
+  }
 
   @Test
   @DisplayName("성공: Redisson 락 획득에 성공하면 만료 시간이 담긴 Optional을 반환한다")
@@ -62,5 +72,6 @@ class SeatLockUseCaseTest {
 
     // then
     assertThat(result).isEmpty();
+    assertThat(meterRegistry.counter(MetricNames.SEAT_LOCK_CONTENTION).count()).isEqualTo(1.0);
   }
 }

--- a/ticket-service/src/main/java/com/ticketrush/boundedcontext/ticket/app/usecase/TicketIssueUseCase.java
+++ b/ticket-service/src/main/java/com/ticketrush/boundedcontext/ticket/app/usecase/TicketIssueUseCase.java
@@ -6,6 +6,9 @@ import com.ticketrush.boundedcontext.ticket.domain.entity.Ticket;
 import com.ticketrush.boundedcontext.ticket.domain.policy.TicketTokenGenerator;
 import com.ticketrush.boundedcontext.ticket.domain.policy.TicketTokenHasher;
 import com.ticketrush.boundedcontext.ticket.out.repository.TicketRepository;
+import com.ticketrush.global.constants.MetricNames;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -31,9 +34,14 @@ public class TicketIssueUseCase {
   private final TicketTokenGenerator ticketTokenGenerator;
   private final TicketTokenHasher ticketTokenHasher;
   private final TicketMapper ticketMapper;
+  private final MeterRegistry meterRegistry;
 
   public TicketIssueResponse execute(Long bookingId) {
     if (ticketRepository.existsByBookingId(bookingId)) {
+      Counter.builder(MetricNames.TICKET_ISSUE)
+          .tag(MetricNames.TAG_RESULT, MetricNames.RESULT_ALREADY_ISSUED)
+          .register(meterRegistry)
+          .increment();
       return TicketIssueResponse.alreadyIssued();
     }
 
@@ -43,6 +51,10 @@ public class TicketIssueUseCase {
     // Inbox 트랜잭션에 조인된 상태로 저장한다. unique(booking_id/ticket_token_hash) 충돌 시 예외를 그대로 전파해
     // 트랜잭션을 롤백시키고(Inbox 미기록) 재소비로 처리한다.
     ticketRepository.saveAndFlush(ticket);
+    Counter.builder(MetricNames.TICKET_ISSUE)
+        .tag(MetricNames.TAG_RESULT, MetricNames.RESULT_ISSUED)
+        .register(meterRegistry)
+        .increment();
     return TicketIssueResponse.issued(token);
   }
 }

--- a/ticket-service/src/main/java/com/ticketrush/boundedcontext/ticket/in/eventlistener/PaymentConfirmedEventListener.java
+++ b/ticket-service/src/main/java/com/ticketrush/boundedcontext/ticket/in/eventlistener/PaymentConfirmedEventListener.java
@@ -1,6 +1,7 @@
 package com.ticketrush.boundedcontext.ticket.in.eventlistener;
 
 import com.ticketrush.boundedcontext.ticket.app.usecase.TicketIssueUseCase;
+import com.ticketrush.global.constants.MetricNames;
 import com.ticketrush.global.event.DomainEventEnvelope;
 import com.ticketrush.global.event.KafkaConsumerErrorPolicy;
 import com.ticketrush.global.event.KafkaConsumerGroup;
@@ -8,6 +9,8 @@ import com.ticketrush.global.inbox.DuplicateEventException;
 import com.ticketrush.global.inbox.InboxService;
 import com.ticketrush.global.json.JsonConverter;
 import com.ticketrush.shared.payment.event.PaymentConfirmedEvent;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.annotation.KafkaListener;
@@ -23,6 +26,7 @@ public class PaymentConfirmedEventListener {
   private final TicketIssueUseCase ticketIssueUseCase;
   private final JsonConverter jsonConverter;
   private final InboxService inboxService;
+  private final MeterRegistry meterRegistry;
 
   @KafkaListener(topics = PaymentConfirmedEvent.TOPIC, groupId = KafkaConsumerGroup.TICKET)
   public void handlePaymentConfirmed(@Payload DomainEventEnvelope envelope, Acknowledgment ack) {
@@ -78,6 +82,9 @@ public class PaymentConfirmedEventListener {
               envelope.eventId(),
               failedBookingId,
               e);
+          Counter.builder(MetricNames.TICKET_ISSUE_CRITICAL_FAILURE)
+              .register(meterRegistry)
+              .increment();
         }
         // 영구 실패는 재시도해도 결과가 바뀌지 않으므로 커밋해 파티션 블로킹을 막는다.
         ack.acknowledge();

--- a/ticket-service/src/test/java/com/ticketrush/boundedcontext/ticket/app/usecase/TicketIssueUseCaseTest.java
+++ b/ticket-service/src/test/java/com/ticketrush/boundedcontext/ticket/app/usecase/TicketIssueUseCaseTest.java
@@ -15,6 +15,9 @@ import com.ticketrush.boundedcontext.ticket.domain.policy.TicketTokenGenerator;
 import com.ticketrush.boundedcontext.ticket.domain.policy.TicketTokenHasher;
 import com.ticketrush.boundedcontext.ticket.domain.types.TicketStatus;
 import com.ticketrush.boundedcontext.ticket.out.repository.TicketRepository;
+import com.ticketrush.global.constants.MetricNames;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -38,6 +41,8 @@ class TicketIssueUseCaseTest {
   @Mock private TicketTokenHasher ticketTokenHasher;
 
   @Spy private TicketMapper ticketMapper = Mappers.getMapper(TicketMapper.class);
+
+  @Spy private MeterRegistry meterRegistry = new SimpleMeterRegistry();
 
   @Test
   @DisplayName("성공: 예매 ID 기준으로 티켓 토큰 해시와 UNUSED 상태를 저장한다")
@@ -64,6 +69,12 @@ class TicketIssueUseCaseTest {
     assertThat(savedTicket.getTicketTokenHash()).doesNotContain("raw-ticket-token");
     assertThat(savedTicket.getTicketStatus()).isEqualTo(TicketStatus.UNUSED);
     assertThat(savedTicket.getUsedAt()).isNull();
+    assertThat(
+            meterRegistry
+                .counter(
+                    MetricNames.TICKET_ISSUE, MetricNames.TAG_RESULT, MetricNames.RESULT_ISSUED)
+                .count())
+        .isEqualTo(1.0);
   }
 
   @Test
@@ -82,6 +93,14 @@ class TicketIssueUseCaseTest {
     then(ticketTokenGenerator).should(never()).generate();
     then(ticketTokenHasher).shouldHaveNoInteractions();
     then(ticketRepository).should(never()).saveAndFlush(any());
+    assertThat(
+            meterRegistry
+                .counter(
+                    MetricNames.TICKET_ISSUE,
+                    MetricNames.TAG_RESULT,
+                    MetricNames.RESULT_ALREADY_ISSUED)
+                .count())
+        .isEqualTo(1.0);
   }
 
   @Test

--- a/ticket-service/src/test/java/com/ticketrush/boundedcontext/ticket/in/eventlistener/PaymentConfirmedEventListenerTest.java
+++ b/ticket-service/src/test/java/com/ticketrush/boundedcontext/ticket/in/eventlistener/PaymentConfirmedEventListenerTest.java
@@ -20,6 +20,8 @@ import com.ticketrush.global.json.DeserializationException;
 import com.ticketrush.global.json.JsonConverter;
 import com.ticketrush.global.status.ErrorStatus;
 import com.ticketrush.shared.payment.event.PaymentConfirmedEvent;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import org.junit.jupiter.api.DisplayName;
@@ -27,6 +29,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.kafka.support.Acknowledgment;
@@ -41,6 +44,8 @@ class PaymentConfirmedEventListenerTest {
   @Mock private JsonConverter jsonConverter;
 
   @Mock private InboxService inboxService;
+
+  @Spy private MeterRegistry meterRegistry = new SimpleMeterRegistry();
 
   @Mock private Acknowledgment acknowledgment;
 


### PR DESCRIPTION
## 🔗 관련 이슈

- close #335

---

## 📌 주요 변경 사항

- 핵심 도메인(예매·좌석·결제·티켓) + 횡단(Kafka/Outbox/DLT)에 Micrometer 비즈니스 메트릭(Counter/Gauge/Timer) 신규 계측
- 공용 메트릭 이름·태그 상수 `MetricNames` 신설, 태그는 유한 집합만 사용(카디널리티 방지)
- 기존 도메인 로직/동작은 변경하지 않고 계측만 추가

---

## 🛠 상세 구현 내용

- **common**: `MetricNames` 상수 신설. `InboxService`(`ticketrush.kafka.inbox` — consumer_group 태그, result=processed|duplicate 중앙 집계), `DeadLetterConsumer`(`ticketrush.kafka.dlt`), `OutboxStatusUpdater`(`ticketrush.outbox.relay` result=success|fail), `OutboxRelayService`+`OutboxRepository`(`ticketrush.outbox.backlog` Gauge)
- **booking**: `BookingCreateUseCase` → `ticketrush.booking.created`
- **seat**: `SeatHoldUseCase`(`ticketrush.seat.hold` result=success|unavailable), `SeatLockUseCase`(`ticketrush.seat.lock.contention`), `SeatRepository.countHeldSeats` + `SeatHeldGaugeMetrics`(`ticketrush.seat.held` 전역 Gauge, 30s 갱신, DB 집계 진실원)
- **payment**: `PaymentConfirmUseCase`(`ticketrush.payment.confirm` result=success|failure+reason, PG approve Timer), `PaymentRefundByBookingUseCase`(PG cancel Timer, provider 태그), `RefundRequestedEventListener`(`ticketrush.payment.refund` outcome, `ticketrush.payment.refund.failed`)
- **ticket**: `TicketIssueUseCase`(`ticketrush.ticket.issue` result=issued|already_issued), `PaymentConfirmedEventListener`(`ticketrush.ticket.issue.critical_failure`)
- 설계 결정: Kafka 처리 결과는 InboxService 중앙 집계, Hold 좌석 수는 전역 총량 Gauge. Timer는 try/finally로 감싸 예외 시에도 Latency 기록·원래 예외 전파.

---

## ✅ 테스트

### 테스트 방법

- 각 계측 지점에 `SimpleMeterRegistry` 기반 단위 테스트를 신규 작성/보강해 Counter 증가·태그·Timer 기록을 검증:
  - `./gradlew :common:test`(InboxService processed/duplicate 등), `:booking-service:test`(BookingCreateUseCase), `:seat-service:test`(SeatHoldUseCase success/unavailable, SeatLockUseCase 경합), `:payment-service:test`(PaymentConfirmUseCase 성공/실패+reason, approve 예외 시 Timer 기록, refund Timer), `:ticket-service:test`(TicketIssueUseCase issued/already_issued)
- 전체 통합: `./gradlew build`

### 테스트 결과

- 전 모듈 단위 테스트 통과. `./gradlew build` → **BUILD SUCCESSFUL**(전 모듈 컴파일 + 전체 테스트 + spotless + checkstyle)
- 계측 도입으로 깨진 기존 테스트(생성자 시그니처 변경분)는 `SimpleMeterRegistry` 주입으로 수리, 전부 통과
<!--
### 📸 스크린샷

- (서비스 기동 후 `/actuator/prometheus`의 `ticketrush_*` 노출 및 #45 대시보드 반영은 직접 확인/첨부 필요 — DB/Kafka 필요라 로컬/CI)
-->
---

## 👀 리뷰 요청 사항

- Kafka 처리결과 Counter를 InboxService 중앙 집계로 둔 결정(리스너별 영구/일시 실패 세분화는 후속 알림 이슈로 분리)이 적절한지 확인 부탁드립니다.

---

## ⚠️ 배포 시 주의사항

- **전역 Gauge 다중 인스턴스**: `ticketrush.seat.held`·`ticketrush.outbox.backlog`는 각 인스턴스가 전역 DB 집계를 보고하므로, 서비스 N개 복제 시 동일 시계열이 N개 생성됨 → 대시보드에서 `sum()` 대신 `max()`/`avg()` 사용 권장.
- **`payment.confirm{result=failure}`는 화이트리스트(RECORDABLE 3종) 한정**(#297 정책) → 전체 실패율로 해석 금지(통신 실패·금액불일치 등은 미집계).
- **`kafka.dlt`는 DB 저장 재시도 시 중복 카운트 가능**(지속적 DB 장애 상황 한정).
- 이 계측은 #44(수집)·#45(시각화) 전제. 비즈니스 패널은 이 지표 위에 별도 후속 작업으로 구성.
