### PR TITLE
[Feat] #334 환불 실패(RefundStatus.FAILED) 영속화 및 #91 보상 정합

### DIFF
--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/usecase/FailedRefundRecorder.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/usecase/FailedRefundRecorder.java
@@ -1,0 +1,75 @@
+package com.ticketrush.boundedcontext.payment.app.usecase;
+
+import com.ticketrush.boundedcontext.payment.domain.entity.Payment;
+import com.ticketrush.boundedcontext.payment.domain.entity.Refund;
+import com.ticketrush.global.exception.BusinessException;
+import com.ticketrush.global.status.ErrorStatus;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+
+/**
+ * PG 환불 거절 시 {@code RefundStatus.FAILED} 환불 이력을 남기는 공유 컴포넌트(#334).
+ *
+ * <p>이벤트 경로({@link PaymentRefundByBookingUseCase}, #91)와 API 취소 경로({@link PaymentCancelUseCase},
+ * #22)가 동일한 실패 기록 로직을 공유하므로 별도 빈으로 분리했다. 저장 자체({@link PaymentCancelPersister#persistFailedRefund})는
+ * {@code @Transactional}이라, 그 {@code DataIntegrityViolationException}을 트랜잭션 경계 밖에서 잡으려면 호출부가 별도
+ * 빈이어야 한다(persister self-invocation 프록시 한계와 동일 이유).
+ *
+ * <p>기록은 <b>PG 거절({@link ErrorStatus#PAYMENT_REFUND_FAILED}, 결정적 실패)일 때만</b> 수행한다. PG 통신 실패(성공 여부
+ * 불명)는 재시도→DLT로 넘겨야 하므로 FAILED로 확정 기록하지 않는다(리스너 분류와 동일 기준). 저장 실패는 원래의 환불 실패 예외(보상 흐름)를 가리지 않도록
+ * 삼킨다.
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class FailedRefundRecorder {
+
+  private final PaymentCancelPersister paymentCancelPersister;
+
+  /**
+   * PG 환불 실패 중 "결정적 거절"(FAILED 기록·보상 대상)인지 판별하는 단일 기준(SSOT).
+   *
+   * <p>통신 실패({@link ErrorStatus#PAYMENT_PG_COMMUNICATION_FAILED}, 성공 여부 불명 → 재시도)와 구분한다. FAILED 이력
+   * 기록(본 컴포넌트)과 보상 이벤트 발행({@link
+   * com.ticketrush.boundedcontext.payment.in.eventlistener.RefundRequestedEventListener})이 반드시 같은
+   * 기준으로 짝을 맞춰야 하므로, 두 곳이 각각 하드코딩하지 않고 이 술어를 공유한다.
+   */
+  public static boolean isDeterministicRejection(BusinessException e) {
+    return e.getErrorStatus() == ErrorStatus.PAYMENT_REFUND_FAILED;
+  }
+
+  /**
+   * PG 거절로 확정된 실패면 FAILED 환불 이력을 남긴다. 그 외(통신 실패 등)는 남기지 않는다.
+   *
+   * <p>부수효과일 뿐이므로 호출자는 이 메서드 호출 후 원 예외를 그대로 재던져 #91 보상/재시도 흐름을 유지한다.
+   *
+   * <p><b>불변식</b>: 호출자({@code UseCase.execute})는 트랜잭션 밖이어야 한다. 그래야 {@code
+   * persistFailedRefund}(REQUIRED)가 독립 트랜잭션으로 커밋돼, 호출자가 원 예외를 재던져도 FAILED 이력이 함께 롤백되지 않는다. execute를
+   * 트랜잭션으로 감싸면 이 보증이 깨진다(#297 동일 전제).
+   */
+  public void recordIfRejected(Payment payment, BusinessException e) {
+    if (!isDeterministicRejection(e)) {
+      return;
+    }
+    try {
+      Refund failed =
+          Refund.failed(
+              payment.getId(),
+              payment.getBookingId(),
+              payment.getAmount(),
+              ErrorStatus.PAYMENT_REFUND_FAILED.getMessage(),
+              LocalDateTime.now());
+      paymentCancelPersister.persistFailedRefund(failed);
+    } catch (DataIntegrityViolationException dup) {
+      // 재전달/DLT 재처리로 이미 FAILED 이력이 있으면 payment_id unique 위반 = 정상 멱등. 원 예외는 호출부에서 그대로 재던져 보상된다.
+      log.info("FAILED 환불 이력이 이미 존재합니다(멱등). bookingId={}", payment.getBookingId());
+    } catch (Exception ex) {
+      // 이력 저장 실패는 추적 누락이다. 원 환불 실패 예외를 가리지 않도록 삼키고 error 로그로 알람 대상화한다(#297 recordFailedPayment와
+      // 동일).
+      log.error("FAILED 환불 이력 저장에 실패했습니다. bookingId={}", payment.getBookingId(), ex);
+    }
+  }
+}

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentCancelPersister.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentCancelPersister.java
@@ -2,6 +2,7 @@ package com.ticketrush.boundedcontext.payment.app.usecase;
 
 import com.ticketrush.boundedcontext.payment.domain.entity.Payment;
 import com.ticketrush.boundedcontext.payment.domain.entity.Refund;
+import com.ticketrush.boundedcontext.payment.domain.types.RefundStatus;
 import com.ticketrush.boundedcontext.payment.out.repository.PaymentRepository;
 import com.ticketrush.boundedcontext.payment.out.repository.RefundRepository;
 import com.ticketrush.global.exception.BusinessException;
