### PR TITLE
[Infra] #342 부하 테스트 인프라 구축 (k6 시나리오 + 대량 SQL 시딩 + remote-write 연동)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -103,6 +103,29 @@ services:
     networks:
       - ticketrush-net
 
+  # 부하 생성기. run-to-completion이라 상시 기동 대상이 아니므로 profile로 분리한다.
+  #   실행: docker compose run --rm k6 run /scripts/scenarios/seat-layouts.js
+  #   K6_OUT로 remote-write가 기본 적용되어 -o 플래그 없이도 Prometheus로 push된다.
+  #   같은 네트워크라 prometheus엔 서비스명으로, 호스트에서 도는 앱엔 host.docker.internal로 접근.
+  # ponytail: 부하 생성기와 대상이 같은 머신이라 리소스는 공유된다. 큰 부하는 별도 머신에서.
+  k6:
+    image: grafana/k6:latest
+    container_name: k6
+    profiles: ["loadtest"]
+    depends_on:
+      - prometheus
+    environment:
+      K6_OUT: experimental-prometheus-rw
+      K6_PROMETHEUS_RW_SERVER_URL: http://prometheus:9090/api/v1/write
+      K6_PROMETHEUS_RW_TREND_STATS: "p(95),p(99),avg"
+      BASE_URL: http://host.docker.internal:8080
+    volumes:
+      - ./load-test:/scripts:ro
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    networks:
+      - ticketrush-net
+
 volumes:
   redis_data:
   kafka-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -65,6 +65,14 @@ services:
   prometheus:
     image: prom/prometheus:v2.53.0
     container_name: prometheus
+    # command는 이미지 기본 CMD를 통째로 덮으므로 기본 플래그를 재명시해야 한다.
+    # 마지막 줄만 실질 변경: k6 remote-write(-o experimental-prometheus-rw) 수신용 receiver 활성화.
+    command:
+      - "--config.file=/etc/prometheus/prometheus.yml"
+      - "--storage.tsdb.path=/prometheus"
+      - "--web.console.libraries=/usr/share/prometheus/console_libraries"
+      - "--web.console.templates=/usr/share/prometheus/consoles"
+      - "--web.enable-remote-write-receiver"
     ports:
       - "127.0.0.1:9090:9090"
     volumes:

