### PR TITLE
[Infra] #349 운영(prod) 프로파일 추가 및 인프라 접속정보 외부화

### DIFF
--- a/.env.prod.example
+++ b/.env.prod.example
@@ -1,0 +1,80 @@
+# 운영(prod) 프로파일 환경변수 템플릿 — 값은 비워둔다(평문 커밋 금지).
+# 실제 값은 배포 시 컨테이너 환경변수/Secret으로 주입한다. 사용법: 이 파일을 복사해 .env.prod 로 채운 뒤
+# SPRING_PROFILES_ACTIVE=prod 로 각 서비스를 구동한다(.env.prod 는 .gitignore 로 커밋되지 않는다).
+
+# ===== 공통 (전 서비스) =====
+SPRING_PROFILES_ACTIVE=prod
+# DB (RDS 등) — url = jdbc:mysql://${DB_HOST}:${DB_PORT}/${DB_NAME}
+DB_HOST=
+DB_PORT=3306
+DB_NAME=
+MYSQL_USERNAME=
+MYSQL_PASSWORD=
+# Kafka (MSK 등)
+KAFKA_BOOTSTRAP_SERVERS=
+# Redis (ElastiCache 등)
+REDIS_HOST=
+REDIS_PORT=6379
+# 게이트웨이 내부 호출 토큰(전 서비스 공유, 반드시 오버라이드)
+GATEWAY_INTERNAL_TOKEN=
+# Swagger 노출 서버 URL
+SWAGGER_SERVER_URL=
+# 서비스 간 호출 base URL(localhost 기본값 오버라이드)
+AUTH_SERVICE_URL=
+USER_SERVICE_URL=
+SEAT_SERVICE_URL=
+BOOKING_SERVICE_URL=
+
+# ===== gateway-service =====
+JWT_SECRET=
+CORS_ALLOWED_ORIGIN=
+# 라우팅 대상 서비스 호스트(host-only, 포트는 라우트에 고정)
+USER_SERVICE_HOST=
+AUTH_SERVICE_HOST=
+PERFORMANCE_SERVICE_HOST=
+BOOKING_SERVICE_HOST=
+PAYMENT_SERVICE_HOST=
+SEAT_SERVICE_HOST=
+TICKET_SERVICE_HOST=
+
+# ===== auth-service =====
+# JWT_SECRET 은 gateway 와 동일 값 재사용
+MAIL_USERNAME=
+MAIL_PASSWORD=
+KAKAO_CLIENT_ID=
+KAKAO_CLIENT_SECRET=
+KAKAO_REDIRECT_URI=
+GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=
+GOOGLE_REDIRECT_URI=
+NAVER_CLIENT_ID=
+NAVER_CLIENT_SECRET=
+NAVER_REDIRECT_URI=
+# OAuth 로그인 후 리다이렉트 허용 도메인(운영 프론트 도메인)
+OAUTH_ALLOWED_REDIRECT_DOMAIN=
+
+# ===== performance-service (S3) =====
+AWS_S3_BUCKET=
+# 운영은 IAM 인스턴스 롤 권장. 롤 사용 시 아래 두 값은 비워둔다.
+AWS_S3_ACCESS_KEY=
+AWS_S3_SECRET_KEY=
+
+# ===== payment-service (Toss PG) =====
+PAYMENT_PG_STUB_ENABLED=false
+TOSS_PAYMENTS_ENABLED=true
+TOSS_PAYMENTS_SECRET_KEY=
+TOSS_PAYMENTS_WEBHOOK_SECRET=
+# TOSS_PAYMENTS_BASE_URL=   # 선택, 기본 https://api.tosspayments.com
+
+# ===== ticket-service =====
+# QR 서명 시크릿(기본값 없음 — 미주입 시 기동 실패)
+TICKET_QR_SECRET=
+# TICKET_QR_TTL_MILLIS=     # 선택, 기본 300000
+
+# ===== booking-service (운영 배치/알림 토글, 기본은 모두 비활성) =====
+DLT_MONITOR_ENABLED=true
+# DLT_RETENTION_DAYS=30
+SLACK_ENABLED=true
+SLACK_WEBHOOK_URL=
+INBOX_RETENTION_ENABLED=true
+# INBOX_RETENTION_DAYS=30

--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,7 @@ web_modules/
 .env
 .env.*
 !.env.example
+!.env.prod.example
 
 # parcel-bundler cache (https://parceljs.org/)
 .cache

--- a/auth-service/src/main/resources/application-prod.yml
+++ b/auth-service/src/main/resources/application-prod.yml
@@ -1,17 +1,17 @@
 spring:
   datasource:
-    url: jdbc:mysql://localhost:3306/ticket_rush
+    url: jdbc:mysql://${DB_HOST}:${DB_PORT}/${DB_NAME}
     username: ${MYSQL_USERNAME}
     password: ${MYSQL_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
   jpa:
     hibernate:
-      ddl-auto: ${SPRING_JPA_HIBERNATE_DDL_AUTO:update}
+      ddl-auto: validate
   kafka:
-    bootstrap-servers: localhost:29092
+    bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS}
   data:
     redis:
-      host: ${REDIS_HOST:localhost}
+      host: ${REDIS_HOST}
       port: ${REDIS_PORT:6379}
 
 oauth:
@@ -30,9 +30,18 @@ oauth:
     client-secret: ${NAVER_CLIENT_SECRET}
     redirect-uri: ${NAVER_REDIRECT_URI}
 
+gateway:
+  # 운영은 게이트웨이 내부 토큰을 반드시 주입(base의 test-token 기본값 오버라이드, 미주입 시 fail-fast).
+  internal-token: ${GATEWAY_INTERNAL_TOKEN}
+
 custom:
   security:
     oauth2:
       allowed-redirect-domains:
-        - localhost
-        - 127.0.0.1
+        - ${OAUTH_ALLOWED_REDIRECT_DOMAIN}
+    permit-urls:
+      - /swagger-ui/**
+      - /v3/api-docs/**
+      - /
+      - /favicon.ico
+      - /error

--- a/auth-service/src/main/resources/application.yml
+++ b/auth-service/src/main/resources/application.yml
@@ -7,16 +7,34 @@ spring:
     active: ${SPRING_PROFILES_ACTIVE:local}
   application:
     name: auth-service
+  jpa:
+    open-in-view: false
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: ${MAIL_USERNAME}
+    password: ${MAIL_PASSWORD}
+    properties:
+      mail:
+        smtp:
+          auth: true
+          connectiontimeout: 5000
+          timeout: 5000
+          writetimeout: 5000
+          starttls:
+            enable: true
 
 oauth:
   kakao:
     authorization-uri: https://kauth.kakao.com/oauth/authorize
+    auth-uri: https://kauth.kakao.com/oauth/authorize
     token-uri: https://kauth.kakao.com/oauth/token
     user-info-uri: https://kapi.kakao.com/v2/user/me
     user-name-attribute: id
 
   google:
     authorization-uri: https://accounts.google.com/o/oauth2/v2/auth
+    auth-uri: https://accounts.google.com/o/oauth2/v2/auth
     token-uri: https://oauth2.googleapis.com/token
     user-info-uri: https://www.googleapis.com/oauth2/v2/userinfo
 
@@ -29,9 +47,20 @@ oauth:
 
 custom:
   global:
-    internalBackUrl: http://localhost:${server.port:8082}
+    internalBackUrl: ${INTERNAL_BACK_URL:http://localhost:${server.port:8082}}
   swagger:
-    serverUrl: http://localhost:8080
+    serverUrl: ${SWAGGER_SERVER_URL:http://localhost:8080}
+  security:
+    permit-all: false
+    internal-token: ${GATEWAY_INTERNAL_TOKEN}
+    permit-urls:
+      # ========== 개발 도구 ==========
+      - /h2-console/**
+      - /swagger-ui/**
+      - /v3/api-docs/**
+      - /
+      - /favicon.ico
+      - /error
 
 service:
   user:
@@ -39,6 +68,10 @@ service:
   http:
     connect-timeout-ms: ${SERVICE_HTTP_CONNECT_TIMEOUT_MS:3000}
     read-timeout-ms: ${SERVICE_HTTP_READ_TIMEOUT_MS:10000}
+
+app:
+  event-publisher:
+    type: kafka
 
 jwt:
   secret: ${JWT_SECRET}

--- a/booking-service/src/main/resources/application-local.yml
+++ b/booking-service/src/main/resources/application-local.yml
@@ -7,27 +7,9 @@ spring:
   jpa:
     hibernate:
       ddl-auto: ${SPRING_JPA_HIBERNATE_DDL_AUTO:update}
-    open-in-view: false
   kafka:
     bootstrap-servers: localhost:29092
-app:
-  event-publisher:
-    type: kafka
-  outbox:
-    aggregate-types:
-      - Booking
-    batch-size: 100
-    max-retries: 3
-    retention-hours: 72
-
-custom:
-  security:
-    permit-all: false
-    permit-urls:
-      # ========== 개발 도구 ==========
-      - /h2-console/**
-      - /swagger-ui/**
-      - /v3/api-docs/**
-      - /
-      - /favicon.ico
-      - /error
+  data:
+    redis:
+      host: ${REDIS_HOST:localhost}
+      port: ${REDIS_PORT:6379}

--- a/booking-service/src/main/resources/application-prod.yml
+++ b/booking-service/src/main/resources/application-prod.yml
@@ -1,0 +1,28 @@
+spring:
+  datasource:
+    url: jdbc:mysql://${DB_HOST}:${DB_PORT}/${DB_NAME}
+    username: ${MYSQL_USERNAME}
+    password: ${MYSQL_PASSWORD}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+  jpa:
+    hibernate:
+      ddl-auto: validate
+  kafka:
+    bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS}
+  data:
+    redis:
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT:6379}
+
+gateway:
+  # 운영은 게이트웨이 내부 토큰을 반드시 주입(base의 test-token 기본값 오버라이드, 미주입 시 fail-fast).
+  internal-token: ${GATEWAY_INTERNAL_TOKEN}
+
+custom:
+  security:
+    permit-urls:
+      - /swagger-ui/**
+      - /v3/api-docs/**
+      - /
+      - /favicon.ico
+      - /error

--- a/booking-service/src/main/resources/application.yml
+++ b/booking-service/src/main/resources/application.yml
@@ -7,6 +7,8 @@ spring:
     active: ${SPRING_PROFILES_ACTIVE:local}
   application:
     name: booking-service
+  jpa:
+    open-in-view: false
 
 service:
   seat:
@@ -17,9 +19,19 @@ service:
 
 custom:
   global:
-    internalBackUrl: http://localhost:${server.port:8084}
+    internalBackUrl: ${INTERNAL_BACK_URL:http://localhost:${server.port:8084}}
   swagger:
-    serverUrl: http://localhost:8080
+    serverUrl: ${SWAGGER_SERVER_URL:http://localhost:8080}
+  security:
+    permit-all: false
+    permit-urls:
+      # ========== 개발 도구 ==========
+      - /h2-console/**
+      - /swagger-ui/**
+      - /v3/api-docs/**
+      - /
+      - /favicon.ico
+      - /error
 
 springdoc:
   api-docs:
@@ -34,6 +46,14 @@ gateway:
 # 기본은 비활성이며, 운영 환경에서 환경변수로 켠다(DLT_MONITOR_ENABLED=true, SLACK_ENABLED=true, SLACK_WEBHOOK_URL=...).
 # local/test는 미설정(기본 false)으로 비활성.
 app:
+  event-publisher:
+    type: kafka
+  outbox:
+    aggregate-types:
+      - Booking
+    batch-size: 100
+    max-retries: 3
+    retention-hours: 72
   dlt:
     monitor:
       enabled: ${DLT_MONITOR_ENABLED:false}

--- a/docs/backend-convention.md
+++ b/docs/backend-convention.md
@@ -254,6 +254,25 @@ Diary diary = diaryRepository.findByDiaryIdAndUserId(diaryId, userId)
 * **Java:** 21
 * **Spring Boot:** 4.0.3 (LTS)
 
+### 🌱 프로파일 및 인프라 접속정보 외부화
+
+각 서비스는 `application.yml`(환경 무관 공통 설정) + 프로파일별 오버라이드(`application-local.yml` / `application-prod.yml` / 테스트용 `application-test.yml`) 구조를 따른다.
+
+* **설정 분리 원칙(SSOT):**
+    * **환경 무관 앱 설정**(`app.event-publisher.type`, `app.outbox.*`, `custom.security.permit-urls`, OAuth provider URI, mail 정적 프로퍼티, `spring.datasource.driver-class-name`, `spring.jpa.open-in-view` 등)은 `application.yml`(base)에 둔다.
+    * **접속 엔드포인트·환경가변 값**(DB/Redis/Kafka 호스트, `ddl-auto`, OAuth `allowed-redirect-domains`, gateway `services.*.host`, CORS origin, swagger serverUrl 등)만 프로파일 yml에 둔다.
+* **프로파일 활성화:** 컨테이너에서 `SPRING_PROFILES_ACTIVE=prod` 환경변수로 구동한다. base의 `spring.profiles.active: ${SPRING_PROFILES_ACTIVE:local}` 기본값이 local이다.
+* **접속정보 환경변수 규칙:**
+    * **DB:** `url: jdbc:mysql://${DB_HOST}:${DB_PORT}/${DB_NAME}`, 자격증명은 `${MYSQL_USERNAME}` / `${MYSQL_PASSWORD}`(기본값 없음, 미주입 시 기동 실패).
+    * **Redis:** `spring.data.redis.host/port` 를 **명시적으로 설정**한다(오토컨피그 localhost:6379 암묵 의존 금지). local은 `${REDIS_HOST:localhost}`, prod는 `${REDIS_HOST}`.
+    * **Kafka:** local은 `localhost:29092`, prod는 `${KAFKA_BOOTSTRAP_SERVERS}`.
+    * **gateway 서비스 호스트:** `${<NAME>_SERVICE_HOST}`(host-only). 포트가 포함된 서비스 URL(`${<NAME>_SERVICE_URL}`, [§ 서비스 간 호출 프로퍼티 키](#️-서비스-간-호출-프로퍼티-키-restclient) 참고)과는 별개의 host 전용 패턴이다.
+    * 값이 있는 것은 `${VAR:default}`, 자격증명·비밀키는 기본값 없는 `${VAR}`(fail-fast).
+* **운영 안전값:** prod의 `spring.jpa.hibernate.ddl-auto` 는 **`validate`**(스키마 사전 마이그레이션 전제). `management` actuator 노출은 `health, info, prometheus` + `health.show-details: never` 로 제한, prod `custom.security.permit-urls` 에서 `/h2-console/**` 등 개발도구 경로는 제외한다.
+* **민감정보:** 커밋 파일(yml 포함)에 평문 비밀값을 남기지 않는다. 운영 환경변수 키 전체 목록은 리포 루트 [`.env.prod.example`](../.env.prod.example)(값 비움)을 SSOT로 참고하며, 실제 값은 컨테이너 환경변수/Secret으로 주입한다.
+
+> 실제 RDS/ElastiCache/MSK 프로비저닝·CD 파이프라인 연동은 별도 배포(CD) 이슈에서 다룬다. 이 규칙은 **애플리케이션 설정 외부화**에 한정한다.
+
 ### 🏷 주석 컨벤션
 
 * **코드 길이 제한:** 100자 (Checkstyle `LineLength max=100` 강제)

--- a/gateway-service/src/main/resources/application-local.yml
+++ b/gateway-service/src/main/resources/application-local.yml
@@ -2,11 +2,6 @@ custom:
   swagger:
     serverUrl: ${SWAGGER_SERVER_URL:http://localhost:8080}
     description: "Local Server"
-  security:
-    permit-all: false
-    permit-urls:
-      - /swagger-ui/**
-      - /v3/api-docs/**
 
   cors:
     enabled: true

--- a/gateway-service/src/main/resources/application-prod.yml
+++ b/gateway-service/src/main/resources/application-prod.yml
@@ -1,0 +1,29 @@
+custom:
+  swagger:
+    serverUrl: ${SWAGGER_SERVER_URL}
+    description: "Production Server"
+
+  cors:
+    enabled: true
+    allowed-origins:
+      - ${CORS_ALLOWED_ORIGIN}
+
+services:
+  user:
+    host: ${USER_SERVICE_HOST}
+  auth:
+    host: ${AUTH_SERVICE_HOST}
+  performance:
+    host: ${PERFORMANCE_SERVICE_HOST}
+  booking:
+    host: ${BOOKING_SERVICE_HOST}
+  payment:
+    host: ${PAYMENT_SERVICE_HOST}
+  seat:
+    host: ${SEAT_SERVICE_HOST}
+  ticket:
+    host: ${TICKET_SERVICE_HOST}
+
+gateway:
+  # 운영은 게이트웨이 내부 토큰을 반드시 주입(base의 test-token 기본값 오버라이드, 미주입 시 fail-fast).
+  internal-token: ${GATEWAY_INTERNAL_TOKEN}

--- a/gateway-service/src/main/resources/application.yml
+++ b/gateway-service/src/main/resources/application.yml
@@ -1,17 +1,11 @@
 server:
   port: 8080
 
-custom:
-  cors:
-    enabled: true
-    allowed-origins:
-      - http://localhost:3000
-      - http://localhost:8080
-
-
 spring:
   application:
     name: gateway-service
+  profiles:
+    active: ${SPRING_PROFILES_ACTIVE:local}
 
   cloud:
     gateway:
@@ -102,6 +96,13 @@ jwt:
 
 gateway:
   internal-token: ${GATEWAY_INTERNAL_TOKEN:test-token}
+
+custom:
+  security:
+    permit-all: false
+    permit-urls:
+      - /swagger-ui/**
+      - /v3/api-docs/**
 
 management:
   endpoints:

--- a/payment-service/src/main/resources/application-local.yml
+++ b/payment-service/src/main/resources/application-local.yml
@@ -7,21 +7,9 @@ spring:
   jpa:
     hibernate:
       ddl-auto: ${SPRING_JPA_HIBERNATE_DDL_AUTO:update}
-    open-in-view: false
   kafka:
     bootstrap-servers: localhost:29092
-app:
-  event-publisher:
-    type: kafka
-
-custom:
-  security:
-    permit-all: false
-    permit-urls:
-      # ========== 개발 도구 ==========
-      - /h2-console/**
-      - /swagger-ui/**
-      - /v3/api-docs/**
-      - /
-      - /favicon.ico
-      - /error
+  data:
+    redis:
+      host: ${REDIS_HOST:localhost}
+      port: ${REDIS_PORT:6379}

--- a/payment-service/src/main/resources/application-prod.yml
+++ b/payment-service/src/main/resources/application-prod.yml
@@ -1,0 +1,28 @@
+spring:
+  datasource:
+    url: jdbc:mysql://${DB_HOST}:${DB_PORT}/${DB_NAME}
+    username: ${MYSQL_USERNAME}
+    password: ${MYSQL_PASSWORD}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+  jpa:
+    hibernate:
+      ddl-auto: validate
+  kafka:
+    bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS}
+  data:
+    redis:
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT:6379}
+
+gateway:
+  # 운영은 게이트웨이 내부 토큰을 반드시 주입(base의 test-token 기본값 오버라이드, 미주입 시 fail-fast).
+  internal-token: ${GATEWAY_INTERNAL_TOKEN}
+
+custom:
+  security:
+    permit-urls:
+      - /swagger-ui/**
+      - /v3/api-docs/**
+      - /
+      - /favicon.ico
+      - /error

--- a/payment-service/src/main/resources/application.yml
+++ b/payment-service/src/main/resources/application.yml
@@ -7,12 +7,28 @@ spring:
     active: ${SPRING_PROFILES_ACTIVE:local}
   application:
     name: payment-service
+  jpa:
+    open-in-view: false
+
+app:
+  event-publisher:
+    type: kafka
 
 custom:
   global:
-    internalBackUrl: http://localhost:${server.port:8085}
+    internalBackUrl: ${INTERNAL_BACK_URL:http://localhost:${server.port:8085}}
   swagger:
-    serverUrl: http://localhost:8080
+    serverUrl: ${SWAGGER_SERVER_URL:http://localhost:8080}
+  security:
+    permit-all: false
+    permit-urls:
+      # ========== 개발 도구 ==========
+      - /h2-console/**
+      - /swagger-ui/**
+      - /v3/api-docs/**
+      - /
+      - /favicon.ico
+      - /error
 
 springdoc:
   api-docs:

--- a/performance-service/src/main/resources/application-local.yml
+++ b/performance-service/src/main/resources/application-local.yml
@@ -1,8 +1,6 @@
 springdoc:
   swagger-ui:
     enabled: true
-  api-docs:
-    enabled: true
   servers:
     - url: http://localhost:8083
       description: 로컬 서버
@@ -16,42 +14,16 @@ spring:
   jpa:
     hibernate:
       ddl-auto: ${SPRING_JPA_HIBERNATE_DDL_AUTO:update}
-    open-in-view: false
-  servlet:
-    multipart:
-      enabled: true
-      max-file-size: 10MB
-      max-request-size: 50MB
   kafka:
     bootstrap-servers: localhost:29092
+  data:
+    redis:
+      host: ${REDIS_HOST:localhost}
+      port: ${REDIS_PORT:6379}
   cloud:
     aws:
-      region:
-        static: ap-northeast-2
       credentials:
         access-key: local-dummy-key
         secret-key: local-dummy-secret
-      stack:
-        auto: false
       s3:
         bucket: ticket-rush-local-bucket
-app:
-  event-publisher:
-    type: kafka
-  kafka:
-    topics:
-      performance-events:
-        partitions: 1
-        replicas: 1
-
-custom:
-  security:
-    permit-all: false
-    permit-urls:
-      # ========== 개발 도구 ==========
-      - /h2-console/**
-      - /swagger-ui/**
-      - /v3/api-docs/**
-      - /
-      - /favicon.ico
-      - /error

--- a/performance-service/src/main/resources/application-prod.yml
+++ b/performance-service/src/main/resources/application-prod.yml
@@ -1,0 +1,36 @@
+spring:
+  datasource:
+    url: jdbc:mysql://${DB_HOST}:${DB_PORT}/${DB_NAME}
+    username: ${MYSQL_USERNAME}
+    password: ${MYSQL_PASSWORD}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+  jpa:
+    hibernate:
+      ddl-auto: validate
+  kafka:
+    bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS}
+  data:
+    redis:
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT:6379}
+  cloud:
+    aws:
+      # 운영은 IAM 인스턴스 롤 사용 권장(access/secret 미주입 시 DefaultCredentialsProvider로 폴백).
+      credentials:
+        access-key: ${AWS_S3_ACCESS_KEY:}
+        secret-key: ${AWS_S3_SECRET_KEY:}
+      s3:
+        bucket: ${AWS_S3_BUCKET}
+
+gateway:
+  # 운영은 게이트웨이 내부 토큰을 반드시 주입(base의 test-token 기본값 오버라이드, 미주입 시 fail-fast).
+  internal-token: ${GATEWAY_INTERNAL_TOKEN}
+
+custom:
+  security:
+    permit-urls:
+      - /swagger-ui/**
+      - /v3/api-docs/**
+      - /
+      - /favicon.ico
+      - /error

--- a/performance-service/src/main/resources/application.yml
+++ b/performance-service/src/main/resources/application.yml
@@ -7,12 +7,44 @@ spring:
     active: ${SPRING_PROFILES_ACTIVE:local}
   application:
     name: performance-service
+  jpa:
+    open-in-view: false
+  servlet:
+    multipart:
+      enabled: true
+      max-file-size: 10MB
+      max-request-size: 50MB
+  cloud:
+    aws:
+      region:
+        static: ap-northeast-2
+      stack:
+        auto: false
+
+app:
+  event-publisher:
+    type: kafka
+  kafka:
+    topics:
+      performance-events:
+        partitions: 1
+        replicas: 1
 
 custom:
   global:
-    internalBackUrl: http://localhost:${server.port:8083}
+    internalBackUrl: ${INTERNAL_BACK_URL:http://localhost:${server.port:8083}}
   swagger:
-    serverUrl: http://localhost:8080
+    serverUrl: ${SWAGGER_SERVER_URL:http://localhost:8080}
+  security:
+    permit-all: false
+    permit-urls:
+      # ========== 개발 도구 ==========
+      - /h2-console/**
+      - /swagger-ui/**
+      - /v3/api-docs/**
+      - /
+      - /favicon.ico
+      - /error
 
 springdoc:
   api-docs:

--- a/seat-service/src/main/resources/application-local.yml
+++ b/seat-service/src/main/resources/application-local.yml
@@ -7,27 +7,9 @@ spring:
   jpa:
     hibernate:
       ddl-auto: ${SPRING_JPA_HIBERNATE_DDL_AUTO:update}
-    open-in-view: false
   kafka:
     bootstrap-servers: localhost:29092
-app:
-  event-publisher:
-    type: outbox
-  outbox:
-    aggregate-types:
-      - Seat
-    batch-size: 100
-    max-retries: 3
-    retention-hours: 72
-
-custom:
-  security:
-    permit-all: false
-    permit-urls:
-      # ========== 개발 도구 ==========
-      - /h2-console/**
-      - /swagger-ui/**
-      - /v3/api-docs/**
-      - /
-      - /favicon.ico
-      - /error
+  data:
+    redis:
+      host: ${REDIS_HOST:localhost}
+      port: ${REDIS_PORT:6379}

--- a/seat-service/src/main/resources/application-prod.yml
+++ b/seat-service/src/main/resources/application-prod.yml
@@ -1,0 +1,28 @@
+spring:
+  datasource:
+    url: jdbc:mysql://${DB_HOST}:${DB_PORT}/${DB_NAME}
+    username: ${MYSQL_USERNAME}
+    password: ${MYSQL_PASSWORD}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+  jpa:
+    hibernate:
+      ddl-auto: validate
+  kafka:
+    bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS}
+  data:
+    redis:
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT:6379}
+
+gateway:
+  # 운영은 게이트웨이 내부 토큰을 반드시 주입(base의 test-token 기본값 오버라이드, 미주입 시 fail-fast).
+  internal-token: ${GATEWAY_INTERNAL_TOKEN}
+
+custom:
+  security:
+    permit-urls:
+      - /swagger-ui/**
+      - /v3/api-docs/**
+      - /
+      - /favicon.ico
+      - /error

--- a/seat-service/src/main/resources/application.yml
+++ b/seat-service/src/main/resources/application.yml
@@ -7,12 +7,24 @@ spring:
     active: ${SPRING_PROFILES_ACTIVE:local}
   application:
     name: seat-service
+  jpa:
+    open-in-view: false
 
 custom:
   global:
-    internalBackUrl: http://localhost:${server.port:8086}
+    internalBackUrl: ${INTERNAL_BACK_URL:http://localhost:${server.port:8086}}
   swagger:
-    serverUrl: http://localhost:8080
+    serverUrl: ${SWAGGER_SERVER_URL:http://localhost:8080}
+  security:
+    permit-all: false
+    permit-urls:
+      # ========== 개발 도구 ==========
+      - /h2-console/**
+      - /swagger-ui/**
+      - /v3/api-docs/**
+      - /
+      - /favicon.ico
+      - /error
 
 springdoc:
   api-docs:
@@ -28,6 +40,14 @@ app:
     release:
       chunk-size: 100
       max-chunks: 20
+  event-publisher:
+    type: outbox
+  outbox:
+    aggregate-types:
+      - Seat
+    batch-size: 100
+    max-retries: 3
+    retention-hours: 72
 
 management:
   endpoints:

--- a/ticket-service/src/main/resources/application-local.yml
+++ b/ticket-service/src/main/resources/application-local.yml
@@ -7,21 +7,9 @@ spring:
   jpa:
     hibernate:
       ddl-auto: ${SPRING_JPA_HIBERNATE_DDL_AUTO:update}
-    open-in-view: false
   kafka:
     bootstrap-servers: localhost:29092
-app:
-  event-publisher:
-    type: kafka
-
-custom:
-  security:
-    permit-all: false
-    permit-urls:
-      # ========== 개발 도구 ==========
-      - /h2-console/**
-      - /swagger-ui/**
-      - /v3/api-docs/**
-      - /
-      - /favicon.ico
-      - /error
+  data:
+    redis:
+      host: ${REDIS_HOST:localhost}
+      port: ${REDIS_PORT:6379}

--- a/ticket-service/src/main/resources/application-prod.yml
+++ b/ticket-service/src/main/resources/application-prod.yml
@@ -1,0 +1,28 @@
+spring:
+  datasource:
+    url: jdbc:mysql://${DB_HOST}:${DB_PORT}/${DB_NAME}
+    username: ${MYSQL_USERNAME}
+    password: ${MYSQL_PASSWORD}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+  jpa:
+    hibernate:
+      ddl-auto: validate
+  kafka:
+    bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS}
+  data:
+    redis:
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT:6379}
+
+gateway:
+  # 운영은 게이트웨이 내부 토큰을 반드시 주입(base의 test-token 기본값 오버라이드, 미주입 시 fail-fast).
+  internal-token: ${GATEWAY_INTERNAL_TOKEN}
+
+custom:
+  security:
+    permit-urls:
+      - /swagger-ui/**
+      - /v3/api-docs/**
+      - /
+      - /favicon.ico
+      - /error

--- a/ticket-service/src/main/resources/application.yml
+++ b/ticket-service/src/main/resources/application.yml
@@ -7,6 +7,8 @@ spring:
     active: ${SPRING_PROFILES_ACTIVE:local}
   application:
     name: ticket-service
+  jpa:
+    open-in-view: false
 
 service:
   booking:
@@ -15,11 +17,25 @@ service:
     connect-timeout-ms: ${SERVICE_HTTP_CONNECT_TIMEOUT_MS:3000}
     read-timeout-ms: ${SERVICE_HTTP_READ_TIMEOUT_MS:10000}
 
+app:
+  event-publisher:
+    type: kafka
+
 custom:
   global:
-    internalBackUrl: http://localhost:${server.port:8087}
+    internalBackUrl: ${INTERNAL_BACK_URL:http://localhost:${server.port:8087}}
   swagger:
-    serverUrl: http://localhost:8080
+    serverUrl: ${SWAGGER_SERVER_URL:http://localhost:8080}
+  security:
+    permit-all: false
+    permit-urls:
+      # ========== 개발 도구 ==========
+      - /h2-console/**
+      - /swagger-ui/**
+      - /v3/api-docs/**
+      - /
+      - /favicon.ico
+      - /error
 
 springdoc:
   api-docs:

--- a/user-service/src/main/resources/application-local.yml
+++ b/user-service/src/main/resources/application-local.yml
@@ -7,22 +7,9 @@ spring:
   jpa:
     hibernate:
       ddl-auto: ${SPRING_JPA_HIBERNATE_DDL_AUTO:update}
-    open-in-view: false
   kafka:
     bootstrap-servers: localhost:29092
-app:
-  event-publisher:
-    type: kafka
-
-custom:
-  security:
-    internal-token: ${GATEWAY_INTERNAL_TOKEN}
-    permit-all: false
-    permit-urls:
-      # ========== 개발 도구 ==========
-      - /h2-console/**
-      - /swagger-ui/**
-      - /v3/api-docs/**
-      - /
-      - /favicon.ico
-      - /error
+  data:
+    redis:
+      host: ${REDIS_HOST:localhost}
+      port: ${REDIS_PORT:6379}

--- a/user-service/src/main/resources/application-prod.yml
+++ b/user-service/src/main/resources/application-prod.yml
@@ -1,0 +1,28 @@
+spring:
+  datasource:
+    url: jdbc:mysql://${DB_HOST}:${DB_PORT}/${DB_NAME}
+    username: ${MYSQL_USERNAME}
+    password: ${MYSQL_PASSWORD}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+  jpa:
+    hibernate:
+      ddl-auto: validate
+  kafka:
+    bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS}
+  data:
+    redis:
+      host: ${REDIS_HOST}
+      port: ${REDIS_PORT:6379}
+
+gateway:
+  # 운영은 게이트웨이 내부 토큰을 반드시 주입(base의 test-token 기본값 오버라이드, 미주입 시 fail-fast).
+  internal-token: ${GATEWAY_INTERNAL_TOKEN}
+
+custom:
+  security:
+    permit-urls:
+      - /swagger-ui/**
+      - /v3/api-docs/**
+      - /
+      - /favicon.ico
+      - /error

--- a/user-service/src/main/resources/application.yml
+++ b/user-service/src/main/resources/application.yml
@@ -7,6 +7,8 @@ spring:
     active: ${SPRING_PROFILES_ACTIVE:local}
   application:
     name: user-service
+  jpa:
+    open-in-view: false
 
 service:
   auth:
@@ -15,11 +17,26 @@ service:
     connect-timeout-ms: ${SERVICE_HTTP_CONNECT_TIMEOUT_MS:3000}
     read-timeout-ms: ${SERVICE_HTTP_READ_TIMEOUT_MS:10000}
 
+app:
+  event-publisher:
+    type: kafka
+
 custom:
   global:
-    internalBackUrl: http://localhost:${server.port:8081}
+    internalBackUrl: ${INTERNAL_BACK_URL:http://localhost:${server.port:8081}}
   swagger:
-    serverUrl: http://localhost:8080
+    serverUrl: ${SWAGGER_SERVER_URL:http://localhost:8080}
+  security:
+    internal-token: ${GATEWAY_INTERNAL_TOKEN}
+    permit-all: false
+    permit-urls:
+      # ========== 개발 도구 ==========
+      - /h2-console/**
+      - /swagger-ui/**
+      - /v3/api-docs/**
+      - /
+      - /favicon.ico
+      - /error
 
 springdoc:
   api-docs:


### PR DESCRIPTION
## 🔗 관련 이슈

- close #349

---

## 📌 주요 변경 사항

- 8개 서비스에 운영 프로파일(`application-prod.yml`) 추가
- DB·Redis·Kafka 접속정보를 환경변수로 외부화(엔드포인트만 바꿔 분리 배포 가능)
- 환경 무관 앱 설정을 `application.yml`(base)로 승격하는 리팩터(local/prod는 접속정보만)
- Redis 접속정보 명시화로 기본값 localhost 의존 제거
- 운영 안전 설정(prod `ddl-auto: validate`, 내부 토큰 fail-fast) 적용
- 운영 환경변수 템플릿(`.env.prod.example`)·컨벤션 문서 추가

---

## 🛠 상세 구현 내용

- **prod 프로파일 8종 신규**: DB `jdbc:mysql://${DB_HOST}:${DB_PORT}/${DB_NAME}`, 자격증명 `${MYSQL_USERNAME}`/`${MYSQL_PASSWORD}`, Kafka `${KAFKA_BOOTSTRAP_SERVERS}`, Redis `${REDIS_HOST}`/`${REDIS_PORT:6379}`, `ddl-auto: validate`
- **base 승격 리팩터**: `app.event-publisher.type`, `app.outbox`, `custom.security`(permit-urls 등), OAuth provider URI, mail 정적 프로퍼티, `jpa.open-in-view` 등 환경 무관 설정을 각 서비스 base로 이동. 접속 엔드포인트·환경가변 값(url, kafka, redis, ddl-auto, CORS, swagger, gateway 서비스 호스트)만 local/prod에 유지
- **auth**: 코드가 `@Value`로 주입하는 `oauth.kakao/google.auth-uri`(원래 local 전용)를 base로 승격 → prod 기동 시 placeholder 미해석 실패 방지
- **Redis 명시화**: `common` 모듈이 전 서비스에 `spring-data-redis` + 기동 시 즉시 연결하는 `RedisMessageListenerContainer`를 제공하므로, common 의존 7개 서비스에 `spring.data.redis` 접속정보를 명시(local `${REDIS_HOST:localhost}`, prod `${REDIS_HOST}`)
- **gateway**(webflux, common 미의존): DB/Redis/Kafka 없이 프로파일·서비스 호스트(`${*_SERVICE_HOST}`)·CORS·swagger serverUrl만 외부화
- **보안 하드닝**: prod `permit-urls`에서 `/h2-console/**` 제외, `gateway.internal-token`을 prod에서 `${GATEWAY_INTERNAL_TOKEN}`(기본값 없음)으로 오버라이드해 미주입 시 fail-fast
- **산출물**: 루트 `.env.prod.example`(값 비움, 평문 금지), `.gitignore`에 `!.env.prod.example` 예외, `docs/backend-convention.md`에 prod 프로파일/환경변수 컨벤션 섹션 추가

---

## ✅ 테스트

### 테스트 방법

- 이번 PR은 설정(yml) 변경으로 신규 단위/통합 테스트는 추가하지 않았고, 기존 전체 테스트 스위트로 회귀를 검증함
- `./gradlew build` — 전 모듈 컴파일 + 기존 test 실행(local/test 프로파일 무회귀 확인)
- `./gradlew spotlessCheck` — 포맷 검증
- 전 `application*.yml` YAML 파싱 검증 + prod 필수 환경변수(no-default `${VAR}`)가 `.env.prod.example`에 모두 문서화됐는지 정적 교차검증

### 테스트 결과

- `./gradlew build` **BUILD SUCCESSFUL** (전 서비스 test 통과)
- `./gradlew spotlessCheck` **통과(exit 0)**
- YAML 파싱 정상(0 오류), prod 필수 env 27개 전부 `.env.prod.example`에 존재(누락 0)
- 회귀 발견 및 수정: `driver-class-name`을 base로 올리자 test 프로파일이 이를 상속해 payment `contextLoads()`가 임베디드 H2 대신 MySQL 드라이버로 붙어 실패 → base에서 제거하고 local/prod로 되돌려 해결
<!--
### 📸 스크린샷

- 
-->
---

## 👀 리뷰 요청 사항

- base 승격 시 local/test 프로파일 동작이 바뀌지 않는지(특히 YAML 리스트 replace 여부, `open-in-view`)
- gateway 서비스 호스트 변수명 `${<NAME>_SERVICE_HOST}`(host-only) 컨벤션 승인
- prod `custom.security.permit-urls`/CORS/OAuth 리다이렉트 도메인의 운영 정책 값 적정성

---

## ⚠️ 배포 시 주의사항

- 실제 RDS/ElastiCache/MSK 접속으로 `SPRING_PROFILES_ACTIVE=prod` 부팅 스모크 테스트 필요(설정은 정적 검증 완료, 실인프라 연결은 미실행)
- prod `ddl-auto: validate` → 스키마가 엔티티와 일치하도록 **사전 마이그레이션** 필요
- `GATEWAY_INTERNAL_TOKEN`·`TICKET_QR_SECRET` 등 기본값 없는 필수 env 미주입 시 기동 실패(의도)
- performance는 IAM 인스턴스 롤 사용 권장(`AWS_S3_ACCESS_KEY`/`SECRET_KEY` 비움 시 폴백) — 실제 S3 접근 확인 필요
- CORS 오리진/OAuth 리다이렉트 도메인이 다중 필요 시 현재 단일 env 구조 확장 필요
