### PR TITLE
[Feat] #333 booking당 FAILED 결제 이력 상한으로 무제한 누적 방어

### DIFF
--- a/common/src/main/java/com/ticketrush/global/constants/MetricNames.java
+++ b/common/src/main/java/com/ticketrush/global/constants/MetricNames.java
@@ -24,6 +24,9 @@ public class MetricNames {
   public static final String PAYMENT_REFUND = "ticketrush.payment.refund";
   public static final String PAYMENT_PG_CANCEL = "ticketrush.payment.pg.cancel"; // Timer
   public static final String PAYMENT_REFUND_FAILED = "ticketrush.payment.refund.failed";
+  // booking당 FAILED 이력 상한 초과로 기록을 억제한 횟수(#333).
+  public static final String PAYMENT_FAILED_RECORD_SUPPRESSED =
+      "ticketrush.payment.failed_record.suppressed";
 
   // ticket
   public static final String TICKET_ISSUE = "ticketrush.ticket.issue";

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentConfirmUseCase.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentConfirmUseCase.java
@@ -52,6 +52,20 @@ public class PaymentConfirmUseCase {
           ErrorStatus.PAYMENT_LIMIT_EXCEEDED,
           ErrorStatus.PAYMENT_SESSION_NOT_FOUND);
 
+  /**
+   * booking당 보존하는 FAILED 이력 상한(#333).
+   *
+   * <p>FAILED row는 unique 제약에 걸리지 않아 동일 booking에 무제한 누적될 수 있다. 화이트리스트({@link
+   * #RECORDABLE_FAILURES})가 무작위 스팸은 이미 거르지만, 인증 사용자의 정상 거절 반복은 여전히 쌓인다. 첫 {@value}건까지는 재시도 이력으로
+   * 보존하고(#297) 초과분은 저장하지 않아 팽창을 유계로 만든다. 초과 억제는 {@link
+   * MetricNames#PAYMENT_FAILED_RECORD_SUPPRESSED} 메트릭으로 관측한다.
+   *
+   * <p>{@code execute}에 트랜잭션이 없어 count→insert 사이 TOCTOU가 있으므로 이 상한은 정확한 하드 리밋이 아니라 <b>근사 상한(soft
+   * cap)</b>이다. 동시 실패가 겹치면 상한을 근소하게 넘길 수 있으나, 목적이 "무제한 누적 방지(유계화)"라 수용한다(엄밀 상한은 DDL/락이 필요하나 이번 범위는
+   * 스키마 무변경).
+   */
+  private static final long MAX_FAILED_HISTORY_PER_BOOKING = 5;
+
   private final PaymentRepository paymentRepository;
   private final PaymentApprovalClientRouter paymentApprovalClientRouter;
   private final PaymentEventPublisher paymentEventPublisher;
@@ -171,6 +185,23 @@ public class PaymentConfirmUseCase {
       pgFailureReason = pge.getRawMessage();
     }
     try {
+      // booking당 FAILED 이력이 상한에 도달하면 더 쌓지 않는다(무제한 누적/쓰기 증폭 방어, #333). 첫 상한건까지는 이력으로
+      // 보존되고, 초과 실패는 저장 대신 억제 메트릭으로만 관측한다. count 조회도 이 try 안에서 수행해, 조회가 DB 장애로 실패하더라도
+      // 아래 catch가 삼켜 원래의 결제 실패 예외를 가리지 않게 한다(저장 실패와 동일한 불변식).
+      if (paymentRepository.countByBookingIdAndStatus(request.bookingId(), PaymentStatus.FAILED)
+          >= MAX_FAILED_HISTORY_PER_BOOKING) {
+        Counter.builder(MetricNames.PAYMENT_FAILED_RECORD_SUPPRESSED)
+            .tag(MetricNames.TAG_REASON, e.getErrorStatus().getCode())
+            .register(meterRegistry)
+            .increment();
+        // 억제 자체는 위 메트릭으로 관측한다. 상한 도달 booking의 반복 재시도로 로그가 증폭되지 않도록 debug로 남긴다.
+        log.debug(
+            "FAILED 결제 이력이 booking당 상한({})에 도달해 기록을 억제합니다. bookingId={}, failureCode={}",
+            MAX_FAILED_HISTORY_PER_BOOKING,
+            request.bookingId(),
+            e.getErrorStatus().getCode());
+        return;
+      }
       Payment failed =
           Payment.failed(
               request.bookingId(),
@@ -189,9 +220,10 @@ public class PaymentConfirmUseCase {
           .register(meterRegistry)
           .increment();
     } catch (Exception ex) {
-      // 추적이 목적인 기능이라 이력 저장 실패는 집계 누락이다. error 레벨로 올려 알람/메트릭 대상이 되게 한다.
+      // 추적이 목적인 기능이라 이력 기록 실패는 집계 누락이다. error 레벨로 올려 알람/메트릭 대상이 되게 한다.
+      // 상한 조회(count)와 저장(saveAndFlush)이 같은 try 안이라, 어느 단계에서 실패했든 이 경로로 모인다(원 결제 실패 예외는 호출부가 재던진다).
       log.error(
-          "FAILED 결제 이력 저장에 실패했습니다. bookingId={}, failureCode={}",
+          "FAILED 결제 이력 기록(상한 조회·저장)에 실패했습니다. bookingId={}, failureCode={}",
           request.bookingId(),
           e.getErrorStatus().getCode(),
           ex);

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/out/repository/PaymentRepository.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/out/repository/PaymentRepository.java
@@ -23,4 +23,11 @@ public interface PaymentRepository extends JpaRepository<Payment, Long> {
   Optional<Payment> findByIdAndUserId(Long id, Long userId);
 
   Optional<Payment> findByPaymentKey(String paymentKey);
+
+  /*
+   * booking당 FAILED 이력 누적 상한을 판정하기 위해 현재 개수를 센다(#333). FAILED row는
+   * payment_key·completed_booking_id가 NULL이라 어떤 unique 제약에도 걸리지 않아 동일 booking에 무제한 누적될 수
+   * 있으므로, 기록 직전 이 개수로 상한을 건다.
+   */
+  long countByBookingIdAndStatus(Long bookingId, PaymentStatus status);
 }

--- a/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentConfirmUseCaseTest.java
+++ b/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentConfirmUseCaseTest.java
@@ -293,6 +293,79 @@ class PaymentConfirmUseCaseTest {
   }
 
   @Test
+  @DisplayName("booking당 FAILED 이력이 상한에 도달하면 화이트리스트 실패라도 저장하지 않고 억제 메트릭만 남긴다(#333)")
+  void execute_does_not_record_failed_when_cap_reached() {
+    // given
+    Long userId = 10L;
+    Long bookingId = 100L;
+    PaymentConfirmRequest request =
+        new PaymentConfirmRequest(bookingId, 200L, PaymentProvider.TOSS, 55_000L, "pgKey_xyz");
+
+    given(paymentRepository.existsByBookingIdAndStatus(bookingId, PaymentStatus.COMPLETED))
+        .willReturn(false);
+    given(paymentApprovalClientRouter.approve(any()))
+        .willThrow(new BusinessException(ErrorStatus.PAYMENT_METHOD_REJECTED));
+    // 이미 상한(5)만큼 FAILED 이력이 쌓여 있다.
+    given(paymentRepository.countByBookingIdAndStatus(bookingId, PaymentStatus.FAILED))
+        .willReturn(5L);
+
+    // when & then: 결제 실패 예외 자체는 그대로 전파된다.
+    assertThatThrownBy(() -> paymentConfirmUseCase.execute(userId, request))
+        .isInstanceOf(BusinessException.class)
+        .extracting("errorStatus")
+        .isEqualTo(ErrorStatus.PAYMENT_METHOD_REJECTED);
+
+    // 상한 초과라 FAILED row는 저장하지 않는다.
+    verify(paymentRepository, never()).saveAndFlush(any(Payment.class));
+    // 대신 억제 메트릭이 사유 태그와 함께 1 증가한다.
+    assertThat(
+            meterRegistry
+                .counter(
+                    MetricNames.PAYMENT_FAILED_RECORD_SUPPRESSED,
+                    MetricNames.TAG_REASON,
+                    ErrorStatus.PAYMENT_METHOD_REJECTED.getCode())
+                .count())
+        .isEqualTo(1.0);
+  }
+
+  @Test
+  @DisplayName("booking당 FAILED 이력이 상한 직전(4건)이면 이번 실패는 저장되고 억제 메트릭은 증가하지 않는다(#333 경계)")
+  void execute_records_failed_when_below_cap() {
+    // given
+    Long userId = 10L;
+    Long bookingId = 100L;
+    PaymentConfirmRequest request =
+        new PaymentConfirmRequest(bookingId, 200L, PaymentProvider.TOSS, 55_000L, "pgKey_xyz");
+
+    given(paymentRepository.existsByBookingIdAndStatus(bookingId, PaymentStatus.COMPLETED))
+        .willReturn(false);
+    given(paymentApprovalClientRouter.approve(any()))
+        .willThrow(new BusinessException(ErrorStatus.PAYMENT_METHOD_REJECTED));
+    // 상한(5) 직전인 4건 → 이번 실패는 5번째로 기록되어야 한다.
+    given(paymentRepository.countByBookingIdAndStatus(bookingId, PaymentStatus.FAILED))
+        .willReturn(4L);
+
+    // when & then
+    assertThatThrownBy(() -> paymentConfirmUseCase.execute(userId, request))
+        .isInstanceOf(BusinessException.class)
+        .extracting("errorStatus")
+        .isEqualTo(ErrorStatus.PAYMENT_METHOD_REJECTED);
+
+    ArgumentCaptor<Payment> failedCaptor = ArgumentCaptor.forClass(Payment.class);
+    verify(paymentRepository).saveAndFlush(failedCaptor.capture());
+    assertThat(failedCaptor.getValue().getStatus()).isEqualTo(PaymentStatus.FAILED);
+    // 억제 메트릭은 증가하지 않는다.
+    assertThat(
+            meterRegistry
+                .counter(
+                    MetricNames.PAYMENT_FAILED_RECORD_SUPPRESSED,
+                    MetricNames.TAG_REASON,
+                    ErrorStatus.PAYMENT_METHOD_REJECTED.getCode())
+                .count())
+        .isEqualTo(0.0);
+  }
+
+  @Test
   @DisplayName("PG 통신 실패(결과 불명)는 고아 청구 위험이 있어 FAILED 이력을 남기지 않는다")
   void execute_does_not_record_when_pg_communication_failed() {
     // given


### PR DESCRIPTION
## 🔗 관련 이슈

- close #333

---

## 📌 주요 변경 사항

- 동일 booking에 무제한 누적되던 FAILED payment row에 **booking당 상한(MAX=5)** 을 적용해 팽창을 유계화
- 상한 초과 실패는 저장 대신 **억제 메트릭**(`PAYMENT_FAILED_RECORD_SUPPRESSED`)으로만 관측
- 스키마 변경 없음 (기존 `payment.status` 컬럼만 사용) — prod `validate` 배포 무해

---

## 🛠 상세 구현 내용

- `PaymentRepository.countByBookingIdAndStatus(bookingId, status)` 파생 쿼리 추가
- `PaymentConfirmUseCase.recordFailedPayment`에 상한 가드 추가: 화이트리스트(#297) 통과 후 `count(FAILED) >= MAX`면 억제 카운터 증가 + `return`. 첫 5건은 재시도 이력으로 보존해 #297 취지 유지
- count 조회를 저장(`saveAndFlush`)과 **같은 try 안**에 두어, 조회가 DB 장애로 실패해도 원 결제 실패 예외를 가리지 않게 함(기존 불변식 유지)
- `execute`에 트랜잭션이 없어 count→insert TOCTOU가 있으므로 **근사 상한(soft cap)** 임을 상수 Javadoc에 명시 (목적은 무제한 누적 방지)
- `MetricNames.PAYMENT_FAILED_RECORD_SUPPRESSED` 상수 추가

### 범위 밖 (후속 이슈로 분리 예정)
- paymentKey DTO 형식/길이 하드닝 + #357 형식필터 confirm 공용화
- 게이트웨이/인프라 레이트리밋
- `payment.booking_id` 인덱스 추가

---

## ✅ 테스트

### 테스트 방법

- `PaymentConfirmUseCaseTest`에 경계 테스트 2건 추가:
  - `execute_does_not_record_failed_when_cap_reached` — count=5(상한 도달) → `saveAndFlush` 미호출 + 억제 메트릭 1 증가 + 원 결제 실패 예외 정상 전파 검증
  - `execute_records_failed_when_below_cap` — count=4(상한 직전) → FAILED 저장 + 억제 메트릭 미증가 검증
- 실행: `./gradlew :common:checkstyleMain :payment-service:checkstyleMain :payment-service:checkstyleTest :payment-service:compileJava :payment-service:test`

### 테스트 결과

- BUILD SUCCESSFUL — payment-service 전체 테스트 통과, checkstyle(main/test)·compile 통과
- 기존 FAILED 기록/미기록 테스트 회귀 없음 (신규 count 미스텁 시 기본 0L → 저장 경로 유지)

### 📸 스크린샷

- 

---

## 👀 리뷰 요청 사항

- 상한 기본값 MAX=5의 적정성 (재시도 UX ↔ 방어 강도)
- soft cap(TOCTOU 근소 초과 허용) 수용 판단

---

## ⚠️ 배포 시 주의사항

- 스키마 변경 없음 → 별도 DDL/ALTER 불필요