--- a/docs/load-test-guide.md
+++ b/docs/load-test-guide.md
@@ -1,0 +1,102 @@
+# 부하 테스트 실행 가이드
+
+seat/booking/ticket 핫패스의 처리량·latency를 k6로 측정하고, 기존 Prometheus + Grafana 스택에서 관측한다.
+
+## 1. 개요
+
+```
+k6 (호스트) --(remote-write)--> Prometheus :9090 --(scrape)--> Grafana :3000
+                                     ↑
+              앱 8개 /actuator/prometheus (기존 scrape)
+```
+
+- k6 결과는 **내장 remote-write 출력**(`-o experimental-prometheus-rw`)으로 Prometheus에 push한다. 커스텀 xk6 빌드나 InfluxDB는 쓰지 않는다.
+- k6 시계열(`k6_*`)과 앱 계측(`ticketrush_*`)이 같은 Prometheus에 모여, 하나의 Grafana에서 교차 관측된다.
+
+## 2. 사전 조건
+
+### 2.1 도구
+- [k6](https://grafana.com/docs/k6/latest/set-up/install-k6/) (remote-write 출력은 v0.42+ 내장)
+- MySQL 클라이언트 (`mysql`), MySQL **8.0+** (시딩 스크립트가 재귀 CTE·윈도우 함수 사용)
+
+### 2.2 모니터링 스택
+```bash
+docker compose up -d prometheus grafana
+```
+`docker-compose.yml`의 prometheus에 `--web.enable-remote-write-receiver`가 포함되어 있어 `/api/v1/write` 수신 엔드포인트가 열린다. 확인:
+```bash
+curl -s -o /dev/null -w "%{http_code}\n" -XPOST http://localhost:9090/api/v1/write
+# 405/400 등 응답이 오면 receiver 활성(연결 거부가 아니면 OK)
+```
+
+### 2.3 앱 스택
+MySQL(3306)과 측정 대상 서비스를 호스트에서 기동한다. 최소 구성:
+- 게이트웨이 8080, auth 8082(DevToken), booking 8084, seat 8086
+- DB 계정은 `.env.local`의 `MYSQL_USERNAME`/`MYSQL_PASSWORD`
+
+> DevToken(`/api/v1/dev/auth/token`)은 `local`/`dev` 프로파일에서만 노출된다.
+
+## 3. 대량 데이터 시딩
+
+`load-test/seed/seed_load.sql` 상단 `@vars`로 규모를 정한다:
+
+| 변수 | 의미 | 기본 |
+|------|------|------|
+| `@perf_count` | 공연 수 | 10 |
+| `@rows_per` | 공연당 좌석 행(≤26) | 20 |
+| `@cols_per` | 공연당 좌석 열 | 30 |
+| `@booking_pct` | PENDING 예매+HOLD 선점 비율(%) | 0 |
+
+총 좌석 = `perf_count × rows_per × cols_per`. 수십만 건은 `perf_count`/`cols_per`를 키운다.
+
+```bash
+# 시딩 (idempotent: 마커 LOADTEST 기준, 재실행은 cleanup 먼저)
+mysql -h 127.0.0.1 -u "$MYSQL_USERNAME" -p"$MYSQL_PASSWORD" ticket_rush < load-test/seed/seed_load.sql
+
+# 리셋(규모 변경/정리) → 반드시 cleanup 먼저, 그다음 재시딩
+mysql -h 127.0.0.1 -u "$MYSQL_USERNAME" -p"$MYSQL_PASSWORD" ticket_rush < load-test/seed/cleanup_load.sql
+```
+
+시딩 끝에 검증 카운트(performances/seats/bookings)가 출력된다. `@booking_pct>0`이면 이슈의 "PENDING 예매 대량 생성(만료/조회/인덱스 측정)" 요건을 만족한다.
+
+## 4. k6 실행
+
+공통 환경변수:
+```bash
+export K6_PROMETHEUS_RW_SERVER_URL=http://localhost:9090/api/v1/write
+export K6_PROMETHEUS_RW_TREND_STATS="p(95),p(99),avg"   # 미설정 시 p95가 Grafana에서 비어 보임
+```
+
+시나리오 파라미터는 `-e KEY=VALUE`로 덮는다 (`BASE_URL, PERF_ID, USER_ID, SEAT_ID_MIN, SEAT_ID_MAX, VUS, RAMP, STEADY`).
+
+```bash
+# (b) 좌석 조회 — 인증 불필요, 먼저 파이프라인 검증용
+k6 run -o experimental-prometheus-rw \
+  -e PERF_ID=1 -e VUS=50 \
+  load-test/scenarios/seat-layouts.js
+
+# (a) 예매 생성 — setup()에서 DevToken 자동 발급 후 Bearer 호출
+k6 run -o experimental-prometheus-rw \
+  -e PERF_ID=1 -e USER_ID=1 -e SEAT_ID_MIN=1 -e SEAT_ID_MAX=6000 \
+  load-test/scenarios/booking-create.js
+```
+
+## 5. Grafana 관측
+
+1. http://localhost:3000 (기본 `admin`/`admin`) 접속
+2. Explore → datasource Prometheus(uid `prometheus`)
+3. 처리량·latency:
+   - `rate(k6_http_reqs_total[1m])` — 초당 요청 수
+   - `k6_http_req_duration` (p95 등) — 응답 지연
+4. 앱 계측 교차 확인:
+   - `rate(ticketrush_booking_created_total[1m])` — 예매 생성 소화율
+   - `ticketrush_seat_lock_contention_total` — 좌석 락 경합
+   - `ticketrush_outbox_backlog`, `ticketrush_kafka_inbox_total` — 파이프라인 적체/멱등
+5. (선택) 반복 관측이 필요해지면 k6용 대시보드 JSON을 `monitoring/grafana/dashboards/`에 추가하면 provisioning이 자동 로드한다.
+
+## 6. 트러블슈팅 / 리스크
+
+- **좌석 고갈**: 예매 부하가 좌석을 HOLD로 소모해 지속 부하 시 `SEAT_NOT_AVAILABLE`이 늘 수 있다. 대응 — `@cols_per`를 키워 AVAILABLE 풀을 크게, `SEAT_ID_MAX`를 넓게 분산, 실행 사이 cleanup+재시드 또는 `UPDATE seat SET seat_status='AVAILABLE', booking_number=NULL, hold_expired_at=NULL WHERE ...`로 리셋. 순수 처리량은 좌석 조회 시나리오로, 예매는 짧은 스파이크로 본다.
+- **Grafana에 p95가 없음**: `K6_PROMETHEUS_RW_TREND_STATS` 설정 확인.
+- **remote-write 연결 실패**: prometheus 컨테이너에 receiver 플래그가 적용됐는지(`docker inspect prometheus`의 command), 포트 9090 매핑 확인.
+- **공유/운영 DB 시딩 금지**: 시딩·cleanup은 마커 범위만 건드리지만 반드시 로컬 전용 DB에서만 실행한다.

--- a/docs/load-test-guide.md
+++ b/docs/load-test-guide.md
@@ -5,18 +5,20 @@ seat/booking/ticket 핫패스의 처리량·latency를 k6로 측정하고, 기�
 ## 1. 개요
 
 ```
-k6 (호스트) --(remote-write)--> Prometheus :9090 --(scrape)--> Grafana :3000
-                                     ↑
-              앱 8개 /actuator/prometheus (기존 scrape)
+k6 (컨테이너, loadtest profile) --(remote-write)--> Prometheus :9090 --(scrape)--> Grafana :3000
+                                                          ↑
+                        앱 8개(호스트) /actuator/prometheus (기존 scrape)
 ```
 
-- k6 결과는 **내장 remote-write 출력**(`-o experimental-prometheus-rw`)으로 Prometheus에 push한다. 커스텀 xk6 빌드나 InfluxDB는 쓰지 않는다.
+- k6는 docker-compose의 `loadtest` profile 컨테이너로 실행한다(호스트에 k6 설치 불필요, 평소 `up`엔 안 뜸).
+- k6 결과는 **내장 remote-write 출력**(`experimental-prometheus-rw`, compose의 `K6_OUT`로 기본 적용)으로 Prometheus에 push한다. 커스텀 xk6 빌드나 InfluxDB는 쓰지 않는다.
+- 부하 생성기와 대상이 같은 머신을 공유하므로 리소스가 경쟁한다. 큰 규모 부하는 별도 머신에서 이 k6 서비스 정의를 재사용해 실행하는 것을 권장한다.
 - k6 시계열(`k6_*`)과 앱 계측(`ticketrush_*`)이 같은 Prometheus에 모여, 하나의 Grafana에서 교차 관측된다.
 
 ## 2. 사전 조건
 
 ### 2.1 도구
-- [k6](https://grafana.com/docs/k6/latest/set-up/install-k6/) (remote-write 출력은 v0.42+ 내장)
+- Docker / Docker Compose (k6는 `loadtest` profile 컨테이너로 실행 — 로컬 k6 설치 불필요)
 - MySQL 클라이언트 (`mysql`), MySQL **8.0+** (시딩 스크립트가 재귀 CTE·윈도우 함수 사용)
 
 ### 2.2 모니터링 스택
@@ -61,25 +63,23 @@ mysql -h 127.0.0.1 -u "$MYSQL_USERNAME" -p"$MYSQL_PASSWORD" ticket_rush < load-t
 
 ## 4. k6 실행
 
-공통 환경변수:
-```bash
-export K6_PROMETHEUS_RW_SERVER_URL=http://localhost:9090/api/v1/write
-export K6_PROMETHEUS_RW_TREND_STATS="p(95),p(99),avg"   # 미설정 시 p95가 Grafana에서 비어 보임
-```
+k6는 `loadtest` profile 컨테이너로 실행한다. remote-write 관련 설정(`K6_OUT`, `K6_PROMETHEUS_RW_SERVER_URL`, `K6_PROMETHEUS_RW_TREND_STATS`)과 `BASE_URL`(→ `host.docker.internal:8080`)은 compose에 정의돼 있어 매번 `-o`/URL을 줄 필요가 없다.
 
-시나리오 파라미터는 `-e KEY=VALUE`로 덮는다 (`BASE_URL, PERF_ID, USER_ID, SEAT_ID_MIN, SEAT_ID_MAX, VUS, RAMP, STEADY`).
+스크립트는 `./load-test`가 컨테이너 안 `/scripts`로 마운트된다. 시나리오 파라미터는 `-e KEY=VALUE`로 덮는다 (`BASE_URL, PERF_ID, USER_ID, SEAT_ID_MIN, SEAT_ID_MAX, VUS, RAMP, STEADY`).
 
 ```bash
 # (b) 좌석 조회 — 인증 불필요, 먼저 파이프라인 검증용
-k6 run -o experimental-prometheus-rw \
+docker compose run --rm k6 run \
   -e PERF_ID=1 -e VUS=50 \
-  load-test/scenarios/seat-layouts.js
+  /scripts/scenarios/seat-layouts.js
 
 # (a) 예매 생성 — setup()에서 DevToken 자동 발급 후 Bearer 호출
-k6 run -o experimental-prometheus-rw \
+docker compose run --rm k6 run \
   -e PERF_ID=1 -e USER_ID=1 -e SEAT_ID_MIN=1 -e SEAT_ID_MAX=6000 \
-  load-test/scenarios/booking-create.js
+  /scripts/scenarios/booking-create.js
 ```
+
+> 대상 앱(게이트웨이·auth·seat 등)은 호스트에서 기동 중이어야 하고, prometheus/grafana 스택도 먼저 떠 있어야 한다(2.2). 컨테이너는 이들에 `host.docker.internal`로 접근한다.
 
 ## 5. Grafana 관측
 
@@ -97,6 +97,7 @@ k6 run -o experimental-prometheus-rw \
 ## 6. 트러블슈팅 / 리스크
 
 - **좌석 고갈**: 예매 부하가 좌석을 HOLD로 소모해 지속 부하 시 `SEAT_NOT_AVAILABLE`이 늘 수 있다. 대응 — `@cols_per`를 키워 AVAILABLE 풀을 크게, `SEAT_ID_MAX`를 넓게 분산, 실행 사이 cleanup+재시드 또는 `UPDATE seat SET seat_status='AVAILABLE', booking_number=NULL, hold_expired_at=NULL WHERE ...`로 리셋. 순수 처리량은 좌석 조회 시나리오로, 예매는 짧은 스파이크로 본다.
-- **Grafana에 p95가 없음**: `K6_PROMETHEUS_RW_TREND_STATS` 설정 확인.
-- **remote-write 연결 실패**: prometheus 컨테이너에 receiver 플래그가 적용됐는지(`docker inspect prometheus`의 command), 포트 9090 매핑 확인.
+- **Grafana에 p95가 없음**: compose의 `K6_PROMETHEUS_RW_TREND_STATS` 설정 확인.
+- **remote-write 연결 실패**: k6 컨테이너와 prometheus가 같은 `ticketrush-net`에 있는지, prometheus에 receiver 플래그가 적용됐는지(`docker inspect prometheus`의 command) 확인.
+- **앱 접근 실패**: 대상 서비스가 호스트에서 기동 중인지, k6 컨테이너의 `BASE_URL`이 `host.docker.internal:8080`인지 확인(Linux는 compose의 `extra_hosts`로 매핑됨).
 - **공유/운영 DB 시딩 금지**: 시딩·cleanup은 마커 범위만 건드리지만 반드시 로컬 전용 DB에서만 실행한다.

--- a/load-test/README.md
+++ b/load-test/README.md
@@ -10,6 +10,8 @@ load-test/
 └── seed/     # seed_load.sql(대량 시딩), cleanup_load.sql(정리)
 ```
 
+k6는 docker-compose의 `loadtest` profile로 분리된 컨테이너에서 실행한다(상시 기동 대상 아님).
+
 빠른 실행:
 
 ```bash
@@ -19,10 +21,8 @@ docker compose up -d prometheus grafana
 # 2) 대량 시딩 (규모는 seed_load.sql 상단 @vars 에서 조정)
 mysql -h 127.0.0.1 -u "$MYSQL_USERNAME" -p"$MYSQL_PASSWORD" ticket_rush < seed/seed_load.sql
 
-# 3) k6 실행 → Prometheus remote-write → Grafana
-K6_PROMETHEUS_RW_SERVER_URL=http://localhost:9090/api/v1/write \
-K6_PROMETHEUS_RW_TREND_STATS="p(95),p(99),avg" \
-k6 run -o experimental-prometheus-rw scenarios/seat-layouts.js
+# 3) k6 실행 (컨테이너, remote-write는 K6_OUT로 기본 적용) → Grafana
+docker compose run --rm k6 run /scripts/scenarios/seat-layouts.js
 ```
 
 상세(사전조건·Grafana 관측·트러블슈팅)는 [`docs/load-test-guide.md`](../docs/load-test-guide.md) 참고.

--- a/load-test/README.md
+++ b/load-test/README.md
@@ -1,0 +1,28 @@
+# load-test
+
+seat/booking/ticket 핫패스 성능·정합성을 정량 측정하기 위한 k6 부하 테스트 인프라.
+
+```
+load-test/
+├── config/   # env.js(환경변수), options.js(공통 stages·thresholds)
+├── lib/      # auth.js(DevToken 발급)
+├── scenarios/# booking-create.js(예매 생성, 인증), seat-layouts.js(좌석 조회, 비인증)
+└── seed/     # seed_load.sql(대량 시딩), cleanup_load.sql(정리)
+```
+
+빠른 실행:
+
+```bash
+# 1) 모니터링 스택 (remote-write receiver 포함)
+docker compose up -d prometheus grafana
+
+# 2) 대량 시딩 (규모는 seed_load.sql 상단 @vars 에서 조정)
+mysql -h 127.0.0.1 -u "$MYSQL_USERNAME" -p"$MYSQL_PASSWORD" ticket_rush < seed/seed_load.sql
+
+# 3) k6 실행 → Prometheus remote-write → Grafana
+K6_PROMETHEUS_RW_SERVER_URL=http://localhost:9090/api/v1/write \
+K6_PROMETHEUS_RW_TREND_STATS="p(95),p(99),avg" \
+k6 run -o experimental-prometheus-rw scenarios/seat-layouts.js
+```
+
+상세(사전조건·Grafana 관측·트러블슈팅)는 [`docs/load-test-guide.md`](../docs/load-test-guide.md) 참고.

--- a/load-test/config/env.js
+++ b/load-test/config/env.js
@@ -1,0 +1,14 @@
+// k6 시나리오 공통 환경변수 파싱 + 기본값. 실행 시 `-e KEY=VALUE` 또는 K6_* 로 덮는다.
+export const BASE_URL = __ENV.BASE_URL || 'http://localhost:8080'; // 게이트웨이
+
+export const PERF_ID = Number(__ENV.PERF_ID || 1); // 시딩한 공연 ID
+export const USER_ID = Number(__ENV.USER_ID || 1); // DevToken 발급 대상
+
+// booking 시나리오가 예매 시도할 seat_id 범위(시딩 규모에 맞춰 넓게 잡아 좌석 고갈 완화)
+export const SEAT_ID_MIN = Number(__ENV.SEAT_ID_MIN || 1);
+export const SEAT_ID_MAX = Number(__ENV.SEAT_ID_MAX || 100);
+
+// 부하 프로파일(램프업)
+export const VUS = Number(__ENV.VUS || 50);
+export const RAMP = __ENV.RAMP || '30s';
+export const STEADY = __ENV.STEADY || '1m';

--- a/load-test/config/options.js
+++ b/load-test/config/options.js
@@ -1,0 +1,15 @@
+import { VUS, RAMP, STEADY } from './env.js';
+
+// 전 시나리오 공통 옵션. 시나리오가 spread 후 필요한 필드만 덮어쓴다.
+export const baseOptions = {
+  stages: [
+    { duration: RAMP, target: VUS }, // 램프업
+    { duration: STEADY, target: VUS }, // 정상 부하
+    { duration: RAMP, target: 0 }, // 램프다운
+  ],
+  thresholds: {
+    // ponytail: 초기 기준값. 실측 후 read/write 시나리오별로 조정(read는 더 타이트하게).
+    http_req_duration: ['p(95)<800'],
+    http_req_failed: ['rate<0.01'],
+  },
+};

--- a/load-test/lib/auth.js
+++ b/load-test/lib/auth.js
@@ -1,0 +1,14 @@
+import http from 'k6/http';
+import { check } from 'k6';
+import { BASE_URL } from '../config/env.js';
+
+// DevToken 발급(local/dev 프로파일 전용): POST /api/v1/dev/auth/token → access token.
+// 응답은 ApiResponse 래핑이라 result.accessToken 으로 꺼낸다.
+// 시나리오 setup()에서 1회만 호출할 것(VU마다 발급하면 auth가 병목처럼 왜곡된다).
+export function devToken(userId) {
+  const res = http.post(`${BASE_URL}/api/v1/dev/auth/token`, JSON.stringify({ userId }), {
+    headers: { 'Content-Type': 'application/json' },
+  });
+  check(res, { 'devToken 200': (r) => r.status === 200 });
+  return res.json('result.accessToken');
+}

--- a/load-test/scenarios/booking-create.js
+++ b/load-test/scenarios/booking-create.js
@@ -1,0 +1,35 @@
+// (a) 예매 생성 핫패스 — POST /api/v1/booking (인증). 좌석 락/HOLD는 이 요청이 발행한
+// Kafka 이벤트로 비동기 처리되므로 HTTP 응답은 대부분 201이고, 경합은 seat-service 메트릭에서 드러난다.
+import http from 'k6/http';
+import { check } from 'k6';
+import { Rate } from 'k6/metrics';
+import { BASE_URL, PERF_ID, USER_ID, SEAT_ID_MIN, SEAT_ID_MAX } from '../config/env.js';
+import { baseOptions } from '../config/options.js';
+import { devToken } from '../lib/auth.js';
+
+export const options = baseOptions;
+
+// 좌석 경합/선점불가(4xx)는 부하 결과에선 실패가 아니라 별도 관측치.
+const seatConflict = new Rate('seat_conflict');
+
+export function setup() {
+  return { token: devToken(USER_ID) };
+}
+
+export default function (data) {
+  // seat_id를 VU/반복으로 분산해 특정 좌석 집중·고갈을 완화(ponytail: 단순 분산이라 완전 유일성은 아님).
+  const span = SEAT_ID_MAX - SEAT_ID_MIN + 1;
+  const seatId = SEAT_ID_MIN + ((__VU * 1000 + __ITER) % span);
+
+  const res = http.post(
+    `${BASE_URL}/api/v1/booking`,
+    JSON.stringify({ performance_id: PERF_ID, seat_id: seatId }),
+    { headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${data.token}` } },
+  );
+
+  seatConflict.add(res.status === 409 || res.status === 400);
+  check(res, {
+    'booking created(201) or conflict': (r) =>
+      r.status === 201 || r.status === 409 || r.status === 400,
+  });
+}

