### PR TITLE
[Fix] #379 부하테스트 인증을 DevToken에서 정상 로그인으로 전환

### DIFF
--- a/docs/load-test-guide.md
+++ b/docs/load-test-guide.md
@@ -52,12 +52,18 @@ MySQL(3306)과 측정 대상 서비스를 호스트에서 기동한다. 최소 �
 
 총 좌석 = `perf_count × rows_per × cols_per`. 수십만 건은 `perf_count`/`cols_per`를 키운다.
 
+두 스크립트 모두 **오실행 가드**가 걸려 있다. `@i_confirm_loadtest_db=1`을 명시하지 않으면 `ERROR 1146`으로 즉시 중단되고 본문은 돌지 않는다. 시드가 실제로 로그인되는 계정을 만들기 때문에, 운영 DB에 잘못 실행하면 그대로 백도어가 된다.
+
 ```bash
+GUARD='SET @i_confirm_loadtest_db=1'
+
 # 시딩 (idempotent: 마커 LOADTEST 기준, 재실행은 cleanup 먼저)
-mysql -h 127.0.0.1 -u "$MYSQL_USERNAME" -p"$MYSQL_PASSWORD" ticket_rush < load-test/seed/seed_load.sql
+mysql -h 127.0.0.1 -u "$MYSQL_USERNAME" -p"$MYSQL_PASSWORD" \
+  --init-command="$GUARD" ticket_rush < load-test/seed/seed_load.sql
 
 # 리셋(규모 변경/정리) → 반드시 cleanup 먼저, 그다음 재시딩
-mysql -h 127.0.0.1 -u "$MYSQL_USERNAME" -p"$MYSQL_PASSWORD" ticket_rush < load-test/seed/cleanup_load.sql
+mysql -h 127.0.0.1 -u "$MYSQL_USERNAME" -p"$MYSQL_PASSWORD" \
+  --init-command="$GUARD" ticket_rush < load-test/seed/cleanup_load.sql
 ```
 
 시딩 끝에 검증 카운트(load_users/performances/seats/bookings)가 출력된다. `@booking_pct>0`이면 이슈의 "PENDING 예매 대량 생성(만료/조회/인덱스 측정)" 요건을 만족한다.
@@ -65,6 +71,7 @@ mysql -h 127.0.0.1 -u "$MYSQL_USERNAME" -p"$MYSQL_PASSWORD" ticket_rush < load-t
 시드는 공연·좌석과 함께 **부하테스트 전용 계정 1개**(`loadtest@ticketrush.local`)를 만든다. `booking-create`가 이 계정으로 로그인한다.
 
 > 비밀번호 **평문은 커밋하지 않는다.** `seed_load.sql`의 `@load_pw_hash`(bcrypt cost 10)와 쌍을 이루며, 평문은 팀 내부에서만 공유하고 k6 실행 시 `-e LOAD_USER_PASSWORD=...`로 넘긴다.
+> bcrypt 해시에는 salt가 그대로 들어 있어 저장소를 가진 사람은 무제한 오프라인 대입을 할 수 있다. 평문은 **길고 무작위**여야 하며, 다른 계정·환경에서 재사용하지 않는다.
 
 ## 4. k6 실행
 

--- a/docs/load-test-guide.md
+++ b/docs/load-test-guide.md
@@ -33,10 +33,11 @@ curl -s -o /dev/null -w "%{http_code}\n" -XPOST http://localhost:9090/api/v1/wri
 
 ### 2.3 앱 스택
 MySQL(3306)과 측정 대상 서비스를 호스트에서 기동한다. 최소 구성:
-- 게이트웨이 8080, auth 8082(DevToken), booking 8084, seat 8086
+- 게이트웨이 8080, auth 8082(로그인), user 8081, booking 8084, seat 8086
 - DB 계정은 `.env.local`의 `MYSQL_USERNAME`/`MYSQL_PASSWORD`
 
-> DevToken(`/api/v1/dev/auth/token`)은 `local`/`dev` 프로파일에서만 노출된다.
+> `booking-create`는 `POST /api/v1/auth/login`으로 인증한다. 계정은 3장에서 함께 시딩된다.
+> DevToken(`/api/v1/dev/auth/token`)은 로컬 프론트엔드 테스트 전용이며 부하 테스트는 쓰지 않는다.
 
 ## 3. 대량 데이터 시딩
 
