### PR TITLE
[Feat] #227 SeatHoldExpiredEvent 발행 및 booking EXPIRED 이벤트 동기화

### DIFF
--- a/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/app/usecase/ExpireBookingByNumberUseCase.java
+++ b/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/app/usecase/ExpireBookingByNumberUseCase.java
@@ -1,0 +1,46 @@
+package com.ticketrush.boundedcontext.booking.app.usecase;
+
+import com.ticketrush.boundedcontext.booking.domain.types.BookingStatus;
+import com.ticketrush.boundedcontext.booking.out.repository.BookingRepository;
+import com.ticketrush.global.eventpublisher.EventPublisher;
+import com.ticketrush.shared.booking.event.BookingExpiredEvent;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+/**
+ * 좌석 hold 만료 이벤트를 받아 대상 예매를 EXPIRED로 전이한다.
+ *
+ * <p>seat-service가 보유한 식별자는 {@code bookingNumber}뿐이므로, id를 해소한 뒤 기존 {@code
+ * expirePendingBookingById}(조건부 UPDATE)를 재사용한다. 전이가 실제로 일어난 경우에만({@code updated == 1}) {@link
+ * BookingExpiredEvent}를 재발행해 payment 다운스트림(만료 예매 가드)과의 정합성을 유지한다.
+ *
+ * <p>멱등성: {@code WHERE bookingStatus = PENDING} 가드로 이미 EXPIRED/CONFIRMED/CANCELED인 예매는 no-op이 된다.
+ * 리스너의 {@code InboxService.runIfFirst(...)} 트랜잭션 안에서 호출되므로 별도 {@code @Transactional}은 두지 않는다.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ExpireBookingByNumberUseCase {
+
+  private final BookingRepository bookingRepository;
+  private final EventPublisher eventPublisher;
+
+  public void execute(String bookingNumber, LocalDateTime expiredAt) {
+    Long bookingId = bookingRepository.findIdByBookingNumber(bookingNumber).orElse(null);
+    if (bookingId == null) {
+      log.warn("좌석 hold 만료 이벤트 수신: 대상 예매를 찾을 수 없어 스킵합니다. bookingNumber: {}", bookingNumber);
+      return;
+    }
+
+    int updated =
+        bookingRepository.expirePendingBookingById(
+            bookingId, BookingStatus.PENDING, BookingStatus.EXPIRED);
+
+    if (updated == 1) {
+      eventPublisher.publish(new BookingExpiredEvent(bookingId, expiredAt));
+      log.info("좌석 hold 만료로 예매 {}를 EXPIRED로 전이했습니다. bookingNumber: {}", bookingId, bookingNumber);
+    }
+  }
+}

--- a/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/in/eventlistener/SeatHoldExpiredEventListener.java
+++ b/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/in/eventlistener/SeatHoldExpiredEventListener.java
@@ -1,0 +1,85 @@
+package com.ticketrush.boundedcontext.booking.in.eventlistener;
+
+import com.ticketrush.boundedcontext.booking.app.usecase.ExpireBookingByNumberUseCase;
+import com.ticketrush.global.event.DomainEventEnvelope;
+import com.ticketrush.global.event.KafkaConsumerErrorPolicy;
+import com.ticketrush.global.event.KafkaConsumerGroup;
+import com.ticketrush.global.inbox.DuplicateEventException;
+import com.ticketrush.global.inbox.InboxService;
+import com.ticketrush.global.json.JsonConverter;
+import com.ticketrush.shared.seat.event.SeatHoldExpiredEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class SeatHoldExpiredEventListener {
+
+  private final ExpireBookingByNumberUseCase expireBookingByNumberUseCase;
+  private final JsonConverter jsonConverter;
+  private final InboxService inboxService;
+
+  @KafkaListener(topics = SeatHoldExpiredEvent.TOPIC, groupId = KafkaConsumerGroup.BOOKING)
+  public void handleSeatHoldExpired(@Payload DomainEventEnvelope envelope, Acknowledgment ack) {
+
+    SeatHoldExpiredEvent event = null;
+
+    try {
+      event = jsonConverter.deserialize(envelope.payload(), SeatHoldExpiredEvent.class);
+      final SeatHoldExpiredEvent expiredEvent = event;
+
+      log.info(
+          "좌석 hold 만료 이벤트 수신. bookingNumber: {}, seatId: {}",
+          expiredEvent.bookingNumber(),
+          expiredEvent.seatId());
+
+      // Inbox로 중복 처리를 방지한다(#110). 최초 수신일 때만 예매 만료를 수행하고 처리와 Inbox 기록을 한 트랜잭션으로 묶는다.
+      boolean processed =
+          inboxService.runIfFirst(
+              KafkaConsumerGroup.BOOKING,
+              envelope,
+              () ->
+                  expireBookingByNumberUseCase.execute(
+                      expiredEvent.bookingNumber(), expiredEvent.expiredAt()));
+
+      if (!processed) {
+        log.info(
+            "이미 처리된 좌석 hold 만료 이벤트(inbox 중복 스킵). eventId: {}, bookingNumber: {}",
+            envelope.eventId(),
+            expiredEvent.bookingNumber());
+      }
+
+      // 성공 시에만 오프셋을 커밋한다(#269 표준).
+      ack.acknowledge();
+
+    } catch (DuplicateEventException e) {
+      // 동시 중복 수신으로 inbox unique가 경합함 → 멱등(중복) 정상으로 간주하고 커밋한다(#110).
+      log.info("동시 중복 수신(inbox unique 경합). eventId: {}", envelope.eventId());
+      ack.acknowledge();
+    } catch (Exception e) {
+      // #269 표준: 영구(비즈니스/결정적) 실패는 로그 후 ack, 일시(인프라) 실패는 re-throw 하여 재시도→DLT로 보존.
+      String failedBookingNumber = (event != null) ? event.bookingNumber() : null;
+
+      if (KafkaConsumerErrorPolicy.isPermanent(e)) {
+        if (KafkaConsumerErrorPolicy.isExpectedConflict(e)) {
+          log.warn("좌석 hold 만료 처리 중 예상된 상태충돌(멱등 처리). bookingNumber: {}", failedBookingNumber, e);
+        } else {
+          log.error(
+              "[CRITICAL] 좌석 hold 만료에 대한 예매 EXPIRED 전이 중 치명적 오류 발생! "
+                  + "데이터 정합성 확인이 필요합니다. bookingNumber: {}",
+              failedBookingNumber,
+              e);
+        }
+        ack.acknowledge();
+      } else {
+        log.warn("좌석 hold 만료 처리 중 일시적 오류. 재시도합니다. bookingNumber: {}", failedBookingNumber, e);
+        throw e;
+      }
+    }
+  }
+}

--- a/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/out/repository/BookingRepository.java
+++ b/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/out/repository/BookingRepository.java
@@ -21,6 +21,9 @@ public interface BookingRepository extends JpaRepository<Booking, Long> {
 
   Optional<Booking> findByBookingNumberAndUserId(String bookingNumber, Long userId);
 
+  @Query("SELECT b.id FROM Booking b WHERE b.bookingNumber = :bookingNumber")
+  Optional<Long> findIdByBookingNumber(@Param("bookingNumber") String bookingNumber);
+
   @Query(
       "SELECT b.id FROM Booking b "
           + "WHERE b.bookingStatus = :bookingStatus AND b.createdAt <= :cutoff "

--- a/booking-service/src/test/java/com/ticketrush/boundedcontext/booking/app/usecase/ExpireBookingByNumberUseCaseTest.java
+++ b/booking-service/src/test/java/com/ticketrush/boundedcontext/booking/app/usecase/ExpireBookingByNumberUseCaseTest.java
@@ -1,0 +1,85 @@
+package com.ticketrush.boundedcontext.booking.app.usecase;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import com.ticketrush.boundedcontext.booking.domain.types.BookingStatus;
+import com.ticketrush.boundedcontext.booking.out.repository.BookingRepository;
+import com.ticketrush.global.eventpublisher.EventPublisher;
+import com.ticketrush.shared.booking.event.BookingExpiredEvent;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ExpireBookingByNumberUseCaseTest {
+
+  @Mock private BookingRepository bookingRepository;
+  @Mock private EventPublisher eventPublisher;
+
+  @InjectMocks private ExpireBookingByNumberUseCase expireBookingByNumberUseCase;
+
+  private static final String BOOKING_NUMBER = "BK-1";
+  private static final Long BOOKING_ID = 10L;
+  private static final LocalDateTime EXPIRED_AT = LocalDateTime.now();
+
+  @Test
+  @DisplayName("PENDING 예매를 EXPIRED로 전이하면 BookingExpiredEvent를 발행한다")
+  void execute_WhenTransitioned_PublishesBookingExpiredEvent() {
+    // given
+    given(bookingRepository.findIdByBookingNumber(BOOKING_NUMBER))
+        .willReturn(Optional.of(BOOKING_ID));
+    given(
+            bookingRepository.expirePendingBookingById(
+                BOOKING_ID, BookingStatus.PENDING, BookingStatus.EXPIRED))
+        .willReturn(1);
+
+    // when
+    expireBookingByNumberUseCase.execute(BOOKING_NUMBER, EXPIRED_AT);
+
+    // then
+    verify(eventPublisher).publish(new BookingExpiredEvent(BOOKING_ID, EXPIRED_AT));
+  }
+
+  @Test
+  @DisplayName("이미 EXPIRED/CONFIRMED 등이라 전이가 일어나지 않으면(updated==0) 이벤트를 발행하지 않는다(멱등)")
+  void execute_WhenAlreadyTerminal_DoesNotPublish() {
+    // given
+    given(bookingRepository.findIdByBookingNumber(BOOKING_NUMBER))
+        .willReturn(Optional.of(BOOKING_ID));
+    given(
+            bookingRepository.expirePendingBookingById(
+                BOOKING_ID, BookingStatus.PENDING, BookingStatus.EXPIRED))
+        .willReturn(0);
+
+    // when
+    expireBookingByNumberUseCase.execute(BOOKING_NUMBER, EXPIRED_AT);
+
+    // then
+    verify(eventPublisher, never()).publish(any());
+  }
+
+  @Test
+  @DisplayName("대상 예매를 찾을 수 없으면 만료 처리를 스킵하고 이벤트를 발행하지 않는다")
+  void execute_WhenBookingNotFound_Skips() {
+    // given
+    given(bookingRepository.findIdByBookingNumber(BOOKING_NUMBER)).willReturn(Optional.empty());
+
+    // when
+    expireBookingByNumberUseCase.execute(BOOKING_NUMBER, EXPIRED_AT);
+
+    // then
+    verify(bookingRepository, never())
+        .expirePendingBookingById(any(), eq(BookingStatus.PENDING), eq(BookingStatus.EXPIRED));
+    verifyNoInteractions(eventPublisher);
+  }
+}

--- a/booking-service/src/test/java/com/ticketrush/boundedcontext/booking/in/eventlistener/SeatHoldExpiredEventListenerTest.java
+++ b/booking-service/src/test/java/com/ticketrush/boundedcontext/booking/in/eventlistener/SeatHoldExpiredEventListenerTest.java
@@ -1,0 +1,174 @@
+package com.ticketrush.boundedcontext.booking.in.eventlistener;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.ticketrush.boundedcontext.booking.app.usecase.ExpireBookingByNumberUseCase;
+import com.ticketrush.global.event.DomainEventEnvelope;
+import com.ticketrush.global.event.KafkaConsumerGroup;
+import com.ticketrush.global.exception.BusinessException;
+import com.ticketrush.global.inbox.DuplicateEventException;
+import com.ticketrush.global.inbox.InboxService;
+import com.ticketrush.global.json.JsonConverter;
+import com.ticketrush.global.status.ErrorStatus;
+import com.ticketrush.shared.seat.event.SeatHoldExpiredEvent;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.kafka.support.Acknowledgment;
+
+@ExtendWith(MockitoExtension.class)
+class SeatHoldExpiredEventListenerTest {
+
+  @InjectMocks private SeatHoldExpiredEventListener listener;
+
+  @Mock private ExpireBookingByNumberUseCase expireBookingByNumberUseCase;
+
+  @Mock private JsonConverter jsonConverter;
+
+  @Mock private InboxService inboxService;
+
+  @Mock private Acknowledgment acknowledgment;
+
+  private static final String PAYLOAD = "payload";
+  private static final String BOOKING_NUMBER = "BK-1";
+  private static final LocalDateTime EXPIRED_AT = LocalDateTime.now();
+
+  private DomainEventEnvelope envelope() {
+    return new DomainEventEnvelope(
+        "event-id",
+        SeatHoldExpiredEvent.class.getSimpleName(),
+        Instant.now(),
+        SeatHoldExpiredEvent.TOPIC,
+        PAYLOAD,
+        null);
+  }
+
+  private SeatHoldExpiredEvent event() {
+    return new SeatHoldExpiredEvent(3L, BOOKING_NUMBER, EXPIRED_AT);
+  }
+
+  /** Inbox가 최초 수신으로 판정해 비즈니스 콜백을 실행하고 true를 반환하도록 스텁한다. */
+  private void givenInboxProcessesFirst() {
+    given(
+            inboxService.runIfFirst(
+                eq(KafkaConsumerGroup.BOOKING),
+                any(DomainEventEnvelope.class),
+                any(Runnable.class)))
+        .willAnswer(
+            invocation -> {
+              invocation.getArgument(2, Runnable.class).run();
+              return true;
+            });
+  }
+
+  @Test
+  @DisplayName("최초 수신이면 예매를 만료 처리하고 오프셋을 커밋한다")
+  void handleSeatHoldExpired() {
+    // given
+    final DomainEventEnvelope envelope = envelope();
+    given(jsonConverter.deserialize(PAYLOAD, SeatHoldExpiredEvent.class)).willReturn(event());
+    givenInboxProcessesFirst();
+
+    // when
+    listener.handleSeatHoldExpired(envelope, acknowledgment);
+
+    // then
+    verify(expireBookingByNumberUseCase).execute(BOOKING_NUMBER, EXPIRED_AT);
+    verify(acknowledgment).acknowledge();
+  }
+
+  @Test
+  @DisplayName("이미 처리된 이벤트(inbox 중복)면 만료를 실행하지 않고 오프셋만 커밋한다")
+  void handleSeatHoldExpiredSkipsDuplicate() {
+    // given
+    final DomainEventEnvelope envelope = envelope();
+    given(jsonConverter.deserialize(PAYLOAD, SeatHoldExpiredEvent.class)).willReturn(event());
+    given(
+            inboxService.runIfFirst(
+                eq(KafkaConsumerGroup.BOOKING),
+                any(DomainEventEnvelope.class),
+                any(Runnable.class)))
+        .willReturn(false);
+
+    // when
+    listener.handleSeatHoldExpired(envelope, acknowledgment);
+
+    // then
+    verify(expireBookingByNumberUseCase, never()).execute(anyString(), any(LocalDateTime.class));
+    verify(acknowledgment).acknowledge();
+  }
+
+  @Test
+  @DisplayName("동시 중복 수신으로 inbox unique가 경합하면 예외를 전파하지 않고 오프셋을 커밋한다")
+  void handleSeatHoldExpiredAcksOnInboxRace() {
+    // given
+    final DomainEventEnvelope envelope = envelope();
+    given(jsonConverter.deserialize(PAYLOAD, SeatHoldExpiredEvent.class)).willReturn(event());
+    given(
+            inboxService.runIfFirst(
+                eq(KafkaConsumerGroup.BOOKING),
+                any(DomainEventEnvelope.class),
+                any(Runnable.class)))
+        .willThrow(
+            new DuplicateEventException(
+                KafkaConsumerGroup.BOOKING,
+                "event-id",
+                new DataIntegrityViolationException("duplicate")));
+
+    // when & then
+    assertThatCode(() -> listener.handleSeatHoldExpired(envelope, acknowledgment))
+        .doesNotThrowAnyException();
+
+    verify(acknowledgment).acknowledge();
+  }
+
+  @Test
+  @DisplayName("일시적(인프라) 예외가 발생하면 예외를 전파하고 오프셋을 커밋하지 않는다(재시도→DLT 위임)")
+  void handleSeatHoldExpiredRethrowsTransientFailure() {
+    // given
+    final DomainEventEnvelope envelope = envelope();
+    given(jsonConverter.deserialize(PAYLOAD, SeatHoldExpiredEvent.class)).willReturn(event());
+    givenInboxProcessesFirst();
+    willThrow(new RuntimeException("DB 일시 장애"))
+        .given(expireBookingByNumberUseCase)
+        .execute(BOOKING_NUMBER, EXPIRED_AT);
+
+    // when & then
+    assertThatThrownBy(() -> listener.handleSeatHoldExpired(envelope, acknowledgment))
+        .isInstanceOf(RuntimeException.class);
+
+    verify(acknowledgment, never()).acknowledge();
+  }
+
+  @Test
+  @DisplayName("영구(비즈니스) 예외가 발생하면 예외를 전파하지 않고 오프셋을 커밋한다")
+  void handleSeatHoldExpiredAcksPermanentFailure() {
+    // given
+    final DomainEventEnvelope envelope = envelope();
+    given(jsonConverter.deserialize(PAYLOAD, SeatHoldExpiredEvent.class)).willReturn(event());
+    givenInboxProcessesFirst();
+    willThrow(new BusinessException(ErrorStatus.BOOKING_CANCEL_NOT_ALLOWED))
+        .given(expireBookingByNumberUseCase)
+        .execute(BOOKING_NUMBER, EXPIRED_AT);
+
+    // when & then
+    assertThatCode(() -> listener.handleSeatHoldExpired(envelope, acknowledgment))
+        .doesNotThrowAnyException();
+
+    verify(acknowledgment).acknowledge();
+  }
+}

