### PR TITLE
[Fix] #357 결제 webhook 재조회 전 paymentKey 형식 사전 필터로 증폭 DoS 완화

### DIFF
--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentWebhookUseCase.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentWebhookUseCase.java
@@ -8,6 +8,7 @@ import com.ticketrush.boundedcontext.payment.out.repository.PaymentRepository;
 import com.ticketrush.global.exception.BusinessException;
 import com.ticketrush.global.status.ErrorStatus;
 import java.util.Optional;
+import java.util.regex.Pattern;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -33,6 +34,14 @@ import tools.jackson.databind.json.JsonMapper;
 @RequiredArgsConstructor
 public class PaymentWebhookUseCase {
 
+  /*
+   * 재조회(외부 호출) 전에 값싸게 거를 paymentKey 형식 필터. 비인증 webhook 엔드포인트가 요청마다 Toss 조회 API를
+   * 호출하는 증폭(amplification) 벡터를 완화한다(#357). Toss는 paymentKey 최대 길이를 200자로 규정하지만 문자셋은
+   * 공식 규정이 없어(orderId만 규정), 좁은 화이트리스트는 정상 요청을 오탐 기각할 수 있다. 따라서 제어문자/공백/멀티바이트만
+   * 배제하는 넓은 인쇄가능 ASCII(0x21~0x7E, 1~200자)로 잡아 실제 Toss 키는 모두 통과시키고 가비지만 거른다.
+   */
+  private static final Pattern PAYMENT_KEY_PATTERN = Pattern.compile("[\\x21-\\x7E]{1,200}");
+
   private final PaymentInquiryClientRouter inquiryClientRouter;
   private final PaymentRepository paymentRepository;
 
@@ -47,6 +56,17 @@ public class PaymentWebhookUseCase {
       // 구독 대상이 아닌 이벤트(또는 paymentKey가 없는 이벤트)는 처리할 수 없으므로 무시한다(PG 재전송 방지를 위해 200).
       log.info("[PG-WEBHOOK] 처리 대상이 아닌 이벤트입니다. 무시합니다. eventType={}", request.eventType());
       return;
+    }
+
+    // 사전 필터(#357): 형식상 성립 불가능한 paymentKey는 정상 Toss가 절대 보내지 않으므로, 재조회(외부 호출) 전에
+    // 값싸게(CPU만으로) 거부해 비인증 webhook의 증폭(amplification) 공격 표면을 줄인다. 위조/무효로 취급해 재조회
+    // 실패와 동일하게 401로 거부한다.
+    if (!PAYMENT_KEY_PATTERN.matcher(paymentKey).matches()) {
+      // 형식 위반 값은 제어문자/CRLF를 담을 수 있어(마스킹은 새니타이즈가 아님) 로그에 내용을 찍지 않고 길이만 남긴다(로그 인젝션 방지).
+      log.warn(
+          "[PG-WEBHOOK] paymentKey 형식이 유효하지 않습니다. 재조회 없이 거부합니다. paymentKeyLength={}",
+          paymentKey.length());
+      throw new BusinessException(ErrorStatus.PAYMENT_WEBHOOK_INVALID);
     }
 
     // 재조회 검증: PG에 실제 존재하는 결제인지 확인한다. 존재하지 않으면 위조/무효 webhook으로 거부하고,

--- a/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentWebhookUseCaseTest.java
+++ b/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentWebhookUseCaseTest.java
@@ -71,6 +71,15 @@ class PaymentWebhookUseCaseTest {
                     PAYMENT_KEY, "BKG-0000100", 55_000L, "DONE", LocalDateTime.now())));
   }
 