@@ -43,10 +44,39 @@ public class PaymentCancelPersister {
             .findById(paymentId)
             .orElseThrow(() -> new BusinessException(ErrorStatus.PAYMENT_NOT_FOUND));
 
-    Refund saved = refundRepository.saveAndFlush(refund);
+    // 이전 시도에서 FAILED 환불 이력이 있으면(재시도 성공, #334) unique(payment_id) 슬롯을 재사용하도록 새 INSERT 대신 전이한다.
+    // 이 선-조회가 없으면 FAILED row와 unique 충돌이 나고, 그 DataIntegrityViolationException을 상위(Facade/리스너)가
+    // "이미 환불됨(멱등)"으로 오분류해 실제 성공한 환불이 은폐된다. 동시 최초 환불의 경합은 여전히 아래 saveAndFlush에서 표면화된다.
+    Refund existingFailed =
+        refundRepository
+            .findByPaymentId(paymentId)
+            .filter(r -> r.getStatus() == RefundStatus.FAILED)
+            .orElse(null);
+
+    Refund saved;
+    if (existingFailed != null) {
+      existingFailed.markCompleted(
+          refund.getPgRefundKey(), refund.getReason(), refund.getConfirmedAt());
+      saved = existingFailed;
+    } else {
+      saved = refundRepository.saveAndFlush(refund);
+    }
     payment.markCanceled();
 
     return new CancelPersisted(payment, saved);
+  }
+
+  /**
+   * 실패(FAILED) 환불 이력만 저장한다(#334). 결제는 취소되지 않았으므로 {@code markCanceled}는 호출하지 않는다(Payment는 COMPLETED
+   * 유지).
+   *
+   * <p>{@code saveAndFlush}로 즉시 flush해 {@code payment_id} unique 위반({@code
+   * DataIntegrityViolationException})을 트랜잭션 경계 밖(호출자 {@link FailedRefundRecorder})에서 멱등 처리할 수 있게
+   * 한다. 재전달/DLT 재처리로 이미 FAILED 이력이 있으면 위반이 난다.
+   */
+  @Transactional
+  public void persistFailedRefund(Refund failedRefund) {
+    refundRepository.saveAndFlush(failedRefund);
   }
 
   /** 영속화 결과. {@code payment}는 CANCELED로 전이된 상태다. */

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentCancelUseCase.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentCancelUseCase.java
@@ -40,6 +40,7 @@ public class PaymentCancelUseCase {
   private final RefundRepository refundRepository;
   private final PaymentCancelClientRouter paymentCancelClientRouter;
   private final PaymentCancelPersister paymentCancelPersister;
+  private final FailedRefundRecorder failedRefundRecorder;
   private final PaymentEventPublisher paymentEventPublisher;
   private final PaymentMapper paymentMapper;
 
@@ -59,26 +60,31 @@ public class PaymentCancelUseCase {
     }
 
     // PG 취소는 트랜잭션 밖에서 호출한다(외부 왕복 동안 DB 커넥션을 점유하지 않기 위함).
-    PaymentCancelResult result =
-        paymentCancelClientRouter.cancel(
-            new PaymentCancelCommand(
-                payment.getProvider(),
-                payment.getPaymentKey(),
-                payment.getAmount(),
-                request.reason(),
-                generateIdempotencyKey(paymentId)));
+    PaymentCancelResult result;
+    try {
+      result =
+          paymentCancelClientRouter.cancel(
+              new PaymentCancelCommand(
+                  payment.getProvider(),
+                  payment.getPaymentKey(),
+                  payment.getAmount(),
+                  request.reason(),
+                  generateIdempotencyKey(paymentId)));
+    } catch (BusinessException e) {
+      // PG 거절이면 FAILED 환불 이력을 남긴다(부수효과). 원 예외는 그대로 던져 사용자에게 실패를 전달한다(#334).
+      failedRefundRecorder.recordIfRejected(payment, e);
+      throw e;
+    }
 
     Refund refund =
-        Refund.builder()
-            .paymentId(payment.getId())
-            .bookingId(payment.getBookingId())
-            .price(payment.getAmount())
-            .status(RefundStatus.COMPLETED)
-            .pgRefundKey(result.pgRefundKey())
-            .reason(request.reason())
-            .requestedAt(LocalDateTime.now())
-            .confirmedAt(result.canceledAt())
-            .build();
+        Refund.completed(
+            payment.getId(),
+            payment.getBookingId(),
+            payment.getAmount(),
+            result.pgRefundKey(),
+            request.reason(),
+            LocalDateTime.now(),
+            result.canceledAt());
 
     // 영속화(refund 저장 + 상태 전이)만 짧은 트랜잭션으로 분리한다. 동시 취소 시 unique 위반은 PaymentFacade가 멱등 처리한다.
     CancelPersisted persisted = paymentCancelPersister.persist(paymentId, refund);
@@ -118,6 +124,11 @@ public class PaymentCancelUseCase {
         refundRepository
             .findByPaymentId(paymentId)
             .orElseThrow(() -> new BusinessException(ErrorStatus.PAYMENT_REFUND_INCONSISTENT));
+    // FAILED 이력만 있고 취소 완료가 아니면 "취소됨"으로 응답하면 안 된다. unique 슬롯을 FAILED가 점유한 상태의 충돌(#334)을
+    // 멱등 성공으로 오분류해 미환불/미정합을 은폐하는 것을 막고, 불일치로 표면화한다.
+    if (existing.getStatus() != RefundStatus.COMPLETED) {
+      throw new BusinessException(ErrorStatus.PAYMENT_REFUND_INCONSISTENT);
+    }
     return paymentMapper.toCancelResponse(payment, existing);
   }
 

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentGetDetailUseCase.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentGetDetailUseCase.java
@@ -4,6 +4,7 @@ import com.ticketrush.boundedcontext.payment.app.dto.response.PaymentDetailRespo
 import com.ticketrush.boundedcontext.payment.app.mapper.PaymentMapper;
 import com.ticketrush.boundedcontext.payment.domain.entity.Payment;
 import com.ticketrush.boundedcontext.payment.domain.entity.Refund;
+import com.ticketrush.boundedcontext.payment.domain.types.RefundStatus;
 import com.ticketrush.boundedcontext.payment.out.repository.PaymentRepository;
 import com.ticketrush.boundedcontext.payment.out.repository.RefundRepository;
 import com.ticketrush.global.exception.BusinessException;
@@ -28,7 +29,13 @@ public class PaymentGetDetailUseCase {
             .findByIdAndUserId(paymentId, userId)
             .orElseThrow(() -> new BusinessException(ErrorStatus.PAYMENT_NOT_FOUND));
 
-    Refund refund = refundRepository.findByBookingId(payment.getBookingId()).orElse(null);
+    // COMPLETED 환불만 상세에 노출한다. #334로 COMPLETED 결제에도 FAILED 환불 이력이 남을 수 있어, 상태 무관 매핑 시
+    // 정상 결제 상세에 "환불 실패" 정보가 잘못 노출된다.
+    Refund refund =
+        refundRepository
+            .findByBookingId(payment.getBookingId())
+            .filter(r -> r.getStatus() == RefundStatus.COMPLETED)
+            .orElse(null);
 
     return paymentMapper.toDetailResponse(payment, refund);
   }

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentRefundByBookingUseCase.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentRefundByBookingUseCase.java
@@ -5,13 +5,13 @@ import com.ticketrush.boundedcontext.payment.app.usecase.PaymentCancelPersister.
 import com.ticketrush.boundedcontext.payment.domain.entity.Payment;
 import com.ticketrush.boundedcontext.payment.domain.entity.Refund;
 import com.ticketrush.boundedcontext.payment.domain.types.PaymentStatus;
-import com.ticketrush.boundedcontext.payment.domain.types.RefundStatus;
 import com.ticketrush.boundedcontext.payment.out.apiclient.PaymentCancelClientRouter;
 import com.ticketrush.boundedcontext.payment.out.apiclient.PaymentCancelCommand;
 import com.ticketrush.boundedcontext.payment.out.apiclient.PaymentCancelResult;
 import com.ticketrush.boundedcontext.payment.out.repository.PaymentRepository;
 import com.ticketrush.boundedcontext.payment.out.repository.RefundRepository;
 import com.ticketrush.global.constants.MetricNames;
+import com.ticketrush.global.exception.BusinessException;
 import com.ticketrush.shared.booking.event.RefundRequestedEvent;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Timer;
@@ -44,6 +44,7 @@ public class PaymentRefundByBookingUseCase {
   private final RefundRepository refundRepository;
   private final PaymentCancelClientRouter paymentCancelClientRouter;
   private final PaymentCancelPersister paymentCancelPersister;
+  private final FailedRefundRecorder failedRefundRecorder;
   private final PaymentEventPublisher paymentEventPublisher;
   private final MeterRegistry meterRegistry;
 
@@ -69,7 +70,8 @@ public class PaymentRefundByBookingUseCase {
 
     // PG 취소는 트랜잭션 밖에서 호출한다(외부 왕복 동안 DB 커넥션을 점유하지 않기 위함). paymentId 기반 고정 멱등 키로 PG 측 중복 취소를 막는다.
     Timer.Sample sample = Timer.start(meterRegistry);
-    PaymentCancelResult result;
+    PaymentCancelResult result = null;
+    BusinessException failure = null;
     try {
       result =
           paymentCancelClientRouter.cancel(
@@ -79,24 +81,30 @@ public class PaymentRefundByBookingUseCase {
                   payment.getAmount(),
                   REFUND_REASON,
                   generateIdempotencyKey(payment.getId())));
+    } catch (BusinessException e) {
+      failure = e;
     } finally {
+      // 타이머는 PG 왕복만 측정하도록 FAILED 저장(recordIfRejected)보다 먼저 멈춘다.
       sample.stop(
           Timer.builder(MetricNames.PAYMENT_PG_CANCEL)
               .tag(MetricNames.TAG_PROVIDER, payment.getProvider().name())
               .register(meterRegistry));
     }
+    if (failure != null) {
+      // PG 거절이면 FAILED 환불 이력을 남긴다(부수효과). 원 예외는 그대로 재던져 리스너가 보상/재시도로 분류하게 한다(#91, #334).
+      failedRefundRecorder.recordIfRejected(payment, failure);
+      throw failure;
+    }
 
     Refund refund =
-        Refund.builder()
-            .paymentId(payment.getId())
-            .bookingId(payment.getBookingId())
-            .price(payment.getAmount())
-            .status(RefundStatus.COMPLETED)
-            .pgRefundKey(result.pgRefundKey())
-            .reason(REFUND_REASON)
-            .requestedAt(LocalDateTime.now())
-            .confirmedAt(result.canceledAt())
-            .build();
+        Refund.completed(
+            payment.getId(),
+            payment.getBookingId(),
+            payment.getAmount(),
+            result.pgRefundKey(),
+            REFUND_REASON,
+            LocalDateTime.now(),
+            result.canceledAt());
 
     // 영속화(refund 저장 + 상태 전이)만 짧은 트랜잭션으로 분리한다. 동시 환불 시 unique 위반은 리스너가 멱등 처리한다(#296).
     CancelPersisted persisted = paymentCancelPersister.persist(payment.getId(), refund);

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/domain/entity/Refund.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/domain/entity/Refund.java
@@ -64,4 +64,63 @@ public class Refund extends AutoIdBaseEntity {
     this.requestedAt = requestedAt;
     this.confirmedAt = confirmedAt;
   }
+
+  /** PG 환불이 성공해 확정(COMPLETED)된 환불 이력을 만든다. */
+  public static Refund completed(
+      Long paymentId,
+      Long bookingId,
+      Long price,
+      String pgRefundKey,
+      String reason,
+      LocalDateTime requestedAt,
+      LocalDateTime confirmedAt) {
+    return Refund.builder()
+        .paymentId(paymentId)
+        .bookingId(bookingId)
+        .price(price)
+        .status(RefundStatus.COMPLETED)
+        .pgRefundKey(pgRefundKey)
+        .reason(reason)
+        .requestedAt(requestedAt)
+        .confirmedAt(confirmedAt)
+        .build();
+  }
+
+  /**
+   * PG 환불이 거절돼 실패(FAILED)로 확정된 환불 이력을 만든다(#334).
+   *
+   * <p>{@code pgRefundKey}·{@code confirmedAt}은 확정된 환불이 아니므로 비운다. PG 원본 거절 코드/사유는 취소 클라이언트가 아직 포착하지
+   * 않아 담지 않는다(#332의 취소판은 후속). {@code reason}에는 내부 실패 사유({@code ErrorStatus} 메시지)만 남긴다.
+   */
+  public static Refund failed(
+      Long paymentId, Long bookingId, Long price, String reason, LocalDateTime requestedAt) {
+    return Refund.builder()
+        .paymentId(paymentId)
+        .bookingId(bookingId)
+        .price(price)
+        .status(RefundStatus.FAILED)
+        .reason(reason)
+        .requestedAt(requestedAt)
+        .build();
+  }
+
+  /**
+   * 실패(FAILED)한 환불을 재시도해 성공하면 COMPLETED로 전이한다(#334).
+   *
+   * <p>FAILED 상태에서만 전이할 수 있고 그 외 상태에서 호출되면 도메인 불변식 위반이므로 {@link IllegalStateException}을 던진다({@link
+   * Payment#markCanceled()}와 동일한 방어선). PG 환불 식별자·확정 시각과 함께 사유도 성공 사유로 갱신해 status와의 모순(실패 사유 잔존)을
+   * 없앤다.
+   *
+   * <p>재시도 성공 시 이미 존재하는 FAILED row의 unique(payment_id) 슬롯을 재사용하기 위해 {@link
+   * PaymentCancelPersister#persist}가 새 INSERT 대신 이 전이를 사용한다. 관리자 수동 복구 배선은 후속이다.
+   */
+  public void markCompleted(String pgRefundKey, String reason, LocalDateTime confirmedAt) {
+    if (this.status != RefundStatus.FAILED) {
+      throw new IllegalStateException("환불 완료 전이는 FAILED 상태에서만 가능합니다. 현재 상태=" + this.status);
+    }
+    this.status = RefundStatus.COMPLETED;
+    this.pgRefundKey = pgRefundKey;
+    this.reason = reason;
+    this.confirmedAt = confirmedAt;
+  }
 }

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/in/eventlistener/RefundRequestedEventListener.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/in/eventlistener/RefundRequestedEventListener.java
@@ -1,6 +1,7 @@
 package com.ticketrush.boundedcontext.payment.in.eventlistener;
 
 import com.ticketrush.boundedcontext.payment.app.support.PaymentEventPublisher;
+import com.ticketrush.boundedcontext.payment.app.usecase.FailedRefundRecorder;
 import com.ticketrush.boundedcontext.payment.app.usecase.PaymentRefundByBookingUseCase;
 import com.ticketrush.boundedcontext.payment.app.usecase.PaymentRefundByBookingUseCase.RefundOutcome;
 import com.ticketrush.global.constants.MetricNames;
@@ -92,7 +93,8 @@ public class RefundRequestedEventListener {
       ack.acknowledge();
     } catch (BusinessException e) {
       // PG 거절(결정적)만 보상한다. 통신 실패는 환불 성공 여부가 불명이라 재시도→DLT로 넘겨 섣부른 REFUND_FAILED 확정을 피한다.
-      if (event != null && e.getErrorStatus() == ErrorStatus.PAYMENT_REFUND_FAILED) {
+      // 결정적 거절 판별은 FAILED 이력 기록(FailedRefundRecorder)과 동일한 술어를 공유해 저장/보상 짝이 어긋나지 않게 한다(#334).
+      if (event != null && FailedRefundRecorder.isDeterministicRejection(e)) {
         log.error(
             "[CRITICAL] PG 환불 거절(결정적) → 보상 이벤트(RefundFailed) 발행. bookingId: {}",
             event.bookingId(),

--- a/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/app/usecase/FailedRefundRecorderTest.java
+++ b/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/app/usecase/FailedRefundRecorderTest.java
@@ -1,0 +1,129 @@
+package com.ticketrush.boundedcontext.payment.app.usecase;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.ticketrush.boundedcontext.payment.domain.entity.Payment;
+import com.ticketrush.boundedcontext.payment.domain.entity.Refund;
+import com.ticketrush.boundedcontext.payment.domain.types.PaymentProvider;
+import com.ticketrush.boundedcontext.payment.domain.types.PaymentStatus;
+import com.ticketrush.boundedcontext.payment.domain.types.RefundStatus;
+import com.ticketrush.global.exception.BusinessException;
+import com.ticketrush.global.status.ErrorStatus;
+import java.lang.reflect.Field;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
+
+@ExtendWith(MockitoExtension.class)
+class FailedRefundRecorderTest {
+
+  private static final Long PAYMENT_ID = 1L;
+  private static final Long BOOKING_ID = 100L;
+  private static final Long AMOUNT = 55_000L;
+
+  @Mock private PaymentCancelPersister paymentCancelPersister;
+
+  @InjectMocks private FailedRefundRecorder failedRefundRecorder;
+
+  @Test
+  @DisplayName("PG 거절(PAYMENT_REFUND_FAILED)이면 FAILED 환불 이력을 저장한다")
+  void records_failed_refund_on_pg_rejection() throws Exception {
+    // given
+    Payment payment = completedPayment();
+    BusinessException rejected = new BusinessException(ErrorStatus.PAYMENT_REFUND_FAILED);
+
+    // when
+    failedRefundRecorder.recordIfRejected(payment, rejected);
+
+    // then
+    ArgumentCaptor<Refund> captor = ArgumentCaptor.forClass(Refund.class);
+    verify(paymentCancelPersister).persistFailedRefund(captor.capture());
+    Refund saved = captor.getValue();
+    assertThat(saved.getStatus()).isEqualTo(RefundStatus.FAILED);
+    assertThat(saved.getPaymentId()).isEqualTo(PAYMENT_ID);
+    assertThat(saved.getBookingId()).isEqualTo(BOOKING_ID);
+    assertThat(saved.getPrice()).isEqualTo(AMOUNT);
+    assertThat(saved.getReason()).isEqualTo(ErrorStatus.PAYMENT_REFUND_FAILED.getMessage());
+    assertThat(saved.getPgRefundKey()).isNull();
+    assertThat(saved.getConfirmedAt()).isNull();
+  }
+
+  @Test
+  @DisplayName("PG 통신 실패(PAYMENT_PG_COMMUNICATION_FAILED)는 성공 여부 불명이라 FAILED 이력을 저장하지 않는다")
+  void does_not_record_on_communication_failure() throws Exception {
+    // given
+    Payment payment = completedPayment();
+    BusinessException communication =
+        new BusinessException(ErrorStatus.PAYMENT_PG_COMMUNICATION_FAILED);
+
+    // when
+    failedRefundRecorder.recordIfRejected(payment, communication);
+
+    // then
+    verify(paymentCancelPersister, never()).persistFailedRefund(any());
+  }
+
+  @Test
+  @DisplayName("이미 FAILED 이력이 있어 unique 위반이 나면 삼켜 멱등 처리한다(예외 전파 없음)")
+  void swallows_unique_violation_for_idempotency() throws Exception {
+    // given
+    Payment payment = completedPayment();
+    BusinessException rejected = new BusinessException(ErrorStatus.PAYMENT_REFUND_FAILED);
+    willThrow(new DataIntegrityViolationException("duplicate paymentId"))
+        .given(paymentCancelPersister)
+        .persistFailedRefund(any());
+
+    // when & then: 원 환불 실패 예외를 가리지 않도록 멱등 무시한다.
+    assertThatCode(() -> failedRefundRecorder.recordIfRejected(payment, rejected))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  @DisplayName("이력 저장 중 예기치 못한 예외가 나도 삼켜 원 환불 실패 예외를 가리지 않는다")
+  void swallows_unexpected_persistence_error() throws Exception {
+    // given
+    Payment payment = completedPayment();
+    BusinessException rejected = new BusinessException(ErrorStatus.PAYMENT_REFUND_FAILED);
+    willThrow(new RuntimeException("db down"))
+        .given(paymentCancelPersister)
+        .persistFailedRefund(any());
+
+    // when & then
+    assertThatCode(() -> failedRefundRecorder.recordIfRejected(payment, rejected))
+        .doesNotThrowAnyException();
+  }
+
+  private Payment completedPayment() throws Exception {
+    Payment payment =
+        Payment.builder()
+            .bookingId(BOOKING_ID)
+            .userId(10L)
+            .seatId(200L)
+            .provider(PaymentProvider.TOSS)
+            .amount(AMOUNT)
+            .status(PaymentStatus.COMPLETED)
+            .paymentKey("pgKey_xyz")
+            .approvalNumber("APR-1")
+            .paidAt(LocalDateTime.of(2026, 5, 1, 10, 0))
+            .build();
+    setId(payment, PAYMENT_ID);
+    return payment;
+  }
+
+  private void setId(Object entity, Long id) throws Exception {
+    Field idField = entity.getClass().getSuperclass().getDeclaredField("id");
+    idField.setAccessible(true);
+    idField.set(entity, id);
+  }
+}

--- a/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentCancelPersisterTest.java
+++ b/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentCancelPersisterTest.java
@@ -95,6 +95,58 @@ class PaymentCancelPersisterTest {
     verify(refundRepository, never()).saveAndFlush(any(Refund.class));
   }
 
+  @Test
+  @DisplayName("이전 FAILED 환불 이력이 있으면 새 INSERT 대신 COMPLETED로 전이하고 결제를 CANCELED로 바꾼다")
+  void persist_transitions_existing_failed_refund() throws Exception {
+    // given: 이전 시도에서 FAILED row가 unique(payment_id) 슬롯을 점유한 상태에서 재시도가 성공한 상황
+    Long paymentId = 1L;
+    Payment payment = completedPayment(paymentId);
+    final Refund incoming = refund(paymentId); // UseCase가 만든 COMPLETED 환불
+    Refund existingFailed =
+        Refund.failed(
+            paymentId, 100L, 55_000L, "PG사 환불 처리에 실패했습니다.", LocalDateTime.of(2026, 5, 22, 10, 0));
+    setId(existingFailed, 777L);
+    given(paymentRepository.findById(paymentId)).willReturn(Optional.of(payment));
+    given(refundRepository.findByPaymentId(paymentId)).willReturn(Optional.of(existingFailed));
+
+    // when
+    CancelPersisted result = paymentCancelPersister.persist(paymentId, incoming);
+
+    // then: 새 INSERT 없이 기존 row를 전이(unique 슬롯 재사용)하고 결제는 CANCELED로 전이한다.
+    assertThat(result.refund()).isSameAs(existingFailed);
+    assertThat(result.refund().getStatus()).isEqualTo(RefundStatus.COMPLETED);
+    assertThat(result.payment().getStatus()).isEqualTo(PaymentStatus.CANCELED);
+    verify(refundRepository, never()).saveAndFlush(any(Refund.class));
+  }
+
+  @Test
+  @DisplayName("persistFailedRefund는 FAILED 환불만 저장하고 결제 상태 전이는 하지 않는다")
+  void persistFailedRefund_saves_only_failed_refund() {
+    // given
+    Refund failed = Refund.failed(1L, 100L, 55_000L, "PG사 환불 처리에 실패했습니다.", LocalDateTime.now());
+
+    // when
+    paymentCancelPersister.persistFailedRefund(failed);
+
+    // then: 환불 저장만 수행하고 결제 조회/전이는 일어나지 않는다(Payment는 COMPLETED 유지).
+    verify(refundRepository).saveAndFlush(failed);
+    verify(paymentRepository, never()).findById(any());
+    assertThat(failed.getStatus()).isEqualTo(RefundStatus.FAILED);
+  }
+
+  @Test
+  @DisplayName("persistFailedRefund의 paymentId unique 위반은 호출자(FailedRefundRecorder)로 전파된다")
+  void persistFailedRefund_propagates_unique_violation() {
+    // given
+    Refund failed = Refund.failed(1L, 100L, 55_000L, "PG사 환불 처리에 실패했습니다.", LocalDateTime.now());
+    given(refundRepository.saveAndFlush(failed))
+        .willThrow(new DataIntegrityViolationException("duplicate paymentId"));
+
+    // when & then: 트랜잭션 경계 밖에서 멱등 처리하도록 예외를 그대로 전파한다.
+    assertThatThrownBy(() -> paymentCancelPersister.persistFailedRefund(failed))
+        .isInstanceOf(DataIntegrityViolationException.class);
+  }
+
   private Payment completedPayment(Long paymentId) throws Exception {
     Payment payment =
         Payment.builder()

--- a/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentCancelUseCaseTest.java
+++ b/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentCancelUseCaseTest.java
@@ -48,6 +48,7 @@ class PaymentCancelUseCaseTest {
   @Mock private RefundRepository refundRepository;
   @Mock private PaymentCancelClientRouter paymentCancelClientRouter;
   @Mock private PaymentCancelPersister paymentCancelPersister;
+  @Mock private FailedRefundRecorder failedRefundRecorder;
   @Mock private PaymentEventPublisher paymentEventPublisher;
 
   @Spy private PaymentMapper paymentMapper = Mappers.getMapper(PaymentMapper.class);
@@ -320,6 +321,48 @@ class PaymentCancelUseCaseTest {
     assertThat(response.status()).isEqualTo("CANCELED");
     verify(paymentCancelClientRouter, never()).cancel(any());
     verify(paymentCancelPersister, never()).persist(any(), any(Refund.class));
+  }
+
+  @Test
+  @DisplayName("PG 취소가 실패하면 FailedRefundRecorder에 위임하고 원 예외를 사용자에게 그대로 던진다(영속화·발행 없음)")
+  void execute_delegates_to_recorder_and_rethrows_on_pg_failure() throws Exception {
+    // given
+    Long userId = 10L;
+    Long paymentId = 1L;
+    final PaymentCancelRequest request = new PaymentCancelRequest("단순 변심");
+    Payment payment = completedPayment(paymentId, userId, 100L, 200L, 55_000L);
+    given(paymentRepository.findByIdAndUserId(paymentId, userId)).willReturn(Optional.of(payment));
+    BusinessException rejected = new BusinessException(ErrorStatus.PAYMENT_REFUND_FAILED);
+    given(paymentCancelClientRouter.cancel(any())).willThrow(rejected);
+
+    // when & then: 저장은 부수효과일 뿐 사용자 응답은 예외 그대로 유지된다.
+    assertThatThrownBy(() -> paymentCancelUseCase.execute(userId, paymentId, request))
+        .isSameAs(rejected);
+
+    verify(failedRefundRecorder).recordIfRejected(payment, rejected);
+    verify(paymentCancelPersister, never()).persist(any(), any(Refund.class));
+    verify(paymentEventPublisher, never())
+        .publishCanceled(any(), any(), any(), any(), any(), any(), any(), any());
+  }
+
+  @Test
+  @DisplayName("getCanceledResponse가 COMPLETED가 아닌 환불(FAILED)만 있으면 REFUND_INCONSISTENT로 표면화한다")
+  void getCanceledResponse_rejects_non_completed_refund() throws Exception {
+    // given: FAILED가 unique 슬롯을 점유한 상태의 충돌(#334)을 멱등 성공으로 오분류하지 않도록 표면화해야 한다.
+    Long userId = 10L;
+    Long paymentId = 1L;
+    Payment payment = completedPayment(paymentId, userId, 100L, 200L, 55_000L);
+    Refund failed =
+        Refund.failed(
+            paymentId, 100L, 55_000L, "PG사 환불 처리에 실패했습니다.", LocalDateTime.of(2026, 5, 22, 10, 0));
+    given(paymentRepository.findByIdAndUserId(paymentId, userId)).willReturn(Optional.of(payment));
+    given(refundRepository.findByPaymentId(paymentId)).willReturn(Optional.of(failed));
+
+    // when & then
+    assertThatThrownBy(() -> paymentCancelUseCase.getCanceledResponse(userId, paymentId))
+        .isInstanceOf(BusinessException.class)
+        .extracting("errorStatus")
+        .isEqualTo(ErrorStatus.PAYMENT_REFUND_INCONSISTENT);
   }
 
   private Payment completedPayment(

--- a/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentGetDetailUseCaseTest.java
+++ b/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentGetDetailUseCaseTest.java
@@ -97,6 +97,31 @@ class PaymentGetDetailUseCaseTest {
     verifyNoInteractions(refundRepository);
   }
 
+  @Test
+  @DisplayName("FAILED 환불 이력만 있으면(정상 결제) 상세의 refund는 null이다")
+  void execute_hides_failed_refund() throws Exception {
+    // given: #334로 COMPLETED 결제에도 FAILED 환불 이력이 남을 수 있다.
+    Long userId = 10L;
+    Long paymentId = 1L;
+    Long bookingId = 100L;
+    Payment payment = samplePayment(paymentId, userId, bookingId);
+    Refund failed =
+        Refund.failed(
+            paymentId,
+            bookingId,
+            55_000L,
+            "PG사 환불 처리에 실패했습니다.",
+            LocalDateTime.of(2026, 5, 2, 12, 0));
+    given(paymentRepository.findByIdAndUserId(paymentId, userId)).willReturn(Optional.of(payment));
+    given(refundRepository.findByBookingId(bookingId)).willReturn(Optional.of(failed));
+
+    // when
+    PaymentDetailResponse response = paymentGetDetailUseCase.execute(userId, paymentId);
+
+    // then: 실패 이력은 정상 결제 상세에 노출하지 않는다.
+    assertThat(response.refund()).isNull();
+  }
+
   private Payment samplePayment(Long id, Long userId, Long bookingId) throws Exception {
     Payment payment =
         Payment.builder()

--- a/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentRefundByBookingUseCaseTest.java
+++ b/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentRefundByBookingUseCaseTest.java
@@ -1,6 +1,7 @@
 package com.ticketrush.boundedcontext.payment.app.usecase;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
@@ -21,6 +22,8 @@ import com.ticketrush.boundedcontext.payment.out.apiclient.PaymentCancelResult;
 import com.ticketrush.boundedcontext.payment.out.repository.PaymentRepository;
 import com.ticketrush.boundedcontext.payment.out.repository.RefundRepository;
 import com.ticketrush.global.constants.MetricNames;
+import com.ticketrush.global.exception.BusinessException;
+import com.ticketrush.global.status.ErrorStatus;
 import com.ticketrush.shared.booking.event.RefundRequestedEvent;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.lang.reflect.Field;
@@ -42,6 +45,7 @@ class PaymentRefundByBookingUseCaseTest {
   @Mock private RefundRepository refundRepository;
   @Mock private PaymentCancelClientRouter paymentCancelClientRouter;
   @Mock private PaymentCancelPersister paymentCancelPersister;
+  @Mock private FailedRefundRecorder failedRefundRecorder;
   @Mock private PaymentEventPublisher paymentEventPublisher;
 
   private SimpleMeterRegistry meterRegistry;
@@ -56,6 +60,7 @@ class PaymentRefundByBookingUseCaseTest {
             refundRepository,
             paymentCancelClientRouter,
             paymentCancelPersister,
+            failedRefundRecorder,
             paymentEventPublisher,
             meterRegistry);
   }
@@ -201,6 +206,26 @@ class PaymentRefundByBookingUseCaseTest {
             eq(AMOUNT),
             eq("사용자 예매 취소"),
             eq(refundConfirmedAt));
+  }
+
+  @Test
+  @DisplayName("PG 취소가 실패하면 FailedRefundRecorder에 위임하고 원 예외를 재던진다(영속화·발행 없음)")
+  void execute_delegates_to_recorder_and_rethrows_on_pg_failure() throws Exception {
+    // given
+    Payment payment = completedPayment();
+    given(paymentRepository.findFirstByBookingIdAndStatus(BOOKING_ID, PaymentStatus.COMPLETED))
+        .willReturn(Optional.of(payment));
+    BusinessException rejected = new BusinessException(ErrorStatus.PAYMENT_REFUND_FAILED);
+    given(paymentCancelClientRouter.cancel(any())).willThrow(rejected);
+
+    // when & then: 원 예외가 그대로 리스너로 전파돼 보상/재시도로 분류된다.
+    assertThatThrownBy(() -> paymentRefundByBookingUseCase.execute(event())).isSameAs(rejected);
+
+    // FAILED 이력 기록은 recorder에 위임한다(분류·저장·멱등은 FailedRefundRecorderTest에서 검증).
+    verify(failedRefundRecorder).recordIfRejected(payment, rejected);
+    verify(paymentCancelPersister, never()).persist(any(), any(Refund.class));
+    verify(paymentEventPublisher, never())
+        .publishCanceled(any(), any(), any(), any(), any(), any(), any(), any());
   }
 
   private Payment completedPayment() throws Exception {

--- a/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/domain/entity/RefundTest.java
+++ b/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/domain/entity/RefundTest.java
@@ -1,0 +1,89 @@
+package com.ticketrush.boundedcontext.payment.domain.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.ticketrush.boundedcontext.payment.domain.types.RefundStatus;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class RefundTest {
+
+  private static final Long PAYMENT_ID = 1L;
+  private static final Long BOOKING_ID = 100L;
+  private static final Long PRICE = 55_000L;
+
+  @Test
+  @DisplayName("completed 팩토리는 COMPLETED 상태의 환불 이력을 만든다")
+  void completed_factory_builds_completed_refund() {
+    LocalDateTime requestedAt = LocalDateTime.of(2026, 5, 22, 10, 0);
+    LocalDateTime confirmedAt = LocalDateTime.of(2026, 5, 22, 10, 1);
+
+    Refund refund =
+        Refund.completed(
+            PAYMENT_ID, BOOKING_ID, PRICE, "PG-REFUND-1", "사용자 예매 취소", requestedAt, confirmedAt);
+
+    assertThat(refund.getStatus()).isEqualTo(RefundStatus.COMPLETED);
+    assertThat(refund.getPaymentId()).isEqualTo(PAYMENT_ID);
+    assertThat(refund.getBookingId()).isEqualTo(BOOKING_ID);
+    assertThat(refund.getPrice()).isEqualTo(PRICE);
+    assertThat(refund.getPgRefundKey()).isEqualTo("PG-REFUND-1");
+    assertThat(refund.getReason()).isEqualTo("사용자 예매 취소");
+    assertThat(refund.getConfirmedAt()).isEqualTo(confirmedAt);
+  }
+
+  @Test
+  @DisplayName("failed 팩토리는 FAILED 상태로 만들고 pgRefundKey·confirmedAt은 비운다")
+  void failed_factory_builds_failed_refund_without_pg_fields() {
+    LocalDateTime requestedAt = LocalDateTime.of(2026, 5, 22, 10, 0);
+
+    Refund refund = Refund.failed(PAYMENT_ID, BOOKING_ID, PRICE, "PG사 환불 처리에 실패했습니다.", requestedAt);
+
+    assertThat(refund.getStatus()).isEqualTo(RefundStatus.FAILED);
+    assertThat(refund.getPaymentId()).isEqualTo(PAYMENT_ID);
+    assertThat(refund.getBookingId()).isEqualTo(BOOKING_ID);
+    assertThat(refund.getPrice()).isEqualTo(PRICE);
+    assertThat(refund.getReason()).isEqualTo("PG사 환불 처리에 실패했습니다.");
+    assertThat(refund.getRequestedAt()).isEqualTo(requestedAt);
+    assertThat(refund.getPgRefundKey()).isNull();
+    assertThat(refund.getConfirmedAt()).isNull();
+  }
+
+  @Test
+  @DisplayName("markCompleted는 FAILED 환불을 COMPLETED로 전이하고 pgRefundKey·confirmedAt을 채운다")
+  void markCompleted_transitions_failed_to_completed() {
+    Refund refund =
+        Refund.failed(
+            PAYMENT_ID,
+            BOOKING_ID,
+            PRICE,
+            "PG사 환불 처리에 실패했습니다.",
+            LocalDateTime.of(2026, 5, 22, 10, 0));
+    LocalDateTime confirmedAt = LocalDateTime.of(2026, 5, 23, 9, 0);
+
+    refund.markCompleted("PG-REFUND-RETRY", "사용자 예매 취소", confirmedAt);
+
+    assertThat(refund.getStatus()).isEqualTo(RefundStatus.COMPLETED);
+    assertThat(refund.getPgRefundKey()).isEqualTo("PG-REFUND-RETRY");
+    assertThat(refund.getReason()).isEqualTo("사용자 예매 취소");
+    assertThat(refund.getConfirmedAt()).isEqualTo(confirmedAt);
+  }
+
+  @Test
+  @DisplayName("markCompleted를 FAILED가 아닌 상태에서 호출하면 IllegalStateException을 던진다")
+  void markCompleted_rejects_non_failed_state() {
+    Refund completed =
+        Refund.completed(
+            PAYMENT_ID,
+            BOOKING_ID,
+            PRICE,
+            "PG-REFUND-1",
+            "사용자 예매 취소",
+            LocalDateTime.of(2026, 5, 22, 10, 0),
+            LocalDateTime.of(2026, 5, 22, 10, 1));
+
+    assertThatThrownBy(() -> completed.markCompleted("PG-REFUND-2", "재시도", LocalDateTime.now()))
+        .isInstanceOf(IllegalStateException.class);
+  }
+}


### PR DESCRIPTION
## 🔗 관련 이슈

- close #334

---

## 📌 주요 변경 사항

- PG 환불 거절 시 `RefundStatus.FAILED` Refund 이력을 실패 사유와 함께 영속화 (이벤트 경로 #91 + API 취소 경로 #22 대칭)
- #91 이벤트 보상(RefundRequestedEventListener) 흐름과 중복·모순 없이 정합 — 리스너 무변경(보상 단일 출처 유지)
- `Refund`에 상태 전이 메서드(`markCompleted`) 도입 및 미사용이던 `RefundStatus.FAILED` 실제 편입

---

## 🛠 상세 구현 내용

- **`FailedRefundRecorder`(신설)**: PG 거절(`PAYMENT_REFUND_FAILED`)일 때만 FAILED 이력 기록, 통신 실패(`PAYMENT_PG_COMMUNICATION_FAILED`)는 미기록(재시도→DLT). `DataIntegrityViolationException`은 삼켜 멱등, 그 외 저장 실패도 삼켜 원 예외를 가리지 않음(#297 `recordFailedPayment` 대칭). `execute()`가 비트랜잭션이라 `persistFailedRefund`가 독립 커밋되어 예외 재던짐에도 이력 생존
- **`Refund`**: 정적 팩토리 `completed()`/`failed()` + 상태전이 `markCompleted(pgRefundKey, reason, confirmedAt)`(FAILED에서만 허용, 아니면 `IllegalStateException` — `Payment.markCanceled()` 동일 패턴). 관리자 복구 자동 배선은 후속
- **`PaymentCancelPersister`**: `persistFailedRefund()` 추가(saveAndFlush만, markCanceled 없음). `persist()`는 기존 FAILED row가 있으면 새 INSERT 대신 `markCompleted`로 전이해 unique(payment_id) 슬롯 재사용 → 재시도 성공이 FAILED row와 충돌해 은폐되던 문제 방지
- **`PaymentCancelUseCase`/`PaymentRefundByBookingUseCase`**: PG 취소를 `catch(BusinessException)`로 감싸 `FailedRefundRecorder`에 위임 후 원 예외 재던짐(사용자 응답·보상 흐름 불변). 해피패스는 `Refund.completed()` 팩토리로 치환
- **`toExistingRefundResponse`**: 기존 refund가 COMPLETED가 아니면(FAILED만 존재) `PAYMENT_REFUND_INCONSISTENT`로 표면화 — 멱등 성공 오분류 차단
- **`PaymentGetDetailUseCase`**: COMPLETED 환불만 상세에 노출(정상 결제에 실패 이력 노출 방지)
- **분류 SSOT**: 결정적 거절 판별을 `FailedRefundRecorder.isDeterministicRejection()` static 술어로 통일 — 리스너·recorder가 공유해 저장/보상 짝 어긋남 방지
- **메트릭**: PG 취소 타이머를 FAILED 저장 전에 stop해 PG 왕복만 측정
- 스키마 무변경(status enum에 FAILED·reason 컬럼 기존재) → prod ALTER 불필요

---

## ✅ 테스트

### 테스트 방법

- 신규 `RefundTest`: 팩토리(completed/failed), `markCompleted` 전이(FAILED→COMPLETED), COMPLETED 재전이 시 `IllegalStateException`
- 신규 `FailedRefundRecorderTest`: PG 거절 시 FAILED 저장 / 통신 실패 시 미저장 / DIV 멱등 삼킴 / 예기치 못한 예외 삼킴
- 보강 `PaymentCancelPersisterTest`: `persistFailedRefund`(저장만), 기존 FAILED row 전이, unique 위반 전파
- 보강 `PaymentRefundByBookingUseCaseTest`/`PaymentCancelUseCaseTest`: PG 실패 시 recorder 위임+원 예외 재던짐, `getCanceledResponse` FAILED-only 가드
- 보강 `PaymentGetDetailUseCaseTest`: FAILED 이력은 상세에 미노출
- 실행: `./gradlew :payment-service:test`

### 테스트 결과

- `:payment-service:test` — 전체 통과(BUILD SUCCESSFUL). 리스너 정합 회귀 테스트 포함 그린
- 빌드 검증: `spotlessCheck → checkstyleMain → checkstyleTest → compileJava` 통과

### 📸 스크린샷

<!-- 스크린샷 (필요 시 작성) -->

---

## 👀 리뷰 요청 사항

- `PaymentCancelPersister.persist()`의 "기존 FAILED row 전이(unique 슬롯 재사용)"와 멱등 handler의 `PAYMENT_REFUND_INCONSISTENT` 가드가 재시도 성공 은폐를 막는 설계 — 정합성 검토 부탁드립니다
- `markCompleted`는 도메인 메서드로 도입하되 관리자 복구 자동 배선은 후속입니다(현재 배선처는 persist의 재시도 전이 경로)

---

## ⚠️ 배포 시 주의사항

- 스키마 무변경(FAILED enum·reason 컬럼 기존재) → prod ALTER 불필요
- 후속 예정: PG 원본 거절코드 저장(취소 클라이언트 `PgRejectionException` 전환 + Refund 신규 컬럼, #332의 취소판), 관리자 수동 복구(FAILED→COMPLETED) 배선, FAILED row 누적 방어(#333)