--- a/booking-service/src/test/java/com/ticketrush/boundedcontext/booking/out/repository/BookingRepositoryTest.java
+++ b/booking-service/src/test/java/com/ticketrush/boundedcontext/booking/out/repository/BookingRepositoryTest.java
@@ -1,0 +1,48 @@
+package com.ticketrush.boundedcontext.booking.out.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.ticketrush.boundedcontext.booking.domain.entity.Booking;
+import com.ticketrush.boundedcontext.booking.domain.types.BookingStatus;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+
+@DataJpaTest
+class BookingRepositoryTest {
+
+  @Autowired private BookingRepository bookingRepository;
+
+  @Test
+  @DisplayName("bookingNumber로 예매 id를 조회한다")
+  void findIdByBookingNumber_ReturnsId() {
+    // given
+    Booking booking =
+        Booking.builder()
+            .userId(1L)
+            .performanceId(2L)
+            .seatId(3L)
+            .bookingNumber("BK-1")
+            .bookingStatus(BookingStatus.PENDING)
+            .build();
+    Booking saved = bookingRepository.save(booking);
+
+    // when
+    Optional<Long> found = bookingRepository.findIdByBookingNumber("BK-1");
+
+    // then
+    assertThat(found).contains(saved.getId());
+  }
+
+  @Test
+  @DisplayName("존재하지 않는 bookingNumber로 조회하면 빈 값을 반환한다")
+  void findIdByBookingNumber_WhenNotExists_ReturnsEmpty() {
+    // when
+    Optional<Long> found = bookingRepository.findIdByBookingNumber("NON-EXISTENT");
+
+    // then
+    assertThat(found).isEmpty();
+  }
+}