--- a/load-test/scenarios/seat-layouts.js
+++ b/load-test/scenarios/seat-layouts.js
@@ -1,0 +1,12 @@
+// (b) 좌석 조회 핫패스 — 인증 불필요. read 시나리오.
+import http from 'k6/http';
+import { check } from 'k6';
+import { BASE_URL, PERF_ID } from '../config/env.js';
+import { baseOptions } from '../config/options.js';
+
+export const options = baseOptions;
+
+export default function () {
+  const res = http.get(`${BASE_URL}/api/v1/seat/${PERF_ID}/seat-layouts`);
+  check(res, { 'seat-layouts 200': (r) => r.status === 200 });
+}

--- a/load-test/seed/cleanup_load.sql
+++ b/load-test/seed/cleanup_load.sql
@@ -1,0 +1,21 @@
+-- ============================================================================
+-- 부하 테스트 시딩 데이터 정리 (마커 @marker 범위만 삭제).
+--   DB-level FK가 없으므로 앱 정합 역순으로 삭제: booking -> seat -> seat_layout -> performance.
+--   performance를 마지막에 지워야 앞의 JOIN으로 대상 범위를 찾을 수 있다.
+--   ⚠ 로컬 전용 DB에서만 실행할 것.
+-- ============================================================================
+SET @marker = 'LOADTEST';
+
+DELETE b FROM booking b
+JOIN performance p ON p.performance_id = b.performance_id
+WHERE p.title LIKE CONCAT(@marker, '-%');
+
+DELETE s FROM seat s
+JOIN performance p ON p.performance_id = s.performance_id
+WHERE p.title LIKE CONCAT(@marker, '-%');
+
+DELETE sl FROM seat_layout sl
+JOIN performance p ON p.performance_id = sl.performance_id
+WHERE p.title LIKE CONCAT(@marker, '-%');
+
+DELETE FROM performance WHERE title LIKE CONCAT(@marker, '-%');

