### PR TITLE
[Refactor] #206 만료 HOLD 좌석 해제를 청크 단위 트랜잭션 처리로 개선

### DIFF
--- a/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/app/usecase/SeatReleaseExpiredChunkProcessor.java
+++ b/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/app/usecase/SeatReleaseExpiredChunkProcessor.java
@@ -1,0 +1,40 @@
+package com.ticketrush.boundedcontext.seat.app.usecase;
+
+import com.ticketrush.boundedcontext.seat.app.support.SeatStatusEventPublisher;
+import com.ticketrush.boundedcontext.seat.domain.entity.Seat;
+import com.ticketrush.boundedcontext.seat.out.repository.SeatRepository;
+import com.ticketrush.global.types.SeatStatus;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 만료 HOLD 좌석 해제를 청크 단위 트랜잭션으로 처리한다.
+ *
+ * <p>{@link SeatReleaseExpiredUseCase}(오케스트레이터)와 별도 빈으로 분리한 이유: 오케스트레이터의 반복 호출이 Spring 프록시를 거쳐
+ * <b>청크마다 새 트랜잭션</b>을 열도록 하기 위함이다. 같은 클래스의 메서드로 두면 self-invocation으로 프록시를 우회해 단일 트랜잭션이 되어버린다. 청크마다
+ * 커밋되므로 {@code afterCommit} SSE 이벤트도 청크 단위로 발화되고, 트랜잭션 범위는 {@code chunkSize}로 제한된다.
+ */
+@Service
+@RequiredArgsConstructor
+public class SeatReleaseExpiredChunkProcessor {
+
+  private final SeatRepository seatRepository;
+  private final SeatStatusEventPublisher seatStatusEventPublisher;
+
+  @Transactional
+  public int releaseChunk(LocalDateTime now, int chunkSize) {
+    List<Seat> expiredSeats =
+        seatRepository.findExpiredHoldSeats(SeatStatus.HOLD, now, PageRequest.of(0, chunkSize));
+
+    for (Seat seat : expiredSeats) {
+      seat.releaseHold();
+      seatStatusEventPublisher.publishAfterCommit(seat);
+    }
+
+    return expiredSeats.size();
+  }
+}

--- a/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/app/usecase/SeatReleaseExpiredUseCase.java
+++ b/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/app/usecase/SeatReleaseExpiredUseCase.java
@@ -1,36 +1,58 @@
 package com.ticketrush.boundedcontext.seat.app.usecase;
 
-import com.ticketrush.boundedcontext.seat.app.support.SeatStatusEventPublisher;
-import com.ticketrush.boundedcontext.seat.domain.entity.Seat;
-import com.ticketrush.boundedcontext.seat.out.repository.SeatRepository;
-import com.ticketrush.global.types.SeatStatus;
+import com.ticketrush.global.config.SeatReleaseProperties;
 import java.time.LocalDateTime;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
