### PR TITLE
[Refactor] #364 QR 조회의 booking-service 동기 호출 제거 (userId denormalization)

### DIFF
--- a/infra/mysql/init/01-schema.sql
+++ b/infra/mysql/init/01-schema.sql
@@ -233,6 +233,7 @@ CREATE TABLE `ticket` (
   `created_at` datetime(6) DEFAULT NULL,
   `updated_at` datetime(6) DEFAULT NULL,
   `booking_id` bigint NOT NULL,
+  `user_id` bigint DEFAULT NULL,
   `ticket_status` enum('CANCELED','UNUSED','USED') NOT NULL,
   `ticket_token_hash` varchar(64) NOT NULL,
   `used_at` datetime(6) DEFAULT NULL,

--- a/ticket-service/src/main/java/com/ticketrush/boundedcontext/ticket/app/mapper/TicketMapper.java
+++ b/ticket-service/src/main/java/com/ticketrush/boundedcontext/ticket/app/mapper/TicketMapper.java
@@ -20,8 +20,8 @@ public interface TicketMapper {
   @Mapping(source = "ticket.createdAt", target = "issuedAt")
   TicketQrResponse toTicketQrResponse(Ticket ticket, String payload, LocalDateTime expiresAt);
 
-  // 식별자 + 계산된 토큰 해시 -> Entity. @Builder 대상(bookingId/ticketTokenHash/ticketStatus)만 target이라
+  // 식별자 + 계산된 토큰 해시 -> Entity. @Builder 대상(bookingId/userId/ticketTokenHash/ticketStatus)만 target이라
   // id/usedAt은 ignore가 불필요하며, 발급 시 상태는 UNUSED로 고정한다.
   @Mapping(target = "ticketStatus", constant = "UNUSED")
-  Ticket toEntity(Long bookingId, String ticketTokenHash);
+  Ticket toEntity(Long bookingId, Long userId, String ticketTokenHash);
 }

--- a/ticket-service/src/main/java/com/ticketrush/boundedcontext/ticket/app/usecase/EntryVerifyUseCase.java
+++ b/ticket-service/src/main/java/com/ticketrush/boundedcontext/ticket/app/usecase/EntryVerifyUseCase.java
@@ -48,8 +48,8 @@ public class EntryVerifyUseCase {
             .findById(claims.ticketId())
             .orElseThrow(() -> new BusinessException(ErrorStatus.TICKET_NOT_FOUND));
 
-    // 취소 전파가 ticket-service로 들어오지 않으므로(로컬 ticketStatus만으로는 취소를 알 수 없음), 예매 확정/취소 판정은 booking 동기 조회로
-    // 한다.
+    // 취소는 PaymentCanceledEventListener가 로컬 ticketStatus=CANCELED로 투영하지만, REFUNDING/REFUND_FAILED 등
+    // 환불 진행 상태는 로컬에 반영되지 않는다. 입장은 되돌릴 수 없는 행위이므로 권위 있는 bookingStatus로 최종 판정한다(#364).
     BookingInfoResponse booking = bookingRestClient.getBooking(ticket.getBookingId());
     if (!CONFIRMED_STATUS.equals(booking.bookingStatus())) {
       throw new BusinessException(ErrorStatus.TICKET_NOT_USABLE);

--- a/ticket-service/src/main/java/com/ticketrush/boundedcontext/ticket/app/usecase/TicketIssueUseCase.java
+++ b/ticket-service/src/main/java/com/ticketrush/boundedcontext/ticket/app/usecase/TicketIssueUseCase.java
@@ -36,7 +36,7 @@ public class TicketIssueUseCase {
   private final TicketMapper ticketMapper;
   private final MeterRegistry meterRegistry;
 
-  public TicketIssueResponse execute(Long bookingId) {
+  public TicketIssueResponse execute(Long bookingId, Long userId) {
     if (ticketRepository.existsByBookingId(bookingId)) {
       Counter.builder(MetricNames.TICKET_ISSUE)
           .tag(MetricNames.TAG_RESULT, MetricNames.RESULT_ALREADY_ISSUED)
@@ -46,7 +46,7 @@ public class TicketIssueUseCase {
     }
 
     String token = ticketTokenGenerator.generate();
-    Ticket ticket = ticketMapper.toEntity(bookingId, ticketTokenHasher.hash(token));
+    Ticket ticket = ticketMapper.toEntity(bookingId, userId, ticketTokenHasher.hash(token));
 
     // Inbox 트랜잭션에 조인된 상태로 저장한다. unique(booking_id/ticket_token_hash) 충돌 시 예외를 그대로 전파해
     // 트랜잭션을 롤백시키고(Inbox 미기록) 재소비로 처리한다.

--- a/ticket-service/src/main/java/com/ticketrush/boundedcontext/ticket/app/usecase/TicketQrGetUseCase.java
+++ b/ticket-service/src/main/java/com/ticketrush/boundedcontext/ticket/app/usecase/TicketQrGetUseCase.java
@@ -5,8 +5,7 @@ import com.ticketrush.boundedcontext.ticket.app.mapper.TicketMapper;
 import com.ticketrush.boundedcontext.ticket.domain.entity.Ticket;
 import com.ticketrush.boundedcontext.ticket.domain.policy.QrPayload;
 import com.ticketrush.boundedcontext.ticket.domain.policy.TicketQrPayloadGenerator;
-import com.ticketrush.boundedcontext.ticket.out.apiclient.BookingRestClient;
-import com.ticketrush.boundedcontext.ticket.out.apiclient.dto.BookingInfoResponse;
+import com.ticketrush.boundedcontext.ticket.domain.types.TicketStatus;
 import com.ticketrush.boundedcontext.ticket.out.repository.TicketRepository;
 import com.ticketrush.global.exception.BusinessException;
 import com.ticketrush.global.status.ErrorStatus;
@@ -17,35 +16,35 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class TicketQrGetUseCase {
 
-  /** 확정된(CONFIRMED) 예매만 QR payload 조회를 허용한다. booking-service의 BookingStatus enum 이름과 일치. */
-  private static final String CONFIRMED_STATUS = "CONFIRMED";
-
-  private final BookingRestClient bookingRestClient;
   private final TicketRepository ticketRepository;
   private final TicketQrPayloadGenerator ticketQrPayloadGenerator;
   private final TicketMapper ticketMapper;
 
   /**
-   * 외부 동기 호출(booking-service)을 트랜잭션 밖에서 먼저 수행해 DB 커넥션을 장시간 점유하지 않는다. 실제 DB 접근은 findByBookingId
-   * 단건뿐이라 Spring Data의 기본 트랜잭션으로 충분하므로 메서드 레벨 트랜잭션을 두지 않는다.
+   * QR 조회는 booking-service 동기 호출 없이 로컬 데이터로만 처리한다(#364). 소유권은 발급 시 복제한 {@code ticket.userId}로, 유효성은
+   * PaymentCanceledEvent가 투영한 로컬 {@code ticketStatus}로 판정한다.
+   *
+   * <p>REFUNDING/REFUND_FAILED 등 환불 진행 상태는 로컬에 반영되지 않아 이 경로에서 걸러지지 않는다. QR 조회는 되돌릴 수 없는 행위가 아니므로
+   * 허용하고, 실제 입장 게이트({@code EntryVerifyUseCase})가 권위 있는 bookingStatus로 최종 차단한다.
+   *
+   * <p>DB 접근이 findByBookingId 단건뿐이라 Spring Data의 기본 트랜잭션으로 충분하므로 메서드 레벨 트랜잭션을 두지 않는다.
    */
   public TicketQrResponse execute(Long userId, Long bookingId) {
-    BookingInfoResponse booking = bookingRestClient.getBooking(bookingId);
-
-    // 본인 예매가 아니면 미존재와 동일하게 404로 통일해 다른 사용자 예매의 존재 여부 노출을 막는다.
-    if (!userId.equals(booking.userId())) {
-      throw new BusinessException(ErrorStatus.TICKET_NOT_FOUND);
-    }
-
-    // 미확정/취소 예매는 입장권 조회가 불가능하다.
-    if (!CONFIRMED_STATUS.equals(booking.bookingStatus())) {
-      throw new BusinessException(ErrorStatus.TICKET_NOT_USABLE);
-    }
-
     Ticket ticket =
         ticketRepository
             .findByBookingId(bookingId)
             .orElseThrow(() -> new BusinessException(ErrorStatus.TICKET_NOT_FOUND));
+
+    // 본인 예매가 아니면 미존재와 동일하게 404로 통일해 다른 사용자 예매의 존재 여부 노출을 막는다.
+    // backfill 되지 않은 과거 티켓(userId == null)도 여기서 404가 된다.
+    if (!userId.equals(ticket.getUserId())) {
+      throw new BusinessException(ErrorStatus.TICKET_NOT_FOUND);
+    }
+
+    // 취소된 예매는 입장권 조회가 불가능하다.
+    if (ticket.getTicketStatus() == TicketStatus.CANCELED) {
+      throw new BusinessException(ErrorStatus.TICKET_NOT_USABLE);
+    }
 
     QrPayload qrPayload = ticketQrPayloadGenerator.generate(ticket);
     return ticketMapper.toTicketQrResponse(ticket, qrPayload.payload(), qrPayload.expiresAt());

--- a/ticket-service/src/main/java/com/ticketrush/boundedcontext/ticket/app/usecase/TicketQrGetUseCase.java
+++ b/ticket-service/src/main/java/com/ticketrush/boundedcontext/ticket/app/usecase/TicketQrGetUseCase.java
@@ -24,8 +24,10 @@ public class TicketQrGetUseCase {
    * QR 조회는 booking-service 동기 호출 없이 로컬 데이터로만 처리한다(#364). 소유권은 발급 시 복제한 {@code ticket.userId}로, 유효성은
    * PaymentCanceledEvent가 투영한 로컬 {@code ticketStatus}로 판정한다.
    *
-   * <p>REFUNDING/REFUND_FAILED 등 환불 진행 상태는 로컬에 반영되지 않아 이 경로에서 걸러지지 않는다. QR 조회는 되돌릴 수 없는 행위가 아니므로
-   * 허용하고, 실제 입장 게이트({@code EntryVerifyUseCase})가 권위 있는 bookingStatus로 최종 차단한다.
+   * <p>REFUNDING/REFUND_FAILED 등 환불 진행 상태는 로컬에 반영되지 않아 이 경로에서 걸러지지 않는다. 특히 PG 환불이 거절되면 {@code
+   * PaymentCanceledEvent}가 끝내 발행되지 않아(RefundFailedEvent는 booking-service만 구독) {@code
+   * booking=REFUND_FAILED, ticket=UNUSED} 상태가 영구히 남는다. QR 조회는 되돌릴 수 없는 행위가 아니므로 허용하고, 실제 입장
+   * 게이트({@code EntryVerifyUseCase})가 권위 있는 bookingStatus로 최종 차단한다.
    *
    * <p>DB 접근이 findByBookingId 단건뿐이라 Spring Data의 기본 트랜잭션으로 충분하므로 메서드 레벨 트랜잭션을 두지 않는다.
    */

--- a/ticket-service/src/main/java/com/ticketrush/boundedcontext/ticket/domain/entity/Ticket.java
+++ b/ticket-service/src/main/java/com/ticketrush/boundedcontext/ticket/domain/entity/Ticket.java
@@ -24,6 +24,10 @@ public class Ticket extends AutoIdBaseEntity {
   @Column(name = "booking_id", nullable = false, unique = true)
   private Long bookingId;
 
+  /** PaymentConfirmedEvent에서 복제한 예매자. QR 조회의 소유권 확인을 booking 동기 호출 없이 로컬에서 수행하기 위함(#364). */
+  @Column(name = "user_id")
+  private Long userId;
+
   @Column(name = "ticket_token_hash", length = 64, nullable = false, unique = true)
   private String ticketTokenHash;
 
@@ -35,8 +39,9 @@ public class Ticket extends AutoIdBaseEntity {
   private LocalDateTime usedAt;
 
   @Builder
-  public Ticket(Long bookingId, String ticketTokenHash, TicketStatus ticketStatus) {
+  public Ticket(Long bookingId, Long userId, String ticketTokenHash, TicketStatus ticketStatus) {
     this.bookingId = bookingId;
+    this.userId = userId;
     this.ticketTokenHash = ticketTokenHash;
     this.ticketStatus = ticketStatus;
   }

--- a/ticket-service/src/main/java/com/ticketrush/boundedcontext/ticket/in/api/v1/TicketQrController.java
+++ b/ticket-service/src/main/java/com/ticketrush/boundedcontext/ticket/in/api/v1/TicketQrController.java
@@ -25,7 +25,10 @@ public class TicketQrController {
 
   @Operation(
       summary = "입장권 QR payload 조회",
-      description = "로그인 사용자 본인의 확정된 예매에 한해 QR로 렌더링할 payload와 입장권 메타데이터를 반환합니다.")
+      description =
+          "로그인 사용자 본인의 취소되지 않은 예매에 한해 QR로 렌더링할 payload와 입장권 메타데이터를 반환합니다. "
+              + "환불 진행 중(REFUNDING)이거나 환불에 실패한(REFUND_FAILED) 예매도 payload를 반환하므로, "
+              + "조회 성공을 입장 가능으로 해석하면 안 됩니다. 입장 가능 여부는 입장 검증 API가 최종 판정합니다.")
   @GetMapping("/bookings/{bookingId}/qr")
   public ResponseEntity<ApiResponse<TicketQrResponse>> getTicketQr(
       @AuthenticationPrincipal CustomUserDetails user, @PathVariable Long bookingId) {

--- a/ticket-service/src/main/java/com/ticketrush/boundedcontext/ticket/in/eventlistener/PaymentConfirmedEventListener.java
+++ b/ticket-service/src/main/java/com/ticketrush/boundedcontext/ticket/in/eventlistener/PaymentConfirmedEventListener.java
@@ -36,14 +36,24 @@ public class PaymentConfirmedEventListener {
     try {
       event = jsonConverter.deserialize(envelope.payload(), PaymentConfirmedEvent.class);
       final Long bookingId = event.bookingId();
+      final Long userId = event.userId();
 
       log.info("결제 완료 이벤트 수신. 티켓 발급 처리. bookingId: {}", bookingId);
 
+      // userId가 없으면 티켓은 발급되지만 소유권 확인에 실패해 소유자조차 QR을 조회할 수 없다(#364).
+      // 발급 자체는 막지 않되(입장 게이트는 booking 동기 조회로 동작), 사후 추적이 가능하도록 남긴다.
+      if (userId == null) {
+        log.warn("결제 완료 이벤트에 userId가 없습니다. QR 조회가 불가능한 티켓이 발급됩니다. bookingId: {}", bookingId);
+      }
+
       // Inbox로 중복 처리를 방지한다(#110). 최초 수신일 때만 발급하고 처리와 Inbox 기록을 한 트랜잭션으로 묶는다.
-      // 티켓 발급에는 bookingId만 사용한다. 이미 발급된 케이스는 TicketIssueUseCase가 멱등하게(alreadyIssued) 처리한다.
+      // userId는 티켓에 복제 저장해 QR 조회가 booking-service 동기 호출 없이 소유권을 확인하게 한다(#364).
+      // 이미 발급된 케이스는 TicketIssueUseCase가 멱등하게(alreadyIssued) 처리한다.
       boolean processed =
           inboxService.runIfFirst(
-              KafkaConsumerGroup.TICKET, envelope, () -> ticketIssueUseCase.execute(bookingId));
+              KafkaConsumerGroup.TICKET,
+              envelope,
+              () -> ticketIssueUseCase.execute(bookingId, userId));
 
       if (processed) {
         log.info("티켓 발급 처리 완료. bookingId: {}", bookingId);

--- a/ticket-service/src/test/java/com/ticketrush/boundedcontext/ticket/app/usecase/TicketIssueUseCaseTest.java
+++ b/ticket-service/src/test/java/com/ticketrush/boundedcontext/ticket/app/usecase/TicketIssueUseCaseTest.java
@@ -45,10 +45,11 @@ class TicketIssueUseCaseTest {
   @Spy private MeterRegistry meterRegistry = new SimpleMeterRegistry();
 
   @Test
-  @DisplayName("성공: 예매 ID 기준으로 티켓 토큰 해시와 UNUSED 상태를 저장한다")
+  @DisplayName("성공: 예매 ID 기준으로 예매자(userId)·티켓 토큰 해시와 UNUSED 상태를 저장한다")
   void execute_issues_ticket() {
     // given
     Long bookingId = 1L;
+    Long userId = 42L;
     String token = "raw-ticket-token";
     String tokenHash = "5ef9a9d540243d7534e3d322d14817b1290f0f2f7f57feafe57f5e5d1f13b450";
     given(ticketRepository.existsByBookingId(bookingId)).willReturn(false);
@@ -56,7 +57,7 @@ class TicketIssueUseCaseTest {
     given(ticketTokenHasher.hash(token)).willReturn(tokenHash);
 
     // when
-    TicketIssueResponse response = ticketIssueUseCase.execute(bookingId);
+    TicketIssueResponse response = ticketIssueUseCase.execute(bookingId, userId);
 
     // then
     ArgumentCaptor<Ticket> ticketCaptor = ArgumentCaptor.forClass(Ticket.class);
@@ -65,6 +66,8 @@ class TicketIssueUseCaseTest {
     assertThat(response.issued()).isTrue();
     assertThat(response.token()).isEqualTo(token);
     assertThat(savedTicket.getBookingId()).isEqualTo(bookingId);
+    // QR 조회가 booking 동기 호출 없이 소유권을 확인하려면 발급 시점에 userId가 복제돼야 한다(#364).
+    assertThat(savedTicket.getUserId()).isEqualTo(userId);
     assertThat(savedTicket.getTicketTokenHash()).isEqualTo(tokenHash);
     assertThat(savedTicket.getTicketTokenHash()).doesNotContain("raw-ticket-token");
     assertThat(savedTicket.getTicketStatus()).isEqualTo(TicketStatus.UNUSED);
@@ -85,7 +88,7 @@ class TicketIssueUseCaseTest {
     given(ticketRepository.existsByBookingId(bookingId)).willReturn(true);
 
     // when
-    TicketIssueResponse response = ticketIssueUseCase.execute(bookingId);
+    TicketIssueResponse response = ticketIssueUseCase.execute(bookingId, 42L);
 
     // then
     assertThat(response.issued()).isFalse();
@@ -118,7 +121,7 @@ class TicketIssueUseCaseTest {
         .saveAndFlush(any(Ticket.class));
 
     // when & then: DIVE는 그대로 전파된다(#269상 일시 실패로 분류→재소비). 삼키지 않는다.
-    assertThatThrownBy(() -> ticketIssueUseCase.execute(bookingId))
+    assertThatThrownBy(() -> ticketIssueUseCase.execute(bookingId, 42L))
         .isInstanceOf(DataIntegrityViolationException.class);
   }
 }

--- a/ticket-service/src/test/java/com/ticketrush/boundedcontext/ticket/app/usecase/TicketQrGetUseCaseTest.java
+++ b/ticket-service/src/test/java/com/ticketrush/boundedcontext/ticket/app/usecase/TicketQrGetUseCaseTest.java
@@ -3,8 +3,6 @@ package com.ticketrush.boundedcontext.ticket.app.usecase;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.BDDMockito.then;
-import static org.mockito.Mockito.never;
 
 import com.ticketrush.boundedcontext.ticket.app.dto.response.TicketQrResponse;
 import com.ticketrush.boundedcontext.ticket.app.mapper.TicketMapper;
@@ -12,8 +10,6 @@ import com.ticketrush.boundedcontext.ticket.domain.entity.Ticket;
 import com.ticketrush.boundedcontext.ticket.domain.policy.QrPayload;
 import com.ticketrush.boundedcontext.ticket.domain.policy.TicketQrPayloadGenerator;
 import com.ticketrush.boundedcontext.ticket.domain.types.TicketStatus;
-import com.ticketrush.boundedcontext.ticket.out.apiclient.BookingRestClient;
-import com.ticketrush.boundedcontext.ticket.out.apiclient.dto.BookingInfoResponse;
 import com.ticketrush.boundedcontext.ticket.out.repository.TicketRepository;
 import com.ticketrush.global.exception.BusinessException;
 import com.ticketrush.global.status.ErrorStatus;
@@ -29,12 +25,14 @@ import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
+/** QR 조회는 booking-service 동기 호출 없이 로컬 데이터(ticket.userId, ticketStatus)로만 판정한다(#364). */
 @ExtendWith(MockitoExtension.class)
 class TicketQrGetUseCaseTest {
 
-  @InjectMocks private TicketQrGetUseCase ticketQrGetUseCase;
+  private static final Long USER_ID = 10L;
+  private static final Long BOOKING_ID = 100L;
 
-  @Mock private BookingRestClient bookingRestClient;
+  @InjectMocks private TicketQrGetUseCase ticketQrGetUseCase;
 
   @Mock private TicketRepository ticketRepository;
 
@@ -42,12 +40,13 @@ class TicketQrGetUseCaseTest {
 
   @Spy private TicketMapper ticketMapper = Mappers.getMapper(TicketMapper.class);
 
-  private Ticket ticket(Long bookingId, LocalDateTime createdAt) {
+  private Ticket ticket(Long userId, TicketStatus status, LocalDateTime createdAt) {
     Ticket ticket =
         Ticket.builder()
-            .bookingId(bookingId)
+            .bookingId(BOOKING_ID)
+            .userId(userId)
             .ticketTokenHash("hash")
-            .ticketStatus(TicketStatus.UNUSED)
+            .ticketStatus(status)
             .build();
     ReflectionTestUtils.setField(ticket, "id", 1L);
     ReflectionTestUtils.setField(ticket, "createdAt", createdAt);
@@ -55,22 +54,18 @@ class TicketQrGetUseCaseTest {
   }
 
   @Test
-  @DisplayName("성공: 본인 확정 예매면 QR payload와 메타데이터를 반환한다")
+  @DisplayName("성공: 본인 티켓이면 booking 호출 없이 QR payload와 메타데이터를 반환한다")
   void execute_returns_qr_payload() {
     // given
-    Long userId = 10L;
-    Long bookingId = 100L;
     LocalDateTime issuedAt = LocalDateTime.of(2026, 6, 25, 10, 0);
     LocalDateTime expiresAt = issuedAt.plusMinutes(5);
-    given(bookingRestClient.getBooking(bookingId))
-        .willReturn(new BookingInfoResponse(bookingId, userId, "CONFIRMED"));
-    Ticket ticket = ticket(bookingId, issuedAt);
-    given(ticketRepository.findByBookingId(bookingId)).willReturn(Optional.of(ticket));
+    Ticket ticket = ticket(USER_ID, TicketStatus.UNUSED, issuedAt);
+    given(ticketRepository.findByBookingId(BOOKING_ID)).willReturn(Optional.of(ticket));
     given(ticketQrPayloadGenerator.generate(ticket))
         .willReturn(new QrPayload("jwt-payload", expiresAt));
 
     // when
-    TicketQrResponse response = ticketQrGetUseCase.execute(userId, bookingId);
+    TicketQrResponse response = ticketQrGetUseCase.execute(USER_ID, BOOKING_ID);
 
     // then
     assertThat(response.payload()).isEqualTo("jwt-payload");
@@ -80,65 +75,53 @@ class TicketQrGetUseCaseTest {
   }
 
   @Test
-  @DisplayName("실패: 본인 예매가 아니면 미존재와 동일한 TICKET_NOT_FOUND로 통일한다")
-  void execute_fails_when_not_owner() {
-    // given
-    Long userId = 10L;
-    Long bookingId = 100L;
-    given(bookingRestClient.getBooking(bookingId))
-        .willReturn(new BookingInfoResponse(bookingId, 999L, "CONFIRMED"));
-
-    // when & then
-    assertThatThrownBy(() -> ticketQrGetUseCase.execute(userId, bookingId))
-        .isInstanceOf(BusinessException.class)
-        .hasFieldOrPropertyWithValue("errorStatus", ErrorStatus.TICKET_NOT_FOUND);
-    then(ticketRepository).should(never()).findByBookingId(bookingId);
-  }
-
-  @Test
-  @DisplayName("실패: 미확정 예매는 TICKET_NOT_USABLE로 조회를 막는다")
-  void execute_fails_when_pending() {
-    // given
-    Long userId = 10L;
-    Long bookingId = 100L;
-    given(bookingRestClient.getBooking(bookingId))
-        .willReturn(new BookingInfoResponse(bookingId, userId, "PENDING"));
-
-    // when & then
-    assertThatThrownBy(() -> ticketQrGetUseCase.execute(userId, bookingId))
-        .isInstanceOf(BusinessException.class)
-        .hasFieldOrPropertyWithValue("errorStatus", ErrorStatus.TICKET_NOT_USABLE);
-    then(ticketRepository).should(never()).findByBookingId(bookingId);
-  }
-
-  @Test
-  @DisplayName("실패: 취소된 예매는 TICKET_NOT_USABLE로 조회를 막는다")
-  void execute_fails_when_canceled() {
-    // given
-    Long userId = 10L;
-    Long bookingId = 100L;
-    given(bookingRestClient.getBooking(bookingId))
-        .willReturn(new BookingInfoResponse(bookingId, userId, "CANCELED"));
-
-    // when & then
-    assertThatThrownBy(() -> ticketQrGetUseCase.execute(userId, bookingId))
-        .isInstanceOf(BusinessException.class)
-        .hasFieldOrPropertyWithValue("errorStatus", ErrorStatus.TICKET_NOT_USABLE);
-  }
-
-  @Test
-  @DisplayName("실패: 확정 예매라도 발급된 티켓이 없으면 TICKET_NOT_FOUND를 던진다")
+  @DisplayName("실패: 발급된 티켓이 없으면 TICKET_NOT_FOUND를 던진다")
   void execute_fails_when_ticket_not_issued() {
     // given
-    Long userId = 10L;
-    Long bookingId = 100L;
-    given(bookingRestClient.getBooking(bookingId))
-        .willReturn(new BookingInfoResponse(bookingId, userId, "CONFIRMED"));
-    given(ticketRepository.findByBookingId(bookingId)).willReturn(Optional.empty());
+    given(ticketRepository.findByBookingId(BOOKING_ID)).willReturn(Optional.empty());
 
     // when & then
-    assertThatThrownBy(() -> ticketQrGetUseCase.execute(userId, bookingId))
+    assertThatThrownBy(() -> ticketQrGetUseCase.execute(USER_ID, BOOKING_ID))
         .isInstanceOf(BusinessException.class)
         .hasFieldOrPropertyWithValue("errorStatus", ErrorStatus.TICKET_NOT_FOUND);
+  }
+
+  @Test
+  @DisplayName("실패: 본인 티켓이 아니면 미존재와 동일한 TICKET_NOT_FOUND로 통일한다")
+  void execute_fails_when_not_owner() {
+    // given
+    Ticket ticket = ticket(999L, TicketStatus.UNUSED, LocalDateTime.now());
+    given(ticketRepository.findByBookingId(BOOKING_ID)).willReturn(Optional.of(ticket));
+
+    // when & then
+    assertThatThrownBy(() -> ticketQrGetUseCase.execute(USER_ID, BOOKING_ID))
+        .isInstanceOf(BusinessException.class)
+        .hasFieldOrPropertyWithValue("errorStatus", ErrorStatus.TICKET_NOT_FOUND);
+  }
+
+  @Test
+  @DisplayName("실패: backfill 되지 않은 티켓(userId=null)도 소유권 확인에 실패해 TICKET_NOT_FOUND를 던진다")
+  void execute_fails_when_user_id_not_backfilled() {
+    // given
+    Ticket ticket = ticket(null, TicketStatus.UNUSED, LocalDateTime.now());
+    given(ticketRepository.findByBookingId(BOOKING_ID)).willReturn(Optional.of(ticket));
+
+    // when & then
+    assertThatThrownBy(() -> ticketQrGetUseCase.execute(USER_ID, BOOKING_ID))
+        .isInstanceOf(BusinessException.class)
+        .hasFieldOrPropertyWithValue("errorStatus", ErrorStatus.TICKET_NOT_FOUND);
+  }
+
+  @Test
+  @DisplayName("실패: 취소된 예매(로컬 ticketStatus=CANCELED)는 TICKET_NOT_USABLE로 조회를 막는다")
+  void execute_fails_when_canceled() {
+    // given
+    Ticket ticket = ticket(USER_ID, TicketStatus.CANCELED, LocalDateTime.now());
+    given(ticketRepository.findByBookingId(BOOKING_ID)).willReturn(Optional.of(ticket));
+
+    // when & then
+    assertThatThrownBy(() -> ticketQrGetUseCase.execute(USER_ID, BOOKING_ID))
+        .isInstanceOf(BusinessException.class)
+        .hasFieldOrPropertyWithValue("errorStatus", ErrorStatus.TICKET_NOT_USABLE);
   }
 }

--- a/ticket-service/src/test/java/com/ticketrush/boundedcontext/ticket/in/eventlistener/PaymentConfirmedEventListenerTest.java
+++ b/ticket-service/src/test/java/com/ticketrush/boundedcontext/ticket/in/eventlistener/PaymentConfirmedEventListenerTest.java
@@ -53,6 +53,7 @@ class PaymentConfirmedEventListenerTest {
   // 따라서 payload는 의미 없는 식별 문자열로 둔다.
   private static final String PAYLOAD = "payload";
   private static final Long BOOKING_ID = 10L;
+  private static final Long USER_ID = 4L;
 
   private DomainEventEnvelope envelope() {
     return new DomainEventEnvelope(
@@ -66,7 +67,7 @@ class PaymentConfirmedEventListenerTest {
 
   private PaymentConfirmedEvent event() {
     return new PaymentConfirmedEvent(
-        1L, BOOKING_ID, 3L, 4L, 50000L, LocalDateTime.of(2026, 5, 22, 10, 30));
+        1L, BOOKING_ID, 3L, USER_ID, 50000L, LocalDateTime.of(2026, 5, 22, 10, 30));
   }
 
   /** Inbox가 최초 수신으로 판정해 비즈니스 콜백을 실행하고 true를 반환하도록 스텁한다. */
@@ -93,7 +94,7 @@ class PaymentConfirmedEventListenerTest {
     listener.handlePaymentConfirmed(envelope, acknowledgment);
 
     // then
-    verify(ticketIssueUseCase).execute(BOOKING_ID);
+    verify(ticketIssueUseCase).execute(BOOKING_ID, USER_ID);
     verify(acknowledgment).acknowledge();
   }
 
@@ -112,7 +113,7 @@ class PaymentConfirmedEventListenerTest {
     listener.handlePaymentConfirmed(envelope, acknowledgment);
 
     // then
-    verify(ticketIssueUseCase, never()).execute(anyLong());
+    verify(ticketIssueUseCase, never()).execute(anyLong(), anyLong());
     verify(acknowledgment).acknowledge();
   }
 
@@ -145,14 +146,16 @@ class PaymentConfirmedEventListenerTest {
     final DomainEventEnvelope envelope = envelope();
     given(jsonConverter.deserialize(PAYLOAD, PaymentConfirmedEvent.class)).willReturn(event());
     givenInboxProcessesFirst();
-    willThrow(new RuntimeException("DB 일시 장애")).given(ticketIssueUseCase).execute(BOOKING_ID);
+    willThrow(new RuntimeException("DB 일시 장애"))
+        .given(ticketIssueUseCase)
+        .execute(BOOKING_ID, USER_ID);
 
     // when & then: 일시 실패는 리스너 밖으로 전파되어 컨테이너 재시도→DLT 파이프라인을 태운다
     assertThatThrownBy(() -> listener.handlePaymentConfirmed(envelope, acknowledgment))
         .isInstanceOf(RuntimeException.class);
 
     // then: 발급은 시도되었으나 오프셋은 커밋되지 않는다
-    verify(ticketIssueUseCase).execute(BOOKING_ID);
+    verify(ticketIssueUseCase).execute(BOOKING_ID, USER_ID);
     verify(acknowledgment, never()).acknowledge();
   }
 
@@ -165,14 +168,14 @@ class PaymentConfirmedEventListenerTest {
     givenInboxProcessesFirst();
     willThrow(new BusinessException(ErrorStatus.BOOKING_NOT_FOUND))
         .given(ticketIssueUseCase)
-        .execute(BOOKING_ID);
+        .execute(BOOKING_ID, USER_ID);
 
     // when & then: 영구 실패는 로그 후 커밋되어 파티션 블로킹을 막는다
     assertThatCode(() -> listener.handlePaymentConfirmed(envelope, acknowledgment))
         .doesNotThrowAnyException();
 
     // then
-    verify(ticketIssueUseCase).execute(BOOKING_ID);
+    verify(ticketIssueUseCase).execute(BOOKING_ID, USER_ID);
     verify(acknowledgment).acknowledge();
   }
 
@@ -189,7 +192,7 @@ class PaymentConfirmedEventListenerTest {
         .doesNotThrowAnyException();
 
     // then: 발급 유스케이스는 호출되지 않고, 오프셋은 커밋된다
-    verify(ticketIssueUseCase, never()).execute(anyLong());
+    verify(ticketIssueUseCase, never()).execute(anyLong(), anyLong());
     verify(acknowledgment).acknowledge();
   }
 }


### PR DESCRIPTION
## 🔗 관련 이슈

- close #364

---

## 📌 주요 변경 사항

- QR 조회(`TicketQrGetUseCase`)를 **완전 로컬화** — `booking-service` HTTP 동기 호출 제거
- `Ticket`에 `userId` denormalization (`PaymentConfirmedEvent`에서 복제)
- 입장 검증(`EntryVerifyUseCase`)은 동기 호출 **유지** — stale 주석만 정정

---

## 🛠 상세 구현 내용

- `Ticket` 엔티티에 `user_id` 컬럼(nullable) 추가, `@Builder` 파라미터 포함
- `TicketMapper.toEntity(bookingId, userId, ticketTokenHash)`로 확장
- `TicketIssueUseCase.execute(bookingId, userId)`로 변경, `PaymentConfirmedEventListener`에서 `event.userId()` 전달
  - `userId`가 null이면 소유자도 QR 조회가 불가능한 티켓이 조용히 발급되므로 warn 로그로 관측 가능하게 둠
- `TicketQrGetUseCase`: `BookingRestClient` 의존 제거 → `findByBookingId`로 로드, `ticket.userId`로 소유권 확인(불일치·null 모두 `TICKET_NOT_FOUND`), `ticketStatus == CANCELED`면 `TICKET_NOT_USABLE`
- `EntryVerifyUseCase`: 로직 무변경. "취소 전파가 ticket-service로 들어오지 않으므로"라는 stale 주석을 실제 이유(REFUNDING/REFUND_FAILED는 로컬 상태로 못 막으므로 게이트는 authoritative한 `bookingStatus`로 최종 판정)로 교체
- `infra/mysql/init/01-schema.sql`: `ticket.user_id` 컬럼 추가
- `TicketQrController`: Swagger 설명을 변경 후 실제 동작(REFUNDING/REFUND_FAILED도 payload 반환)에 맞게 정정
- `BookingRestClient`/DTO/설정/`TICKET_BOOKING_COMMUNICATION_FAILED`는 EntryVerify가 계속 쓰므로 **유지**. booking-service·common 변경 없음

---

## ✅ 테스트

### 테스트 방법

- `./gradlew :ticket-service:test :ticket-service:spotlessCheck`
- `TicketQrGetUseCaseTest` 재작성 (`BookingRestClient` mock 제거, 5케이스)
  - 본인 티켓 + UNUSED → QR payload 반환
  - 티켓 미발급 → `TICKET_NOT_FOUND`
  - 타인 티켓 → `TICKET_NOT_FOUND`
  - backfill 미완 티켓(`userId = null`) → `TICKET_NOT_FOUND`
  - `ticketStatus = CANCELED` → `TICKET_NOT_USABLE`
- `TicketIssueUseCaseTest`: `execute(bookingId, userId)` 시그니처 반영 + 저장된 `Ticket.userId` 복제 검증
- `PaymentConfirmedEventListenerTest`: `execute(bookingId, userId)` 호출 검증 (#269 에러 정책 케이스 6종 회귀 확인)
- `EntryVerifyUseCaseTest`는 **무수정 통과** (입장 검증 회귀 없음)

### 테스트 결과

- `./gradlew :ticket-service:test :ticket-service:spotlessCheck` → **BUILD SUCCESSFUL**
- pre-commit 훅(spotlessApply + checkstyleMain/Test) 통과
<!--
### 📸 스크린샷

- (작성 필요)
-->
---

## 👀 리뷰 요청 사항

**QR 조회의 정합성 완화가 수용 가능한지** 봐주세요. `bookingStatus` 판정을 로컬 `ticketStatus`로 대체하면서, booking이 CONFIRMED가 아닌 두 상태에서도 QR 조회가 성공(200)합니다. booking 상태 전이·이벤트 발행 지점·좌석 반환 경로를 코드로 추적해 확정한 내용입니다.

#### 1. 환불 진행 중(REFUNDING) — 이번 변경으로 새로 노출되는 구간

사용자가 취소를 요청하면 `Booking.requestRefund()`가 즉시 REFUNDING으로 전이하고 `RefundRequestedEvent`만 발행합니다. ticket-service는 이 이벤트를 구독하지 않습니다. 로컬 `ticketStatus`를 CANCELED로 바꾸는 유일한 트리거인 `PaymentCanceledEvent`는 **PG 환불이 성공한 뒤에야** 발행되므로(payment-service 발행 지점 3곳 모두 동일), 취소 요청 시점부터 PG 왕복 + Kafka 2홉이 끝날 때까지 QR이 조회됩니다.

→ **이 구간이 이번 트레이드오프의 실질입니다.** 입장 게이트(`EntryVerifyUseCase`)가 booking 동기 조회로 차단하므로 실제 입장은 막힙니다.

#### 2. 환불 실패(REFUND_FAILED) — 완화가 아니라 오히려 정합적인 동작

처음엔 이 상태의 QR 노출을 결함으로 봤으나, refund-first 설계를 확인한 결과 **QR이 조회되는 편이 맞습니다.**

| | 환불 성공(`PaymentCanceledEvent`) | 환불 실패(`RefundFailedEvent`) |
|---|---|---|
| Payment | CANCELED | **COMPLETED 유지 — 돈 안 돌아감** |
| 좌석 | seat-service가 release | **구독자 없음 → SOLD 유지** |
| Booking | REFUNDED | REFUND_FAILED |

`RefundFailedEventListener`: *"좌석은 환불되지 않았으므로 SOLD를 유지한다(반환 이벤트를 발행하지 않는다)."* `Booking.requestRefund()` Javadoc: *"환불도 못 받고 좌석만 잃는 역방향 공백 차단."*

즉 REFUND_FAILED 사용자는 **돈을 냈고 좌석도 여전히 본인 것**이므로, 티켓 소유도 유지되는 게 일관됩니다. 기존 코드가 이 경우 QR을 막았던 건 `bookingStatus != CONFIRMED`를 일괄 차단한 부수효과에 가깝습니다.

#### 정리

- 완화 지점은 **REFUNDING 하나**이며, 입장 게이트가 최종 차단합니다. QR 조회는 되돌릴 수 없는 행위가 아니므로 수용 가능하다고 봅니다. **판단 부탁드립니다.**
- 이에 맞춰 `TicketQrController`의 Swagger 설명을 "확정된 예매에 한해" → "취소되지 않은 예매에 한해 + 조회 성공이 입장 가능을 뜻하지 않음"으로 정정했습니다(43cfe7b).
- 조사 중 발견한 REFUND_FAILED 관련 설계 공백은 이 PR 범위를 넘으므로 담당 경계에 맞춰 **별도 이슈로 분리**했습니다.
  - #391 [예매] REFUND_FAILED 흡수 상태 고착 — 복구 전이 부재, `markRefunded()`의 소스 상태 누락
  - #392 [결제] 결제 취소 API의 예매 상태 미고려 — 환불 최종 실패 건 재처리 수단 부재

**그 외**: `user_id`를 NOT NULL로 조이지 않았습니다(backfill이 `WHERE user_id IS NULL`을 쓰므로). backfill 미완 티켓은 소유자도 404가 되는 fail-closed 동작입니다.

---

## ⚠️ 배포 시 주의사항

- **prod는 `ddl-auto: validate`이므로 앱 배포 전에 아래 DDL을 수동 실행해야 합니다.** Flyway/Liquibase 미사용 레포라 `infra/mysql/init/01-schema.sql`은 신규 환경 초기화용이며, 기존 DB에는 적용되지 않습니다.

  ```sql
  -- 1) 컬럼 추가 (앱 배포 전)
  ALTER TABLE ticket ADD COLUMN user_id BIGINT NULL AFTER booking_id;

  -- 2) 기존 티켓 backfill
  UPDATE ticket t
    JOIN booking b ON t.booking_id = b.booking_id
    SET t.user_id = b.user_id
  WHERE t.user_id IS NULL;
  ```

- backfill을 건너뛰면 기존 티켓 소유자의 QR 조회가 404로 실패합니다(입장 검증은 영향 없음).