+  /** 형식상 유효한 paymentKey 전용 헬퍼. 인자를 JSON 이스케이프하지 않으므로 {@code "}·{@code \} 등이 든 키에는 쓰지 않는다. */
+  private byte[] bodyWithKey(String paymentKey) {
+    String json =
+        "{ \"eventType\": \"PAYMENT_STATUS_CHANGED\", \"data\": { \"paymentKey\": \""
+            + paymentKey
+            + "\", \"orderId\": \"BKG-0000100\", \"status\": \"DONE\" } }";
+    return json.getBytes(StandardCharsets.UTF_8);
+  }
+
   @Test
   @DisplayName("재조회로 존재가 확인되고 COMPLETED 결제가 있으면 멱등 처리하고 예외 없이 끝난다")
   void handle_idempotent_when_payment_completed() {
@@ -140,6 +149,56 @@ class PaymentWebhookUseCaseTest {
     assertThatCode(() -> paymentWebhookUseCase.handle(bodyWithoutKey)).doesNotThrowAnyException();
     verify(inquiryClientRouter, never()).inquire(any(), any());
     verify(paymentRepository, never()).findByPaymentKey(any());
+  }
+
+  @Test
+  @DisplayName("paymentKey가 200자를 초과하면 재조회 없이 PAYMENT_401_001로 거부한다(증폭 방어)")
+  void handle_rejects_when_payment_key_too_long() {
+    // given
+    byte[] tooLong = bodyWithKey("a".repeat(201));
+
+    // when & then
+    assertThatThrownBy(() -> paymentWebhookUseCase.handle(tooLong))
+        .isInstanceOf(BusinessException.class)
+        .extracting("errorStatus")
+        .isEqualTo(ErrorStatus.PAYMENT_WEBHOOK_INVALID);
+    verify(inquiryClientRouter, never()).inquire(any(), any());
+    verify(paymentRepository, never()).findByPaymentKey(any());
+  }
+
+  @Test
+  @DisplayName("paymentKey에 제어문자가 섞이면 재조회 없이 PAYMENT_401_001로 거부한다(증폭 방어)")
+  void handle_rejects_when_payment_key_has_control_char() {
+    // given (JSON 이스케이프 \n → 파싱 시 실제 개행 0x0A, 인쇄가능 ASCII 범위 밖)
+    byte[] withControlChar =
+        "{ \"eventType\": \"PAYMENT_STATUS_CHANGED\", \"data\": { \"paymentKey\": \"toss\\nkey\", \"orderId\": \"BKG-0000100\", \"status\": \"DONE\" } }"
+            .getBytes(StandardCharsets.UTF_8);
+
+    // when & then
+    assertThatThrownBy(() -> paymentWebhookUseCase.handle(withControlChar))
+        .isInstanceOf(BusinessException.class)
+        .extracting("errorStatus")
+        .isEqualTo(ErrorStatus.PAYMENT_WEBHOOK_INVALID);
+    verify(inquiryClientRouter, never()).inquire(any(), any());
+    verify(paymentRepository, never()).findByPaymentKey(any());
+  }
+
+  @Test
+  @DisplayName("정확히 200자인 정상 형식 paymentKey는 사전 필터를 통과해 재조회까지 도달한다(오탐 없음)")
+  void handle_passes_filter_when_payment_key_at_boundary() {
+    // given
+    String key200 = "a".repeat(200);
+    given(inquiryClientRouter.inquire(PaymentProvider.TOSS, key200))
+        .willReturn(
+            Optional.of(
+                new PaymentInquiryResult(
+                    key200, "BKG-0000100", 55_000L, "DONE", LocalDateTime.now())));
+    given(paymentRepository.findByPaymentKey(key200)).willReturn(Optional.empty());
+
+    // when & then
+    assertThatCode(() -> paymentWebhookUseCase.handle(bodyWithKey(key200)))
+        .doesNotThrowAnyException();
+    verify(inquiryClientRouter).inquire(PaymentProvider.TOSS, key200);
   }
 
   @Test


### PR DESCRIPTION
## 🔗 관련 이슈

- close #357

---

## 📌 주요 변경 사항

- 비인증(permitAll) 결제 webhook 엔드포인트가 요청마다 Toss 조회 API로 외부 호출을 유발하던 증폭(amplification) 공격 표면을 완화 (#355 재조회 검증 도입의 후속)
- `inquire()`(외부 재조회) 직전에 값싼 `paymentKey` 형식 사전 필터를 추가해, 형식상 성립 불가능한 요청을 CPU만으로 조기 기각

---

## 🛠 상세 구현 내용

- `PaymentWebhookUseCase.handle()`에 형식 사전 필터 추가: `PAYMENT_KEY_PATTERN`으로 **인쇄가능 ASCII 1~200자**만 허용 (Toss 최대 길이 200자 규격 기반)
- 문자셋은 Toss가 `paymentKey` 규격을 **공식 미규정**하므로, 정상 요청 오탐을 피해 넓게(제어문자/공백/멀티바이트만 배제) 설정
- 형식 위반 시 재조회 없이 기존 `PAYMENT_WEBHOOK_INVALID`(401)로 거부 (재조회 위조 거부와 동일 계열, 신규 ErrorStatus 없음)
- 형식 위반 로그는 키 내용 대신 **길이만** 남겨 로그 인젝션 방지
- **완전 차단이 아닌 '부분 완화'**: 200자 이내 유효 형식 가비지는 여전히 재조회로 감. 레이트리밋/본문 크기 제한 등 근본 방어는 인프라 부재로 후속 범위(이슈 본문 반영)
- `ErrorStatus`·`SecurityConfig`·컨트롤러·common 무변경 → 타 서비스 영향 없음

---

## ✅ 테스트

### 테스트 방법

- `PaymentWebhookUseCaseTest`에 사전 필터 단위 테스트 4종 추가
  - 201자 초과 → 401 거부 + `verify(never()).inquire(...)` (재조회 미발생)
  - 제어문자(개행) 포함 → 401 거부 + 재조회 미발생
  - 200자 경계 정상 키 → 필터 통과 후 재조회 도달 (오탐 없음)
- 실행: `./gradlew :payment-service:spotlessApply :payment-service:checkstyleMain :payment-service:checkstyleTest :payment-service:compileJava :payment-service:test --tests "...PaymentWebhookUseCaseTest"`

### 테스트 결과

- BUILD SUCCESSFUL — 신규 4종 + 기존 7종 전부 통과, checkstyle(main/test)·spotless 통과

### 📸 스크린샷

- 

---

## 👀 리뷰 요청 사항

- 사전 필터 문자셋 범위(넓은 인쇄가능 ASCII)가 정상 Toss webhook 오탐을 충분히 피하는지 검토 요청
- 형식 위반 응답을 200 무시가 아닌 401 거부로 택한 판단(관측/재전송 가능성 우선) 적절성

---

## ⚠️ 배포 시 주의사항

- 없음 (DB 스키마·설정·공통 모듈 변경 없음)
