### PR TITLE
[Refactor] #366 seat/booking 내부 API 경로 /api/v1/internal 표준화 + 토큰검증 통일

### DIFF
--- a/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/app/dto/request/SeatSoldConfirmRequest.java
+++ b/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/app/dto/request/SeatSoldConfirmRequest.java
@@ -2,6 +2,6 @@ package com.ticketrush.boundedcontext.booking.app.dto.request;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-/** seat-service 좌석 판매 확정 API(POST /api/v1/seat/internal/sold) 요청 바디. */
+/** seat-service 좌석 판매 확정 API(POST /api/v1/internal/seat/sold) 요청 바디. */
 public record SeatSoldConfirmRequest(
     @JsonProperty("booking_number") String bookingNumber, @JsonProperty("seat_id") Long seatId) {}

--- a/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/in/api/v1/BookingInternalController.java
+++ b/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/in/api/v1/BookingInternalController.java
@@ -3,46 +3,31 @@ package com.ticketrush.boundedcontext.booking.in.api.v1;
 import com.ticketrush.boundedcontext.booking.app.dto.response.BookingInternalResponse;
 import com.ticketrush.boundedcontext.booking.app.usecase.BookingGetInternalUseCase;
 import com.ticketrush.global.dto.response.ApiResponse;
-import com.ticketrush.global.exception.BusinessException;
-import com.ticketrush.global.status.ErrorStatus;
 import com.ticketrush.global.status.SuccessStatus;
+import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Hidden // 내부 전용 API — 공개 OpenAPI 문서(/v3/api-docs)에 노출하지 않는다.
 @Tag(name = "BookingInternal", description = "예매 내부 통신 API")
 @RestController
-@RequestMapping("/api/v1/booking")
+@RequestMapping("/api/v1/internal/booking")
 @RequiredArgsConstructor
 public class BookingInternalController {
 
-  private static final String INTERNAL_TOKEN_HEADER = "X-Internal-Token";
-
   private final BookingGetInternalUseCase bookingGetInternalUseCase;
 
-  @Value("${gateway.internal-token}")
-  private String internalToken;
-
-  @Operation(summary = "예매 소유자/상태 내부 조회", description = "내부 토큰을 검증한 뒤 예매의 소유자와 상태를 반환합니다.")
-  @GetMapping("/internal/{bookingId}")
+  @Operation(summary = "예매 소유자/상태 내부 조회", description = "예매의 소유자와 상태를 반환합니다.")
+  @GetMapping("/{bookingId}")
   public ResponseEntity<ApiResponse<BookingInternalResponse>> getBookingInternal(
-      @RequestHeader(value = INTERNAL_TOKEN_HEADER, required = false) String internalTokenHeader,
       @PathVariable Long bookingId) {
-    validateInternalToken(internalTokenHeader);
     BookingInternalResponse response = bookingGetInternalUseCase.execute(bookingId);
     return ApiResponse.onSuccess(SuccessStatus.OK, response);
-  }
-
-  private void validateInternalToken(String internalTokenHeader) {
-    if (!internalToken.equals(internalTokenHeader)) {
-      throw new BusinessException(ErrorStatus.FORBIDDEN);
-    }
   }
 }