@@ -59,13 +60,17 @@ mysql -h 127.0.0.1 -u "$MYSQL_USERNAME" -p"$MYSQL_PASSWORD" ticket_rush < load-t
 mysql -h 127.0.0.1 -u "$MYSQL_USERNAME" -p"$MYSQL_PASSWORD" ticket_rush < load-test/seed/cleanup_load.sql
 ```
 
-시딩 끝에 검증 카운트(performances/seats/bookings)가 출력된다. `@booking_pct>0`이면 이슈의 "PENDING 예매 대량 생성(만료/조회/인덱스 측정)" 요건을 만족한다.
+시딩 끝에 검증 카운트(load_users/performances/seats/bookings)가 출력된다. `@booking_pct>0`이면 이슈의 "PENDING 예매 대량 생성(만료/조회/인덱스 측정)" 요건을 만족한다.
+
+시드는 공연·좌석과 함께 **부하테스트 전용 계정 1개**(`loadtest@ticketrush.local`)를 만든다. `booking-create`가 이 계정으로 로그인한다.
+
+> 비밀번호 **평문은 커밋하지 않는다.** `seed_load.sql`의 `@load_pw_hash`(bcrypt cost 10)와 쌍을 이루며, 평문은 팀 내부에서만 공유하고 k6 실행 시 `-e LOAD_USER_PASSWORD=...`로 넘긴다.
 
 ## 4. k6 실행
 
 k6는 `loadtest` profile 컨테이너로 실행한다. remote-write 관련 설정(`K6_OUT`, `K6_PROMETHEUS_RW_SERVER_URL`, `K6_PROMETHEUS_RW_TREND_STATS`)과 `BASE_URL`(→ `host.docker.internal:8080`)은 compose에 정의돼 있어 매번 `-o`/URL을 줄 필요가 없다.
 
-스크립트는 `./load-test`가 컨테이너 안 `/scripts`로 마운트된다. 시나리오 파라미터는 `-e KEY=VALUE`로 덮는다 (`BASE_URL, PERF_ID, USER_ID, SEAT_ID_MIN, SEAT_ID_MAX, VUS, RAMP, STEADY`).
+스크립트는 `./load-test`가 컨테이너 안 `/scripts`로 마운트된다. 시나리오 파라미터는 `-e KEY=VALUE`로 덮는다 (`BASE_URL, PERF_ID, LOAD_USER_EMAIL, LOAD_USER_PASSWORD, SEAT_ID_MIN, SEAT_ID_MAX, VUS, RAMP, STEADY`).
 
 ```bash
 # (b) 좌석 조회 — 인증 불필요, 먼저 파이프라인 검증용
@@ -73,9 +78,10 @@ docker compose run --rm k6 run \
   -e PERF_ID=1 -e VUS=50 \
   /scripts/scenarios/seat-layouts.js
 
-# (a) 예매 생성 — setup()에서 DevToken 자동 발급 후 Bearer 호출
+# (a) 예매 생성 — setup()에서 1회 로그인 후 Bearer 호출
 docker compose run --rm k6 run \
-  -e PERF_ID=1 -e USER_ID=1 -e SEAT_ID_MIN=1 -e SEAT_ID_MAX=6000 \
+  -e PERF_ID=1 -e LOAD_USER_PASSWORD='<평문>' \
+  -e SEAT_ID_MIN=1 -e SEAT_ID_MAX=6000 \
   /scripts/scenarios/booking-create.js
 ```
 
@@ -126,8 +132,8 @@ k6 (로컬 loadtest 컨테이너) ──HTTP────────────
 - 부하 대상 앱을 AWS에 배포하고 게이트웨이 공인 엔드포인트(`https://<aws-gateway>`)를 확보한다.
 - 관측 스택이 기동 중이고, Prometheus 9090이 **본인 공인 IP에 대해서만** 열려 있어야 한다. remote-write 수신에는 인증이 없다.
 - `seat-layouts`(read)는 **인증 불필요** → 배포 프로파일과 무관하게 바로 가능.