--- a/load-test/seed/seed_load.sql
+++ b/load-test/seed/seed_load.sql
@@ -1,0 +1,92 @@
+-- ============================================================================
+-- 부하 테스트용 대량 데이터 시딩 (MySQL 8.0+ / 스키마 ticket_rush)
+--   생성 순서: performance -> seat_layout -> seat -> (선택) booking + seat HOLD
+--   전 로우는 title 마커(@marker)로 표식 -> cleanup_load.sql 로 일괄 삭제.
+--   표준 재실행 절차: cleanup_load.sql 먼저 -> seed_load.sql.
+--   ⚠ 로컬 전용 DB에서만 실행할 것 (공유/운영 DB 금지).
+-- ============================================================================
+
+-- ---- 규모 파라미터 (여기만 조정) -------------------------------------------
+SET @perf_count  = 10;   -- 공연 수
+SET @rows_per    = 20;   -- 공연당 좌석 행 수  (ponytail: 'A'~'Z' 사용, 26 이하로. 초과 시 CHAR 확장 필요)
+SET @cols_per    = 30;   -- 공연당 좌석 열 수  -> 공연당 좌석 = rows*cols
+SET @booking_pct = 0;    -- 좌석 중 PENDING 예매+HOLD로 선점할 비율(%) (0 = 좌석만 생성)
+SET @marker      = 'LOADTEST';
+-- 공연당 좌석 rows*cols, 총 좌석 = perf_count*rows*cols (예: 10*20*30 = 6,000)
+-- 재귀 CTE 깊이는 max(perf_count, rows, cols)까지만 쓰므로 여유있게 상향.
+SET SESSION cte_max_recursion_depth = 100000;
+
+-- ---- 1) performance --------------------------------------------------------
+-- @SQLRestriction(deleted_at IS NULL)은 앱 레벨이라 직접 INSERT엔 무관. status는 ON_SALE 직접 지정.
+-- created_at/updated_at은 JPA Auditing이 채우는 값이라 직삽입 시 NOW() 명시 필수.
+INSERT INTO performance
+  (title, genre, show_date, show_time, duration_minutes, price, total_seats,
+   performance_status, created_at, updated_at)
+WITH RECURSIVE p(n) AS (
+  SELECT 1 UNION ALL SELECT n + 1 FROM p WHERE n < @perf_count
+)
+SELECT CONCAT(@marker, '-', LPAD(p.n, 6, '0')),
+       'MUSICAL', CURDATE() + INTERVAL 30 DAY, '19:00:00',
+       120, 50000, @rows_per * @cols_per, 'ON_SALE', NOW(), NOW()
+FROM p
+WHERE NOT EXISTS (
+  SELECT 1 FROM performance ex WHERE ex.title = CONCAT(@marker, '-', LPAD(p.n, 6, '0'))
+);
+
+-- ---- 2) seat_layout (공연당 1건, performance_id UNIQUE) ---------------------
+INSERT INTO seat_layout (performance_id, total_rows, max_cols, created_at, updated_at)
+SELECT p.performance_id, @rows_per, @cols_per, NOW(), NOW()
+FROM performance p
+WHERE p.title LIKE CONCAT(@marker, '-%')
+  AND NOT EXISTS (SELECT 1 FROM seat_layout sl WHERE sl.performance_id = p.performance_id);
+
+-- ---- 3) seat (공연 × 행 × 열, 전부 AVAILABLE, seat_number = 'A-1' 형식) -----
+INSERT INTO seat (seat_layout_id, performance_id, seat_number, seat_status, created_at, updated_at)
+WITH RECURSIVE
+  r(ri) AS (SELECT 1 UNION ALL SELECT ri + 1 FROM r WHERE ri < @rows_per),
+  c(ci) AS (SELECT 1 UNION ALL SELECT ci + 1 FROM c WHERE ci < @cols_per)
+SELECT sl.seat_layout_id, sl.performance_id,
+       CONCAT(CHAR(64 + r.ri), '-', c.ci), 'AVAILABLE', NOW(), NOW()
+FROM seat_layout sl
+JOIN performance p ON p.performance_id = sl.performance_id AND p.title LIKE CONCAT(@marker, '-%')
+CROSS JOIN r
+CROSS JOIN c
+WHERE NOT EXISTS (
+  SELECT 1 FROM seat s
+  WHERE s.performance_id = sl.performance_id
+    AND s.seat_number = CONCAT(CHAR(64 + r.ri), '-', c.ci)
+);
+
+-- ---- 4) (선택) PENDING 예매 + 좌석 HOLD 동기화 -----------------------------
+-- @booking_pct=0 이면 FLOOR(...)=0 -> 0건 삽입되어 자연스럽게 skip.
+-- 공연별 AVAILABLE 좌석의 앞쪽 pct% 를 PENDING booking으로 만들고 대응 좌석을 HOLD로 선점.
+-- booking_number는 전역 단조 seq로 결정적 생성(UNIQUE 보장, 랜덤 금지). 재실행은 cleanup 선행 전제.
+INSERT INTO booking
+  (user_id, performance_id, seat_id, booking_number, booking_status, created_at, updated_at)
+WITH ranked AS (
+  SELECT s.seat_id, s.performance_id,
+         ROW_NUMBER() OVER (PARTITION BY s.performance_id ORDER BY s.seat_id) AS rn,
+         ROW_NUMBER() OVER (ORDER BY s.seat_id)                               AS gseq
+  FROM seat s
+  JOIN performance p ON p.performance_id = s.performance_id AND p.title LIKE CONCAT(@marker, '-%')
+  WHERE s.seat_status = 'AVAILABLE'
+)
+SELECT 1, r.performance_id, r.seat_id,
+       CONCAT('LT-', LPAD(r.gseq, 10, '0')), 'PENDING', NOW(), NOW()
+FROM ranked r
+WHERE r.rn <= FLOOR(@rows_per * @cols_per * @booking_pct / 100);
+
+UPDATE seat s
+JOIN booking b ON b.seat_id = s.seat_id AND b.booking_number LIKE 'LT-%'
+SET s.seat_status    = 'HOLD',
+    s.booking_number = b.booking_number,
+    s.hold_expired_at = NOW() + INTERVAL 5 MINUTE
+WHERE s.seat_status = 'AVAILABLE' AND b.booking_status = 'PENDING';
+
+-- ---- 검증 쿼리 -------------------------------------------------------------
+SELECT
+  (SELECT COUNT(*) FROM performance WHERE title LIKE CONCAT(@marker, '-%')) AS performances,
+  (SELECT COUNT(*) FROM seat s JOIN performance p ON p.performance_id = s.performance_id
+     WHERE p.title LIKE CONCAT(@marker, '-%'))                              AS seats,
+  (SELECT COUNT(*) FROM booking b JOIN performance p ON p.performance_id = b.performance_id
+     WHERE p.title LIKE CONCAT(@marker, '-%'))                              AS bookings;