--- a/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/out/apiclient/SeatRestClient.java
+++ b/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/out/apiclient/SeatRestClient.java
@@ -28,7 +28,7 @@ public class SeatRestClient {
 
     seatServiceRestClient
         .post()
-        .uri("/api/v1/seat/internal/sold")
+        .uri("/api/v1/internal/seat/sold")
         .header(INTERNAL_TOKEN_HEADER, internalToken)
         .body(request)
         .retrieve()

--- a/booking-service/src/main/java/com/ticketrush/global/config/InternalApiTokenFilter.java
+++ b/booking-service/src/main/java/com/ticketrush/global/config/InternalApiTokenFilter.java
@@ -1,0 +1,62 @@
+package com.ticketrush.global.config;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.security.MessageDigest;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Component
+@RequiredArgsConstructor
+public class InternalApiTokenFilter extends OncePerRequestFilter {
+
+  private static final String INTERNAL_TOKEN_HEADER = "X-Internal-Token";
+
+  private static final String INTERNAL_API_PREFIX = "/api/v1/internal/booking/";
+
+  private final CustomSecurityProperties securityProperties;
+
+  @Override
+  protected boolean shouldNotFilter(HttpServletRequest request) {
+    return !isInternalApi(request);
+  }
+
+  @Override
+  protected void doFilterInternal(
+      HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+      throws ServletException, IOException {
+
+    String expectedToken = securityProperties.getInternalToken();
+    String actualToken = request.getHeader(INTERNAL_TOKEN_HEADER);
+
+    if (!StringUtils.hasText(expectedToken)
+        || !StringUtils.hasText(actualToken)
+        || !MessageDigest.isEqual(expectedToken.getBytes(UTF_8), actualToken.getBytes(UTF_8))) {
+      response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+      return;
+    }
+
+    UsernamePasswordAuthenticationToken authentication =
+        new UsernamePasswordAuthenticationToken(
+            "internal-service", null, List.of(new SimpleGrantedAuthority("ROLE_INTERNAL")));
+
+    SecurityContextHolder.getContext().setAuthentication(authentication);
+
+    filterChain.doFilter(request, response);
+  }
+
+  private boolean isInternalApi(HttpServletRequest request) {
+    return request.getRequestURI().startsWith(INTERNAL_API_PREFIX);
+  }
+}

--- a/booking-service/src/main/java/com/ticketrush/global/config/SecurityConfig.java
+++ b/booking-service/src/main/java/com/ticketrush/global/config/SecurityConfig.java
@@ -23,6 +23,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 public class SecurityConfig {
 
   private final GatewayHeaderFilter gatewayHeaderFilter;
+  private final InternalApiTokenFilter internalApiTokenFilter;
 
   @Bean
   public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -30,7 +31,16 @@ public class SecurityConfig {
         .cors(cors -> {})
         .httpBasic(httpBasic -> httpBasic.disable())
         .formLogin(formLogin -> formLogin.disable())
+        // 필터 순서 주의: gatewayHeaderFilter가 internalApiTokenFilter보다 먼저 실행돼야 한다.
+        // gatewayHeaderFilter는 토큰 불일치 시 SecurityContext를 clear하므로, 순서가 뒤집히면
+        // internalApiTokenFilter가 세팅한 ROLE_INTERNAL이 지워져 내부 호출이 403이 된다.
+        // (두 addFilterBefore가 같은 기준 필터를 쓰지만 정렬이 stable하므로 등록 순서가 보존된다.)
+        // 두 키를 분리하려면 필터 순서만으로는 부족하다: 내부 호출의 송신 측(SeatRestClient 등)이
+        // @Value("${gateway.internal-token}")을 헤더에 싣는 반면 이 필터는 custom.security.internal-token으로
+        // 검증하므로, 분리 시 송신 측 헤더 소스도 함께 바꾸지 않으면 모든 내부 호출이 403이 된다.
+        // 지금은 두 키가 같은 GATEWAY_INTERNAL_TOKEN 시크릿으로 해석돼 일치한다.
         .addFilterBefore(gatewayHeaderFilter, UsernamePasswordAuthenticationFilter.class)
+        .addFilterBefore(internalApiTokenFilter, UsernamePasswordAuthenticationFilter.class)
         .exceptionHandling(
             exception ->
                 exception.authenticationEntryPoint(
@@ -52,6 +62,8 @@ public class SecurityConfig {
                 auth.requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html")
                     // TODO: 인증 이후 허용 범위 수정
                     .permitAll()
+                    .requestMatchers("/api/v1/internal/booking/**")
+                    .hasRole("INTERNAL")
                     .requestMatchers(HttpMethod.POST, "/api/v1/booking")
                     .authenticated()
                     .anyRequest()

--- a/booking-service/src/main/resources/application-prod.yml
+++ b/booking-service/src/main/resources/application-prod.yml
@@ -20,6 +20,8 @@ gateway:
 
 custom:
   security:
+    # 운영은 내부 API 토큰을 반드시 주입(base의 test-token 기본값 오버라이드, 미주입 시 fail-fast).
+    internal-token: ${GATEWAY_INTERNAL_TOKEN}
     permit-urls:
       - /swagger-ui/**
       - /v3/api-docs/**

--- a/booking-service/src/main/resources/application.yml
+++ b/booking-service/src/main/resources/application.yml
@@ -23,6 +23,9 @@ custom:
   swagger:
     serverUrl: ${SWAGGER_SERVER_URL:http://localhost:8080}
   security:
+    # 내부 API 토큰. gateway.internal-token과 동일한 GATEWAY_INTERNAL_TOKEN 시크릿을 의도적으로 공유한다
+    # (게이트웨이↔서비스 공유 시크릿 재사용, performance/user/auth 서비스와 동일).
+    internal-token: ${GATEWAY_INTERNAL_TOKEN:test-token}
     permit-all: false
     permit-urls:
       # ========== 개발 도구 ==========

--- a/booking-service/src/test/java/com/ticketrush/boundedcontext/booking/in/api/v1/BookingControllerTest.java
+++ b/booking-service/src/test/java/com/ticketrush/boundedcontext/booking/in/api/v1/BookingControllerTest.java
@@ -15,6 +15,8 @@ import com.ticketrush.boundedcontext.booking.app.dto.response.BookingPendingResp
 import com.ticketrush.boundedcontext.booking.app.dto.response.BookingSummaryResponse;
 import com.ticketrush.boundedcontext.booking.app.facade.BookingFacade;
 import com.ticketrush.boundedcontext.booking.domain.types.BookingStatus;
+import com.ticketrush.global.config.CustomSecurityProperties;
+import com.ticketrush.global.config.InternalApiTokenFilter;
 import com.ticketrush.global.config.JacksonConfig;
 import com.ticketrush.global.config.SecurityConfig;
 import com.ticketrush.global.dto.request.OffsetPageRequest;
@@ -35,7 +37,13 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(BookingController.class)
-@Import({JacksonConfig.class, SecurityConfig.class, GatewayHeaderFilter.class})
+@Import({
+  JacksonConfig.class,
+  SecurityConfig.class,
+  GatewayHeaderFilter.class,
+  InternalApiTokenFilter.class,
+  CustomSecurityProperties.class
+})
 @TestPropertySource(properties = "gateway.internal-token=test-token")
 class BookingControllerTest {
 

--- a/booking-service/src/test/java/com/ticketrush/boundedcontext/booking/in/api/v1/BookingInternalControllerTest.java
+++ b/booking-service/src/test/java/com/ticketrush/boundedcontext/booking/in/api/v1/BookingInternalControllerTest.java
@@ -9,10 +9,11 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.ticketrush.boundedcontext.booking.app.dto.response.BookingInternalResponse;
 import com.ticketrush.boundedcontext.booking.app.usecase.BookingGetInternalUseCase;
 import com.ticketrush.boundedcontext.booking.domain.types.BookingStatus;
+import com.ticketrush.global.config.CustomSecurityProperties;
+import com.ticketrush.global.config.InternalApiTokenFilter;
 import com.ticketrush.global.config.JacksonConfig;
 import com.ticketrush.global.config.SecurityConfig;
 import com.ticketrush.global.filter.GatewayHeaderFilter;
-import com.ticketrush.global.status.ErrorStatus;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -23,11 +24,21 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(BookingInternalController.class)
-@Import({JacksonConfig.class, SecurityConfig.class, GatewayHeaderFilter.class})
-@TestPropertySource(properties = "gateway.internal-token=test-token")
+@Import({
+  JacksonConfig.class,
+  SecurityConfig.class,
+  GatewayHeaderFilter.class,
+  InternalApiTokenFilter.class,
+  CustomSecurityProperties.class
+})
+@TestPropertySource(
+    properties = {
+      "gateway.internal-token=test-token",
+      "custom.security.internal-token=test-internal-token"
+    })
 class BookingInternalControllerTest {
 
-  private static final String INTERNAL_TOKEN = "test-token";
+  private static final String INTERNAL_TOKEN_HEADER = "X-Internal-Token";
 
   @Autowired private MockMvc mockMvc;
 
@@ -44,8 +55,8 @@ class BookingInternalControllerTest {
     // when & then
     mockMvc
         .perform(
-            get("/api/v1/booking/internal/{bookingId}", bookingId)
-                .header("X-Internal-Token", INTERNAL_TOKEN))
+            get("/api/v1/internal/booking/{bookingId}", bookingId)
+                .header(INTERNAL_TOKEN_HEADER, "test-internal-token"))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.is_success").value(true))
         .andExpect(jsonPath("$.result.booking_id").value(100))
@@ -59,10 +70,9 @@ class BookingInternalControllerTest {
     // when & then
     mockMvc
         .perform(
-            get("/api/v1/booking/internal/{bookingId}", 100L).header("X-Internal-Token", "wrong"))
-        .andExpect(status().isForbidden())
-        .andExpect(jsonPath("$.is_success").value(false))
-        .andExpect(jsonPath("$.code").value(ErrorStatus.FORBIDDEN.getCode()));
+            get("/api/v1/internal/booking/{bookingId}", 100L)
+                .header(INTERNAL_TOKEN_HEADER, "wrong"))
+        .andExpect(status().isForbidden());
 
     verifyNoInteractions(bookingGetInternalUseCase);
   }
@@ -72,9 +82,8 @@ class BookingInternalControllerTest {
   void getBookingInternal_fails_when_token_missing() throws Exception {
     // when & then
     mockMvc
-        .perform(get("/api/v1/booking/internal/{bookingId}", 100L))
-        .andExpect(status().isForbidden())
-        .andExpect(jsonPath("$.code").value(ErrorStatus.FORBIDDEN.getCode()));
+        .perform(get("/api/v1/internal/booking/{bookingId}", 100L))
+        .andExpect(status().isForbidden());
 
     verifyNoInteractions(bookingGetInternalUseCase);
   }

--- a/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/in/api/v1/SeatController.java
+++ b/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/in/api/v1/SeatController.java
@@ -1,29 +1,21 @@
 package com.ticketrush.boundedcontext.seat.in.api.v1;
 
-import com.ticketrush.boundedcontext.seat.app.dto.request.SeatSoldConfirmRequest;
 import com.ticketrush.boundedcontext.seat.app.dto.response.SeatLayoutResponse;
 import com.ticketrush.boundedcontext.seat.app.dto.response.SeatNumberResponse;
 import com.ticketrush.boundedcontext.seat.app.dto.response.SeatStatusCountsResponse;
 import com.ticketrush.boundedcontext.seat.app.facade.SeatFacade;
 import com.ticketrush.global.dto.response.ApiResponse;
-import com.ticketrush.global.exception.BusinessException;
-import com.ticketrush.global.status.ErrorStatus;
 import com.ticketrush.global.status.SuccessStatus;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import jakarta.validation.Valid;
 import jakarta.validation.constraints.Size;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -35,12 +27,7 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 @RequiredArgsConstructor
 public class SeatController {
 
-  private static final String INTERNAL_TOKEN_HEADER = "X-Internal-Token";
-
   private final SeatFacade seatFacade;
-
-  @Value("${gateway.internal-token}")
-  private String internalToken;
 
   @GetMapping("/{performanceId}/seat-layouts")
   @Operation(summary = "공연별 좌석 배치 조회", description = "공연 ID에 해당하는 좌석 ID, 좌석 배치 ID, 좌석 번호를 조회합니다.")
@@ -75,21 +62,5 @@ public class SeatController {
   @Operation(summary = "공연별 좌석 상태 SSE 구독", description = "공연 ID에 해당하는 좌석 상태 변경 이벤트를 실시간으로 구독합니다.")
   public SseEmitter subscribeSeatStatus(@PathVariable Long performanceId) {
     return seatFacade.subscribeSeatStatus(performanceId);
-  }
-
-  @PostMapping("/internal/sold")
-  @Operation(summary = "좌석 판매 확정", description = "내부 토큰을 검증한 뒤 HOLD 상태 좌석을 SOLD 상태로 확정합니다.")
-  public ResponseEntity<ApiResponse<Void>> confirmSold(
-      @RequestHeader(value = INTERNAL_TOKEN_HEADER, required = false) String internalTokenHeader,
-      @Valid @RequestBody SeatSoldConfirmRequest request) {
-    validateInternalToken(internalTokenHeader);
-    seatFacade.confirmSold(request.bookingNumber(), request.seatId());
-    return ApiResponse.onSuccess(SuccessStatus.OK);
-  }
-
-  private void validateInternalToken(String internalTokenHeader) {
-    if (!internalToken.equals(internalTokenHeader)) {
-      throw new BusinessException(ErrorStatus.FORBIDDEN);
-    }
   }
 }

--- a/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/in/api/v1/SeatInternalController.java
+++ b/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/in/api/v1/SeatInternalController.java
@@ -1,0 +1,34 @@
+package com.ticketrush.boundedcontext.seat.in.api.v1;
+
+import com.ticketrush.boundedcontext.seat.app.dto.request.SeatSoldConfirmRequest;
+import com.ticketrush.boundedcontext.seat.app.facade.SeatFacade;
+import com.ticketrush.global.dto.response.ApiResponse;
+import com.ticketrush.global.status.SuccessStatus;
+import io.swagger.v3.oas.annotations.Hidden;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Hidden // 내부 전용 API — 공개 OpenAPI 문서(/v3/api-docs)에 노출하지 않는다.
+@Tag(name = "SeatInternal", description = "좌석 내부 통신 API")
+@RestController
+@RequestMapping("/api/v1/internal/seat")
+@RequiredArgsConstructor
+public class SeatInternalController {
+
+  private final SeatFacade seatFacade;
+
+  @Operation(summary = "좌석 판매 확정", description = "HOLD 상태 좌석을 SOLD 상태로 확정합니다.")
+  @PostMapping("/sold")
+  public ResponseEntity<ApiResponse<Void>> confirmSold(
+      @Valid @RequestBody SeatSoldConfirmRequest request) {
+    seatFacade.confirmSold(request.bookingNumber(), request.seatId());
+    return ApiResponse.onSuccess(SuccessStatus.OK);
+  }
+}

--- a/seat-service/src/main/java/com/ticketrush/global/config/InternalApiTokenFilter.java
+++ b/seat-service/src/main/java/com/ticketrush/global/config/InternalApiTokenFilter.java
@@ -1,0 +1,62 @@
+package com.ticketrush.global.config;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.security.MessageDigest;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Component
+@RequiredArgsConstructor
+public class InternalApiTokenFilter extends OncePerRequestFilter {
+
+  private static final String INTERNAL_TOKEN_HEADER = "X-Internal-Token";
+
+  private static final String INTERNAL_API_PREFIX = "/api/v1/internal/seat/";
+
+  private final CustomSecurityProperties securityProperties;
+
+  @Override
+  protected boolean shouldNotFilter(HttpServletRequest request) {
+    return !isInternalApi(request);
+  }
+
+  @Override
+  protected void doFilterInternal(
+      HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+      throws ServletException, IOException {
+
+    String expectedToken = securityProperties.getInternalToken();
+    String actualToken = request.getHeader(INTERNAL_TOKEN_HEADER);
+
+    if (!StringUtils.hasText(expectedToken)
+        || !StringUtils.hasText(actualToken)
+        || !MessageDigest.isEqual(expectedToken.getBytes(UTF_8), actualToken.getBytes(UTF_8))) {
+      response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+      return;
+    }
+
+    UsernamePasswordAuthenticationToken authentication =
+        new UsernamePasswordAuthenticationToken(
+            "internal-service", null, List.of(new SimpleGrantedAuthority("ROLE_INTERNAL")));
+
+    SecurityContextHolder.getContext().setAuthentication(authentication);
+
+    filterChain.doFilter(request, response);
+  }
+
+  private boolean isInternalApi(HttpServletRequest request) {
+    return request.getRequestURI().startsWith(INTERNAL_API_PREFIX);
+  }
+}

--- a/seat-service/src/main/java/com/ticketrush/global/config/SecurityConfig.java
+++ b/seat-service/src/main/java/com/ticketrush/global/config/SecurityConfig.java
@@ -9,6 +9,7 @@ import org.springframework.security.config.annotation.method.configuration.Enabl
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
 @EnableWebSecurity
@@ -17,15 +18,20 @@ import org.springframework.security.web.SecurityFilterChain;
 @RequiredArgsConstructor
 public class SecurityConfig {
 
+  private final InternalApiTokenFilter internalApiTokenFilter;
+
   @Bean
   public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
     http.csrf(csrf -> csrf.disable())
         .cors(cors -> {})
+        .addFilterBefore(internalApiTokenFilter, UsernamePasswordAuthenticationFilter.class)
         .authorizeHttpRequests(
             auth ->
                 auth.requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html")
                     // TODO: 인증 이후 허용 범위 수정
                     .permitAll()
+                    .requestMatchers("/api/v1/internal/seat/**")
+                    .hasRole("INTERNAL")
                     .anyRequest()
                     .permitAll());
 

--- a/seat-service/src/main/resources/application-prod.yml
+++ b/seat-service/src/main/resources/application-prod.yml
@@ -20,6 +20,8 @@ gateway:
 
 custom:
   security:
+    # 운영은 내부 API 토큰을 반드시 주입(base의 test-token 기본값 오버라이드, 미주입 시 fail-fast).
+    internal-token: ${GATEWAY_INTERNAL_TOKEN}
     permit-urls:
       - /swagger-ui/**
       - /v3/api-docs/**

--- a/seat-service/src/main/resources/application.yml
+++ b/seat-service/src/main/resources/application.yml
@@ -16,6 +16,9 @@ custom:
   swagger:
     serverUrl: ${SWAGGER_SERVER_URL:http://localhost:8080}
   security:
+    # 내부 API 토큰. gateway.internal-token과 동일한 GATEWAY_INTERNAL_TOKEN 시크릿을 의도적으로 공유한다
+    # (게이트웨이↔서비스 공유 시크릿 재사용, performance/user/auth 서비스와 동일).
+    internal-token: ${GATEWAY_INTERNAL_TOKEN:test-token}
     permit-all: false
     permit-urls:
       # ========== 개발 도구 ==========

--- a/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/in/api/v1/SeatControllerTest.java
+++ b/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/in/api/v1/SeatControllerTest.java
@@ -2,9 +2,7 @@ package com.ticketrush.boundedcontext.seat.in.api.v1;
 
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -12,6 +10,8 @@ import com.ticketrush.boundedcontext.seat.app.dto.response.SeatLayoutResponse;
 import com.ticketrush.boundedcontext.seat.app.dto.response.SeatNumberResponse;
 import com.ticketrush.boundedcontext.seat.app.dto.response.SeatStatusCountsResponse;
 import com.ticketrush.boundedcontext.seat.app.facade.SeatFacade;
+import com.ticketrush.global.config.CustomSecurityProperties;
+import com.ticketrush.global.config.InternalApiTokenFilter;
 import com.ticketrush.global.config.SecurityConfig;
 import com.ticketrush.global.types.SeatStatus;
 import com.ticketrush.support.WebMvcSliceTest;
@@ -20,19 +20,14 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Import;
-import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
-import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 @WebMvcSliceTest(SeatController.class)
-@Import(SecurityConfig.class)
-@TestPropertySource(properties = "gateway.internal-token=test-token")
+@Import({SecurityConfig.class, InternalApiTokenFilter.class, CustomSecurityProperties.class})
 class SeatControllerTest {
-
-  private static final String INTERNAL_TOKEN = "test-token";
 
   @Autowired private MockMvc mockMvc;
 
@@ -123,55 +118,5 @@ class SeatControllerTest {
         .andExpect(jsonPath("$.result.available_count").value(6))
         .andExpect(jsonPath("$.result.sold_count").value(3))
         .andExpect(jsonPath("$.result.hold_count").value(1));
-  }
-
-  @Test
-  @WithMockUser
-  @DisplayName("좌석 판매 확정 요청을 성공하고 200 OK를 반환한다")
-  void confirmSold() throws Exception {
-    // given
-    String requestBody =
-        """
-        {
-          "booking_number": "X7B29-KLPW1",
-          "seat_id": 1
-        }
-        """;
-
-    // when & then
-    mockMvc
-        .perform(
-            post("/api/v1/seat/internal/sold")
-                .with(csrf())
-                .header("X-Internal-Token", INTERNAL_TOKEN)
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(requestBody))
-        .andExpect(status().isOk())
-        .andExpect(jsonPath("$.is_success").value(true));
-
-    verify(seatFacade).confirmSold("X7B29-KLPW1", 1L);
-  }
-
-  @Test
-  @WithMockUser
-  @DisplayName("좌석 판매 확정 요청에 내부 토큰이 없으면 403 Forbidden을 반환한다")
-  void confirmSold_fail_when_internal_token_missing() throws Exception {
-    // given
-    String requestBody =
-        """
-        {
-          "booking_number": "X7B29-KLPW1",
-          "seat_id": 1
-        }
-        """;
-
-    // when & then
-    mockMvc
-        .perform(
-            post("/api/v1/seat/internal/sold")
-                .with(csrf())
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(requestBody))
-        .andExpect(status().isForbidden());
   }
 }

--- a/seat-service/src/test/java/com/ticketrush/global/config/InternalApiTokenFilterTest.java
+++ b/seat-service/src/test/java/com/ticketrush/global/config/InternalApiTokenFilterTest.java
@@ -1,0 +1,89 @@
+package com.ticketrush.global.config;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.ticketrush.boundedcontext.seat.app.facade.SeatFacade;
+import com.ticketrush.boundedcontext.seat.in.api.v1.SeatInternalController;
+import com.ticketrush.support.WebMvcSliceTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcSliceTest(SeatInternalController.class)
+@Import({SecurityConfig.class, InternalApiTokenFilter.class, CustomSecurityProperties.class})
+@TestPropertySource(
+    properties = {
+      "custom.security.internal-token=test-internal-token",
+      "custom.security.permit-all=false"
+    })
+class InternalApiTokenFilterTest {
+
+  private static final String INTERNAL_TOKEN_HEADER = "X-Internal-Token";
+
+  private static final String REQUEST_BODY =
+      """
+      {
+        "booking_number": "X7B29-KLPW1",
+        "seat_id": 1
+      }
+      """;
+
+  @Autowired private MockMvc mockMvc;
+
+  @MockitoBean private SeatFacade seatFacade;
+
+  @Test
+  @DisplayName("내부 API는 내부 토큰이 없으면 403 Forbidden을 반환한다")
+  void internalApi_withoutToken_forbidden() throws Exception {
+    mockMvc
+        .perform(
+            post("/api/v1/internal/seat/sold")
+                .with(csrf())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(REQUEST_BODY))
+        .andExpect(status().isForbidden());
+
+    verifyNoInteractions(seatFacade);
+  }
+
+  @Test
+  @DisplayName("내부 API는 내부 토큰이 틀리면 403 Forbidden을 반환한다")
+  void internalApi_withWrongToken_forbidden() throws Exception {
+    mockMvc
+        .perform(
+            post("/api/v1/internal/seat/sold")
+                .with(csrf())
+                .header(INTERNAL_TOKEN_HEADER, "wrong-token")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(REQUEST_BODY))
+        .andExpect(status().isForbidden());
+
+    verifyNoInteractions(seatFacade);
+  }
+
+  @Test
+  @DisplayName("내부 API는 내부 토큰이 맞으면 요청을 통과시킨다")
+  void internalApi_withValidToken_success() throws Exception {
+    mockMvc
+        .perform(
+            post("/api/v1/internal/seat/sold")
+                .with(csrf())
+                .header(INTERNAL_TOKEN_HEADER, "test-internal-token")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(REQUEST_BODY))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.is_success").value(true));
+
+    verify(seatFacade).confirmSold("X7B29-KLPW1", 1L);
+  }
+}

--- a/ticket-service/src/main/java/com/ticketrush/boundedcontext/ticket/out/apiclient/BookingRestClient.java
+++ b/ticket-service/src/main/java/com/ticketrush/boundedcontext/ticket/out/apiclient/BookingRestClient.java
@@ -34,7 +34,7 @@ public class BookingRestClient {
       response =
           bookingServiceRestClient
               .get()
-              .uri("/api/v1/booking/internal/{bookingId}", bookingId)
+              .uri("/api/v1/internal/booking/{bookingId}", bookingId)
               .header(INTERNAL_TOKEN_HEADER, internalToken)
               .retrieve()
               .onStatus(

--- a/ticket-service/src/test/java/com/ticketrush/boundedcontext/ticket/out/apiclient/BookingRestClientTest.java
+++ b/ticket-service/src/test/java/com/ticketrush/boundedcontext/ticket/out/apiclient/BookingRestClientTest.java
@@ -27,7 +27,7 @@ class BookingRestClientTest {
   private static final String BASE_URL = "http://localhost:8084";
   private static final String INTERNAL_TOKEN = "test-token";
   private static final long BOOKING_ID = 100L;
-  private static final String REQUEST_URL = BASE_URL + "/api/v1/booking/internal/" + BOOKING_ID;
+  private static final String REQUEST_URL = BASE_URL + "/api/v1/internal/booking/" + BOOKING_ID;
 
   private MockRestServiceServer mockServer;
   private BookingRestClient client;


### PR DESCRIPTION
## 🔗 관련 이슈

- close #366

---

## 📌 주요 변경 사항

- seat·booking의 내부 전용 엔드포인트를 `/api/v1/internal/{context}/...` 표준(#365)으로 이동해, Gateway 서비스 와일드카드 라우트를 통한 외부 노출을 차단했습니다.
- 컨트롤러 인라인 토큰검증(`internalToken.equals(header)`)을 `InternalApiTokenFilter` + `hasRole("INTERNAL")`로 통일하고, 토큰 비교를 상수시간 비교로 바꿨습니다.
- 호출자 RestClient(booking→seat, ticket→booking)의 uri를 함께 옮겨 서비스 간 호출을 맞췄습니다.

---

## 🛠 상세 구현 내용

- **경로 이동**
  - seat: `POST /api/v1/seat/internal/sold` → `POST /api/v1/internal/seat/sold`. `SeatController`에 섞여 있던 내부 엔드포인트를 `SeatInternalController`로 분리하고 `@Hidden`으로 공개 OpenAPI 문서에서 제외했습니다.
  - booking: `GET /api/v1/booking/internal/{bookingId}` → `GET /api/v1/internal/booking/{bookingId}`. 기존 `BookingInternalController`의 클래스 매핑만 이동했습니다.
- **토큰 검증 통일**
  - `performance-service`의 `InternalApiTokenFilter`(#367)를 seat/booking에 도입했습니다. `X-Internal-Token`을 `MessageDigest.isEqual`로 상수시간 비교하고, 통과 시 `ROLE_INTERNAL`을 부여합니다.
  - `SecurityConfig`에 필터를 등록하고 `/api/v1/internal/{seat,booking}/**`에 `hasRole("INTERNAL")` 인가를 `anyRequest().permitAll()` 앞에 배치했습니다.
  - booking은 필터 순서(gateway 먼저 → internal 나중)를 유지했습니다. 순서가 뒤집히면 `gatewayHeaderFilter`가 `ROLE_INTERNAL`을 지웁니다.
  - `custom.security.internal-token` 프로퍼티를 추가했습니다(dev 기본값 `test-token`, prod는 `${GATEWAY_INTERNAL_TOKEN}` fail-fast). 기존 `gateway.internal-token`은 common의 `GatewayHeaderFilter`와 송신 측 RestClient가 계속 쓰므로 유지했습니다.
- **호출자 동기화**: booking `SeatRestClient`, ticket `BookingRestClient`의 uri를 새 경로로 변경했습니다.
- **Gateway**: 라우트 predicates가 서비스별 와일드카드뿐이라 `/api/v1/internal/**`는 어떤 라우트에도 걸리지 않습니다. 라우트 미등록만으로 외부 차단이 성립하므로 **gateway 설정 변경은 없습니다.**

### 원래 이슈 본문의 사실 정정

이슈는 "공통 `InternalApiTokenFilter` 재사용(user/auth 기존 구현 재사용)"이라 적었지만, **공통 필터는 존재하지 않습니다.** auth/user/performance에 각각 복붙된 별개 클래스이고 매처도 서로 다릅니다(auth=prefix, user=POST+정확경로, performance=prefix). 이번에는 합의에 따라 performance의 필터를 seat/booking에 **복제**했고, `common` 추출은 5개 서비스의 `SecurityConfig`·테스트를 건드려 범위를 넘으므로 별도 이슈로 분리합니다. user 필터의 매처 결함(DevToken 403)은 #377의 범위로 남겼습니다.

---

## ✅ 테스트

### 테스트 방법

- 신규 `seat-service`의 `InternalApiTokenFilterTest` 3케이스: 토큰 없음 → 403, 틀린 토큰 → 403, 올바른 토큰 → 200 + `seatFacade.confirmSold` 호출 검증
- `booking-service`의 `BookingInternalControllerTest`를 필터 방식으로 갱신(3케이스). 성공 케이스는 `gateway.internal-token`과 `custom.security.internal-token`을 **일부러 다르게** 주입해, 필터 순서가 뒤집히면 403으로 깨지도록 했습니다.
- 필터 자동포함으로 깨진 `BookingControllerTest`에 `CustomSecurityProperties`·`InternalApiTokenFilter` 임포트를 보강했습니다.
- 실행 명령: `./gradlew :seat-service:test :booking-service:test :ticket-service:test spotlessCheck`

### 테스트 결과

- `BUILD SUCCESSFUL` — seat/booking/ticket 테스트 전부 통과, `spotlessCheck` 통과. pre-commit의 `spotlessApply` + `checkstyleMain/Test`도 통과했습니다.
- 컨테이너 기동 통합 검증(서비스 직결 200/403, Gateway 경유 404)은 **미실시**입니다.
<!--
### 📸 스크린샷

- (작성 필요)
-->
---

## 👀 리뷰 요청 사항

- **필터 복제 vs common 추출**: 이번에 seat/booking에 복제하면서 `InternalApiTokenFilter`가 5벌이 됐습니다. common 추출을 별도 이슈로 뺀 판단이 적절한지 봐주세요.
- **403 응답 바디 변화**: 기존 인라인 검증은 `BusinessException(FORBIDDEN)`으로 `{"is_success":false,"code":...}` 바디를 냈지만, 필터는 상태 코드만 세팅해 바디가 없습니다(performance와 동일). 호출자 둘 다 에러 바디를 파싱하지 않아 영향은 없지만, 팀 에러 응답 규약과의 불일치를 감수할지 확인 부탁드립니다.
- **송·수신 토큰 키 불일치**: 송신 측 RestClient는 `gateway.internal-token`을, 수신 필터는 `custom.security.internal-token`을 씁니다. 지금은 같은 `GATEWAY_INTERNAL_TOKEN` 시크릿으로 해석돼 일치하지만, 두 키를 분리하면 내부 호출이 전부 깨집니다. 이 함정을 `SecurityConfig` 주석에 명시해뒀는데, 아예 키를 하나로 정렬하는 게 나을지 의견 주세요.

---

## ⚠️ 배포 시 주의사항

- **경로 변경과 호출자 변경이 한 커밋에 묶여 있어, seat·booking·ticket을 함께 재배포해야 합니다.** 구 버전 호출자와 신 버전 수신자가 섞이면 내부 호출이 404가 됩니다(단일 EC2 Compose 동시 재배포라 실무상 문제는 없습니다).
- 신규 환경변수는 없습니다. `custom.security.internal-token`은 기존 `GATEWAY_INTERNAL_TOKEN`을 그대로 참조합니다. 다만 prod 프로파일에서 이 값이 비어 있으면 기동에 실패(fail-fast)합니다.
- gateway 설정 변경이 없으므로 게이트웨이 재배포는 불필요합니다.