-- `booking-create`(write)는 `DevToken(/api/v1/dev/auth/token)`을 사용하는데 이는 **`local`/`dev` 프로파일에서만 노출**된다. → AWS 배포본을 **`dev` 프로파일(부하테스트 전용 환경)**로 띄우지 않으면 write 시나리오는 **인증 실패**한다.
-- 시딩은 3장과 동일하게 **AWS의 부하테스트용 DB**에 대해 수행한다(운영 DB 금지).
+- `booking-create`(write)도 정상 로그인(`/api/v1/auth/login`)을 쓰므로 배포 프로파일과 무관하다. 다만 AWS에서 실제로 돌릴지는 배포본의 컨테이너·리소스 구성 결정을 따른다(#378).
+- 시딩은 3장과 동일하게 **AWS의 부하테스트용 DB**에 대해 수행한다(운영 DB 금지). 부하테스트 계정도 함께 시딩된다.
 
 ### 7.2 k6 실행 (로컬)
 4장과 동일하되 `BASE_URL`과 `K6_PROMETHEUS_RW_SERVER_URL`을 덮는다.
@@ -146,12 +152,13 @@ docker compose run --rm --no-deps \
   -e PERF_ID=1 -e VUS=50 \
   /scripts/scenarios/seat-layouts.js
 
-# (a) 예매 생성 — AWS가 dev 프로파일(DevToken 노출)일 때만 가능
+# (a) 예매 생성 — booking-create 가 배포본에 포함돼 있을 때
 docker compose run --rm --no-deps \
   -e K6_PROMETHEUS_RW_SERVER_URL=http://<PROM_HOST>:9090/api/v1/write \
   k6 run \
   -e BASE_URL=https://<aws-gateway> \
-  -e PERF_ID=1 -e USER_ID=1 -e SEAT_ID_MIN=1 -e SEAT_ID_MAX=6000 \
+  -e PERF_ID=1 -e LOAD_USER_PASSWORD='<평문>' \
+  -e SEAT_ID_MIN=1 -e SEAT_ID_MAX=6000 \
   /scripts/scenarios/booking-create.js
 ```
 
@@ -163,4 +170,4 @@ docker compose run --rm --no-deps \
 비테스트 시간엔 AWS 리소스를 **반드시 중지**하는 **온디맨드 전제**로 운용한다. 상시 기동 시 24/7 과금된다.
 
 ### 7.4 보안
-부하 대상 공인 엔드포인트, `dev` 프로파일(DevToken 노출), 인증 없는 Prometheus 9090은 **측정 시간에만** 열고, 끝나면 접근을 닫는다. 보안 그룹은 본인 공인 IP `/32`로 제한한다. 부하테스트용 DB·환경을 운영과 분리한다.
+부하 대상 공인 엔드포인트와 인증 없는 Prometheus 9090은 **측정 시간에만** 열고, 끝나면 접근을 닫는다. 보안 그룹은 본인 공인 IP `/32`로 제한한다. 부하테스트용 DB·환경을 운영과 분리한다. 부하테스트 계정 비밀번호 평문은 저장소에 남기지 않는다.

--- a/load-test/README.md
+++ b/load-test/README.md
@@ -5,9 +5,9 @@ seat/booking/ticket 핫패스 성능·정합성을 정량 측정하기 위한 k6
 ```
 load-test/
 ├── config/   # env.js(환경변수), options.js(공통 stages·thresholds)
-├── lib/      # auth.js(DevToken 발급)
+├── lib/      # auth.js(로그인 → access token)
 ├── scenarios/# booking-create.js(예매 생성, 인증), seat-layouts.js(좌석 조회, 비인증)
-└── seed/     # seed_load.sql(대량 시딩), cleanup_load.sql(정리)
+└── seed/     # seed_load.sql(대량 시딩 + 부하테스트 계정), cleanup_load.sql(정리)
 ```
 
 k6는 docker-compose의 `loadtest` profile로 분리된 컨테이너에서 실행한다(상시 기동 대상 아님).

--- a/load-test/README.md
+++ b/load-test/README.md
@@ -19,7 +19,9 @@ k6는 docker-compose의 `loadtest` profile로 분리된 컨테이너에서 실�
 docker compose up -d prometheus grafana
 
 # 2) 대량 시딩 (규모는 seed_load.sql 상단 @vars 에서 조정)
-mysql -h 127.0.0.1 -u "$MYSQL_USERNAME" -p"$MYSQL_PASSWORD" ticket_rush < seed/seed_load.sql
+#    오실행 가드: @i_confirm_loadtest_db=1 없으면 중단된다(운영 DB 보호).
+mysql -h 127.0.0.1 -u "$MYSQL_USERNAME" -p"$MYSQL_PASSWORD" \
+  --init-command="SET @i_confirm_loadtest_db=1" ticket_rush < seed/seed_load.sql
 
 # 3) k6 실행 (컨테이너, remote-write는 K6_OUT로 기본 적용) → Grafana
 docker compose run --rm k6 run /scripts/scenarios/seat-layouts.js

--- a/load-test/config/env.js
+++ b/load-test/config/env.js
@@ -2,7 +2,10 @@
 export const BASE_URL = __ENV.BASE_URL || 'http://localhost:8080'; // 게이트웨이
 
 export const PERF_ID = Number(__ENV.PERF_ID || 1); // 시딩한 공연 ID
-export const USER_ID = Number(__ENV.USER_ID || 1); // DevToken 발급 대상
+
+// 부하테스트 전용 계정(seed_load.sql 이 시딩한다). 비밀번호는 평문을 커밋하지 않으므로 실행 인자로 준다.
+export const LOAD_USER_EMAIL = __ENV.LOAD_USER_EMAIL || 'loadtest@ticketrush.local';
+export const LOAD_USER_PASSWORD = __ENV.LOAD_USER_PASSWORD || '';
 
 // booking 시나리오가 예매 시도할 seat_id 범위(시딩 규모에 맞춰 넓게 잡아 좌석 고갈 완화)
 export const SEAT_ID_MIN = Number(__ENV.SEAT_ID_MIN || 1);

--- a/load-test/lib/auth.js
+++ b/load-test/lib/auth.js
@@ -1,5 +1,5 @@
 import http from 'k6/http';
-import { check } from 'k6';
+import { check, fail } from 'k6';
 import { BASE_URL } from '../config/env.js';
 
 // 부하테스트용 계정으로 로그인해 access token을 받는다: POST /api/v1/auth/login → access token.
@@ -10,5 +10,15 @@ export function login(email, password) {
     headers: { 'Content-Type': 'application/json' },
   });
   check(res, { 'login 200': (r) => r.status === 200 });
-  return res.json('result.access_token');
+
+  const token = res.json('result.access_token');
+  // 토큰 없이 진행하면 전 VU가 Bearer undefined 로 401을 찍어, 부하가 아니라 인증 실패를 측정하게 된다.
+  // setup()에서 1회 호출되므로 여기서 즉시 죽는 편이 측정 시간(=AWS 과금 시간)을 아낀다.
+  if (!token) {
+    fail(
+      `login failed (status=${res.status}). ` +
+        `LOAD_USER_PASSWORD 를 -e 로 주입했는지, seed_load.sql 로 계정을 시딩했는지 확인.`,
+    );
+  }
+  return token;
 }

--- a/load-test/lib/auth.js
+++ b/load-test/lib/auth.js
@@ -2,13 +2,13 @@ import http from 'k6/http';
 import { check } from 'k6';
 import { BASE_URL } from '../config/env.js';
 
-// DevToken 발급(local/dev 프로파일 전용): POST /api/v1/dev/auth/token → access token.
-// 응답은 ApiResponse 래핑이라 result.accessToken 으로 꺼낸다.
-// 시나리오 setup()에서 1회만 호출할 것(VU마다 발급하면 auth가 병목처럼 왜곡된다).
-export function devToken(userId) {
-  const res = http.post(`${BASE_URL}/api/v1/dev/auth/token`, JSON.stringify({ userId }), {
+// 부하테스트용 계정으로 로그인해 access token을 받는다: POST /api/v1/auth/login → access token.
+// 응답은 ApiResponse 래핑 + 앱 ObjectMapper가 전역 snake_case라 result.access_token 으로 꺼낸다.
+// 시나리오 setup()에서 1회만 호출할 것(VU마다 로그인하면 auth가 병목처럼 왜곡된다).
+export function login(email, password) {
+  const res = http.post(`${BASE_URL}/api/v1/auth/login`, JSON.stringify({ email, password }), {
     headers: { 'Content-Type': 'application/json' },
   });
-  check(res, { 'devToken 200': (r) => r.status === 200 });
-  return res.json('result.accessToken');
+  check(res, { 'login 200': (r) => r.status === 200 });
+  return res.json('result.access_token');
 }

--- a/load-test/scenarios/booking-create.js
+++ b/load-test/scenarios/booking-create.js
@@ -3,9 +3,16 @@
 import http from 'k6/http';
 import { check } from 'k6';
 import { Rate } from 'k6/metrics';
-import { BASE_URL, PERF_ID, USER_ID, SEAT_ID_MIN, SEAT_ID_MAX } from '../config/env.js';
+import {
+  BASE_URL,
+  PERF_ID,
+  LOAD_USER_EMAIL,
+  LOAD_USER_PASSWORD,
+  SEAT_ID_MIN,
+  SEAT_ID_MAX,
+} from '../config/env.js';
 import { baseOptions } from '../config/options.js';
-import { devToken } from '../lib/auth.js';
+import { login } from '../lib/auth.js';
 
 export const options = baseOptions;
 
@@ -13,7 +20,7 @@ export const options = baseOptions;
 const seatConflict = new Rate('seat_conflict');
 
 export function setup() {
-  return { token: devToken(USER_ID) };
+  return { token: login(LOAD_USER_EMAIL, LOAD_USER_PASSWORD) };
 }
 
 export default function (data) {

--- a/load-test/seed/cleanup_load.sql
+++ b/load-test/seed/cleanup_load.sql
@@ -4,8 +4,19 @@
 --   performance를 마지막에 지워야 앞의 JOIN으로 대상 범위를 찾을 수 있다.
 --   사용자 계열은 예외 — user_account.user_id 는 user(id) 로 실제 FK 제약이 걸려 있어 순서가 강제된다.
 --   booking.user_id 는 FK가 아니지만 booking을 먼저 지우므로 순서상 안전하다.
---   ⚠ 로컬 전용 DB에서만 실행할 것.
+--   ⚠ 로컬/부하테스트 전용 DB에서만 실행할 것.
 -- ============================================================================
+
+-- ---- 오실행 가드 (seed_load.sql 과 동일) -----------------------------------
+-- 삭제문이므로 오실행 피해가 시드보다 크다. 실행자가 확인 변수를 명시해야만 진행된다:
+--   mysql --init-command="SET @i_confirm_loadtest_db=1" ... < cleanup_load.sql
+SET @stmt := IF(COALESCE(@i_confirm_loadtest_db, 0) = 1,
+                'SELECT ''guard ok'' AS guard',
+                'SELECT * FROM `ABORT__run_with_i_confirm_loadtest_db_eq_1`');
+PREPARE guard_check FROM @stmt;
+EXECUTE guard_check;
+DEALLOCATE PREPARE guard_check;
+
 SET @marker     = 'LOADTEST';
 SET @load_email = 'loadtest@ticketrush.local';
 

--- a/load-test/seed/cleanup_load.sql
+++ b/load-test/seed/cleanup_load.sql
@@ -1,10 +1,13 @@
 -- ============================================================================
--- 부하 테스트 시딩 데이터 정리 (마커 @marker 범위만 삭제).
---   DB-level FK가 없으므로 앱 정합 역순으로 삭제: booking -> seat -> seat_layout -> performance.
+-- 부하 테스트 시딩 데이터 정리 (마커 @marker / @load_email 범위만 삭제).
+--   공연 계열엔 DB-level FK가 없으므로 앱 정합 역순으로 삭제: booking -> seat -> seat_layout -> performance.
 --   performance를 마지막에 지워야 앞의 JOIN으로 대상 범위를 찾을 수 있다.
+--   사용자 계열은 예외 — user_account.user_id 는 user(id) 로 실제 FK 제약이 걸려 있어 순서가 강제된다.
+--   booking.user_id 는 FK가 아니지만 booking을 먼저 지우므로 순서상 안전하다.
 --   ⚠ 로컬 전용 DB에서만 실행할 것.
 -- ============================================================================
-SET @marker = 'LOADTEST';
+SET @marker     = 'LOADTEST';
+SET @load_email = 'loadtest@ticketrush.local';
 
 DELETE b FROM booking b
 JOIN performance p ON p.performance_id = b.performance_id
@@ -19,3 +22,10 @@ JOIN performance p ON p.performance_id = sl.performance_id
 WHERE p.title LIKE CONCAT(@marker, '-%');
 
 DELETE FROM performance WHERE title LIKE CONCAT(@marker, '-%');
+
+-- 부하테스트 전용 계정 (FK 때문에 user_account 를 먼저 지운다).
+DELETE ua FROM user_account ua
+JOIN `user` u ON u.id = ua.user_id
+WHERE u.email = @load_email;
+
+DELETE FROM `user` WHERE email = @load_email;

--- a/load-test/seed/seed_load.sql
+++ b/load-test/seed/seed_load.sql
@@ -1,7 +1,7 @@
 -- ============================================================================
 -- 부하 테스트용 대량 데이터 시딩 (MySQL 8.0+ / 스키마 ticket_rush)
---   생성 순서: performance -> seat_layout -> seat -> (선택) booking + seat HOLD
---   전 로우는 title 마커(@marker)로 표식 -> cleanup_load.sql 로 일괄 삭제.
+--   생성 순서: user -> performance -> seat_layout -> seat -> (선택) booking + seat HOLD
+--   전 로우는 title 마커(@marker) 또는 @load_email 로 표식 -> cleanup_load.sql 로 일괄 삭제.
 --   표준 재실행 절차: cleanup_load.sql 먼저 -> seed_load.sql.
 --   ⚠ 로컬 전용 DB에서만 실행할 것 (공유/운영 DB 금지).
 -- ============================================================================
@@ -15,6 +15,25 @@ SET @marker      = 'LOADTEST';
 -- 공연당 좌석 rows*cols, 총 좌석 = perf_count*rows*cols (예: 10*20*30 = 6,000)
 -- 재귀 CTE 깊이는 max(perf_count, rows, cols)까지만 쓰므로 여유있게 상향.
 SET SESSION cte_max_recursion_depth = 100000;
+
+-- 부하테스트 전용 계정. k6 시나리오가 POST /api/v1/auth/login 으로 이 계정에 로그인한다.
+-- 해시는 BCryptPasswordEncoder 기본 강도(cost 10). 평문은 커밋하지 않고 k6 실행 인자로만 넘긴다.
+SET @load_email   = 'loadtest@ticketrush.local';
+SET @load_pw_hash = '$2a$10$E4BOWKo0z6j93C4j2NMc/OoWhNeF4Mt5GEwvVhEYok/7fZAcO18oa';
+
+-- ---- 0) 부하테스트 전용 사용자 ---------------------------------------------
+-- user -> user_account 순서. user_account.user_id 는 user(id) 로 실제 FK 제약이 걸려 있다.
+-- LAST_INSERT_ID()는 재실행(0건 삽입) 시 값이 어긋나므로 쓰지 않고 email 로 다시 조회한다.
+-- user_role='MEMBER' -> LoginUseCase.normalizeRole() 이 토큰용 'USER' 로 매핑한다.
+INSERT INTO `user` (name, email, user_role, created_at, updated_at)
+SELECT @marker, @load_email, 'MEMBER', NOW(), NOW() FROM DUAL
+WHERE NOT EXISTS (SELECT 1 FROM `user` u WHERE u.email = @load_email);
+
+SET @load_user_id = (SELECT id FROM `user` WHERE email = @load_email);
+
+INSERT INTO user_account (user_id, password, created_at, updated_at)
+SELECT @load_user_id, @load_pw_hash, NOW(), NOW() FROM DUAL
+WHERE NOT EXISTS (SELECT 1 FROM user_account ua WHERE ua.user_id = @load_user_id);
 
 -- ---- 1) performance --------------------------------------------------------
 -- @SQLRestriction(deleted_at IS NULL)은 앱 레벨이라 직접 INSERT엔 무관. status는 ON_SALE 직접 지정.
@@ -71,7 +90,7 @@ WITH ranked AS (
   JOIN performance p ON p.performance_id = s.performance_id AND p.title LIKE CONCAT(@marker, '-%')
   WHERE s.seat_status = 'AVAILABLE'
 )
-SELECT 1, r.performance_id, r.seat_id,
+SELECT @load_user_id, r.performance_id, r.seat_id,
        CONCAT('LT-', LPAD(r.gseq, 10, '0')), 'PENDING', NOW(), NOW()
 FROM ranked r
 WHERE r.rn <= FLOOR(@rows_per * @cols_per * @booking_pct / 100);
@@ -85,6 +104,8 @@ WHERE s.seat_status = 'AVAILABLE' AND b.booking_status = 'PENDING';
 
 -- ---- 검증 쿼리 -------------------------------------------------------------
 SELECT
+  (SELECT COUNT(*) FROM `user` u JOIN user_account ua ON ua.user_id = u.id
+     WHERE u.email = @load_email)                                           AS load_users,
   (SELECT COUNT(*) FROM performance WHERE title LIKE CONCAT(@marker, '-%')) AS performances,
   (SELECT COUNT(*) FROM seat s JOIN performance p ON p.performance_id = s.performance_id
      WHERE p.title LIKE CONCAT(@marker, '-%'))                              AS seats,

--- a/load-test/seed/seed_load.sql
+++ b/load-test/seed/seed_load.sql
@@ -3,8 +3,20 @@
 --   생성 순서: user -> performance -> seat_layout -> seat -> (선택) booking + seat HOLD
 --   전 로우는 title 마커(@marker) 또는 @load_email 로 표식 -> cleanup_load.sql 로 일괄 삭제.
 --   표준 재실행 절차: cleanup_load.sql 먼저 -> seed_load.sql.
---   ⚠ 로컬 전용 DB에서만 실행할 것 (공유/운영 DB 금지).
+--   ⚠ 로컬/부하테스트 전용 DB에서만 실행할 것 (공유/운영 DB 금지).
 -- ============================================================================
+
+-- ---- 오실행 가드 -----------------------------------------------------------
+-- 이 시드는 실제로 로그인되는 계정을 만든다. 운영 DB에 잘못 실행하면 그대로 백도어가 된다.
+-- 주석은 강제력이 없으므로 실행자가 확인 변수를 명시해야만 진행되게 한다:
+--   mysql --init-command="SET @i_confirm_loadtest_db=1" ... < seed_load.sql
+-- 변수가 없으면 없는 테이블을 PREPARE 하다 ERROR 1146 으로 즉시 중단되고 본문은 돌지 않는다.
+SET @stmt := IF(COALESCE(@i_confirm_loadtest_db, 0) = 1,
+                'SELECT ''guard ok'' AS guard',
+                'SELECT * FROM `ABORT__run_with_i_confirm_loadtest_db_eq_1`');
+PREPARE guard_check FROM @stmt;
+EXECUTE guard_check;
+DEALLOCATE PREPARE guard_check;
 
 -- ---- 규모 파라미터 (여기만 조정) -------------------------------------------
 SET @perf_count  = 10;   -- 공연 수
@@ -18,8 +30,10 @@ SET SESSION cte_max_recursion_depth = 100000;
 
 -- 부하테스트 전용 계정. k6 시나리오가 POST /api/v1/auth/login 으로 이 계정에 로그인한다.
 -- 해시는 BCryptPasswordEncoder 기본 강도(cost 10). 평문은 커밋하지 않고 k6 실행 인자로만 넘긴다.
+-- 해시에는 salt가 그대로 들어 있어 오프라인 대입이 가능하다. 평문은 반드시 길고 무작위여야 하며
+-- 다른 계정·환경에서 재사용하지 않는다.
 SET @load_email   = 'loadtest@ticketrush.local';
-SET @load_pw_hash = '$2a$10$E4BOWKo0z6j93C4j2NMc/OoWhNeF4Mt5GEwvVhEYok/7fZAcO18oa';
+SET @load_pw_hash = '$2a$10$suAPTuh/UrqjiHmiGXdcueeABS9HHtxCrkH4r6uy2unY8yrtOq7CW';
 
 -- ---- 0) 부하테스트 전용 사용자 ---------------------------------------------
 -- user -> user_account 순서. user_account.user_id 는 user(id) 로 실제 FK 제약이 걸려 있다.


### PR DESCRIPTION
## 🔗 관련 이슈

- close #379

---

## 📌 주요 변경 사항

- k6 부하테스트가 무인증 DevToken(`POST /api/v1/dev/auth/token`) 대신 정상 로그인(`POST /api/v1/auth/login`)으로 토큰을 받는다.
- `seed_load.sql`이 부하테스트 전용 계정(`user` + `user_account`)을 함께 시딩하고, `cleanup_load.sql`이 FK 순서를 지켜 지운다.
- 시드·cleanup에 **오실행 가드**를 넣어 운영 DB 사고를 막는다.
- 서버 코드는 건드리지 않는다. `load-test/`와 문서만 바뀐다.

---

## 🛠 상세 구현 내용

- `load-test/lib/auth.js` — `devToken(userId)` → `login(email, password)`.
  - 응답 키를 `result.accessToken` → `result.access_token`으로 교정했다. common `JacksonConfig`가 무조건 `SNAKE_CASE`를 적용하므로 **기존 코드는 `undefined`를 반환하고 있었다.**
  - 토큰이 falsy면 `fail()`로 즉시 중단한다. 그렇지 않으면 전 VU가 `Bearer undefined`로 401을 찍어, 부하가 아니라 인증 실패를 측정하게 된다.
- `load-test/config/env.js` — `USER_ID` 제거, `LOAD_USER_EMAIL` / `LOAD_USER_PASSWORD` 추가.
- `load-test/scenarios/booking-create.js` — `setup()`이 1회 로그인해 토큰을 확보한다.
- `load-test/seed/seed_load.sql`
  - 부하테스트 전용 계정 시딩. `user_role='MEMBER'`(→ `normalizeRole()`이 `USER`로 매핑), bcrypt cost 10 해시만 커밋하고 평문은 40자 무작위 값으로 팀 내부 공유.
  - 멱등성은 기존 시드와 같은 `NOT EXISTS` 패턴. `LAST_INSERT_ID()`는 재실행(0건 삽입) 시 값이 어긋나 쓰지 않고 email로 재조회한다.
  - **함께 수정:** booking INSERT가 `user_id`를 상수 `1`로 하드코딩하고 있었다(`@booking_pct>0`에서만 도는 경로). 시딩한 계정 id로 연결했다.
- `load-test/seed/cleanup_load.sql` — `user_account`는 `user(id)`로 **실제 FK 제약**이 있어 먼저 지운다.
- **오실행 가드** (양쪽 SQL) — `@i_confirm_loadtest_db=1`을 명시하지 않으면 `ERROR 1146`으로 본문 전에 중단된다.

  ```bash
  mysql --init-command="SET @i_confirm_loadtest_db=1" ... < load-test/seed/seed_load.sql
  ```

  이 시드는 실제로 로그인되는 계정을 만들므로 운영 DB 오실행이 그대로 백도어가 된다. 운영 스키마명은 `DB_NAME` 환경변수라 `DATABASE()`로 구분할 수 없어 확인 변수 방식을 택했다.
- `docs/load-test-guide.md`, `load-test/README.md` — `-e USER_ID=1` → `-e LOAD_USER_EMAIL=... -e LOAD_USER_PASSWORD=...`. "AWS를 `dev` 프로파일로 띄우지 않으면 write 시나리오는 인증 실패한다"는 서술 삭제. DevToken 안내는 로컬 프론트 테스트 전용으로 정정.

---

## ✅ 테스트

### 테스트 방법

**자동화 단위/통합 테스트는 추가하지 않았다** — 서버 코드 변경이 없고, 바뀐 것은 k6 스크립트·시드 SQL·문서다. 대신 임시 MySQL 8.0 컨테이너에 `infra/mysql/init/01-schema.sql`을 적용하고 auth-service·user-service를 그 DB로 기동해 실제로 실행 검증했다.

- 시드 2회 연속 실행 (멱등성)
- `ALTER TABLE user AUTO_INCREMENT = 555 / 777` 로 id를 1이 아니게 밀고 `@booking_pct=5/10`으로 재시딩 → `booking.user_id` 확인
- cleanup 실행 → 잔존 행 확인, 재실행
- 가드 변수 **없이** seed/cleanup 실행 → 중단 여부 및 본문 미실행 확인
- `curl -XPOST localhost:8082/api/v1/auth/login` 으로 시딩 계정 로그인
- `docker run grafana/k6 run` 으로 `auth.js`의 `login()` 직접 실행 (정상 / 비밀번호 미주입 / 오답)
- `./gradlew spotlessCheck`

### 테스트 결과

- 시드 2회 실행 → 카운트 동일(`load_users=1, performances=10, seats=6000`), 중복 삽입·에러 없음 ✅
- `booking.user_id` 600건 전부 `777`, 300건 전부 `555` → **하드코딩 `1` 제거 확인** ✅
- cleanup → 전 테이블 0행 복귀, FK 위반 없음. 재실행도 무해 ✅
- 가드 없이 실행 → `ERROR 1146 ... 'ABORT__run_with_i_confirm_loadtest_db_eq_1' doesn't exist`, `user` 0행(본문 미실행). 가드 주면 통과 ✅
- 로그인 → `is_success: true`, `role: "USER"`, `access_token` 반환 ✅
- k6 → 정상 시 165자 JWT + `✓ login 200` / 미주입 시 `status=400` 즉시 중단 / 오답 시 `status=401` 즉시 중단 ✅
- `./gradlew spotlessCheck` → `EXIT=0` ✅

> `@booking_pct>0`으로 시드를 **재실행**하면 `booking_number` UNIQUE 충돌이 난다. 이는 기존 동작이며(파일 주석: "재실행은 cleanup 선행 전제") 이번 변경과 무관하다.
<!--
### 📸 스크린샷

- (작성 필요)
-->
---

## 👀 리뷰 요청 사항

- 오실행 가드를 `PREPARE`로 구현했습니다. `@i_confirm_loadtest_db`가 1이 아닐 때만 없는 테이블을 `PREPARE`해 `ERROR 1146`을 냅니다. 조건이 참이면 그 SQL은 준비조차 되지 않아 통과합니다(실제 MySQL 8.0으로 양방향 확인). 더 관용적인 방식이 있다면 알려주세요!
- 비밀번호 평문은 커밋하지 않고 bcrypt 해시만 넣었습니다다. 평문은 팀에게 슬랙으로 공유하였습니다.

---

## ⚠️ 배포 시 주의사항

- **시드 실행 절차가 바뀐다.** `--init-command="SET @i_confirm_loadtest_db=1"` 없이는 `seed_load.sql` / `cleanup_load.sql`이 중단된다.
- **k6 실행 인자가 바뀐다.** `-e USER_ID=1` → `-e LOAD_USER_PASSWORD=<평문>` (이메일은 기본값 사용 가능).