+/**
+ * 만료 HOLD 좌석을 AVAILABLE로 롤백하는 fallback 유스케이스(오케스트레이터).
+ *
+ * <p>대량 만료 시 단일 트랜잭션에 UPDATE/afterCommit이 몰리지 않도록, 만료 좌석을 {@code chunkSize}건 단위로 나눠 {@link
+ * SeatReleaseExpiredChunkProcessor}에 위임한다. 각 청크가 독립 트랜잭션으로 커밋되도록 <b>이 메서드에는 {@code @Transactional}을
+ * 두지 않는다</b>(트랜잭션이 있으면 REQUIRED 전파로 청크 호출이 외부 트랜잭션에 합류해 단일 트랜잭션이 되어버림).
+ */
 @Slf4j
 @Service
 @RequiredArgsConstructor
 public class SeatReleaseExpiredUseCase {
 
-  private final SeatRepository seatRepository;
-  private final SeatStatusEventPublisher seatStatusEventPublisher;
+  private final SeatReleaseExpiredChunkProcessor chunkProcessor;
+  private final SeatReleaseProperties seatReleaseProperties;
 
-  @Transactional
   public void execute() {
     LocalDateTime now = LocalDateTime.now();
-    List<Seat> expiredSeats = seatRepository.findExpiredHoldSeats(SeatStatus.HOLD, now);
+    int chunkSize = seatReleaseProperties.getChunkSize();
+    int maxChunks = seatReleaseProperties.getMaxChunks();
 
-    for (Seat seat : expiredSeats) {
-      seat.releaseHold();
-      seatStatusEventPublisher.publishAfterCommit(seat);
+    int totalReleased = 0;
+    int processedChunks = 0;
+    boolean capReached = false;
+
+    while (processedChunks < maxChunks) {
+      int released = chunkProcessor.releaseChunk(now, chunkSize);
+      totalReleased += released;
+      processedChunks++;
+
+      if (released < chunkSize) {
+        break;
+      }
+      // 마지막 청크까지 가득 찬 채로 maxChunks에 도달 = 처리 상한 소진(잔여 좌석 존재 여부는 미확인).
+      if (processedChunks == maxChunks) {
+        capReached = true;
+      }
     }
 
-    if (!expiredSeats.isEmpty()) {
-      log.info("만료된 좌석 {}개의 상태를 AVAILABLE로 롤백했습니다. 기준 시간: {}", expiredSeats.size(), now);
+    if (capReached) {
+      log.warn(
+          "만료 좌석 처리 상한(chunkSize={} x maxChunks={})에 도달해 이번 tick 처리를 중단했습니다."
+              + " 잔여 만료 좌석이 있으면 다음 스케줄 tick에서 처리됩니다.",
+          chunkSize,
+          maxChunks);
+    }
+    if (totalReleased > 0) {
+      log.info("만료된 좌석 {}개의 상태를 AVAILABLE로 롤백했습니다. 기준 시간: {}", totalReleased, now);
     }
   }
 }

--- a/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/out/repository/SeatRepository.java
+++ b/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/out/repository/SeatRepository.java
@@ -7,6 +7,7 @@ import com.ticketrush.boundedcontext.seat.domain.entity.Seat;
 import com.ticketrush.global.types.SeatStatus;
 import java.time.LocalDateTime;
 import java.util.List;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -56,9 +57,14 @@ public interface SeatRepository extends JpaRepository<Seat, Long> {
           + "WHERE s.id IN :seatIds")
   List<SeatNumberResponse> findSeatNumbersByIdIn(@Param("seatIds") List<Long> seatIds);
 
-  @Query("SELECT s FROM Seat s " + "WHERE s.seatStatus = :holdStatus AND s.holdExpiredAt <= :now")
+  @Query(
+      "SELECT s FROM Seat s "
+          + "WHERE s.seatStatus = :holdStatus AND s.holdExpiredAt <= :now "
+          + "ORDER BY s.id ASC")
   List<Seat> findExpiredHoldSeats(
-      @Param("holdStatus") SeatStatus holdStatus, @Param("now") LocalDateTime now);
+      @Param("holdStatus") SeatStatus holdStatus,
+      @Param("now") LocalDateTime now,
+      Pageable pageable);
 
   @Modifying(clearAutomatically = true)
   @Query(

--- a/seat-service/src/main/java/com/ticketrush/global/config/SeatReleaseProperties.java
+++ b/seat-service/src/main/java/com/ticketrush/global/config/SeatReleaseProperties.java
@@ -1,0 +1,23 @@
+package com.ticketrush.global.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+/**
+ * 만료 HOLD 좌석 해제(fallback 스케줄러) 청크 처리 설정.
+ *
+ * <p>대량 만료 시 단일 트랜잭션에 UPDATE/afterCommit이 몰리는 것을 막기 위해, {@code SeatReleaseExpiredUseCase}는 만료 좌석을
+ * {@link #chunkSize}건 단위로 나눠 각 청크를 독립 트랜잭션으로 처리한다. 한 번의 스케줄 tick에서 최대 {@link #chunkSize} × {@link
+ * #maxChunks}건까지 처리하며, 초과분은 다음 tick 또는 Redis 실시간 리스너가 처리한다.
+ */
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "app.seat.release")
+public class SeatReleaseProperties {
+
+  private int chunkSize = 100; // 청크 1건당 처리(조회/UPDATE)할 좌석 수 = 트랜잭션 범위
+  private int maxChunks = 20; // tick당 최대 청크 수 (처리 상한 = chunkSize x maxChunks)
+}

--- a/seat-service/src/main/resources/application.yml
+++ b/seat-service/src/main/resources/application.yml
@@ -23,6 +23,12 @@ springdoc:
 gateway:
   internal-token: ${GATEWAY_INTERNAL_TOKEN:test-token}
 
+app:
+  seat:
+    release:
+      chunk-size: 100
+      max-chunks: 20
+
 management:
   endpoints:
     web:

--- a/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/app/usecase/SeatReleaseExpiredChunkProcessorTest.java
+++ b/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/app/usecase/SeatReleaseExpiredChunkProcessorTest.java
@@ -1,0 +1,66 @@
+package com.ticketrush.boundedcontext.seat.app.usecase;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import com.ticketrush.boundedcontext.seat.app.support.SeatStatusEventPublisher;
+import com.ticketrush.boundedcontext.seat.domain.entity.Seat;
+import com.ticketrush.boundedcontext.seat.out.repository.SeatRepository;
+import com.ticketrush.global.types.SeatStatus;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+@ExtendWith(MockitoExtension.class)
+class SeatReleaseExpiredChunkProcessorTest {
+
+  @Mock private SeatRepository seatRepository;
+  @Mock private SeatStatusEventPublisher seatStatusEventPublisher;
+
+  @InjectMocks private SeatReleaseExpiredChunkProcessor seatReleaseExpiredChunkProcessor;
+
+  @Test
+  @DisplayName("청크 크기만큼 만료 좌석을 조회해 AVAILABLE로 롤백하고 좌석별 이벤트를 발행한 뒤 처리 건수를 반환한다")
+  void releaseChunk_ReleasesAndPublishesPerSeat() {
+    // given
+    int chunkSize = 100;
+    LocalDateTime now = LocalDateTime.now();
+    Seat expiredSeat1 = buildHoldSeat("A-1", now.minusMinutes(1));
+    Seat expiredSeat2 = buildHoldSeat("A-2", now.minusMinutes(2));
+    given(
+            seatRepository.findExpiredHoldSeats(
+                eq(SeatStatus.HOLD), any(LocalDateTime.class), any(Pageable.class)))
+        .willReturn(List.of(expiredSeat1, expiredSeat2));
+
+    // when
+    int released = seatReleaseExpiredChunkProcessor.releaseChunk(now, chunkSize);
+
+    // then
+    assertThat(released).isEqualTo(2);
+    assertThat(expiredSeat1.getSeatStatus()).isEqualTo(SeatStatus.AVAILABLE);
+    assertThat(expiredSeat2.getSeatStatus()).isEqualTo(SeatStatus.AVAILABLE);
+    verify(seatRepository).findExpiredHoldSeats(SeatStatus.HOLD, now, PageRequest.of(0, chunkSize));
+    verify(seatStatusEventPublisher).publishAfterCommit(expiredSeat1);
+    verify(seatStatusEventPublisher).publishAfterCommit(expiredSeat2);
+  }
+
+  private Seat buildHoldSeat(String seatNumber, LocalDateTime holdExpiredAt) {
+    return Seat.builder()
+        .seatLayoutId(1L)
+        .performanceId(1L)
+        .seatNumber(seatNumber)
+        .seatStatus(SeatStatus.HOLD)
+        .holdExpiredAt(holdExpiredAt)
+        .build();
+  }
+}

--- a/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/app/usecase/SeatReleaseExpiredUseCaseTest.java
+++ b/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/app/usecase/SeatReleaseExpiredUseCaseTest.java
@@ -4,50 +4,101 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 
-import com.ticketrush.boundedcontext.seat.app.support.SeatStatusEventPublisher;
-import com.ticketrush.boundedcontext.seat.domain.entity.Seat;
-import com.ticketrush.boundedcontext.seat.out.repository.SeatRepository;
-import com.ticketrush.global.types.SeatStatus;
+import com.ticketrush.global.config.SeatReleaseProperties;
 import java.time.LocalDateTime;
 import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class SeatReleaseExpiredUseCaseTest {
 
-  @Mock private SeatRepository seatRepository;
-  @Mock private SeatStatusEventPublisher seatStatusEventPublisher;
+  private static final int CHUNK_SIZE = 100;
+  private static final int MAX_CHUNKS = 3;
 
-  @InjectMocks private SeatReleaseExpiredUseCase seatReleaseExpiredUseCase;
+  @Mock private SeatReleaseExpiredChunkProcessor chunkProcessor;
+
+  @Captor private ArgumentCaptor<LocalDateTime> nowCaptor;
+
+  private SeatReleaseExpiredUseCase seatReleaseExpiredUseCase;
+
+  @BeforeEach
+  void setUp() {
+    SeatReleaseProperties properties = new SeatReleaseProperties();
+    properties.setChunkSize(CHUNK_SIZE);
+    properties.setMaxChunks(MAX_CHUNKS);
+    seatReleaseExpiredUseCase = new SeatReleaseExpiredUseCase(chunkProcessor, properties);
+  }
 
   @Test
-  @DisplayName("만료된 좌석을 조회하여 상태를 롤백하는 레포지토리 메서드를 호출한다")
-  void execute_ReleasesExpiredSeats() {
+  @DisplayName("만료 좌석이 청크 크기 미만이면 한 번의 청크 처리로 종료한다")
+  void execute_ReleasesSingleChunkAndStops() {
     // given
-    Seat expiredSeat =
-        Seat.builder()
-            .seatLayoutId(1L)
-            .performanceId(1L)
-            .seatNumber("A-1")
-            .seatStatus(SeatStatus.HOLD)
-            .holdExpiredAt(LocalDateTime.now().minusMinutes(1))
-            .build();
-    given(seatRepository.findExpiredHoldSeats(eq(SeatStatus.HOLD), any(LocalDateTime.class)))
-        .willReturn(List.of(expiredSeat));
+    given(chunkProcessor.releaseChunk(any(LocalDateTime.class), eq(CHUNK_SIZE))).willReturn(30);
 
     // when
     seatReleaseExpiredUseCase.execute();
 
     // then
-    verify(seatRepository).findExpiredHoldSeats(eq(SeatStatus.HOLD), any(LocalDateTime.class));
-    verify(seatStatusEventPublisher).publishAfterCommit(expiredSeat);
-    assertThat(expiredSeat.getSeatStatus()).isEqualTo(SeatStatus.AVAILABLE);
+    verify(chunkProcessor, times(1)).releaseChunk(any(LocalDateTime.class), eq(CHUNK_SIZE));
+    verifyNoMoreInteractions(chunkProcessor);
+  }
+
+  @Test
+  @DisplayName("만료 좌석이 없으면 한 번의 청크 처리로 종료한다")
+  void execute_WhenNoExpiredSeats_StopsAfterSingleChunk() {
+    // given: 첫 청크가 0건 반환
+    given(chunkProcessor.releaseChunk(any(LocalDateTime.class), eq(CHUNK_SIZE))).willReturn(0);
+
+    // when
+    seatReleaseExpiredUseCase.execute();
+
+    // then
+    verify(chunkProcessor, times(1)).releaseChunk(any(LocalDateTime.class), eq(CHUNK_SIZE));
+    verifyNoMoreInteractions(chunkProcessor);
+  }
+
+  @Test
+  @DisplayName("청크가 가득 차면 다음 청크를 계속 처리하고, 청크 크기 미만이 나오면 종료한다")
+  void execute_ProcessesMultipleChunksUntilDrained() {
+    // given: 100, 100 처리 후 40에서 소진
+    given(chunkProcessor.releaseChunk(any(LocalDateTime.class), eq(CHUNK_SIZE)))
+        .willReturn(CHUNK_SIZE, CHUNK_SIZE, 40);
+
+    // when
+    seatReleaseExpiredUseCase.execute();
+
+    // then
+    verify(chunkProcessor, times(3)).releaseChunk(nowCaptor.capture(), eq(CHUNK_SIZE));
+    verifyNoMoreInteractions(chunkProcessor);
+    // 모든 청크에 동일한 기준 시각(now)이 전달되어야 한다(스냅샷 일관성).
+    List<LocalDateTime> capturedNows = nowCaptor.getAllValues();
+    assertThat(capturedNows).containsOnly(capturedNows.get(0));
+  }
+
+  @Test
+  @DisplayName("청크가 계속 가득 차면 처리 상한(maxChunks)만큼만 처리하고 멈춘다")
+  void execute_StopsAtMaxChunks() {
+    // given: 매 청크가 가득 차 상한에 도달
+    given(chunkProcessor.releaseChunk(any(LocalDateTime.class), eq(CHUNK_SIZE)))
+        .willReturn(CHUNK_SIZE);
+
+    // when
+    seatReleaseExpiredUseCase.execute();
+
+    // then
+    verify(chunkProcessor, times(MAX_CHUNKS))
+        .releaseChunk(any(LocalDateTime.class), eq(CHUNK_SIZE));
+    verifyNoMoreInteractions(chunkProcessor);
   }
 }

--- a/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/out/repository/SeatRepositoryTest.java
+++ b/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/out/repository/SeatRepositoryTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
 import org.springframework.boot.jpa.test.autoconfigure.TestEntityManager;
+import org.springframework.data.domain.PageRequest;
 
 @DataJpaTest
 class SeatRepositoryTest {
@@ -148,6 +149,73 @@ class SeatRepositoryTest {
     assertThat(updatedSeat1.getSeatStatus()).isEqualTo(SeatStatus.AVAILABLE); // AVAILABLE로 변경됨
     assertThat(validSeat.getSeatStatus()).isEqualTo(SeatStatus.HOLD); // 변경되지 않음
     assertThat(updatedSoldSeat.getSeatStatus()).isEqualTo(SeatStatus.SOLD); // 변경되지 않음
+  }
+
+  @Test
+  @DisplayName("만료된 HOLD 좌석을 id 오름차순으로 페이지 크기만큼만(청크) 조회하고 비만료 HOLD/SOLD는 제외한다")
+  void findExpiredHoldSeats_ReturnsChunkOrderedById() {
+    // given
+    LocalDateTime now = LocalDateTime.now();
+
+    // 만료된 HOLD 좌석 3개 -> 조회 대상 O (저장 순서를 뒤섞어 id ASC 정렬을 검증)
+    Seat expiredHoldSeat1 =
+        Seat.builder()
+            .seatLayoutId(1L)
+            .performanceId(100L)
+            .seatNumber("A1")
+            .seatStatus(SeatStatus.HOLD)
+            .holdExpiredAt(now.minusMinutes(1))
+            .build();
+    Seat expiredHoldSeat2 =
+        Seat.builder()
+            .seatLayoutId(1L)
+            .performanceId(100L)
+            .seatNumber("A2")
+            .seatStatus(SeatStatus.HOLD)
+            .holdExpiredAt(now.minusMinutes(3))
+            .build();
+    Seat expiredHoldSeat3 =
+        Seat.builder()
+            .seatLayoutId(1L)
+            .performanceId(100L)
+            .seatNumber("A3")
+            .seatStatus(SeatStatus.HOLD)
+            .holdExpiredAt(now.minusMinutes(5))
+            .build();
+
+    // 만료되지 않은 HOLD 좌석 -> 조회 대상 X
+    Seat validHoldSeat =
+        Seat.builder()
+            .seatLayoutId(1L)
+            .performanceId(100L)
+            .seatNumber("A4")
+            .seatStatus(SeatStatus.HOLD)
+            .holdExpiredAt(now.plusMinutes(5))
+            .build();
+
+    // 이미 결제 완료된 SOLD 좌석 -> 조회 대상 X
+    Seat soldSeat =
+        Seat.builder()
+            .seatLayoutId(1L)
+            .performanceId(100L)
+            .seatNumber("A5")
+            .seatStatus(SeatStatus.SOLD)
+            .holdExpiredAt(now.minusMinutes(1))
+            .build();
+
+    seatRepository.saveAll(
+        List.of(expiredHoldSeat1, expiredHoldSeat2, expiredHoldSeat3, validHoldSeat, soldSeat));
+
+    // when: 청크 크기 2로 상위 페이지 조회
+    List<Seat> firstChunk =
+        seatRepository.findExpiredHoldSeats(SeatStatus.HOLD, now, PageRequest.of(0, 2));
+
+    // then: 만료 HOLD만, 정확히 청크 크기(2)만큼, id 오름차순으로 반환
+    assertThat(firstChunk).hasSize(2);
+    assertThat(firstChunk)
+        .extracting(Seat::getId)
+        .containsExactly(expiredHoldSeat1.getId(), expiredHoldSeat2.getId());
+    assertThat(firstChunk).allMatch(seat -> seat.getSeatStatus() == SeatStatus.HOLD);
   }
 
   @Test


### PR DESCRIPTION
## 🔗 관련 이슈

- close #206

---

## 📌 주요 변경 사항

- 만료 HOLD 좌석 해제(fallback 스케줄러 경로)를 단일 트랜잭션 → **청크 단위 독립 트랜잭션** 처리로 개선
- 대량 만료 시 한 트랜잭션에 N건 UPDATE + N건 afterCommit이 몰리던 문제 해소 (트랜잭션 범위를 `chunkSize`로 제한)
- 좌석별 SSE 이벤트 발행 요구사항은 그대로 유지 (bulk UPDATE 회귀 없이 좌석별 dirty checking 방식 보존)

---

## 🛠 상세 구현 내용

- `SeatReleaseExpiredUseCase`를 **트랜잭션 없는 오케스트레이터**로 변경: `now`를 1회 캡처해 청크를 반복 처리하고, 청크 처리량이 `chunkSize` 미만이면 종료·`maxChunks` 도달 시 상한 WARN 로그
- `SeatReleaseExpiredChunkProcessor`(신규, `@Transactional`)에 청크 1건 처리를 위임 — **별도 빈**으로 분리해 Spring 프록시를 경유, 청크마다 새 트랜잭션을 열도록 함 (self-invocation 트랩 회피, 프로젝트 선례 `OutboxStatusUpdater`/`OutboxStatusTransition` 패턴)
  - 청크마다 커밋 → `publishAfterCommit`의 afterCommit 콜백도 청크 단위로 발화되어 좌석별 SSE 이벤트 동등성 유지
- `SeatRepository.findExpiredHoldSeats`에 `Pageable` + `ORDER BY s.id ASC` 추가 (`PageRequest.of(0, chunkSize)` 청크 조회, 처리된 좌석은 HOLD 조건에서 빠져 offset 0 반복이 무한루프 없이 안전)
- `SeatReleaseProperties`(신규, `@ConfigurationProperties(prefix="app.seat.release")`): `chunkSize=100`, `maxChunks=20` → tick당 처리 상한 2,000건. `application.yml`에 기본값 바인딩

---

## ✅ 테스트

### 테스트 방법

- `./gradlew :seat-service:test :seat-service:spotlessCheck`
- 작성/보완한 테스트:
  - `SeatReleaseExpiredUseCaseTest`(Mockito): 단일 청크 종료 / 다중 청크 소진 / 상한(maxChunks) 정지 / 빈 결과 / 모든 청크에 동일 `now` 전달(스냅샷 일관성)
  - `SeatReleaseExpiredChunkProcessorTest`(Mockito, 신규): 좌석별 AVAILABLE 롤백·좌석당 `publishAfterCommit` 1회·처리 건수 반환·paged 오버로드(`PageRequest.of(0, chunkSize)`) 호출 검증
  - `SeatRepositoryTest`(@DataJpaTest, 신규 케이스): 만료 HOLD만 `id ASC`로 청크 크기만큼 조회, 비만료 HOLD/SOLD 제외

### 테스트 결과

- `BUILD SUCCESSFUL` — seat-service 전체 테스트 통과 + spotlessCheck 통과 (pre-commit spotlessApply·checkstyle 통과)
<!--
### 📸 스크린샷

- (해당 없음)
-->
---

## 👀 리뷰 요청 사항

- 트랜잭션 경계 설계 확인: 오케스트레이터에 `@Transactional`을 두지 않고 별도 빈에만 부착해 청크별 커밋을 보장하는 구조가 적절한지
- **동작 변화**: 기존은 루프 중 실패 시 전체 롤백(all-or-nothing)이었으나, 청크 방식은 앞선 청크가 이미 커밋·이벤트 발행됨 → 이후 청크 실패해도 전진 처리(잔여분은 다음 tick). 의도된 개선이나 semantics 변화
- 후속 검토 제안(이번 범위 밖): `(seat_status, hold_expired_at)` 복합 인덱스(청크 반복 조회 성능), 잔여 만료 좌석 백로그 게이지 메트릭, 미사용 벌크 쿼리 `releaseExpiredSeats` 존치 여부

---

## ⚠️ 배포 시 주의사항

- `app.seat.release.chunk-size`(기본 100)·`app.seat.release.max-chunks`(기본 20)로 tick당 처리 상한(2,000건) 튜닝 가능. 대량 만료가 잦으면 값 상향 검토 (ShedLock `lockAtMostFor=2m` 내 처리 시간 유지 전제)
