### PR TITLE
[Refactor] #367 공연 validate 내부 엔드포인트 /api/v1/internal 이동 + 내부 토큰 검증 추가

### DIFF
--- a/performance-service/build.gradle
+++ b/performance-service/build.gradle
@@ -73,6 +73,7 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
     testImplementation 'org.springframework.boot:spring-boot-starter-security-test'
     testImplementation 'org.springframework.boot:spring-boot-starter-webmvc-test'
+    testImplementation testFixtures(project(":common"))
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
     // swagger

--- a/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/in/api/v1/PerformanceInternalController.java
+++ b/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/in/api/v1/PerformanceInternalController.java
@@ -3,6 +3,7 @@ package com.ticketrush.boundedcontext.performance.in.api.v1;
 import com.ticketrush.boundedcontext.performance.app.facade.PerformanceFacade;
 import com.ticketrush.global.dto.response.ApiResponse;
 import com.ticketrush.global.status.SuccessStatus;
+import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -12,9 +13,10 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Hidden // 내부 전용 API — 공개 OpenAPI 문서(/v3/api-docs)에 노출하지 않는다.
 @Tag(name = "Performance", description = "공연 API")
 @RestController
-@RequestMapping("/api/v1/performance")
+@RequestMapping("/api/v1/internal/performance")
 @RequiredArgsConstructor
 public class PerformanceInternalController {
 

--- a/performance-service/src/main/java/com/ticketrush/global/config/InternalApiTokenFilter.java
+++ b/performance-service/src/main/java/com/ticketrush/global/config/InternalApiTokenFilter.java
@@ -1,0 +1,62 @@
+package com.ticketrush.global.config;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.security.MessageDigest;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Component
+@RequiredArgsConstructor
+public class InternalApiTokenFilter extends OncePerRequestFilter {
+
+  private static final String INTERNAL_TOKEN_HEADER = "X-Internal-Token";
+
+  private static final String INTERNAL_API_PREFIX = "/api/v1/internal/performance/";
+
+  private final CustomSecurityProperties securityProperties;
+
+  @Override
+  protected boolean shouldNotFilter(HttpServletRequest request) {
+    return !isInternalApi(request);
+  }
+
+  @Override
+  protected void doFilterInternal(
+      HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+      throws ServletException, IOException {
+
+    String expectedToken = securityProperties.getInternalToken();
+    String actualToken = request.getHeader(INTERNAL_TOKEN_HEADER);
+
+    if (!StringUtils.hasText(expectedToken)
+        || !StringUtils.hasText(actualToken)
+        || !MessageDigest.isEqual(expectedToken.getBytes(UTF_8), actualToken.getBytes(UTF_8))) {
+      response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+      return;
+    }
+
+    UsernamePasswordAuthenticationToken authentication =
+        new UsernamePasswordAuthenticationToken(
+            "internal-service", null, List.of(new SimpleGrantedAuthority("ROLE_INTERNAL")));
+
+    SecurityContextHolder.getContext().setAuthentication(authentication);
+
+    filterChain.doFilter(request, response);
+  }
+
+  private boolean isInternalApi(HttpServletRequest request) {
+    return request.getRequestURI().startsWith(INTERNAL_API_PREFIX);
+  }
+}

--- a/performance-service/src/main/java/com/ticketrush/global/config/SecurityConfig.java
+++ b/performance-service/src/main/java/com/ticketrush/global/config/SecurityConfig.java
@@ -20,16 +20,25 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 public class SecurityConfig {
 
   private final GatewayHeaderFilter gatewayHeaderFilter;
+  private final InternalApiTokenFilter internalApiTokenFilter;
 
   @Bean
   public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
     http.csrf(csrf -> csrf.disable())
         .cors(cors -> {})
+        // 필터 순서 주의: gatewayHeaderFilter가 internalApiTokenFilter보다 먼저 실행돼야 한다.
+        // 현재는 두 필터가 동일 시크릿(GATEWAY_INTERNAL_TOKEN)을 공유해 gateway가 clear하지 않으므로 안전하나,
+        // 향후 custom.security.internal-token을 gateway.internal-token과 분리하면 gatewayHeaderFilter가
+        // 토큰 불일치 시 SecurityContext를 clear한다. 그때 순서가 뒤집히면 internalApiTokenFilter가 세팅한
+        // ROLE_INTERNAL이 지워져 내부 호출이 403이 되므로, 이 순서를 반드시 유지한다.
         .addFilterBefore(gatewayHeaderFilter, UsernamePasswordAuthenticationFilter.class)
+        .addFilterBefore(internalApiTokenFilter, UsernamePasswordAuthenticationFilter.class)
         .authorizeHttpRequests(
             auth ->
                 auth.requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html")
                     .permitAll()
+                    .requestMatchers("/api/v1/internal/performance/**")
+                    .hasRole("INTERNAL")
                     .requestMatchers("/api/v1/performance/admin/**")
                     .hasRole("ADMIN")
                     .anyRequest()

--- a/performance-service/src/main/resources/application-prod.yml
+++ b/performance-service/src/main/resources/application-prod.yml
@@ -28,6 +28,9 @@ gateway:
 
 custom:
   security:
+    # 운영은 내부 API 토큰을 반드시 주입(base의 test-token 기본값 오버라이드, 미주입 시 fail-fast).
+    # gateway.internal-token과 동일한 GATEWAY_INTERNAL_TOKEN 시크릿을 의도적으로 공유한다.
+    internal-token: ${GATEWAY_INTERNAL_TOKEN}
     permit-urls:
       - /swagger-ui/**
       - /v3/api-docs/**

--- a/performance-service/src/main/resources/application.yml
+++ b/performance-service/src/main/resources/application.yml
@@ -36,6 +36,10 @@ custom:
   swagger:
     serverUrl: ${SWAGGER_SERVER_URL:http://localhost:8080}
   security:
+    # 내부 API 토큰. gateway.internal-token과 동일한 GATEWAY_INTERNAL_TOKEN 시크릿을 의도적으로 공유한다
+    # (게이트웨이↔서비스 공유 시크릿 재사용, user/auth 서비스와 동일). 분리하려면 SecurityConfig의 필터 순서
+    # (gateway 먼저 → internal 나중)를 함께 검토해야 한다.
+    internal-token: ${GATEWAY_INTERNAL_TOKEN:test-token}
     permit-all: false
     permit-urls:
       # ========== 개발 도구 ==========

--- a/performance-service/src/test/java/com/ticketrush/boundedcontext/performance/in/api/v1/PerformanceAdminControllerTest.java
+++ b/performance-service/src/test/java/com/ticketrush/boundedcontext/performance/in/api/v1/PerformanceAdminControllerTest.java
@@ -5,6 +5,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.ticketrush.boundedcontext.performance.app.facade.PerformanceFacade;
+import com.ticketrush.global.config.CustomSecurityProperties;
 import com.ticketrush.global.config.JacksonConfig;
 import com.ticketrush.global.config.SecurityConfig;
 import org.junit.jupiter.api.DisplayName;
@@ -17,7 +18,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(PerformanceAdminController.class)
-@Import({JacksonConfig.class, SecurityConfig.class})
+@Import({CustomSecurityProperties.class, JacksonConfig.class, SecurityConfig.class})
 @TestPropertySource(properties = "gateway.internal-token=test-token")
 class PerformanceAdminControllerTest {
 

--- a/performance-service/src/test/java/com/ticketrush/boundedcontext/performance/in/api/v1/PerformanceGetDetailTest.java
+++ b/performance-service/src/test/java/com/ticketrush/boundedcontext/performance/in/api/v1/PerformanceGetDetailTest.java
@@ -10,6 +10,7 @@ import com.ticketrush.boundedcontext.performance.app.dto.response.PerformanceDet
 import com.ticketrush.boundedcontext.performance.app.facade.PerformanceFacade;
 import com.ticketrush.boundedcontext.performance.domain.types.Genre;
 import com.ticketrush.boundedcontext.performance.domain.types.PerformanceStatus;
+import com.ticketrush.global.config.CustomSecurityProperties;
 import com.ticketrush.global.config.JacksonConfig;
 import com.ticketrush.global.config.SecurityConfig;
 import com.ticketrush.global.exception.BusinessException;
@@ -26,7 +27,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(PerformanceController.class)
-@Import({JacksonConfig.class, SecurityConfig.class})
+@Import({CustomSecurityProperties.class, JacksonConfig.class, SecurityConfig.class})
 class PerformanceGetDetailTest {
 
   @Autowired private MockMvc mockMvc;

--- a/performance-service/src/test/java/com/ticketrush/boundedcontext/performance/in/api/v1/PerformanceInternalControllerTest.java
+++ b/performance-service/src/test/java/com/ticketrush/boundedcontext/performance/in/api/v1/PerformanceInternalControllerTest.java
@@ -7,39 +7,51 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.ticketrush.boundedcontext.performance.app.facade.PerformanceFacade;
+import com.ticketrush.global.config.CustomSecurityProperties;
+import com.ticketrush.global.config.InternalApiTokenFilter;
+import com.ticketrush.global.config.SecurityConfig;
 import com.ticketrush.global.exception.BusinessException;
+import com.ticketrush.global.filter.GatewayHeaderFilter;
 import com.ticketrush.global.status.ErrorStatus;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
-import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(PerformanceInternalController.class)
+@Import({
+  SecurityConfig.class,
+  InternalApiTokenFilter.class,
+  GatewayHeaderFilter.class,
+  CustomSecurityProperties.class
+})
+@TestPropertySource(properties = "custom.security.internal-token=test-internal-token")
 class PerformanceInternalControllerTest {
+
+  private static final String INTERNAL_TOKEN_HEADER = "X-Internal-Token";
 
   @Autowired private MockMvc mockMvc;
 
   @MockitoBean private PerformanceFacade performanceFacade;
 
-  final String baseUrl = "/api/v1/performance";
+  final String baseUrl = "/api/v1/internal/performance";
 
   @Test
-  @WithMockUser
   @DisplayName("ON_SALE 상태 공연이면 200을 반환한다")
   void validateOnSalePerformance() throws Exception {
     doNothing().when(performanceFacade).validatePerformance(1L);
 
     mockMvc
-        .perform(get(baseUrl + "/1/validate"))
+        .perform(get(baseUrl + "/1/validate").header(INTERNAL_TOKEN_HEADER, "test-internal-token"))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.isSuccess").value(true));
   }
 
   @Test
-  @WithMockUser
   @DisplayName("ON_SALE이 아닌 공연이면 400을 반환한다")
   void validateNotOnSalePerformance() throws Exception {
     doThrow(new BusinessException(ErrorStatus.PERFORMANCE_NOT_ON_SALE))
@@ -47,14 +59,13 @@ class PerformanceInternalControllerTest {
         .validatePerformance(2L);
 
     mockMvc
-        .perform(get(baseUrl + "/2/validate"))
+        .perform(get(baseUrl + "/2/validate").header(INTERNAL_TOKEN_HEADER, "test-internal-token"))
         .andExpect(status().isBadRequest())
         .andExpect(jsonPath("$.isSuccess").value(false))
         .andExpect(jsonPath("$.code").value("PERFORMANCE_400_005"));
   }
 
   @Test
-  @WithMockUser
   @DisplayName("존재하지 않는 공연이면 404를 반환한다")
   void validateNotFoundPerformance() throws Exception {
     doThrow(new BusinessException(ErrorStatus.PERFORMANCE_NOT_FOUND))
@@ -62,7 +73,8 @@ class PerformanceInternalControllerTest {
         .validatePerformance(999L);
 
     mockMvc
-        .perform(get(baseUrl + "/999/validate"))
+        .perform(
+            get(baseUrl + "/999/validate").header(INTERNAL_TOKEN_HEADER, "test-internal-token"))
         .andExpect(status().isNotFound())
         .andExpect(jsonPath("$.isSuccess").value(false))
         .andExpect(jsonPath("$.code").value("PERFORMANCE_404_001"));

--- a/performance-service/src/test/java/com/ticketrush/boundedcontext/performance/in/api/v1/PerformanceValidationTest.java
+++ b/performance-service/src/test/java/com/ticketrush/boundedcontext/performance/in/api/v1/PerformanceValidationTest.java
@@ -11,6 +11,7 @@ import com.ticketrush.boundedcontext.performance.app.dto.request.PerformanceCrea
 import com.ticketrush.boundedcontext.performance.app.facade.PerformanceFacade;
 import com.ticketrush.boundedcontext.performance.domain.types.Genre;
 import com.ticketrush.boundedcontext.performance.domain.types.PerformanceStatus;
+import com.ticketrush.global.config.CustomSecurityProperties;
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
 import java.time.LocalTime;
@@ -18,6 +19,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.security.test.context.support.WithMockUser;
@@ -28,6 +30,7 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import tools.jackson.databind.ObjectMapper;
 
 @WebMvcTest(PerformanceAdminController.class)
+@Import(CustomSecurityProperties.class)
 class PerformanceValidationTest {
 
   @Autowired private MockMvc mockMvc;

--- a/performance-service/src/test/java/com/ticketrush/global/config/InternalApiTokenFilterTest.java
+++ b/performance-service/src/test/java/com/ticketrush/global/config/InternalApiTokenFilterTest.java
@@ -1,0 +1,68 @@
+package com.ticketrush.global.config;
+
+import static org.mockito.Mockito.doNothing;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.ticketrush.boundedcontext.performance.app.facade.PerformanceFacade;
+import com.ticketrush.boundedcontext.performance.in.api.v1.PerformanceInternalController;
+import com.ticketrush.global.filter.GatewayHeaderFilter;
+import com.ticketrush.support.WebMvcSliceTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcSliceTest(PerformanceInternalController.class)
+@Import({
+  SecurityConfig.class,
+  InternalApiTokenFilter.class,
+  GatewayHeaderFilter.class,
+  CustomSecurityProperties.class
+})
+@TestPropertySource(
+    properties = {
+      "custom.security.internal-token=test-internal-token",
+      "custom.security.permit-all=false"
+    })
+class InternalApiTokenFilterTest {
+
+  private static final String INTERNAL_TOKEN_HEADER = "X-Internal-Token";
+
+  @Autowired private MockMvc mockMvc;
+
+  @MockitoBean private PerformanceFacade performanceFacade;
+
+  @Test
+  @DisplayName("내부 API는 내부 토큰이 없으면 403 Forbidden을 반환한다")
+  void internalApi_withoutToken_forbidden() throws Exception {
+    mockMvc
+        .perform(get("/api/v1/internal/performance/1/validate"))
+        .andExpect(status().isForbidden());
+  }
+
+  @Test
+  @DisplayName("내부 API는 내부 토큰이 틀리면 403 Forbidden을 반환한다")
+  void internalApi_withWrongToken_forbidden() throws Exception {
+    mockMvc
+        .perform(
+            get("/api/v1/internal/performance/1/validate")
+                .header(INTERNAL_TOKEN_HEADER, "wrong-token"))
+        .andExpect(status().isForbidden());
+  }
+
+  @Test
+  @DisplayName("내부 API는 내부 토큰이 맞으면 요청을 통과시킨다")
+  void internalApi_withValidToken_success() throws Exception {
+    doNothing().when(performanceFacade).validatePerformance(1L);
+
+    mockMvc
+        .perform(
+            get("/api/v1/internal/performance/1/validate")
+                .header(INTERNAL_TOKEN_HEADER, "test-internal-token"))
+        .andExpect(status().isOk());
+  }
+}


### PR DESCRIPTION
## 🔗 관련 이슈

- close #367

---

## 📌 주요 변경 사항

- 공연 내부 검증 엔드포인트를 `GET /api/v1/performance/{id}/validate` → `GET /api/v1/internal/performance/{id}/validate`로 이동 (#365 internal 경로 표준)
- performance-service에 내부 토큰 검증(`InternalApiTokenFilter` + `hasRole("INTERNAL")`) 도입 — Gateway 미라우팅(외부 차단) + 토큰 검증(직접 호출 인증) 이중 방어
- 내부 컨트롤러를 공개 OpenAPI 문서(`/v3/api-docs`)에서 제외

---

## 🛠 상세 구현 내용

- `PerformanceInternalController`: 클래스 `@RequestMapping`을 `/api/v1/internal/performance`로 변경, `@Hidden` 추가로 공개 문서 제외 (메서드/검증 로직 무변경)
- `InternalApiTokenFilter`(performance 전용 신설): `X-Internal-Token` 헤더를 `custom.security.internal-token`과 `MessageDigest.isEqual` 상수시간 비교, 실패 시 403, 통과 시 `ROLE_INTERNAL` 부여. `/api/v1/internal/performance/**` 경로만 필터링
- `SecurityConfig`: `internalApiTokenFilter` 등록(gateway 필터 먼저 → internal 나중 순서 유지) + `/api/v1/internal/performance/**` → `hasRole("INTERNAL")` 인가 규칙 추가
- `application.yml`/`application-prod.yml`: `custom.security.internal-token` 추가(dev 기본값 `test-token`, prod fail-fast). `gateway.internal-token`과 동일 `GATEWAY_INTERNAL_TOKEN` 시크릿 공유(user/auth 서비스와 동일)
- `build.gradle`: `testFixtures(project(":common"))` 추가(팀 표준 `@WebMvcSliceTest` 사용)
- 신규 `@Component` 필터가 모든 `@WebMvcTest` 슬라이스에 자동 포함되어 `CustomSecurityProperties` 빈을 요구 → 영향받은 컨트롤러 슬라이스 테스트에 해당 빈 임포트 보강(보안 동작 불변)

---

## ✅ 테스트

### 테스트 방법

- 신규 `InternalApiTokenFilterTest`(`@WebMvcSliceTest`) 작성: 토큰 없음/오토큰 → 403, 정상 토큰 → 200
- 기존 `PerformanceInternalControllerTest`를 새 경로 + `X-Internal-Token` 헤더로 갱신(200/400/404 매핑 검증 유지)
- 실행: `./gradlew :performance-service:test`

### 테스트 결과

- `:performance-service:test` — 47 tests, **0 failed** (BUILD SUCCESSFUL)
- 빌드 검증: `spotlessApply → checkstyleMain → checkstyleTest → compileJava` 통과

### 📸 스크린샷

<!-- 스크린샷 (필요 시 작성) -->

---

## 👀 리뷰 요청 사항

- 두 필터(`GatewayHeaderFilter`, `InternalApiTokenFilter`) 등록 순서 의존성을 주석으로 명시했는데, 명시적 order 고정이 더 나을지 의견 부탁드립니다
- 내부 API의 공개 문서 노출을 `@Hidden`으로 막았습니다 — 향후 internal 엔드포인트 전반에 동일 정책 적용 여부

---

## ⚠️ 배포 시 주의사항

- **prod 배포 전 `GATEWAY_INTERNAL_TOKEN` 환경변수 주입 필수** — 미주입 시 fail-fast(기동 실패). `gateway.internal-token`과 동일 값이어야 함
- 향후 이 엔드포인트를 호출하는 서비스는 새 경로 + `X-Internal-Token: ${GATEWAY_INTERNAL_TOKEN}` 헤더 필요(현재 호출자 없음)
