### PR TITLE
[Feat] #332 결제 실패 이력에 PG(Toss) 원본 거절 코드 저장

### DIFF
--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentConfirmUseCase.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentConfirmUseCase.java
@@ -9,6 +9,7 @@ import com.ticketrush.boundedcontext.payment.domain.types.PaymentStatus;
 import com.ticketrush.boundedcontext.payment.out.apiclient.PaymentApprovalClientRouter;
 import com.ticketrush.boundedcontext.payment.out.apiclient.PaymentApprovalRequest;
 import com.ticketrush.boundedcontext.payment.out.apiclient.PaymentApprovalResponse;
+import com.ticketrush.boundedcontext.payment.out.apiclient.PgRejectionException;
 import com.ticketrush.boundedcontext.payment.out.repository.ExpiredBookingRepository;
 import com.ticketrush.boundedcontext.payment.out.repository.PaymentRepository;
 import com.ticketrush.global.constants.MetricNames;
@@ -162,6 +163,13 @@ public class PaymentConfirmUseCase {
     if (!RECORDABLE_FAILURES.contains(e.getErrorStatus())) {
       return;
     }
+    // PG(Toss)가 원본 거절 코드/사유를 실어 보낸 경우(PgRejectionException) 내부 ErrorStatus와 함께 원본도 남긴다(#332).
+    String pgFailureCode = null;
+    String pgFailureReason = null;
+    if (e instanceof PgRejectionException pge) {
+      pgFailureCode = pge.getRawCode();
+      pgFailureReason = pge.getRawMessage();
+    }
     try {
       Payment failed =
           Payment.failed(
@@ -171,7 +179,9 @@ public class PaymentConfirmUseCase {
               request.provider(),
               request.amount(),
               e.getErrorStatus().getCode(),
-              e.getErrorStatus().getMessage());
+              e.getErrorStatus().getMessage(),
+              pgFailureCode,
+              pgFailureReason);
       paymentRepository.saveAndFlush(failed);
       Counter.builder(MetricNames.PAYMENT_CONFIRM)
           .tag(MetricNames.TAG_RESULT, MetricNames.RESULT_FAILURE)

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/domain/entity/Payment.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/domain/entity/Payment.java
@@ -60,6 +60,14 @@ public class Payment extends AutoIdBaseEntity {
   @Column(length = 255)
   private String failureReason; // 실패 사유 (사람이 읽는 메시지)
 
+  /* PG(예: Toss)가 4xx로 내려준 원본 거절 코드/사유. 내부 failureCode(카테고리)와 별개로 원본 사유를 남겨 CS·정밀
+   * 분석에 쓴다(#332). 성공 결제·원본 미확보(에러 body 파싱 실패) 시 NULL이다. */
+  @Column(length = 50)
+  private String pgFailureCode; // PG 원본 거절 코드
+
+  @Column(length = 255)
+  private String pgFailureReason; // PG 원본 거절 사유
+
   /* completedBookingId는 status=COMPLETED일 때만 booking_id 값을 갖는 DB generated 컬럼이다(그 외 NULL). 이 컬럼의
    * unique 제약(uk_payment_completed_booking)으로 동일 booking에 서로 다른 paymentKey를 가진 confirm이 동시에 들어와도
    * COMPLETED 결제가 2건 생성되지 못하게 DB 레벨에서 막는다(#296, TOCTOU 최종 방어선). MySQL은 NULL을 unique 중복으로 보지 않으므로
@@ -97,6 +105,9 @@ public class Payment extends AutoIdBaseEntity {
    * approvalNumber}·{@code paidAt}은 비운다. 특히 {@code paymentKey}를 비워 unique 제약과 충돌하지 않게 해 재결제(재시도)를
    * 막지 않는다. {@code completedBookingId}(generated)도 COMPLETED가 아니므로 NULL이라 동일 booking에 FAILED가 여러 건
    * 누적될 수 있다(재시도 이력). PG 통신 실패(결과 불명)는 고아 청구 위험이 있어 이 팩토리로 기록하지 않는다(UseCase에서 분기).
+   *
+   * <p>{@code pgFailureCode}/{@code pgFailureReason}는 PG 원본 거절 코드/사유로, 미확보 시 null이다(#332). 컬럼
+   * 길이(50/255)를 넘는 원본이 들어와도 이력 저장(INSERT)이 깨져 #297 추적까지 유실되지 않도록 팩토리 내부에서 잘라 담는다.
    */
   public static Payment failed(
       Long bookingId,
@@ -105,7 +116,9 @@ public class Payment extends AutoIdBaseEntity {
       PaymentProvider provider,
       Long amount,
       String failureCode,
-      String failureReason) {
+      String failureReason,
+      String pgFailureCode,
+      String pgFailureReason) {
     Payment payment =
         Payment.builder()
             .bookingId(bookingId)
@@ -117,7 +130,17 @@ public class Payment extends AutoIdBaseEntity {
             .build();
     payment.failureCode = failureCode;
     payment.failureReason = failureReason;
+    payment.pgFailureCode = truncate(pgFailureCode, 50);
+    payment.pgFailureReason = truncate(pgFailureReason, 255);
     return payment;
+  }
+
+  /* 컬럼 길이 초과 원본으로 INSERT가 깨지지 않도록 방어적으로 자른다. null은 그대로 둔다. */
+  private static String truncate(String value, int maxLength) {
+    if (value == null || value.length() <= maxLength) {
+      return value;
+    }
+    return value.substring(0, maxLength);
   }
 
   /**

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/out/apiclient/PgRejectionException.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/out/apiclient/PgRejectionException.java
@@ -1,0 +1,28 @@
+package com.ticketrush.boundedcontext.payment.out.apiclient;
+
+import com.ticketrush.global.exception.BusinessException;
+import com.ticketrush.global.status.ErrorStatus;
+import lombok.Getter;
+
+/**
+ * PG(예: Toss)가 4xx로 내려준 결제 거절을 나타내는 예외(#332).
+ *
+ * <p>매핑된 내부 {@link ErrorStatus}와 함께 PG가 준 <b>원본</b> 거절 코드/사유를 실어, {@code
+ * PaymentConfirmUseCase.recordFailedPayment}가 FAILED 이력에 원본을 저장할 수 있게 한다. 원본 추적은 내부용이므로 상위 {@code
+ * BusinessException.data}는 채우지 않는다({@code super(errorStatus)} → data=null). 그러면 {@code
+ * GlobalExceptionHandler}가 data 미설정 경로로 흘러 원본 PG 코드가 HTTP 응답 body에 노출되지 않는다.
+ *
+ * <p>{@code rawCode}/{@code rawMessage}는 에러 응답 body 파싱 실패 시 null일 수 있다.
+ */
+@Getter
+public class PgRejectionException extends BusinessException {
+
+  private final String rawCode;
+  private final String rawMessage;
+
+  public PgRejectionException(ErrorStatus errorStatus, String rawCode, String rawMessage) {
+    super(errorStatus);
+    this.rawCode = rawCode;
+    this.rawMessage = rawMessage;
+  }
+}

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/out/apiclient/TossPaymentApprovalClient.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/out/apiclient/TossPaymentApprovalClient.java
@@ -63,6 +63,7 @@ public class TossPaymentApprovalClient implements PaymentApprovalClient {
                   (req, res) -> {
                     TossErrorResponse errorBody = readErrorBody(res);
                     String tossCode = errorBody == null ? null : errorBody.code();
+                    String tossMessage = errorBody == null ? null : errorBody.message();
                     TossErrorCode mapped = TossErrorCode.from(tossCode);
                     log.warn(
                         "[PG-TOSS] 결제 승인 거절. status={}, tossCode={}, mapped={}, "
@@ -72,7 +73,9 @@ public class TossPaymentApprovalClient implements PaymentApprovalClient {
                         mapped,
                         request.orderId(),
                         request.bookingId());
-                    throw new BusinessException(mapped.getErrorStatus());
+                    // 원본 Toss code/message를 UseCase까지 전달해 FAILED 이력에 남긴다(#332). data는 채우지
+                    // 않아(super(errorStatus)) 원본이 HTTP 응답 body에 노출되지 않게 한다.
+                    throw new PgRejectionException(mapped.getErrorStatus(), tossCode, tossMessage);
                   })
               .onStatus(
                   HttpStatusCode::is5xxServerError,

--- a/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentConfirmUseCaseTest.java
+++ b/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentConfirmUseCaseTest.java
@@ -19,6 +19,7 @@ import com.ticketrush.boundedcontext.payment.domain.types.PaymentStatus;
 import com.ticketrush.boundedcontext.payment.out.apiclient.PaymentApprovalClientRouter;
 import com.ticketrush.boundedcontext.payment.out.apiclient.PaymentApprovalRequest;
 import com.ticketrush.boundedcontext.payment.out.apiclient.PaymentApprovalResponse;
+import com.ticketrush.boundedcontext.payment.out.apiclient.PgRejectionException;
 import com.ticketrush.boundedcontext.payment.out.repository.ExpiredBookingRepository;
 import com.ticketrush.boundedcontext.payment.out.repository.PaymentRepository;
 import com.ticketrush.global.constants.MetricNames;
@@ -208,7 +209,7 @@ class PaymentConfirmUseCaseTest {
   }
 
   @Test
-  @DisplayName("PG가 결제를 거절하면(무과금 거절) 예외가 전파되고 FAILED 이력을 남긴다")
+  @DisplayName("PG가 결제를 거절하면(무과금 거절) 예외가 전파되고 원본 코드/사유까지 FAILED 이력에 남긴다")
   void execute_records_failed_when_pg_rejected() {
     // given
     Long userId = 10L;
@@ -221,7 +222,9 @@ class PaymentConfirmUseCaseTest {
     given(paymentRepository.existsByBookingIdAndStatus(bookingId, PaymentStatus.COMPLETED))
         .willReturn(false);
     given(paymentApprovalClientRouter.approve(any()))
-        .willThrow(new BusinessException(ErrorStatus.PAYMENT_METHOD_REJECTED));
+        .willThrow(
+            new PgRejectionException(
+                ErrorStatus.PAYMENT_METHOD_REJECTED, "REJECT_CARD_COMPANY", "카드사에서 거절한 카드입니다"));
 
     // when & then
     assertThatThrownBy(() -> paymentConfirmUseCase.execute(userId, request))
@@ -233,7 +236,10 @@ class PaymentConfirmUseCaseTest {
     verify(paymentRepository).saveAndFlush(failedCaptor.capture());
     Payment failed = failedCaptor.getValue();
     assertThat(failed.getStatus()).isEqualTo(PaymentStatus.FAILED);
+    // 내부 카테고리 코드/사유는 기존대로 유지되고(#297), PG 원본 코드/사유가 함께 저장된다(#332).
     assertThat(failed.getFailureCode()).isEqualTo(ErrorStatus.PAYMENT_METHOD_REJECTED.getCode());
+    assertThat(failed.getPgFailureCode()).isEqualTo("REJECT_CARD_COMPANY");
+    assertThat(failed.getPgFailureReason()).isEqualTo("카드사에서 거절한 카드입니다");
     verify(paymentEventPublisher, never())
         .publishConfirmed(any(), any(), any(), any(), any(), any());
 
@@ -255,6 +261,35 @@ class PaymentConfirmUseCaseTest {
                 .timer(MetricNames.PAYMENT_PG_APPROVE, MetricNames.TAG_PROVIDER, "TOSS")
                 .count())
         .isEqualTo(1L);
+  }
+
+  @Test
+  @DisplayName("원본 없는 화이트리스트 실패(순수 BusinessException)는 PG 원본 필드를 null로 남긴다")
+  void execute_records_failed_with_null_pg_fields_when_no_raw() {
+    // given: PgRejectionException이 아닌 순수 BusinessException(원본 미확보)이 던져진 경우
+    Long userId = 10L;
+    Long bookingId = 100L;
+    PaymentConfirmRequest request =
+        new PaymentConfirmRequest(bookingId, 200L, PaymentProvider.TOSS, 55_000L, "pgKey_xyz");
+
+    given(paymentRepository.existsByBookingIdAndStatus(bookingId, PaymentStatus.COMPLETED))
+        .willReturn(false);
+    given(paymentApprovalClientRouter.approve(any()))
+        .willThrow(new BusinessException(ErrorStatus.PAYMENT_LIMIT_EXCEEDED));
+
+    // when & then
+    assertThatThrownBy(() -> paymentConfirmUseCase.execute(userId, request))
+        .isInstanceOf(BusinessException.class)
+        .extracting("errorStatus")
+        .isEqualTo(ErrorStatus.PAYMENT_LIMIT_EXCEEDED);
+
+    ArgumentCaptor<Payment> failedCaptor = ArgumentCaptor.forClass(Payment.class);
+    verify(paymentRepository).saveAndFlush(failedCaptor.capture());
+    Payment failed = failedCaptor.getValue();
+    assertThat(failed.getStatus()).isEqualTo(PaymentStatus.FAILED);
+    assertThat(failed.getFailureCode()).isEqualTo(ErrorStatus.PAYMENT_LIMIT_EXCEEDED.getCode());
+    assertThat(failed.getPgFailureCode()).isNull();
+    assertThat(failed.getPgFailureReason()).isNull();
   }
 
   @Test

--- a/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/domain/entity/PaymentTest.java
+++ b/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/domain/entity/PaymentTest.java
@@ -78,17 +78,27 @@ class PaymentTest {
   }
 
   @Test
-  @DisplayName("failed 팩토리는 FAILED 상태로 실패 코드/사유를 담고 paymentKey는 비운다")
+  @DisplayName("failed 팩토리는 FAILED 상태로 내부·PG 원본 코드/사유를 담고 paymentKey는 비운다")
   void failed_creates_failed_payment_with_meta() {
     // when
     Payment failed =
         Payment.failed(
-            100L, 10L, 200L, PaymentProvider.TOSS, 55_000L, "PAYMENT_400_003", "결제가 거절되었습니다.");
+            100L,
+            10L,
+            200L,
+            PaymentProvider.TOSS,
+            55_000L,
+            "PAYMENT_400_003",
+            "결제가 거절되었습니다.",
+            "REJECT_CARD_COMPANY",
+            "카드사에서 거절한 카드입니다");
 
     // then
     assertThat(failed.getStatus()).isEqualTo(PaymentStatus.FAILED);
     assertThat(failed.getFailureCode()).isEqualTo("PAYMENT_400_003");
     assertThat(failed.getFailureReason()).isEqualTo("결제가 거절되었습니다.");
+    assertThat(failed.getPgFailureCode()).isEqualTo("REJECT_CARD_COMPANY");
+    assertThat(failed.getPgFailureReason()).isEqualTo("카드사에서 거절한 카드입니다");
     assertThat(failed.getBookingId()).isEqualTo(100L);
     assertThat(failed.getUserId()).isEqualTo(10L);
     assertThat(failed.getSeatId()).isEqualTo(200L);
@@ -98,5 +108,43 @@ class PaymentTest {
     assertThat(failed.getApprovalNumber()).isNull();
     assertThat(failed.getPaidAt()).isNull();
     assertThat(failed.isAlreadyProcessed()).isFalse();
+  }
+
+  @Test
+  @DisplayName("failed 팩토리는 PG 원본 코드/사유가 컬럼 길이를 넘으면 잘라 담는다(50/255)")
+  void failed_truncates_pg_fields_over_column_length() {
+    // given: pgFailureCode 컬럼 길이 50, pgFailureReason 255를 초과하는 원본
+    String longCode = "C".repeat(80);
+    String longReason = "가".repeat(300);
+
+    // when
+    Payment failed =
+        Payment.failed(
+            100L,
+            10L,
+            200L,
+            PaymentProvider.TOSS,
+            55_000L,
+            "PAYMENT_400_003",
+            "거절",
+            longCode,
+            longReason);
+
+    // then
+    assertThat(failed.getPgFailureCode()).hasSize(50).isEqualTo("C".repeat(50));
+    assertThat(failed.getPgFailureReason()).hasSize(255).isEqualTo("가".repeat(255));
+  }
+
+  @Test
+  @DisplayName("failed 팩토리는 PG 원본이 없으면(null) 그대로 null로 둔다")
+  void failed_allows_null_pg_fields() {
+    // when
+    Payment failed =
+        Payment.failed(
+            100L, 10L, 200L, PaymentProvider.TOSS, 55_000L, "PAYMENT_400_003", "거절", null, null);
+
+    // then
+    assertThat(failed.getPgFailureCode()).isNull();
+    assertThat(failed.getPgFailureReason()).isNull();
   }
 }

--- a/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/out/apiclient/TossPaymentApprovalClientTest.java
+++ b/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/out/apiclient/TossPaymentApprovalClientTest.java
@@ -162,6 +162,40 @@ class TossPaymentApprovalClientTest {
     mockServer.verify();
   }
 
+  @Test
+  @DisplayName("Toss 4xx 거절 시 원본 code/message를 PgRejectionException에 실어 던진다")
+  void approve_carries_raw_toss_code_and_message() {
+    expect4xxWithCode("REJECT_CARD_COMPANY");
+
+    assertThatThrownBy(
+            () ->
+                client.approve(
+                    new PaymentApprovalRequest(
+                        PaymentProvider.TOSS, "pgKey_xyz", "BKG-0000100", 100L, 55_000L)))
+        .isInstanceOf(PgRejectionException.class)
+        .extracting("errorStatus", "rawCode", "rawMessage")
+        .containsExactly(ErrorStatus.PAYMENT_METHOD_REJECTED, "REJECT_CARD_COMPANY", "테스트 거절 메시지");
+
+    mockServer.verify();
+  }
+
+  @Test
+  @DisplayName("미정의 코드도 매핑 이전 원본 code를 그대로 보존한다")
+  void approve_preserves_raw_code_for_unknown() {
+    expect4xxWithCode("SOME_UNDEFINED_TOSS_CODE");
+
+    assertThatThrownBy(
+            () ->
+                client.approve(
+                    new PaymentApprovalRequest(
+                        PaymentProvider.TOSS, "pgKey_xyz", "BKG-0000100", 100L, 55_000L)))
+        .isInstanceOf(PgRejectionException.class)
+        .extracting("rawCode")
+        .isEqualTo("SOME_UNDEFINED_TOSS_CODE");
+
+    mockServer.verify();
+  }
+
   private void expect4xxWithCode(String tossCode) {
     mockServer
         .expect(requestTo(CONFIRM_URL))


### PR DESCRIPTION
## 🔗 관련 이슈

- close #332

---

## 📌 주요 변경 사항

- PG(Toss)가 4xx로 내려준 **원본 거절 code/message**를 결제 confirm 실패(FAILED) 이력에 저장
- 기존 내부 `ErrorStatus` 코드(#297)는 그대로 유지하고, PG 원본은 별도 컬럼에 **함께** 저장 → 카테고리 집계(내부 코드) + CS·정밀 분석(PG 원본) 양립
- 원본은 내부 추적용이므로 HTTP 응답에는 노출하지 않음

---

## 🛠 상세 구현 내용

- **`PgRejectionException`(신규)**: `BusinessException` 상속. mapped `ErrorStatus` + PG 원본 `rawCode`/`rawMessage` 보유. `super(errorStatus)`로 `data=null`을 유지해 `GlobalExceptionHandler`가 원본을 응답 body에 싣지 않도록 함
- **`TossPaymentApprovalClient`**: 4xx 분기에서 기존 `BusinessException` 대신 원본 code/message를 실은 `PgRejectionException`을 던짐(매핑 이전 raw 값 전달, errorBody 파싱 실패 시 null)
- **`Payment`**: nullable 컬럼 `pgFailureCode`(50)/`pgFailureReason`(255) 추가. `failed(...)` 팩토리를 확장하고, 컬럼 길이 초과 원본으로 이력 저장이 깨지지 않도록 팩토리 내부에서 방어적 truncate
- **`PaymentConfirmUseCase.recordFailedPayment`**: `RECORDABLE_FAILURES` 화이트리스트(무과금 확정 3건) 통과 후, 예외가 `PgRejectionException`이면 원본을 추출해 저장(아니면 null). 내부 `failureCode`/메트릭 태그 로직은 무변경
- 저장 범위는 #331 화이트리스트 3건으로 한정(UNKNOWN 승격은 후속 과제)

---

## ✅ 테스트

### 테스트 방법

- `./gradlew :payment-service:test` (전체) 및 대상 3개 클래스 개별 실행
- `TossPaymentApprovalClientTest`: 4xx 거절 시 `PgRejectionException`이 원본 code/message 보유 / 미정의 코드도 매핑 이전 raw 보존 / 기존 mapped-ErrorStatus 검증 하위호환 통과
- `PaymentConfirmUseCaseTest`: 거절 시 `pgFailureCode/Reason`==원본 & `failureCode`==내부 코드 유지 / 원본 없는(순수 BusinessException) 화이트리스트건은 pg 필드 null
- `PaymentTest`: `failed` 팩토리의 내부·PG 원본 저장, 50/255 초과 truncate, null 허용
- **라이브 검증(실제 Toss 엔드포인트)**: `POST https://api.tosspayments.com/v1/payments/confirm` 실제 4xx 응답 형태 확인

### 테스트 결과

- `BUILD SUCCESSFUL` — payment-service 전체 테스트 통과 (신규/수정 케이스 + 기존 회귀)
- **라이브 검증 결과**: 실제 Toss 거절 응답이 `{"code":"UNAUTHORIZED_KEY","message":"...","data":null}` 형태로 반환됨을 확인
  - 응답 형태가 `TossErrorResponse(code, message)` 파싱 가정과 일치
  - 원본 코드 `UNAUTHORIZED_KEY`(16자)가 `pgFailureCode` 컬럼(50) 안에 안전하게 들어옴
  - 응답에 포함된 예상 밖 `data` 필드는 `@JsonIgnoreProperties(ignoreUnknown=true)`로 정상 흡수
  - ※ 화이트리스트 거절(REJECT_CARD 등) → DB 저장까지의 풀 플로우는 Toss 샌드박스 시크릿 키·결제 세션이 필요해 별도 수동 시연 필요

### 📸 스크린샷

- 

---

## 👀 리뷰 요청 사항

- 전달 통로로 `PgRejectionException`(payment-service 내부 전용) 도입 방향이 적절한지 (common `BusinessException.data` 재사용 시 HTTP 응답 노출 회피 목적)
- PG 원본 저장 컬럼 분리(pgFailureCode/Reason) vs 기존 failureCode 재사용에 대한 의견

---

## ⚠️ 배포 시 주의사항

- **prod `ddl-auto=validate`라 배포 전 아래 DDL 선실행 필수** (미적용 시 스키마 검증 실패로 payment-service 기동 불가):
  ```sql
  ALTER TABLE payment
    ADD COLUMN pg_failure_code VARCHAR(50) NULL,
    ADD COLUMN pg_failure_reason VARCHAR(255) NULL;
  ```
- 신규 컬럼은 nullable이라 기존 결제 row와 호환됨(성공 결제·기존 FAILED는 NULL)
