### PR TITLE
[Refactor] #393 dev 프로파일 제거 — @Profile({"local","dev"}) → @Profile("local")

### DIFF
--- a/auth-service/src/main/java/com/ticketrush/boundedcontext/auth/app/facade/DevAuthFacade.java
+++ b/auth-service/src/main/java/com/ticketrush/boundedcontext/auth/app/facade/DevAuthFacade.java
@@ -7,7 +7,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
-@Profile({"local", "dev"})
+@Profile("local")
 @Component
 @RequiredArgsConstructor
 public class DevAuthFacade {

--- a/auth-service/src/main/java/com/ticketrush/boundedcontext/auth/app/usecase/DevTokenIssueUseCase.java
+++ b/auth-service/src/main/java/com/ticketrush/boundedcontext/auth/app/usecase/DevTokenIssueUseCase.java
@@ -10,7 +10,7 @@ import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-@Profile({"local", "dev"})
+@Profile("local")
 @Service
 @RequiredArgsConstructor
 @Transactional

--- a/auth-service/src/main/java/com/ticketrush/boundedcontext/auth/in/api/v1/DevTokenController.java
+++ b/auth-service/src/main/java/com/ticketrush/boundedcontext/auth/in/api/v1/DevTokenController.java
@@ -16,7 +16,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-@Profile({"local", "dev"})
+@Profile("local")
 @Tag(name = "Dev Auth", description = "개발 및 테스트용 인증 API")
 @RestController
 @RequestMapping("/api/v1/dev/auth")

--- a/docs/backend-convention.md
+++ b/docs/backend-convention.md
@@ -281,6 +281,7 @@ Diary diary = diaryRepository.findByDiaryIdAndUserId(diaryId, userId)
     * **환경 무관 앱 설정**(`app.event-publisher.type`, `app.outbox.*`, `custom.security.permit-urls`, OAuth provider URI, mail 정적 프로퍼티, `spring.datasource.driver-class-name`, `spring.jpa.open-in-view` 등)은 `application.yml`(base)에 둔다.
     * **접속 엔드포인트·환경가변 값**(DB/Redis/Kafka 호스트, `ddl-auto`, OAuth `allowed-redirect-domains`, gateway `services.*.host`, CORS origin, swagger serverUrl 등)만 프로파일 yml에 둔다.
 * **프로파일 활성화:** 컨테이너에서 `SPRING_PROFILES_ACTIVE=prod` 환경변수로 구동한다. base의 `spring.profiles.active: ${SPRING_PROFILES_ACTIVE:local}` 기본값이 local이다.
+* **프로파일 축은 `local` / `prod` / `test` 셋뿐이다.** 개발 환경 = `local`, 운영 환경 = `prod`, 테스트 환경 = `test`. **`dev` 는 사용하지 않는다** — `application-dev.yml` 은 존재하지 않으며 `@Profile` 에도 `dev` 를 쓰지 않는다(`prod,dev` 처럼 함께 활성화하면 개발 전용 빈이 운영에 끼어드는 백도어가 된다).
 * **접속정보 환경변수 규칙:**
     * **DB:** `url: jdbc:mysql://${DB_HOST}:${DB_PORT}/${DB_NAME}`, 자격증명은 `${MYSQL_USERNAME}` / `${MYSQL_PASSWORD}`(기본값 없음, 미주입 시 기동 실패).
     * **Redis:** `spring.data.redis.host/port` 를 **명시적으로 설정**한다(오토컨피그 localhost:6379 암묵 의존 금지). local은 `${REDIS_HOST:localhost}`, prod는 `${REDIS_HOST}`.

--- a/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/in/datainit/SeatDataInit.java
+++ b/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/in/datainit/SeatDataInit.java
@@ -9,7 +9,7 @@ import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
 @Slf4j
-@Profile({"local", "dev"})
+@Profile("local")
 @Component
 @RequiredArgsConstructor
 public class SeatDataInit implements ApplicationRunner {
@@ -21,6 +21,6 @@ public class SeatDataInit implements ApplicationRunner {
   @Override
   public void run(ApplicationArguments args) {
     seatFacade.createDefaultSeats(DUMMY_PERFORMANCE_ID);
-    log.info("local/dev 프로필용 더미 공연 좌석 초기화를 요청했습니다. performanceId: {}", DUMMY_PERFORMANCE_ID);
+    log.info("local 프로필용 더미 공연 좌석 초기화를 요청했습니다. performanceId: {}", DUMMY_PERFORMANCE_ID);
   }
 }


### PR DESCRIPTION
## 🔗 관련 이슈

- close #393

---

## 📌 주요 변경 사항

- `@Profile({"local", "dev"})` → `@Profile("local")` (auth-service 3파일 + seat-service 1파일)
- `SeatDataInit` 로그 문구의 `local/dev` 표기를 `local`로 정정
- `docs/backend-convention.md`에 프로파일 축이 `local`/`prod`/`test` 셋뿐이며 `dev`는 사용하지 않는다는 규칙 명시

---

## 🛠 상세 구현 내용

- **`dev`는 실체 없는 프로파일이다.** `application-dev.yml`도, `SPRING_PROFILES_ACTIVE`를 `dev`로 켜는 곳도 없다(docker-compose·CI·스크립트 전부). `@Profile` 애노테이션 4곳에만 남아 있었고, 유일한 실효는 **prod에 개발 전용 빈을 끼워 넣는 백도어**였다.
- 이 백도어가 실제로 열릴 뻔했다. #378(AWS 배포본)이 `SPRING_PROFILES_ACTIVE=prod,dev`로 기동한다고 적혀 있었고, 그대로 배포했다면 ① `POST /api/v1/dev/auth/token`이 인증 없이 인터넷에 열리고 ② `SeatDataInit`이 `performanceId=1`에 더미 좌석을 생성해 부하테스트 시딩 데이터(`load-test/config/env.js`의 `PERF_ID` 기본값도 `1`)를 오염시켰을 것이다.
- `@Profile("local")`로 좁히면 `prod,dev`로 기동해도 `local`이 활성 프로파일에 없어 해당 빈들이 등록되지 않는다. `prod,dev` 조합 자체가 구조적으로 무의미해진다.
- 변경 파일:
  - `auth-service/.../auth/in/api/v1/DevTokenController.java`
  - `auth-service/.../auth/app/facade/DevAuthFacade.java`
  - `auth-service/.../auth/app/usecase/DevTokenIssueUseCase.java`
  - `seat-service/.../seat/in/datainit/SeatDataInit.java`
  - `docs/backend-convention.md` — §프로파일 및 인프라 접속정보 외부화
- **범위 밖:** ADR 0004 36행("write 시나리오는 AWS를 `dev` 프로파일로 띄울 때만 실행한다") 정정은 #381에서 처리한다. 이 PR이 그 선행 작업이다.

---

## ✅ 테스트

### 테스트 방법

- `./gradlew :auth-service:test :seat-service:test`
- `./gradlew spotlessCheck :auth-service:compileJava :seat-service:compileJava`
- `grep -rn '"dev"\|local/dev' --include=*.java .` (build 디렉토리 제외)

### 테스트 결과

- `:auth-service:test`, `:seat-service:test` — BUILD SUCCESSFUL
- `spotlessCheck` + 두 모듈 컴파일 — 통과 (pre-commit hook의 Checkstyle도 통과)
- Java 코드에 남은 `dev` 문자열 — **0건**
<!--
### 📸 스크린샷

- (작성 필요)
-->
---

## 👀 리뷰 요청 사항

- `@Profile("local")`로 좁힌 뒤 로컬(`SPRING_PROFILES_ACTIVE=local`) 동작이 기존과 동일한지 — DevToken 발급, 좌석 더미 초기화 모두 그대로 동작해야 합니다.

---

## ⚠️ 배포 시 주의사항

- **`SPRING_PROFILES_ACTIVE`에 `dev`를 넣지 마세요.** 이 PR 이후 `dev`는 아무 빈도 활성화하지 않는 무의미한 값입니다. 운영은 `prod` 단독으로 기동합니다.
- 이 PR이 머지되면 로컬 개발자는 반드시 `local` 프로파일로 띄워야 DevToken 엔드포인트와 좌석 초기화를 쓸 수 있습니다.