--- a/common/src/main/java/com/ticketrush/shared/seat/event/SeatHoldExpiredEvent.java
+++ b/common/src/main/java/com/ticketrush/shared/seat/event/SeatHoldExpiredEvent.java
@@ -1,0 +1,37 @@
+package com.ticketrush.shared.seat.event;
+
+import com.ticketrush.global.event.DomainEvent;
+import com.ticketrush.global.event.EventUtils;
+import java.time.LocalDateTime;
+
+public record SeatHoldExpiredEvent(Long seatId, String bookingNumber, LocalDateTime expiredAt)
+    implements DomainEvent {
+
+  public static final String TOPIC = "seat-hold-expired-topic";
+  public static final String EVENT_NAME = "SeatHoldExpiredEvent";
+
+  @Override
+  public String topic() {
+    return TOPIC;
+  }
+
+  @Override
+  public String key() {
+    return bookingNumber;
+  }
+
+  @Override
+  public String aggregateId() {
+    return String.valueOf(seatId);
+  }
+
+  @Override
+  public String eventName() {
+    return EVENT_NAME;
+  }
+
+  @Override
+  public String traceId() {
+    return EventUtils.extractTraceId();
+  }
+}

--- a/common/src/test/java/com/ticketrush/shared/seat/event/SeatHoldExpiredEventTest.java
+++ b/common/src/test/java/com/ticketrush/shared/seat/event/SeatHoldExpiredEventTest.java
@@ -1,0 +1,27 @@
+package com.ticketrush.shared.seat.event;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class SeatHoldExpiredEventTest {
+
+  @Test
+  @DisplayName("DomainEvent 계약: topic/key(bookingNumber)/aggregateId(seatId)/eventName을 반환한다")
+  void domainEventContract() {
+    // given
+    LocalDateTime expiredAt = LocalDateTime.now();
+    SeatHoldExpiredEvent event = new SeatHoldExpiredEvent(7L, "BK-20260707-0001", expiredAt);
+
+    // then
+    assertThat(event.topic()).isEqualTo("seat-hold-expired-topic");
+    assertThat(event.key()).isEqualTo("BK-20260707-0001"); // 파티션 키 = bookingNumber
+    assertThat(event.aggregateId()).isEqualTo("7"); // Outbox aggregateType=Seat 유도용 seatId
+    assertThat(event.eventName()).isEqualTo("SeatHoldExpiredEvent");
+    assertThat(event.seatId()).isEqualTo(7L);
+    assertThat(event.bookingNumber()).isEqualTo("BK-20260707-0001");
+    assertThat(event.expiredAt()).isEqualTo(expiredAt);
+  }
+}