### PR DESCRIPTION
## 🔗 관련 이슈

- close #342

---

## 📌 주요 변경 사항

- `load-test/` 신설 — 재사용 가능한 k6 시나리오 템플릿(공통 옵션 + 시나리오 2개)
- 대량 데이터 시딩/정리 SQL 스크립트(공연·좌석·PENDING 예매)
- 기존 Prometheus/Grafana 스택에 k6 결과 remote-write 연동(신규 의존성 없음)
- `docs/load-test-guide.md` 실행 가이드 작성

---

## 🛠 상세 구현 내용

- **k6 시나리오** (`load-test/`)
  - `config/options.js`: 공통 stages(램프업) + thresholds(`p95<800ms`, 에러율 `<1%`)
  - `config/env.js`: `BASE_URL`/`PERF_ID`/`SEAT_ID_*`/`VUS` 등 파라미터화
  - `scenarios/booking-create.js`: `POST /api/v1/booking`(인증) — `setup()`에서 DevToken 1회 발급, seat_id 분산으로 좌석 집중 완화, 4xx(경합)는 별도 관측치
  - `scenarios/seat-layouts.js`: `GET /api/v1/seat/{id}/seat-layouts`(비인증) read 시나리오
  - `lib/auth.js`: DevToken(`/api/v1/dev/auth/token`) 발급 헬퍼
