### PR TITLE
[Fix] #377 DevToken 발급 불가 — 내부 API 필터 403 + gateway dev 라우트 부재 404

### DIFF
--- a/gateway-service/src/main/resources/application.yml
+++ b/gateway-service/src/main/resources/application.yml
@@ -22,7 +22,7 @@ spring:
             - id: auth-service
               uri: http://${services.auth.host}:8082
               predicates:
-                - Path=/api/v1/auth/**,/v3/api-docs/auth
+                - Path=/api/v1/auth/**,/api/v1/dev/auth/**,/v3/api-docs/auth
               filters:
                 - RewritePath=/v3/api-docs/auth,/v3/api-docs
 

--- a/user-service/src/main/java/com/ticketrush/global/security/InternalApiTokenFilter.java
+++ b/user-service/src/main/java/com/ticketrush/global/security/InternalApiTokenFilter.java
@@ -11,7 +11,6 @@ import java.io.IOException;
 import java.security.MessageDigest;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -25,7 +24,7 @@ public class InternalApiTokenFilter extends OncePerRequestFilter {
 
   private static final String INTERNAL_TOKEN_HEADER = "X-Internal-Token";
 
-  private static final String USER_AUTH_INFO_PATH = "/api/v1/internal/user/auth-info";
+  private static final String INTERNAL_USER_API_PREFIX = "/api/v1/internal/user";
 
   private final CustomSecurityProperties securityProperties;
 
@@ -59,9 +58,18 @@ public class InternalApiTokenFilter extends OncePerRequestFilter {
   }
 
   private boolean isInternalApi(HttpServletRequest request) {
-    String path = request.getRequestURI();
-    String method = request.getMethod();
+    String path = getRequestPath(request);
 
-    return HttpMethod.POST.matches(method) && USER_AUTH_INFO_PATH.equals(path);
+    return path.equals(INTERNAL_USER_API_PREFIX) || path.startsWith(INTERNAL_USER_API_PREFIX + "/");
+  }
+
+  private String getRequestPath(HttpServletRequest request) {
+    String servletPath = request.getServletPath();
+
+    if (StringUtils.hasText(servletPath)) {
+      return servletPath;
+    }
+
+    return request.getRequestURI();
   }
 }

--- a/user-service/src/test/java/com/ticketrush/global/security/InternalApiTokenFilterTest.java
+++ b/user-service/src/test/java/com/ticketrush/global/security/InternalApiTokenFilterTest.java
@@ -1,5 +1,6 @@
-package com.ticketrush.global.config;
+package com.ticketrush.global.security;
 
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -14,8 +15,9 @@ import com.ticketrush.boundedcontext.user.app.dto.response.UserAuthInfoResponse;
 import com.ticketrush.boundedcontext.user.app.facade.UserFacade;
 import com.ticketrush.boundedcontext.user.in.api.v1.InternalUserController;
 import com.ticketrush.boundedcontext.user.in.api.v1.UserController;
+import com.ticketrush.global.config.CustomSecurityProperties;
+import com.ticketrush.global.config.SecurityConfig;
 import com.ticketrush.global.filter.GatewayHeaderFilter;
-import com.ticketrush.global.security.InternalApiTokenFilter;
 import com.ticketrush.support.WebMvcSliceTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -49,8 +51,8 @@ class InternalApiTokenFilterTest {
   @MockitoBean private UserFacade userFacade;
 
   @Test
-  @DisplayName("내부 API는 내부 토큰이 없으면 403 Forbidden을 반환한다")
-  void internalApi_withoutToken_forbidden() throws Exception {
+  @DisplayName("POST 내부 API는 내부 토큰이 없으면 403 Forbidden을 반환한다")
+  void postInternalApi_withoutToken_forbidden() throws Exception {
     UserAuthInfoRequest request = new UserAuthInfoRequest("test@test.com");
 
     mockMvc
@@ -63,8 +65,8 @@ class InternalApiTokenFilterTest {
   }
 
   @Test
-  @DisplayName("내부 API는 내부 토큰이 틀리면 403 Forbidden을 반환한다")
-  void internalApi_withWrongToken_forbidden() throws Exception {
+  @DisplayName("POST 내부 API는 내부 토큰이 틀리면 403 Forbidden을 반환한다")
+  void postInternalApi_withWrongToken_forbidden() throws Exception {
     UserAuthInfoRequest request = new UserAuthInfoRequest("test@test.com");
 
     mockMvc
@@ -78,8 +80,8 @@ class InternalApiTokenFilterTest {
   }
 
   @Test
-  @DisplayName("내부 API는 내부 토큰이 맞으면 요청을 통과시킨다")
-  void internalApi_withValidToken_success() throws Exception {
+  @DisplayName("POST 내부 API는 내부 토큰이 맞으면 요청을 통과시킨다")
+  void postInternalApi_withValidToken_success() throws Exception {
     UserAuthInfoRequest request = new UserAuthInfoRequest("test@test.com");
 
     given(userFacade.getUserAuthInfoByEmail(anyString()))
@@ -91,6 +93,39 @@ class InternalApiTokenFilterTest {
                 .header(INTERNAL_TOKEN_HEADER, "test-internal-token")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(request)))
+        .andDo(print())
+        .andExpect(status().isOk());
+  }
+
+  @Test
+  @DisplayName("GET 내부 API는 내부 토큰이 없으면 403 Forbidden을 반환한다")
+  void getInternalApi_withoutToken_forbidden() throws Exception {
+    mockMvc
+        .perform(get("/api/v1/internal/user/1/auth-info"))
+        .andDo(print())
+        .andExpect(status().isForbidden());
+  }
+
+  @Test
+  @DisplayName("GET 내부 API는 내부 토큰이 틀리면 403 Forbidden을 반환한다")
+  void getInternalApi_withWrongToken_forbidden() throws Exception {
+    mockMvc
+        .perform(
+            get("/api/v1/internal/user/1/auth-info").header(INTERNAL_TOKEN_HEADER, "wrong-token"))
+        .andDo(print())
+        .andExpect(status().isForbidden());
+  }
+
+  @Test
+  @DisplayName("GET 내부 API는 내부 토큰이 맞으면 요청을 통과시킨다")
+  void getInternalApi_withValidToken_success() throws Exception {
+    given(userFacade.getUserAuthInfoByUserId(anyLong()))
+        .willReturn(new UserAuthInfoResponse(1L, "test@test.com", "passwordHash", "USER"));
+
+    mockMvc
+        .perform(
+            get("/api/v1/internal/user/1/auth-info")
+                .header(INTERNAL_TOKEN_HEADER, "test-internal-token"))
         .andDo(print())
         .andExpect(status().isOk());
   }


### PR DESCRIPTION
## 🔗 관련 이슈

- close #377 

---

## 📌 주요 변경 사항

* DevToken 발급 과정에서 user-service 내부 GET API가 403으로 실패하던 문제를 수정했습니다.
* gateway-service에 `/api/v1/dev/auth/**` 라우트를 추가해 게이트웨이 경유 DevToken 발급 요청이 auth-service로 전달되도록 수정했습니다.
* `InternalApiTokenFilterTest`에 GET 내부 API 토큰 검증 케이스를 추가했습니다.

---

## 🛠 상세 구현 내용

* `user-service`의 `InternalApiTokenFilter`가 `/api/v1/internal/user/**` 하위 경로 전체를 내부 API로 인식하도록 수정했습니다.
* 기존에는 `POST /api/v1/internal/user/auth-info`만 필터 대상이어서 `GET /api/v1/internal/user/{userId}/auth-info` 요청에 `ROLE_INTERNAL`이 부여되지 않아 403이 발생했습니다.
* 내부 API 경로 판단 시 `getServletPath()`를 우선 사용하고, 테스트 환경 등에서 값이 비어 있을 경우 `getRequestURI()`를 fallback으로 사용하도록 처리했습니다.
* `gateway-service`의 auth-service 라우트에 `/api/v1/dev/auth/**`를 추가했습니다.
* `InternalApiTokenFilterTest`에 `GET /api/v1/internal/user/{userId}/auth-info` 요청에 대한 유효 토큰, 잘못된 토큰, 토큰 누락 케이스를 추가했습니다.
* 기존 `POST /api/v1/internal/user/auth-info` 동작이 유지되는지도 함께 검증했습니다.

---

## ✅ 테스트

### 테스트 방법

* user-service 내부 API 필터 테스트 실행

```bash
./gradlew :user-service:test --tests "*InternalApiTokenFilterTest"
```

* gateway-service 테스트 실행

```bash
./gradlew :gateway-service:test
```

* auth-service, user-service, gateway-service 전체 테스트 실행

```bash
./gradlew :auth-service:test :user-service:test :gateway-service:test
```

### 테스트 결과

* `InternalApiTokenFilterTest` 통과
* `gateway-service:test` 통과
* `auth-service:test`, `user-service:test`, `gateway-service:test` 전체 통과
* 최종 결과: `BUILD SUCCESSFUL`