--- a/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/app/support/SeatHoldExpiredPublisher.java
+++ b/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/app/support/SeatHoldExpiredPublisher.java
@@ -1,0 +1,39 @@
+package com.ticketrush.boundedcontext.seat.app.support;
+
+import com.ticketrush.boundedcontext.seat.domain.entity.Seat;
+import com.ticketrush.global.eventpublisher.EventPublisher;
+import com.ticketrush.shared.seat.event.SeatHoldExpiredEvent;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+/**
+ * 좌석 hold 만료 시 {@link SeatHoldExpiredEvent}를 발행한다(Outbox 경유).
+ *
+ * <p>booking-service가 이 이벤트를 받아 예매를 EXPIRED로 전이한다. {@link EventPublisher}(Outbox 구현)는 활성 트랜잭션을
+ * 요구하므로 {@code @Transactional} 유스케이스 안에서만 호출해야 한다.
+ *
+ * <p><b>주의:</b> {@link Seat#releaseHold()}가 {@code bookingNumber}/{@code holdExpiredAt}을 null로
+ * 클리어하므로, 이 메서드는 반드시 {@code releaseHold()} 호출 <b>전에</b> 불러 식별자를 캡처해야 한다.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class SeatHoldExpiredPublisher {
+
+  private final EventPublisher eventPublisher;
+
+  public void publish(Seat seat) {
+    String bookingNumber = seat.getBookingNumber();
+    if (bookingNumber == null || bookingNumber.isBlank()) {
+      log.warn(
+          "HOLD 좌석에 bookingNumber가 없어 SeatHoldExpiredEvent 발행을 스킵합니다. seatId: {}", seat.getId());
+      return;
+    }
+
+    LocalDateTime expiredAt =
+        seat.getHoldExpiredAt() != null ? seat.getHoldExpiredAt() : LocalDateTime.now();
+    eventPublisher.publish(new SeatHoldExpiredEvent(seat.getId(), bookingNumber, expiredAt));
+  }
+}

--- a/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/app/usecase/SeatReleaseExpiredChunkProcessor.java
+++ b/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/app/usecase/SeatReleaseExpiredChunkProcessor.java
@@ -1,5 +1,6 @@
 package com.ticketrush.boundedcontext.seat.app.usecase;
 
+import com.ticketrush.boundedcontext.seat.app.support.SeatHoldExpiredPublisher;
 import com.ticketrush.boundedcontext.seat.app.support.SeatStatusEventPublisher;
 import com.ticketrush.boundedcontext.seat.domain.entity.Seat;
 import com.ticketrush.boundedcontext.seat.out.repository.SeatRepository;
@@ -24,6 +25,7 @@ public class SeatReleaseExpiredChunkProcessor {
 
   private final SeatRepository seatRepository;
   private final SeatStatusEventPublisher seatStatusEventPublisher;
+  private final SeatHoldExpiredPublisher seatHoldExpiredPublisher;
 
   @Transactional
   public int releaseChunk(LocalDateTime now, int chunkSize) {
@@ -31,6 +33,7 @@ public class SeatReleaseExpiredChunkProcessor {
         seatRepository.findExpiredHoldSeats(SeatStatus.HOLD, now, PageRequest.of(0, chunkSize));
 
     for (Seat seat : expiredSeats) {
+      seatHoldExpiredPublisher.publish(seat);
       seat.releaseHold();
       seatStatusEventPublisher.publishAfterCommit(seat);
     }

--- a/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/app/usecase/SeatReleaseSingleUseCase.java
+++ b/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/app/usecase/SeatReleaseSingleUseCase.java
@@ -1,5 +1,6 @@
 package com.ticketrush.boundedcontext.seat.app.usecase;
 
+import com.ticketrush.boundedcontext.seat.app.support.SeatHoldExpiredPublisher;
 import com.ticketrush.boundedcontext.seat.app.support.SeatStatusEventPublisher;
 import com.ticketrush.boundedcontext.seat.out.repository.SeatRepository;
 import com.ticketrush.global.types.SeatStatus;
@@ -15,6 +16,7 @@ public class SeatReleaseSingleUseCase {
 
   private final SeatRepository seatRepository;
   private final SeatStatusEventPublisher seatStatusEventPublisher;
+  private final SeatHoldExpiredPublisher seatHoldExpiredPublisher;
 
   @Transactional
   public void execute(Long seatId) {
@@ -30,6 +32,7 @@ public class SeatReleaseSingleUseCase {
                 return;
               }
 
+              seatHoldExpiredPublisher.publish(seat);
               seat.releaseHold();
               seatStatusEventPublisher.publishAfterCommit(seat);
               log.info("Redis 만료 이벤트 수신: 좌석 {} 상태를 AVAILABLE로 즉시 롤백했습니다.", seatId);

--- a/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/app/support/SeatHoldExpiredPublisherTest.java
+++ b/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/app/support/SeatHoldExpiredPublisherTest.java
@@ -1,0 +1,115 @@
+package com.ticketrush.boundedcontext.seat.app.support;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import com.ticketrush.boundedcontext.seat.domain.entity.Seat;
+import com.ticketrush.global.eventpublisher.EventPublisher;
+import com.ticketrush.global.types.SeatStatus;
+import com.ticketrush.shared.seat.event.SeatHoldExpiredEvent;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class SeatHoldExpiredPublisherTest {
+
+  @Mock private EventPublisher eventPublisher;
+
+  @Captor private ArgumentCaptor<SeatHoldExpiredEvent> eventCaptor;
+
+  @InjectMocks private SeatHoldExpiredPublisher seatHoldExpiredPublisher;
+
+  @Test
+  @DisplayName("bookingNumber와 holdExpiredAt이 있으면 해당 값으로 SeatHoldExpiredEvent를 발행한다")
+  void publish_WithBookingNumberAndExpiry() {
+    // given
+    LocalDateTime holdExpiredAt = LocalDateTime.now().minusMinutes(1);
+    Seat seat =
+        Seat.builder()
+            .seatLayoutId(1L)
+            .performanceId(1L)
+            .seatNumber("A-1")
+            .seatStatus(SeatStatus.HOLD)
+            .holdExpiredAt(holdExpiredAt)
+            .bookingNumber("BK-1")
+            .build();
+
+    // when
+    seatHoldExpiredPublisher.publish(seat);
+
+    // then
+    verify(eventPublisher).publish(eventCaptor.capture());
+    SeatHoldExpiredEvent event = eventCaptor.getValue();
+    assertThat(event.bookingNumber()).isEqualTo("BK-1");
+    assertThat(event.expiredAt()).isEqualTo(holdExpiredAt);
+  }
+
+  @Test
+  @DisplayName("holdExpiredAt이 null이면 현재 시각으로 대체해 발행한다")
+  void publish_WhenHoldExpiredAtNull_UsesNow() {
+    // given
+    LocalDateTime before = LocalDateTime.now();
+    Seat seat =
+        Seat.builder()
+            .seatLayoutId(1L)
+            .performanceId(1L)
+            .seatNumber("A-1")
+            .seatStatus(SeatStatus.HOLD)
+            .bookingNumber("BK-1")
+            .build(); // holdExpiredAt 미설정 → null
+
+    // when
+    seatHoldExpiredPublisher.publish(seat);
+
+    // then
+    verify(eventPublisher).publish(eventCaptor.capture());
+    assertThat(eventCaptor.getValue().expiredAt()).isAfterOrEqualTo(before);
+  }
+
+  @Test
+  @DisplayName("bookingNumber가 null이면 발행하지 않는다")
+  void publish_WhenBookingNumberNull_Skips() {
+    // given
+    Seat seat =
+        Seat.builder()
+            .seatLayoutId(1L)
+            .performanceId(1L)
+            .seatNumber("A-1")
+            .seatStatus(SeatStatus.HOLD)
+            .build(); // bookingNumber 미설정 → null
+
+    // when
+    seatHoldExpiredPublisher.publish(seat);
+
+    // then
+    verifyNoInteractions(eventPublisher);
+  }
+
+  @Test
+  @DisplayName("bookingNumber가 공백이면 발행하지 않는다")
+  void publish_WhenBookingNumberBlank_Skips() {
+    // given
+    Seat seat =
+        Seat.builder()
+            .seatLayoutId(1L)
+            .performanceId(1L)
+            .seatNumber("A-1")
+            .seatStatus(SeatStatus.HOLD)
+            .bookingNumber("   ")
+            .build();
+
+    // when
+    seatHoldExpiredPublisher.publish(seat);
+
+    // then
+    verifyNoInteractions(eventPublisher);
+  }
+}

--- a/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/app/usecase/SeatReleaseExpiredChunkProcessorTest.java
+++ b/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/app/usecase/SeatReleaseExpiredChunkProcessorTest.java
@@ -4,14 +4,17 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willAnswer;
 import static org.mockito.Mockito.verify;
 
+import com.ticketrush.boundedcontext.seat.app.support.SeatHoldExpiredPublisher;
 import com.ticketrush.boundedcontext.seat.app.support.SeatStatusEventPublisher;
 import com.ticketrush.boundedcontext.seat.domain.entity.Seat;
 import com.ticketrush.boundedcontext.seat.out.repository.SeatRepository;
 import com.ticketrush.global.types.SeatStatus;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -26,6 +29,7 @@ class SeatReleaseExpiredChunkProcessorTest {
 
   @Mock private SeatRepository seatRepository;
   @Mock private SeatStatusEventPublisher seatStatusEventPublisher;
+  @Mock private SeatHoldExpiredPublisher seatHoldExpiredPublisher;
 
   @InjectMocks private SeatReleaseExpiredChunkProcessor seatReleaseExpiredChunkProcessor;
 
@@ -52,6 +56,45 @@ class SeatReleaseExpiredChunkProcessorTest {
     verify(seatRepository).findExpiredHoldSeats(SeatStatus.HOLD, now, PageRequest.of(0, chunkSize));
     verify(seatStatusEventPublisher).publishAfterCommit(expiredSeat1);
     verify(seatStatusEventPublisher).publishAfterCommit(expiredSeat2);
+    verify(seatHoldExpiredPublisher).publish(expiredSeat1);
+    verify(seatHoldExpiredPublisher).publish(expiredSeat2);
+  }
+
+  @Test
+  @DisplayName("hold 만료 이벤트 발행은 releaseHold() 전에 일어나 bookingNumber가 살아있는 상태로 캡처된다")
+  void releaseChunk_PublishesBeforeReleaseHold() {
+    // given
+    int chunkSize = 100;
+    LocalDateTime now = LocalDateTime.now();
+    Seat seat =
+        Seat.builder()
+            .seatLayoutId(1L)
+            .performanceId(1L)
+            .seatNumber("A-1")
+            .seatStatus(SeatStatus.HOLD)
+            .holdExpiredAt(now.minusMinutes(1))
+            .bookingNumber("BK-1")
+            .build();
+    given(
+            seatRepository.findExpiredHoldSeats(
+                eq(SeatStatus.HOLD), any(LocalDateTime.class), any(Pageable.class)))
+        .willReturn(List.of(seat));
+
+    AtomicReference<String> bookingNumberAtPublish = new AtomicReference<>();
+    willAnswer(
+            invocation -> {
+              bookingNumberAtPublish.set(invocation.getArgument(0, Seat.class).getBookingNumber());
+              return null;
+            })
+        .given(seatHoldExpiredPublisher)
+        .publish(seat);
+
+    // when
+    seatReleaseExpiredChunkProcessor.releaseChunk(now, chunkSize);
+
+    // then: 발행 시점엔 bookingNumber가 아직 null이 아니어야 한다(releaseHold가 나중에 클리어)
+    assertThat(bookingNumberAtPublish.get()).isEqualTo("BK-1");
+    assertThat(seat.getSeatStatus()).isEqualTo(SeatStatus.AVAILABLE);
   }
 
   private Seat buildHoldSeat(String seatNumber, LocalDateTime holdExpiredAt) {

--- a/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/app/usecase/SeatReleaseSingleUseCaseTest.java
+++ b/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/app/usecase/SeatReleaseSingleUseCaseTest.java
@@ -1,16 +1,20 @@
 package com.ticketrush.boundedcontext.seat.app.usecase;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 
+import com.ticketrush.boundedcontext.seat.app.support.SeatHoldExpiredPublisher;
 import com.ticketrush.boundedcontext.seat.app.support.SeatStatusEventPublisher;
 import com.ticketrush.boundedcontext.seat.domain.entity.Seat;
 import com.ticketrush.boundedcontext.seat.out.repository.SeatRepository;
 import com.ticketrush.global.types.SeatStatus;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -23,11 +27,12 @@ class SeatReleaseSingleUseCaseTest {
 
   @Mock private SeatRepository seatRepository;
   @Mock private SeatStatusEventPublisher seatStatusEventPublisher;
+  @Mock private SeatHoldExpiredPublisher seatHoldExpiredPublisher;
 
   @InjectMocks private SeatReleaseSingleUseCase seatReleaseSingleUseCase;
 
   @Test
-  @DisplayName("존재하는 좌석의 만료 이벤트 수신 시 상태를 AVAILABLE로 롤백한다")
+  @DisplayName("존재하는 좌석의 만료 이벤트 수신 시 상태를 AVAILABLE로 롤백하고 hold 만료 이벤트를 발행한다")
   void execute_WhenSeatExists_ReleasesHold() {
     // given
     Long seatId = 1L;
@@ -37,19 +42,32 @@ class SeatReleaseSingleUseCaseTest {
             .performanceId(1L)
             .seatNumber("A-1")
             .seatStatus(SeatStatus.HOLD)
+            .bookingNumber("BK-1")
             .build();
     given(seatRepository.findById(seatId)).willReturn(Optional.of(seat));
+
+    // hold 만료 이벤트 발행은 releaseHold() '전에' 일어나야 bookingNumber가 살아있다 → 발행 시점 값을 캡처
+    AtomicReference<String> bookingNumberAtPublish = new AtomicReference<>();
+    willAnswer(
+            invocation -> {
+              bookingNumberAtPublish.set(invocation.getArgument(0, Seat.class).getBookingNumber());
+              return null;
+            })
+        .given(seatHoldExpiredPublisher)
+        .publish(seat);
 
     // when
     seatReleaseSingleUseCase.execute(seatId);
 
     // then
     verify(seatRepository).findById(seatId);
+    verify(seatHoldExpiredPublisher).publish(seat);
     verify(seatStatusEventPublisher).publishAfterCommit(seat);
+    assertThat(bookingNumberAtPublish.get()).isEqualTo("BK-1"); // releaseHold 전 캡처 보장
   }
 
   @Test
-  @DisplayName("HOLD 상태가 아닌 좌석의 만료 이벤트 수신 시 상태 변경 이벤트를 발행하지 않는다")
+  @DisplayName("HOLD 상태가 아닌 좌석의 만료 이벤트 수신 시 어떤 이벤트도 발행하지 않는다")
   void execute_WhenSeatIsNotHold_DoesNotPublishEvent() {
     // given
     Long seatId = 1L;
@@ -68,6 +86,7 @@ class SeatReleaseSingleUseCaseTest {
     // then
     verify(seatRepository).findById(seatId);
     verifyNoInteractions(seatStatusEventPublisher);
+    verifyNoInteractions(seatHoldExpiredPublisher);
   }
 
   @Test
@@ -83,5 +102,6 @@ class SeatReleaseSingleUseCaseTest {
     // then
     verify(seatRepository).findById(seatId);
     verify(mock(Seat.class), never()).releaseHold();
+    verifyNoInteractions(seatHoldExpiredPublisher);
   }
 }


### PR DESCRIPTION
## 🔗 관련 이슈

- close #227

---

## 📌 주요 변경 사항

- 좌석 hold 만료를 booking 만료의 **1차 트리거**로 연결. seat-service가 `SeatHoldExpiredEvent`를 발행하고 booking-service가 수신해 예매를 **멱등하게 EXPIRED로 전이**
- booking 자체 fallback scheduler(#24)는 유실 보정용으로 유지하며 **충돌 없이 병행 동작**
- 이벤트/스케줄러 중복 수신에도 상태 전이 멱등 보장

---

## 🛠 상세 구현 내용

- **common**: `SeatHoldExpiredEvent`(record, `DomainEvent`) 추가 — topic `seat-hold-expired-topic`, `key=bookingNumber`, `aggregateId=seatId`. 패키지 `shared.seat.event`로 Outbox aggregateType "Seat" 자동 유도(설정 변경 불필요)
- **seat-service**: hold 만료 시 Outbox로 이벤트를 발행하는 `SeatHoldExpiredPublisher` 추가
  - Redis 단건 만료(`SeatReleaseSingleUseCase`)와 fallback 청크(`SeatReleaseExpiredChunkProcessor`) **두 경로**에 발행 훅 주입
  - `releaseHold()`가 `bookingNumber`/`holdExpiredAt`을 null로 클리어하므로 **호출 전에 캡처**, `bookingNumber` null/blank면 발행 스킵
  - 기존 SSE 발행은 그대로 유지(별개 채널)
- **booking-service**: `SeatHoldExpiredEventListener`가 이벤트 수신 → `ExpireBookingByNumberUseCase`
  - `findIdByBookingNumber`로 id 해소 → 기존 `expirePendingBookingById`(조건부 UPDATE) 재사용 → `updated==1`일 때만 `BookingExpiredEvent` 재발행(payment 다운스트림 파리티 유지)
  - **멱등 이중 방어**: Inbox(`consumer_group+event_id`) + `WHERE status=PENDING` UPDATE 가드. 3중 트리거(Redis/seat fallback/booking scheduler)가 와도 EXPIRED·`BookingExpiredEvent` 정확히 1회
  - 리스너 예외 정책은 `SeatHoldFailedEventListener`(#269 표준: DuplicateEventException·영구실패 ack / 일시실패 rethrow→DLT) 그대로 복제

---

## ✅ 테스트

### 테스트 방법

- `./gradlew :common:test :seat-service:test :booking-service:test`
- `./gradlew :common:spotlessCheck :seat-service:spotlessCheck :booking-service:spotlessCheck`
- 작성한 테스트:
  - common `SeatHoldExpiredEventTest`: DomainEvent 계약(topic/key/aggregateId)
  - seat `SeatHoldExpiredPublisherTest`(null/blank 스킵·holdExpiredAt null→now), `SeatReleaseSingleUseCaseTest`·`SeatReleaseExpiredChunkProcessorTest`(발행 훅 + `releaseHold` **전** 캡처 순서 검증)
  - booking `SeatHoldExpiredEventListenerTest`(멱등 5시나리오), `ExpireBookingByNumberUseCaseTest`(updated==1 발행 / updated==0·미존재 no-op), `BookingRepositoryTest`(@DataJpaTest, `findIdByBookingNumber`)

### 테스트 결과

- `BUILD SUCCESSFUL` — 3개 모듈 전체 테스트 통과 + spotlessCheck·checkstyle 통과
<!--
### 📸 스크린샷

- (해당 없음)
-->
---

## 👀 리뷰 요청 사항

- 식별자 전략: Seat엔 bookingId가 없어 이벤트가 `bookingNumber`를 싣고 booking이 id를 해소하는 방식(옵션 C)을 택함 — 적절성 확인
- **알려진 한계(범위 밖)**: booking-service의 이벤트 발행은 `event-publisher.type=kafka`(afterCommit, at-most-once)라 커밋 직후 브로커 전송 실패 시 `BookingExpiredEvent`가 유실될 수 있음(seat outbox와 비대칭). 이는 booking-service 발행 인프라 전반의 기존 속성으로 본 이슈 범위 밖이며 별도 fix 대상

---

## ⚠️ 배포 시 주의사항

- 신규 Kafka 토픽 `seat-hold-expired-topic`(+ `.DLT`) 프로비저닝 확인 필요
- seat-service는 Outbox(`aggregate-types: [Seat]`)로 발행 — 설정 변경 없음