- **대량 시딩** (`load-test/seed/`)
  - `seed_load.sql`: 세트기반 재귀 CTE로 `performance→seat_layout→seat→(선택)booking` 생성. 상단 `@vars`(공연 수/행/열/예매비율)로 규모 조정, `title` 마커 기반 idempotent, `@booking_pct>0`이면 PENDING 예매 + 좌석 HOLD 동기화
  - `cleanup_load.sql`: 마커 범위만 앱 정합 역순 삭제
- **모니터링 연동** (`docker-compose.yml`)
  - prometheus에 `--web.enable-remote-write-receiver` 활성화(기본 CMD 플래그 재명시 포함) → k6 내장 `-o experimental-prometheus-rw` 수신. 커스텀 xk6 빌드·InfluxDB 불필요, scrape와 공존

---

## ✅ 테스트

### 테스트 방법

- `docker compose config` — compose 정의 유효성(command 블록 포함)
- `node --check` — k6 JS 5개 파일 문법 검증

### 테스트 결과

- `docker compose config`: 통과(`version` obsolete 경고만)
- k6 JS 5개 파일: 전부 문법 통과

### 📸 스크린샷

- [x] k6(컨테이너) → remote-write → Prometheus → Grafana 에서 관측됨을 확인 완료

- `docker compose run --rm k6 run -e PERF_ID=8 -e VUS=30 /scripts/scenarios/seat-layouts.js`

<img width="1031" height="982" alt="스크린샷 2026-07-08 161512" src="https://github.com/user-attachments/assets/dafd0eba-4772-49be-b6b9-531e596652be" />

- grafana
<img width="1911" height="884" alt="스크린샷 2026-07-08 162157" src="https://github.com/user-attachments/assets/d51b4da6-19fb-4df9-9490-5ca6944971d9" />
<img width="1909" height="863" alt="스크린샷 2026-07-08 162232" src="https://github.com/user-attachments/assets/bda67c5a-c03a-4b9d-bc7a-cb4d09f1763d" />

---

## 👀 리뷰 요청 사항

- 시딩 SQL의 세트기반 CTE 접근(재귀 CTE + 윈도우 함수, MySQL 8.0+ 전제)이 적절한지
- remote-write receiver 활성화가 기존 scrape 방식과 충돌 없는지

---

## ⚠️ 배포 시 주의사항

- 시딩/cleanup SQL은 **로컬 전용 DB에서만** 실행(마커 범위만 건드리나 공유/운영 DB 금지)
- DevToken은 `local`/`dev` 프로파일 전용 — 운영 부하 테스트엔 별도 인증 필요
