### PR TITLE
[Fix] #397 환불 경로의 REFUNDING 고착 식별·복구와 동시 환불 중복 발행 보완

### DIFF
--- a/.claude/agents/reviewer.md
+++ b/.claude/agents/reviewer.md
@@ -4,7 +4,7 @@ description: 변경된 코드의 버그·리스크만 찾아 심각도별로 보
 tools: Read, Grep, Glob, Bash
 ---
 
-당신은 10년차 Java/Spring 시니어 개발자이자 TicketRush 팀의 **독립 코드 리뷰어**입니다.
+당신은 20년차 Java/Spring 시니어 개발자이자 TicketRush 팀의 **독립 코드 리뷰어**입니다.
 검증의 독립성을 위해 당신에게는 **Edit/Write 도구가 없습니다.** 또한 `Bash`는 조사용(`git diff`/`gh` 등 읽기)으로만 쓰고, **파일을 변경하는 명령(`>`, `sed -i`, `Set-Content` 등)은 실행하지 않습니다.** 문제를 찾아 보고만 하고, **절대 직접 고치지 않습니다.**
 
 ## 작업 순서

--- a/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/app/dto/response/BookingSummaryResponse.java
+++ b/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/app/dto/response/BookingSummaryResponse.java
@@ -17,7 +17,11 @@ public record BookingSummaryResponse(
     @Schema(
             description = "마지막 환불 실패 시각. null이 아니면 취소를 요청했으나 환불에 실패해 예매가 유지된 것이다.",
             example = "2026-05-23 11:00:00")
-        LocalDateTime refundFailedAt) {
+        LocalDateTime refundFailedAt,
+    @Schema(
+            description = "마지막 변경 시각. REFUNDING이면 환불 요청이 시작된 시각이다 (#397).",
+            example = "2026-05-23 11:00:00")
+        LocalDateTime updatedAt) {
 
   public static BookingSummaryResponse from(Booking booking) {
     return new BookingSummaryResponse(
@@ -28,6 +32,7 @@ public record BookingSummaryResponse(
         booking.getSeatId(),
         booking.getBookingStatus(),
         booking.getConfirmedAt(),
-        booking.getRefundFailedAt());
+        booking.getRefundFailedAt(),
+        booking.getUpdatedAt());
   }
 }

--- a/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/app/facade/BookingFacade.java
+++ b/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/app/facade/BookingFacade.java
@@ -10,6 +10,7 @@ import com.ticketrush.boundedcontext.booking.app.usecase.BookingCountUseCase;
 import com.ticketrush.boundedcontext.booking.app.usecase.BookingCreateUseCase;
 import com.ticketrush.boundedcontext.booking.app.usecase.BookingGetMyBookingsUseCase;
 import com.ticketrush.boundedcontext.booking.app.usecase.BookingGetRefundFailedBookingsUseCase;
+import com.ticketrush.boundedcontext.booking.app.usecase.BookingGetRefundingStuckBookingsUseCase;
 import com.ticketrush.boundedcontext.booking.app.usecase.BookingIssueNumberUseCase;
 import com.ticketrush.boundedcontext.booking.app.usecase.BookingValidateReferencesUseCase;
 import com.ticketrush.boundedcontext.booking.app.usecase.BookingValidateSeatAvailableUseCase;
@@ -34,6 +35,7 @@ public class BookingFacade {
   private final BookingValidateReferencesUseCase bookingValidateReferencesUseCase;
   private final BookingValidateSeatAvailableUseCase bookingValidateSeatAvailableUseCase;
   private final BookingGetRefundFailedBookingsUseCase bookingGetRefundFailedBookingsUseCase;
+  private final BookingGetRefundingStuckBookingsUseCase bookingGetRefundingStuckBookingsUseCase;
   private final BookingAdminRetryRefundUseCase bookingAdminRetryRefundUseCase;
 
   public BookingPendingResponse createBooking(Long userId, Long performanceId, Long seatId) {
@@ -68,6 +70,10 @@ public class BookingFacade {
 
   public Page<BookingSummaryResponse> getRefundFailedBookings(OffsetPageRequest pageRequest) {
     return bookingGetRefundFailedBookingsUseCase.execute(pageRequest);
+  }
+
+  public Page<BookingSummaryResponse> getRefundingStuckBookings(OffsetPageRequest pageRequest) {
+    return bookingGetRefundingStuckBookingsUseCase.execute(pageRequest);
   }
 
   public void retryRefund(Long adminId, String bookingNumber) {

--- a/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/app/usecase/BookingAdminRetryRefundUseCase.java
+++ b/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/app/usecase/BookingAdminRetryRefundUseCase.java
@@ -7,9 +7,10 @@ import com.ticketrush.global.eventpublisher.EventPublisher;
 import com.ticketrush.global.exception.BusinessException;
 import com.ticketrush.global.status.ErrorStatus;
 import com.ticketrush.shared.booking.event.RefundRequestedEvent;
+import java.time.Clock;
 import java.time.LocalDateTime;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -21,23 +22,48 @@ import org.springframework.transaction.annotation.Transactional;
  * 예매</b>로 대상을 제한한다 — 소유자의 의도적 취소와 달리 CS 도구가 정상 예매를 강제 취소해선 안 되기 때문이다. 사용자도 자신의 예매를 다시 취소해 재환불할 수
  * 있으며, 이 API는 CS가 사용자를 대신해 시도하기 위한 것이다.
  *
- * <p>payment-service는 이 이벤트를 받아 결제가 COMPLETED면 PG 환불을 재실행하고, 이미 CANCELED(결제 취소 API로 우회 환불된 경우)면
- * {@code PaymentCanceledEvent}를 재발행해 정합을 self-heal 한다.
+ * <p>추가로 <b>REFUNDING 고착 예매의 복구</b>도 이 API가 담당한다 (#397). PG 통신 실패가 DLT로 빠져 종결 이벤트가 오지 않으면 예매는
+ * REFUNDING에 영구히 머무는데, 이 상태는 {@code requestRefund()}가 막혀 손댈 수 없었다. 임계 시간 이상 멈춘 건이면 상태 전이 없이(이미
+ * REFUNDING) 이벤트만 재발행한다. 임계 미달의 신선한 REFUNDING은 정상 진행 중이므로 여전히 거절한다.
+ *
+ * <p>payment-service는 이 이벤트를 받아 결제가 COMPLETED면 PG 환불을 재실행하고, 이미 CANCELED(결제 취소 API로 우회 환불됐거나 이전 환불이
+ * 실제로는 성공한 경우)면 {@code PaymentCanceledEvent}를 재발행해 정합을 self-heal 한다. 재수신에 완전 멱등이므로 관리자가 같은 고착 건을 중복
+ * 재발행해도 이중 환불은 일어나지 않는다.
  */
 @Slf4j
 @Service
 @Transactional
-@RequiredArgsConstructor
 public class BookingAdminRetryRefundUseCase {
 
   private final BookingRepository bookingRepository;
   private final EventPublisher eventPublisher;
+  private final Clock clock;
+  private final long stuckThresholdMinutes;
+
+  public BookingAdminRetryRefundUseCase(
+      BookingRepository bookingRepository,
+      EventPublisher eventPublisher,
+      Clock clock,
+      @Value(BookingGetRefundingStuckBookingsUseCase.STUCK_THRESHOLD_PROPERTY)
+          long stuckThresholdMinutes) {
+    this.bookingRepository = bookingRepository;
+    this.eventPublisher = eventPublisher;
+    this.clock = clock;
+    this.stuckThresholdMinutes = stuckThresholdMinutes;
+  }
 
   public void execute(Long adminId, String bookingNumber) {
     Booking booking =
         bookingRepository
             .findByBookingNumber(bookingNumber)
             .orElseThrow(() -> new BusinessException(ErrorStatus.BOOKING_NOT_FOUND));
+
+    LocalDateTime cutoff = LocalDateTime.now(clock).minusMinutes(stuckThresholdMinutes);
+    if (booking.isStuckInRefunding(cutoff)) {
+      // 고착 복구 (#397): 상태는 이미 REFUNDING이므로 전이 없이 이벤트만 재발행한다.
+      publishRefundRequested(adminId, booking, "REFUNDING 고착 재발행");
+      return;
+    }
 
     // 이 API의 계약은 "환불 실패 건의 재시도"다. 실패 이력이 없는 예매(또는 이미 환불이 진행·종결된 예매)에
     // 걸리면 관리자 오조작만으로 정상 예매가 강제 취소된다. 소유자의 의도적 취소와는 계약이 다르므로 여기서 막는다.
@@ -48,9 +74,14 @@ public class BookingAdminRetryRefundUseCase {
 
     booking.requestRefund();
 
+    publishRefundRequested(adminId, booking, "환불 재시도");
+  }
+
+  private void publishRefundRequested(Long adminId, Booking booking, String action) {
     // 실제 PG 환불을 유발하는 관리자 행위다. 누가 누구의 예매를 건드렸는지 추적 가능해야 한다.
     log.info(
-        "[ADMIN-AUDIT] 환불 재시도. adminId: {}, bookingNumber: {}, bookingId: {}, userId: {}",
+        "[ADMIN-AUDIT] {}. adminId: {}, bookingNumber: {}, bookingId: {}, userId: {}",
+        action,
         adminId,
         booking.getBookingNumber(),
         booking.getId(),
@@ -62,6 +93,6 @@ public class BookingAdminRetryRefundUseCase {
             booking.getBookingNumber(),
             booking.getSeatId(),
             booking.getUserId(),
-            LocalDateTime.now()));
+            LocalDateTime.now(clock)));
   }
 }

--- a/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/app/usecase/BookingAdminRetryRefundUseCase.java
+++ b/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/app/usecase/BookingAdminRetryRefundUseCase.java
@@ -1,6 +1,7 @@
 package com.ticketrush.boundedcontext.booking.app.usecase;
 
 import com.ticketrush.boundedcontext.booking.domain.entity.Booking;
+import com.ticketrush.boundedcontext.booking.domain.policy.RefundingStuckPolicy;
 import com.ticketrush.boundedcontext.booking.domain.types.BookingStatus;
 import com.ticketrush.boundedcontext.booking.out.repository.BookingRepository;
 import com.ticketrush.global.eventpublisher.EventPublisher;
@@ -9,8 +10,8 @@ import com.ticketrush.global.status.ErrorStatus;
 import com.ticketrush.shared.booking.event.RefundRequestedEvent;
 import java.time.Clock;
 import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -23,34 +24,26 @@ import org.springframework.transaction.annotation.Transactional;
  * 있으며, 이 API는 CS가 사용자를 대신해 시도하기 위한 것이다.
  *
  * <p>추가로 <b>REFUNDING 고착 예매의 복구</b>도 이 API가 담당한다 (#397). PG 통신 실패가 DLT로 빠져 종결 이벤트가 오지 않으면 예매는
- * REFUNDING에 영구히 머무는데, 이 상태는 {@code requestRefund()}가 막혀 손댈 수 없었다. 임계 시간 이상 멈춘 건이면 상태 전이 없이(이미
- * REFUNDING) 이벤트만 재발행한다. 임계 미달의 신선한 REFUNDING은 정상 진행 중이므로 여전히 거절한다.
+ * REFUNDING에 영구히 머무는데, 이 상태는 {@code requestRefund()}가 막혀 손댈 수 없었다. 임계({@link RefundingStuckPolicy})
+ * 이상 멈춘 건이면 상태 전이 없이(이미 REFUNDING) 이벤트만 재발행한다. 임계 미달의 신선한 REFUNDING은 정상 진행 중이므로 여전히 거절한다.
+ *
+ * <p>고착 재발행은 예매를 변경하지 않으므로 그 예매는 <b>종결 이벤트가 도착할 때까지 고착 목록에 그대로 남는다</b>(미해결이라는 뜻이다). 같은 이유로 낙관적 락도 이
+ * 경로는 막지 못해 관리자가 반복 호출하면 그만큼 PG 호출이 나가지만, payment가 재수신에 완전 멱등이라 이중 환불은 일어나지 않는다. 누가 언제 눌렀는지는
+ * ADMIN-AUDIT 로그로 추적한다.
  *
  * <p>payment-service는 이 이벤트를 받아 결제가 COMPLETED면 PG 환불을 재실행하고, 이미 CANCELED(결제 취소 API로 우회 환불됐거나 이전 환불이
- * 실제로는 성공한 경우)면 {@code PaymentCanceledEvent}를 재발행해 정합을 self-heal 한다. 재수신에 완전 멱등이므로 관리자가 같은 고착 건을 중복
- * 재발행해도 이중 환불은 일어나지 않는다.
+ * 실제로는 성공한 경우)면 {@code PaymentCanceledEvent}를 재발행해 정합을 self-heal 한다.
  */
 @Slf4j
 @Service
 @Transactional
+@RequiredArgsConstructor
 public class BookingAdminRetryRefundUseCase {
 
   private final BookingRepository bookingRepository;
   private final EventPublisher eventPublisher;
+  private final RefundingStuckPolicy refundingStuckPolicy;
   private final Clock clock;
-  private final long stuckThresholdMinutes;
-
-  public BookingAdminRetryRefundUseCase(
-      BookingRepository bookingRepository,
-      EventPublisher eventPublisher,
-      Clock clock,
-      @Value(BookingGetRefundingStuckBookingsUseCase.STUCK_THRESHOLD_PROPERTY)
-          long stuckThresholdMinutes) {
-    this.bookingRepository = bookingRepository;
-    this.eventPublisher = eventPublisher;
-    this.clock = clock;
-    this.stuckThresholdMinutes = stuckThresholdMinutes;
-  }
 
   public void execute(Long adminId, String bookingNumber) {
     Booking booking =
@@ -58,8 +51,7 @@ public class BookingAdminRetryRefundUseCase {
             .findByBookingNumber(bookingNumber)
             .orElseThrow(() -> new BusinessException(ErrorStatus.BOOKING_NOT_FOUND));
 
-    LocalDateTime cutoff = LocalDateTime.now(clock).minusMinutes(stuckThresholdMinutes);
-    if (booking.isStuckInRefunding(cutoff)) {
+    if (booking.isStuckInRefunding(refundingStuckPolicy.cutoff())) {
       // 고착 복구 (#397): 상태는 이미 REFUNDING이므로 전이 없이 이벤트만 재발행한다.
       publishRefundRequested(adminId, booking, "REFUNDING 고착 재발행");
       return;

--- a/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/app/usecase/BookingGetRefundingStuckBookingsUseCase.java
+++ b/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/app/usecase/BookingGetRefundingStuckBookingsUseCase.java
@@ -1,0 +1,60 @@
+package com.ticketrush.boundedcontext.booking.app.usecase;
+
+import com.ticketrush.boundedcontext.booking.app.dto.response.BookingSummaryResponse;
+import com.ticketrush.boundedcontext.booking.domain.types.BookingStatus;
+import com.ticketrush.boundedcontext.booking.out.repository.BookingRepository;
+import com.ticketrush.global.dto.request.OffsetPageRequest;
+import java.time.Clock;
+import java.time.LocalDateTime;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * REFUNDING에서 임계 시간 이상 멈춰 있는 고착 예매를 관리자가 조회한다 (#397).
+ *
+ * <p>payment의 PG 통신 실패(성공 여부 불명)는 재시도 소진 후 DLT로 빠지고 종결 이벤트가 끝내 오지 않는다. 이 예매는 돈을 돌려받지 못한 채 좌석이 SOLD로
+ * 묶이고 입장까지 차단되지만, 환불 실패 조회({@link BookingGetRefundFailedBookingsUseCase})는 CONFIRMED로 복원된 건만 잡으므로
+ * 여기서 별도로 노출한다. 오래 멈춘 순({@code updatedAt} 오름차순)으로 정렬한다.
+ *
+ * <p>임계는 Kafka 재시도 소진(약 31초)보다 훨씬 길게 잡아 컨슈머 랙·재배포 중 일시 지연을 고착으로 오탐하지 않게 한다.
+ */
+@Service
+@Transactional(readOnly = true)
+public class BookingGetRefundingStuckBookingsUseCase {
+
+  /*
+   * 고착 식별(이 조회)과 고착 복구(BookingAdminRetryRefundUseCase의 재시도 가드)는 반드시 같은 임계를 봐야 한다.
+   * 키·기본값이 어긋나면 "목록에는 보이는데 재시도는 거절되는" 비정합이 생기므로 여기를 단일 출처로 둔다 (#397).
+   */
+  public static final String STUCK_THRESHOLD_PROPERTY =
+      "${app.booking.refunding-stuck-threshold-minutes:30}";
+
+  private final BookingRepository bookingRepository;
+  private final Clock clock;
+  private final long stuckThresholdMinutes;
+
+  public BookingGetRefundingStuckBookingsUseCase(
+      BookingRepository bookingRepository,
+      Clock clock,
+      @Value(STUCK_THRESHOLD_PROPERTY) long stuckThresholdMinutes) {
+    this.bookingRepository = bookingRepository;
+    this.clock = clock;
+    this.stuckThresholdMinutes = stuckThresholdMinutes;
+  }
+
+  public Page<BookingSummaryResponse> execute(OffsetPageRequest pageRequest) {
+    LocalDateTime cutoff = LocalDateTime.now(clock).minusMinutes(stuckThresholdMinutes);
+
+    return bookingRepository
+        .findByBookingStatusAndUpdatedAtBefore(
+            BookingStatus.REFUNDING,
+            cutoff,
+            PageRequest.of(
+                pageRequest.page(), pageRequest.size(), Sort.by(Sort.Order.asc("updatedAt"))))
+        .map(BookingSummaryResponse::from);
+  }
+}

--- a/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/app/usecase/BookingGetRefundingStuckBookingsUseCase.java
+++ b/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/app/usecase/BookingGetRefundingStuckBookingsUseCase.java
@@ -1,12 +1,11 @@
 package com.ticketrush.boundedcontext.booking.app.usecase;
 
 import com.ticketrush.boundedcontext.booking.app.dto.response.BookingSummaryResponse;
+import com.ticketrush.boundedcontext.booking.domain.policy.RefundingStuckPolicy;
 import com.ticketrush.boundedcontext.booking.domain.types.BookingStatus;
 import com.ticketrush.boundedcontext.booking.out.repository.BookingRepository;
 import com.ticketrush.global.dto.request.OffsetPageRequest;
-import java.time.Clock;
-import java.time.LocalDateTime;
-import org.springframework.beans.factory.annotation.Value;
+import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
@@ -20,39 +19,22 @@ import org.springframework.transaction.annotation.Transactional;
  * 묶이고 입장까지 차단되지만, 환불 실패 조회({@link BookingGetRefundFailedBookingsUseCase})는 CONFIRMED로 복원된 건만 잡으므로
  * 여기서 별도로 노출한다. 오래 멈춘 순({@code updatedAt} 오름차순)으로 정렬한다.
  *
- * <p>임계는 Kafka 재시도 소진(약 31초)보다 훨씬 길게 잡아 컨슈머 랙·재배포 중 일시 지연을 고착으로 오탐하지 않게 한다.
+ * <p>고착 판정 기준은 {@link RefundingStuckPolicy}가 소유한다 — 복구 경로({@link BookingAdminRetryRefundUseCase})와
+ * 같은 임계를 봐야 하기 때문이다.
  */
 @Service
 @Transactional(readOnly = true)
+@RequiredArgsConstructor
 public class BookingGetRefundingStuckBookingsUseCase {
 
-  /*
-   * 고착 식별(이 조회)과 고착 복구(BookingAdminRetryRefundUseCase의 재시도 가드)는 반드시 같은 임계를 봐야 한다.
-   * 키·기본값이 어긋나면 "목록에는 보이는데 재시도는 거절되는" 비정합이 생기므로 여기를 단일 출처로 둔다 (#397).
-   */
-  public static final String STUCK_THRESHOLD_PROPERTY =
-      "${app.booking.refunding-stuck-threshold-minutes:30}";
-
   private final BookingRepository bookingRepository;
-  private final Clock clock;
-  private final long stuckThresholdMinutes;
-
-  public BookingGetRefundingStuckBookingsUseCase(
-      BookingRepository bookingRepository,
-      Clock clock,
-      @Value(STUCK_THRESHOLD_PROPERTY) long stuckThresholdMinutes) {
-    this.bookingRepository = bookingRepository;
-    this.clock = clock;
-    this.stuckThresholdMinutes = stuckThresholdMinutes;
-  }
+  private final RefundingStuckPolicy refundingStuckPolicy;
 
   public Page<BookingSummaryResponse> execute(OffsetPageRequest pageRequest) {
-    LocalDateTime cutoff = LocalDateTime.now(clock).minusMinutes(stuckThresholdMinutes);
-
     return bookingRepository
         .findByBookingStatusAndUpdatedAtBefore(
             BookingStatus.REFUNDING,
-            cutoff,
+            refundingStuckPolicy.cutoff(),
             PageRequest.of(
                 pageRequest.page(), pageRequest.size(), Sort.by(Sort.Order.asc("updatedAt"))))
         .map(BookingSummaryResponse::from);

--- a/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/domain/entity/Booking.java
+++ b/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/domain/entity/Booking.java
@@ -10,6 +10,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.Table;
+import jakarta.persistence.Version;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -45,6 +46,16 @@ public class Booking extends AutoIdBaseEntity {
   /* 마지막으로 PG 환불이 실패한 시각. null이면 환불 실패 이력이 없다. 실패 사유는 payment의 refund 테이블이 SSOT다 (#391). */
   @Column(name = "refund_failed_at")
   private LocalDateTime refundFailedAt;
+
+  /*
+   * 낙관적 락 (#397). requestRefund()가 check-then-act라 사용자 취소와 관리자 재환불이 동시에 검증을 통과하면
+   * RefundRequestedEvent가 이중 발행된다. 이벤트 발행은 afterCommit이므로 늦은 커밋이 버전 충돌로 실패하면 이벤트도 나가지 않는다.
+   * 단, expirePendingBookingById 벌크 UPDATE는 version을 증가시키지도 검사하지도 않는다 — PENDING 전용이라 환불
+   * 경로(CONFIRMED/REFUNDING)와는 겹치지 않지만, confirm-vs-expire 경합은 이 락의 보호 밖이다(기존 한계, ADR 0005).
+   */
+  @Version
+  @Column(nullable = false)
+  private Long version;
 
   @Builder
   public Booking(
@@ -162,5 +173,20 @@ public class Booking extends AutoIdBaseEntity {
       return true;
     }
     return false;
+  }
+
+  /**
+   * REFUNDING에서 {@code cutoff} 이전부터 멈춰 있는 고착 상태인지 판별한다 (#397).
+   *
+   * <p>payment의 PG 통신 실패(성공 여부 불명)는 재시도 소진 후 DLT로 빠지고 종결 이벤트({@code PaymentCanceledEvent}/{@code
+   * RefundFailedEvent})가 끝내 오지 않는다. 이때 예매는 REFUNDING에 영구히 머문다 — 돈은 못 돌려받고 좌석은 SOLD로 묶이고 입장도 막힌다.
+   * REFUNDING 진입 이후 이 엔티티는 갱신되지 않으므로 {@code updatedAt}이 곧 진입 시각이다.
+   *
+   * @param cutoff 고착 판정 기준 시각(현재 시각 - 임계). {@code updatedAt}이 이보다 이전이면 고착이다
+   */
+  public boolean isStuckInRefunding(LocalDateTime cutoff) {
+    return this.bookingStatus == BookingStatus.REFUNDING
+        && getUpdatedAt() != null
+        && getUpdatedAt().isBefore(cutoff);
   }
 }

--- a/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/domain/policy/RefundingStuckPolicy.java
+++ b/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/domain/policy/RefundingStuckPolicy.java
@@ -1,0 +1,33 @@
+package com.ticketrush.boundedcontext.booking.domain.policy;
+
+import java.time.Clock;
+import java.time.LocalDateTime;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+/**
+ * REFUNDING 고착 판정 기준을 소유한다 (#397).
+ *
+ * <p>고착 식별(관리자 조회)과 고착 복구(환불 재시도 가드)는 <b>반드시 같은 임계</b>를 봐야 한다. 어긋나면 "목록에는 보이는데 재시도는 거절되는" 비정합이
+ * 생기므로, 임계와 {@link #cutoff()} 계산을 이 한 곳에 둔다.
+ *
+ * <p>임계는 Kafka 재시도 소진(약 31초)보다 훨씬 길게 잡아 컨슈머 랙·재배포 중 일시 지연을 고착으로 오탐하지 않게 한다.
+ */
+@Component
+public class RefundingStuckPolicy {
+
+  private final Clock clock;
+  private final long thresholdMinutes;
+
+  public RefundingStuckPolicy(
+      Clock clock,
+      @Value("${app.booking.refunding-stuck-threshold-minutes:30}") long thresholdMinutes) {
+    this.clock = clock;
+    this.thresholdMinutes = thresholdMinutes;
+  }
+
+  /** REFUNDING 진입 시각({@code updatedAt})이 이 시각보다 이전이면 고착이다. */
+  public LocalDateTime cutoff() {
+    return LocalDateTime.now(clock).minusMinutes(thresholdMinutes);
+  }
+}

--- a/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/in/api/v1/BookingAdminController.java
+++ b/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/in/api/v1/BookingAdminController.java
@@ -52,13 +52,34 @@ public class BookingAdminController {
   }
 
   @Operation(
+      summary = "환불 고착 예매 조회",
+      description =
+          """
+          환불 진행 중(REFUNDING) 상태에서 임계 시간(기본 30분) 이상 멈춰 있는 예매를 오래된 순으로 조회합니다.
+
+          PG 통신 실패가 재시도 끝에 DLT로 빠지면 환불 종결 이벤트가 오지 않아 예매가 REFUNDING에 영구히
+          머뭅니다 — 돈을 돌려받지 못한 채 좌석은 SOLD로 묶이고 입장도 차단됩니다. 이 조회로 식별한 예매는
+          환불 재시도 API로 환불 요청 이벤트를 재발행해 복구할 수 있습니다. `updatedAt`이 REFUNDING에
+          진입한 시각입니다.
+          """)
+  @GetMapping("/bookings/refunding-stuck")
+  public ResponseEntity<ApiResponse<List<BookingSummaryResponse>>> getRefundingStuckBookings(
+      @ModelAttribute OffsetPageRequest pageRequest) {
+    Page<BookingSummaryResponse> response = bookingFacade.getRefundingStuckBookings(pageRequest);
+
+    return ApiResponse.onSuccess(SuccessStatus.OK, response);
+  }
+
+  @Operation(
       summary = "환불 재시도",
       description =
           """
           환불에 실패한 예매의 환불을 다시 시도합니다. 예매를 REFUNDING으로 전환하고 환불 요청 이벤트를 발행합니다.
 
-          **대상은 환불 실패 이력이 있는 CONFIRMED 예매뿐입니다.** 실패 이력이 없는 정상 예매나 이미 환불이
-          진행·종결된 예매는 `BOOKING_409_005`로 거절합니다.
+          **대상은 환불 실패 이력이 있는 CONFIRMED 예매, 그리고 REFUNDING에서 임계 시간(기본 30분) 이상
+          멈춘 고착 예매입니다.** 고착 예매는 이미 REFUNDING이므로 상태 전이 없이 환불 요청 이벤트만
+          재발행합니다. 그 외(실패 이력이 없는 정상 예매, 정상 진행 중인 REFUNDING, 이미 종결된 예매)는
+          `BOOKING_409_005`로 거절합니다.
 
           결제가 아직 완료 상태면 PG 환불을 재실행하고, 결제 취소 API로 이미 우회 환불된 상태면 결제 취소 이벤트를
           재발행해 예매·좌석 정합을 회복합니다. 사용자도 예매를 다시 취소해 재환불할 수 있으며, 이 API는 CS가 사용자를

--- a/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/in/api/v1/BookingAdminController.java
+++ b/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/in/api/v1/BookingAdminController.java
@@ -61,6 +61,11 @@ public class BookingAdminController {
           머뭅니다 — 돈을 돌려받지 못한 채 좌석은 SOLD로 묶이고 입장도 차단됩니다. 이 조회로 식별한 예매는
           환불 재시도 API로 환불 요청 이벤트를 재발행해 복구할 수 있습니다. `updatedAt`이 REFUNDING에
           진입한 시각입니다.
+
+          **재시도를 눌러도 이 목록에서 즉시 사라지지 않습니다.** 재발행은 예매를 변경하지 않으므로, 환불
+          종결 이벤트가 실제로 도착해 상태가 REFUNDED(또는 CONFIRMED)로 바뀔 때 목록에서 빠집니다.
+          즉 목록에 남아 있다는 것은 아직 미해결이라는 뜻입니다. 이미 재시도를 눌렀는지는 ADMIN-AUDIT
+          로그로 확인하세요.
           """)
   @GetMapping("/bookings/refunding-stuck")
   public ResponseEntity<ApiResponse<List<BookingSummaryResponse>>> getRefundingStuckBookings(
@@ -80,6 +85,10 @@ public class BookingAdminController {
           멈춘 고착 예매입니다.** 고착 예매는 이미 REFUNDING이므로 상태 전이 없이 환불 요청 이벤트만
           재발행합니다. 그 외(실패 이력이 없는 정상 예매, 정상 진행 중인 REFUNDING, 이미 종결된 예매)는
           `BOOKING_409_005`로 거절합니다.
+
+          고착 건에 대한 재발행은 예매를 변경하지 않으므로 반복 호출해도 막히지 않습니다. 그만큼 PG 호출이
+          나가지만 payment가 재수신에 멱등이라 이중 환불은 발생하지 않습니다. 불필요한 재호출을 피하려면
+          ADMIN-AUDIT 로그로 이전 시도 여부를 먼저 확인하세요.
 
           결제가 아직 완료 상태면 PG 환불을 재실행하고, 결제 취소 API로 이미 우회 환불된 상태면 결제 취소 이벤트를
           재발행해 예매·좌석 정합을 회복합니다. 사용자도 예매를 다시 취소해 재환불할 수 있으며, 이 API는 CS가 사용자를

--- a/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/out/repository/BookingRepository.java
+++ b/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/out/repository/BookingRepository.java
@@ -27,6 +27,13 @@ public interface BookingRepository extends JpaRepository<Booking, Long> {
   Page<Booking> findByBookingStatusAndRefundFailedAtIsNotNull(
       BookingStatus bookingStatus, Pageable pageable);
 
+  /*
+   * REFUNDING에서 cutoff 이전부터 멈춰 있는(종결 이벤트가 오지 않는) 고착 예매를 관리자가 조회한다 (#397).
+   * ponytail: updated_at 인덱스 없음 — 관리자 저빈도 조회라 수용, 규모가 커지면 인덱스 추가.
+   */
+  Page<Booking> findByBookingStatusAndUpdatedAtBefore(
+      BookingStatus bookingStatus, LocalDateTime cutoff, Pageable pageable);
+
   @Query("SELECT b.id FROM Booking b WHERE b.bookingNumber = :bookingNumber")
   Optional<Long> findIdByBookingNumber(@Param("bookingNumber") String bookingNumber);
 

--- a/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/out/repository/BookingRepository.java
+++ b/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/out/repository/BookingRepository.java
@@ -29,7 +29,7 @@ public interface BookingRepository extends JpaRepository<Booking, Long> {
 
   /*
    * REFUNDING에서 cutoff 이전부터 멈춰 있는(종결 이벤트가 오지 않는) 고착 예매를 관리자가 조회한다 (#397).
-   * ponytail: updated_at 인덱스 없음 — 관리자 저빈도 조회라 수용, 규모가 커지면 인덱스 추가.
+   * 장애 대응 중 반복 조회하는 경로이므로 (booking_status, updated_at) 복합 인덱스로 받는다.
    */
   Page<Booking> findByBookingStatusAndUpdatedAtBefore(
       BookingStatus bookingStatus, LocalDateTime cutoff, Pageable pageable);

--- a/booking-service/src/main/resources/application.yml
+++ b/booking-service/src/main/resources/application.yml
@@ -49,6 +49,10 @@ gateway:
 # 기본은 비활성이며, 운영 환경에서 환경변수로 켠다(DLT_MONITOR_ENABLED=true, SLACK_ENABLED=true, SLACK_WEBHOOK_URL=...).
 # local/test는 미설정(기본 false)으로 비활성.
 app:
+  booking:
+    # REFUNDING에서 이 시간(분) 이상 멈춘 예매를 고착으로 판정한다 (#397).
+    # Kafka 재시도 소진(약 31초)보다 훨씬 길게 잡아 컨슈머 랙·재배포 중 일시 지연의 오탐을 막는다.
+    refunding-stuck-threshold-minutes: 30
   event-publisher:
     type: kafka
   outbox:

--- a/booking-service/src/test/java/com/ticketrush/boundedcontext/booking/app/facade/BookingFacadeTest.java
+++ b/booking-service/src/test/java/com/ticketrush/boundedcontext/booking/app/facade/BookingFacadeTest.java
@@ -17,6 +17,7 @@ import com.ticketrush.boundedcontext.booking.app.usecase.BookingCancelMyBookingU
 import com.ticketrush.boundedcontext.booking.app.usecase.BookingCountUseCase;
 import com.ticketrush.boundedcontext.booking.app.usecase.BookingCreateUseCase;
 import com.ticketrush.boundedcontext.booking.app.usecase.BookingGetMyBookingsUseCase;
+import com.ticketrush.boundedcontext.booking.app.usecase.BookingGetRefundingStuckBookingsUseCase;
 import com.ticketrush.boundedcontext.booking.app.usecase.BookingIssueNumberUseCase;
 import com.ticketrush.boundedcontext.booking.app.usecase.BookingValidateReferencesUseCase;
 import com.ticketrush.boundedcontext.booking.app.usecase.BookingValidateSeatAvailableUseCase;
@@ -47,6 +48,7 @@ class BookingFacadeTest {
   @Mock private BookingCancelMyBookingUseCase bookingCancelMyBookingUseCase;
   @Mock private BookingValidateReferencesUseCase bookingValidateReferencesUseCase;
   @Mock private BookingValidateSeatAvailableUseCase bookingValidateSeatAvailableUseCase;
+  @Mock private BookingGetRefundingStuckBookingsUseCase bookingGetRefundingStuckBookingsUseCase;
 
   @Test
   @DisplayName("성공: 참조 검증 후 예약번호를 발급하고 예매를 생성한다")
@@ -140,6 +142,7 @@ class BookingFacadeTest {
             3L,
             BookingStatus.CONFIRMED,
             LocalDateTime.of(2026, 5, 22, 10, 30),
+            null,
             null);
 
     given(
@@ -171,6 +174,34 @@ class BookingFacadeTest {
     // then
     assertThat(result).isEqualTo(response);
     verify(bookingCountUseCase).execute(userId, BookingStatus.CONFIRMED);
+  }
+
+  @Test
+  @DisplayName("성공: 환불 고착 예매 조회를 위임한다")
+  void getRefundingStuckBookings_success() {
+    // given
+    BookingSummaryResponse response =
+        new BookingSummaryResponse(
+            100L,
+            "BOOK-1234",
+            1L,
+            2L,
+            3L,
+            BookingStatus.REFUNDING,
+            LocalDateTime.of(2026, 5, 22, 10, 30),
+            null,
+            LocalDateTime.of(2026, 7, 13, 11, 0));
+
+    given(bookingGetRefundingStuckBookingsUseCase.execute(new OffsetPageRequest(0, 10)))
+        .willReturn(new PageImpl<>(List.of(response)));
+
+    // when
+    Page<BookingSummaryResponse> result =
+        bookingFacade.getRefundingStuckBookings(new OffsetPageRequest(0, 10));
+
+    // then
+    assertThat(result.getContent()).containsExactly(response);
+    verify(bookingGetRefundingStuckBookingsUseCase).execute(new OffsetPageRequest(0, 10));
   }
 
   @Test

--- a/booking-service/src/test/java/com/ticketrush/boundedcontext/booking/app/usecase/BookingAdminRetryRefundUseCaseTest.java
+++ b/booking-service/src/test/java/com/ticketrush/boundedcontext/booking/app/usecase/BookingAdminRetryRefundUseCaseTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 
 import com.ticketrush.boundedcontext.booking.domain.entity.Booking;
+import com.ticketrush.boundedcontext.booking.domain.policy.RefundingStuckPolicy;
 import com.ticketrush.boundedcontext.booking.domain.types.BookingStatus;
 import com.ticketrush.boundedcontext.booking.out.repository.BookingRepository;
 import com.ticketrush.global.eventpublisher.EventPublisher;
@@ -46,7 +47,10 @@ class BookingAdminRetryRefundUseCaseTest {
         Clock.fixed(NOW.atZone(ZoneId.systemDefault()).toInstant(), ZoneId.systemDefault());
     bookingAdminRetryRefundUseCase =
         new BookingAdminRetryRefundUseCase(
-            bookingRepository, eventPublisher, fixedClock, STUCK_THRESHOLD_MINUTES);
+            bookingRepository,
+            eventPublisher,
+            new RefundingStuckPolicy(fixedClock, STUCK_THRESHOLD_MINUTES),
+            fixedClock);
   }
 
   private Booking bookingWithStatus(BookingStatus status) {

--- a/booking-service/src/test/java/com/ticketrush/boundedcontext/booking/app/usecase/BookingAdminRetryRefundUseCaseTest.java
+++ b/booking-service/src/test/java/com/ticketrush/boundedcontext/booking/app/usecase/BookingAdminRetryRefundUseCaseTest.java
@@ -15,25 +15,39 @@ import com.ticketrush.boundedcontext.booking.out.repository.BookingRepository;
 import com.ticketrush.global.eventpublisher.EventPublisher;
 import com.ticketrush.global.exception.BusinessException;
 import com.ticketrush.shared.booking.event.RefundRequestedEvent;
+import java.time.Clock;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
 class BookingAdminRetryRefundUseCaseTest {
 
-  @InjectMocks private BookingAdminRetryRefundUseCase bookingAdminRetryRefundUseCase;
+  private BookingAdminRetryRefundUseCase bookingAdminRetryRefundUseCase;
 
   @Mock private BookingRepository bookingRepository;
   @Mock private EventPublisher eventPublisher;
 
   private static final String BOOKING_NUMBER = "BOOK-1234";
   private static final Long ADMIN_ID = 99L;
+  private static final long STUCK_THRESHOLD_MINUTES = 30;
+  private static final LocalDateTime NOW = LocalDateTime.of(2026, 7, 13, 12, 0);
+
+  @BeforeEach
+  void setUp() {
+    Clock fixedClock =
+        Clock.fixed(NOW.atZone(ZoneId.systemDefault()).toInstant(), ZoneId.systemDefault());
+    bookingAdminRetryRefundUseCase =
+        new BookingAdminRetryRefundUseCase(
+            bookingRepository, eventPublisher, fixedClock, STUCK_THRESHOLD_MINUTES);
+  }
 
   private Booking bookingWithStatus(BookingStatus status) {
     return Booking.builder()
@@ -67,6 +81,29 @@ class BookingAdminRetryRefundUseCaseTest {
                         && refundRequested.seatId().equals(3L)
                         && refundRequested.userId().equals(10L)
                         && refundRequested.requestedAt() != null));
+  }
+
+  @Test
+  @DisplayName("성공: 임계 시간 이상 REFUNDING에 멈춘 고착 예매는 상태 전이 없이 이벤트만 재발행한다 (#397)")
+  void execute_republishes_event_for_stuck_refunding() {
+    // given: PG 통신 실패가 DLT로 빠져 종결 이벤트가 오지 않아 임계(30분)를 넘겨 고착된 예매
+    Booking booking = bookingWithStatus(BookingStatus.REFUNDING);
+    ReflectionTestUtils.setField(
+        booking, "updatedAt", NOW.minusMinutes(STUCK_THRESHOLD_MINUTES + 1));
+    given(bookingRepository.findByBookingNumber(BOOKING_NUMBER)).willReturn(Optional.of(booking));
+
+    // when
+    bookingAdminRetryRefundUseCase.execute(ADMIN_ID, BOOKING_NUMBER);
+
+    // then: 이미 REFUNDING이므로 전이 없이 재발행만 한다. payment는 재수신에 멱등이라
+    // 실제 환불 성공 여부에 따라 REFUNDED 또는 CONFIRMED+refundFailedAt로 수렴한다
+    assertThat(booking.getBookingStatus()).isEqualTo(BookingStatus.REFUNDING);
+    verify(eventPublisher)
+        .publish(
+            argThat(
+                event ->
+                    event instanceof RefundRequestedEvent refundRequested
+                        && refundRequested.bookingNumber().equals(BOOKING_NUMBER)));
   }
 
   @Test
@@ -117,12 +154,13 @@ class BookingAdminRetryRefundUseCaseTest {
   }
 
   @Test
-  @DisplayName("실패: 이미 재환불이 진행 중인 예매는 중복 트리거할 수 없다")
+  @DisplayName("실패: 임계 미달의 신선한 REFUNDING은 정상 진행 중이므로 중복 트리거할 수 없다")
   void execute_fail_when_refund_already_in_progress() {
-    // given: 실패 이력이 있으나 이미 REFUNDING으로 재시도가 걸린 예매
+    // given: 실패 이력이 있으나 방금 REFUNDING으로 재시도가 걸린 예매(고착 아님)
     Booking booking = bookingWithStatus(BookingStatus.REFUNDING);
     booking.recordRefundFailure(LocalDateTime.of(2026, 7, 10, 12, 0));
     booking.requestRefund();
+    ReflectionTestUtils.setField(booking, "updatedAt", NOW.minusMinutes(1));
     given(bookingRepository.findByBookingNumber(BOOKING_NUMBER)).willReturn(Optional.of(booking));
 
     // when & then

--- a/booking-service/src/test/java/com/ticketrush/boundedcontext/booking/app/usecase/BookingGetRefundingStuckBookingsUseCaseTest.java
+++ b/booking-service/src/test/java/com/ticketrush/boundedcontext/booking/app/usecase/BookingGetRefundingStuckBookingsUseCaseTest.java
@@ -7,6 +7,7 @@ import static org.mockito.BDDMockito.given;
 
 import com.ticketrush.boundedcontext.booking.app.dto.response.BookingSummaryResponse;
 import com.ticketrush.boundedcontext.booking.domain.entity.Booking;
+import com.ticketrush.boundedcontext.booking.domain.policy.RefundingStuckPolicy;
 import com.ticketrush.boundedcontext.booking.domain.types.BookingStatus;
 import com.ticketrush.boundedcontext.booking.out.repository.BookingRepository;
 import com.ticketrush.global.dto.request.OffsetPageRequest;
@@ -42,7 +43,7 @@ class BookingGetRefundingStuckBookingsUseCaseTest {
         Clock.fixed(NOW.atZone(ZoneId.systemDefault()).toInstant(), ZoneId.systemDefault());
     bookingGetRefundingStuckBookingsUseCase =
         new BookingGetRefundingStuckBookingsUseCase(
-            bookingRepository, fixedClock, STUCK_THRESHOLD_MINUTES);
+            bookingRepository, new RefundingStuckPolicy(fixedClock, STUCK_THRESHOLD_MINUTES));
   }
 
   @Test

--- a/booking-service/src/test/java/com/ticketrush/boundedcontext/booking/app/usecase/BookingGetRefundingStuckBookingsUseCaseTest.java
+++ b/booking-service/src/test/java/com/ticketrush/boundedcontext/booking/app/usecase/BookingGetRefundingStuckBookingsUseCaseTest.java
@@ -1,0 +1,79 @@
+package com.ticketrush.boundedcontext.booking.app.usecase;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+
+import com.ticketrush.boundedcontext.booking.app.dto.response.BookingSummaryResponse;
+import com.ticketrush.boundedcontext.booking.domain.entity.Booking;
+import com.ticketrush.boundedcontext.booking.domain.types.BookingStatus;
+import com.ticketrush.boundedcontext.booking.out.repository.BookingRepository;
+import com.ticketrush.global.dto.request.OffsetPageRequest;
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class BookingGetRefundingStuckBookingsUseCaseTest {
+
+  private BookingGetRefundingStuckBookingsUseCase bookingGetRefundingStuckBookingsUseCase;
+
+  @Mock private BookingRepository bookingRepository;
+
+  private static final long STUCK_THRESHOLD_MINUTES = 30;
+  private static final LocalDateTime NOW = LocalDateTime.of(2026, 7, 13, 12, 0);
+
+  @BeforeEach
+  void setUp() {
+    Clock fixedClock =
+        Clock.fixed(NOW.atZone(ZoneId.systemDefault()).toInstant(), ZoneId.systemDefault());
+    bookingGetRefundingStuckBookingsUseCase =
+        new BookingGetRefundingStuckBookingsUseCase(
+            bookingRepository, fixedClock, STUCK_THRESHOLD_MINUTES);
+  }
+
+  @Test
+  @DisplayName("성공: REFUNDING에서 임계 시간 이상 멈춘 예매를 임계 기준 시각(cutoff)으로 조회한다")
+  void execute_queries_refunding_bookings_stuck_beyond_threshold() {
+    // given: 종결 이벤트가 오지 않아 REFUNDING에 멈춘 예매
+    LocalDateTime stuckSince = NOW.minusMinutes(STUCK_THRESHOLD_MINUTES + 10);
+    Booking booking =
+        Booking.builder()
+            .userId(10L)
+            .performanceId(2L)
+            .seatId(3L)
+            .bookingNumber("BOOK-1234")
+            .bookingStatus(BookingStatus.REFUNDING)
+            .build();
+    ReflectionTestUtils.setField(booking, "updatedAt", stuckSince);
+
+    ArgumentCaptor<LocalDateTime> cutoffCaptor = ArgumentCaptor.forClass(LocalDateTime.class);
+    given(
+            bookingRepository.findByBookingStatusAndUpdatedAtBefore(
+                eq(BookingStatus.REFUNDING), cutoffCaptor.capture(), any(Pageable.class)))
+        .willReturn(new PageImpl<>(List.of(booking)));
+
+    // when
+    Page<BookingSummaryResponse> result =
+        bookingGetRefundingStuckBookingsUseCase.execute(new OffsetPageRequest(0, 10));
+
+    // then: cutoff = 현재 시각 - 임계. updatedAt이 이보다 이전인 REFUNDING만 고착으로 잡힌다 (#397)
+    assertThat(cutoffCaptor.getValue()).isEqualTo(NOW.minusMinutes(STUCK_THRESHOLD_MINUTES));
+    assertThat(result.getContent()).hasSize(1);
+    assertThat(result.getContent().getFirst().bookingStatus()).isEqualTo(BookingStatus.REFUNDING);
+    assertThat(result.getContent().getFirst().updatedAt()).isEqualTo(stuckSince);
+  }
+}

--- a/booking-service/src/test/java/com/ticketrush/boundedcontext/booking/in/api/v1/BookingAdminControllerTest.java
+++ b/booking-service/src/test/java/com/ticketrush/boundedcontext/booking/in/api/v1/BookingAdminControllerTest.java
@@ -60,6 +60,7 @@ class BookingAdminControllerTest {
             3L,
             BookingStatus.CONFIRMED,
             LocalDateTime.of(2026, 5, 22, 10, 30),
+            FAILED_AT,
             FAILED_AT);
 
     given(bookingFacade.getRefundFailedBookings(new OffsetPageRequest(0, 10)))
@@ -81,6 +82,43 @@ class BookingAdminControllerTest {
         .andExpect(jsonPath("$.pagination_info.total_elements").value(1));
 
     verify(bookingFacade).getRefundFailedBookings(new OffsetPageRequest(0, 10));
+  }
+
+  @Test
+  @DisplayName("ADMIN이 환불 고착 예매를 조회하면 REFUNDING 진입 시각(updatedAt)이 함께 응답된다")
+  void getRefundingStuckBookings_returns_stuck_bookings_with_updated_at() throws Exception {
+    // given: REFUNDING에서 임계 시간 이상 멈춘 고착 예매 (#397)
+    LocalDateTime stuckSince = LocalDateTime.of(2026, 7, 13, 11, 0);
+    BookingSummaryResponse response =
+        new BookingSummaryResponse(
+            100L,
+            BOOKING_NUMBER,
+            5L,
+            2L,
+            3L,
+            BookingStatus.REFUNDING,
+            LocalDateTime.of(2026, 5, 22, 10, 30),
+            null,
+            stuckSince);
+
+    given(bookingFacade.getRefundingStuckBookings(new OffsetPageRequest(0, 10)))
+        .willReturn(new PageImpl<>(List.of(response), PageRequest.of(0, 10), 1));
+
+    // when & then
+    mockMvc
+        .perform(
+            get("/api/v1/booking/admin/bookings/refunding-stuck")
+                .header("X-Gateway-Token", INTERNAL_TOKEN)
+                .header("X-User-Id", 1L)
+                .header("X-User-Role", "ADMIN"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.is_success").value(true))
+        .andExpect(jsonPath("$.result[0].booking_number").value(BOOKING_NUMBER))
+        .andExpect(jsonPath("$.result[0].booking_status").value("REFUNDING"))
+        .andExpect(jsonPath("$.result[0].updated_at").value("2026-07-13 11:00:00"))
+        .andExpect(jsonPath("$.pagination_info.total_elements").value(1));
+
+    verify(bookingFacade).getRefundingStuckBookings(new OffsetPageRequest(0, 10));
   }
 
   @Test

--- a/booking-service/src/test/java/com/ticketrush/boundedcontext/booking/in/api/v1/BookingControllerTest.java
+++ b/booking-service/src/test/java/com/ticketrush/boundedcontext/booking/in/api/v1/BookingControllerTest.java
@@ -100,6 +100,7 @@ class BookingControllerTest {
             3L,
             BookingStatus.CONFIRMED,
             LocalDateTime.of(2026, 5, 22, 10, 30),
+            null,
             null);
 
     given(

--- a/booking-service/src/test/java/com/ticketrush/boundedcontext/booking/out/repository/BookingRepositoryTest.java
+++ b/booking-service/src/test/java/com/ticketrush/boundedcontext/booking/out/repository/BookingRepositoryTest.java
@@ -1,24 +1,35 @@
 package com.ticketrush.boundedcontext.booking.out.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.ticketrush.boundedcontext.booking.domain.entity.Booking;
 import com.ticketrush.boundedcontext.booking.domain.types.BookingStatus;
+import com.ticketrush.global.jpa.config.JpaConfig;
 import java.time.LocalDateTime;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.boot.jpa.test.autoconfigure.TestEntityManager;
+import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
 
+/**
+ * {@link JpaConfig}를 임포트해 {@code @EnableJpaAuditing}을 활성화한다 — 고착 조회 테스트가 {@code updatedAt}에 의존한다.
+ */
 @DataJpaTest
+@Import(JpaConfig.class)
 class BookingRepositoryTest {
 
   private static final LocalDateTime FAILED_AT = LocalDateTime.of(2026, 7, 10, 12, 0);
 
   @Autowired private BookingRepository bookingRepository;
+
+  @Autowired private TestEntityManager em;
 
   @Test
   @DisplayName("bookingNumber로 예매 id를 조회한다")
@@ -88,6 +99,54 @@ class BookingRepositoryTest {
     assertThat(found.getContent())
         .extracting(Booking::getBookingNumber)
         .containsExactly("BK-FAILED");
+  }
+
+  @Test
+  @DisplayName("REFUNDING에서 cutoff 이전부터 멈춘 예매만 고착으로 조회한다 (#397)")
+  void findByBookingStatusAndUpdatedAtBefore_ReturnsOnlyStuckRefunding() {
+    // given: 고착 REFUNDING, 신선한 REFUNDING, 무관한 CONFIRMED
+    bookingRepository.save(booking("BK-FRESH", BookingStatus.REFUNDING));
+    bookingRepository.save(booking("BK-CONFIRMED", BookingStatus.CONFIRMED));
+    Booking stuck = bookingRepository.save(booking("BK-STUCK", BookingStatus.REFUNDING));
+    em.flush();
+
+    // auditing이 관리하는 updatedAt은 저장 시각으로 고정되므로, 고착 시나리오는 벌크 UPDATE로 과거로 되돌린다
+    em.getEntityManager()
+        .createQuery("UPDATE Booking b SET b.updatedAt = :past WHERE b.id = :id")
+        .setParameter("past", LocalDateTime.now().minusHours(1))
+        .setParameter("id", stuck.getId())
+        .executeUpdate();
+    em.clear();
+
+    // when: cutoff = 30분 전
+    Page<Booking> found =
+        bookingRepository.findByBookingStatusAndUpdatedAtBefore(
+            BookingStatus.REFUNDING, LocalDateTime.now().minusMinutes(30), PageRequest.of(0, 10));
+
+    // then: 방금 REFUNDING에 들어간 건과 다른 상태는 잡히지 않는다
+    assertThat(found.getContent())
+        .extracting(Booking::getBookingNumber)
+        .containsExactly("BK-STUCK");
+  }
+
+  @Test
+  @DisplayName("stale 버전으로 저장하면 낙관적 락 충돌이 발생한다 (#397)")
+  void save_with_stale_version_throws_optimistic_locking_failure() {
+    // given: 사용자 취소와 관리자 재환불이 같은 예매를 동시에 읽은 상황
+    Booking stale = bookingRepository.save(booking("BK-VER", BookingStatus.CONFIRMED));
+    em.flush();
+    em.detach(stale);
+
+    // 먼저 커밋한 쪽이 버전을 올린다
+    Booking winner = bookingRepository.findById(stale.getId()).orElseThrow();
+    winner.requestRefund();
+    bookingRepository.saveAndFlush(winner);
+    em.detach(winner);
+
+    // when & then: 늦은 쪽(stale 버전)의 저장은 충돌로 실패한다 — 발행이 afterCommit이므로 이벤트 이중 발행도 없다
+    stale.requestRefund();
+    assertThatThrownBy(() -> bookingRepository.saveAndFlush(stale))
+        .isInstanceOf(ObjectOptimisticLockingFailureException.class);
   }
 
   private Booking booking(String bookingNumber, BookingStatus status) {

--- a/common/src/main/java/com/ticketrush/global/exception/GlobalExceptionHandler.java
+++ b/common/src/main/java/com/ticketrush/global/exception/GlobalExceptionHandler.java
@@ -8,6 +8,7 @@ import java.nio.file.AccessDeniedException;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.convert.ConversionFailedException;
+import org.springframework.dao.OptimisticLockingFailureException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.authorization.AuthorizationDeniedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -58,6 +59,19 @@ public class GlobalExceptionHandler {
     storeException(e);
 
     return ApiResponse.onFailure(ErrorStatus.NOT_FOUND);
+  }
+
+  /*
+   * @Version 낙관적 락 충돌은 커밋 시점에 던져져 UseCase에서 잡을 수 없다 (#397).
+   * 동시 수정이 겹친 정상 상황이므로 500이 아니라 409로 변환한다. 늦은 쪽 요청은 재시도하면 된다.
+   */
+  @ExceptionHandler(OptimisticLockingFailureException.class)
+  public ResponseEntity<ApiResponse<?>> handleOptimisticLockingFailureException(
+      OptimisticLockingFailureException e) {
+    storeException(e);
+    log.warn("Optimistic locking conflict: {}", e.getMessage());
+
+    return ApiResponse.onFailure(ErrorStatus.CONFLICT);
   }
 
   @ExceptionHandler(Exception.class)

--- a/common/src/main/java/com/ticketrush/global/status/ErrorStatus.java
+++ b/common/src/main/java/com/ticketrush/global/status/ErrorStatus.java
@@ -14,6 +14,7 @@ public enum ErrorStatus {
   UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "COMMON_401", "인증이 필요합니다."),
   FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON_403", "금지된 요청입니다."),
   NOT_FOUND(HttpStatus.NOT_FOUND, "COMMON_404", "페이지를 찾을 수 없습니다."),
+  CONFLICT(HttpStatus.CONFLICT, "COMMON_409", "동시 수정 충돌이 발생했습니다. 잠시 후 다시 시도해 주세요."),
   // VALID 400
   VALIDATION_ERROR(HttpStatus.BAD_REQUEST, "VALID_400_001", "입력값이 올바르지 않습니다."),
   // Json 501

--- a/deploy/mysql/init/001-ticket-rush-schema.sql
+++ b/deploy/mysql/init/001-ticket-rush-schema.sql
@@ -23,6 +23,7 @@ CREATE TABLE `booking` (
   `refund_failed_at` datetime(6) DEFAULT NULL,
   `seat_id` bigint NOT NULL,
   `user_id` bigint NOT NULL,
+  `version` bigint NOT NULL DEFAULT '0',
   PRIMARY KEY (`booking_id`),
   UNIQUE KEY `UK6j74n7w8mp19sixr5272028mk` (`booking_number`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/deploy/mysql/init/001-ticket-rush-schema.sql
+++ b/deploy/mysql/init/001-ticket-rush-schema.sql
@@ -25,7 +25,8 @@ CREATE TABLE `booking` (
   `user_id` bigint NOT NULL,
   `version` bigint NOT NULL DEFAULT '0',
   PRIMARY KEY (`booking_id`),
-  UNIQUE KEY `UK6j74n7w8mp19sixr5272028mk` (`booking_number`)
+  UNIQUE KEY `UK6j74n7w8mp19sixr5272028mk` (`booking_number`),
+  KEY `idx_booking_status_updated_at` (`booking_status`,`updated_at`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `dead_letter_record`;

--- a/docs/adr/0005-refund-state-machine-and-recovery.md
+++ b/docs/adr/0005-refund-state-machine-and-recovery.md
@@ -72,7 +72,7 @@ payment-service는 손대지 않는다. `RefundFailedEvent`는 Javadoc만 정정
 - **세 결함이 한 번에 해소된다.** 정합성 붕괴는 `markRefunded()` 수정 없이, 입장 차단은 `EntryVerifyUseCase` 수정 없이 해결된다. `ticket-service`는 코드 변경이 전혀 없다 — 이것이 이 설계가 옳다는 신호다.
 - **상태머신이 예매의 생애만 표현한다.** 이후 `bookingStatus`를 다루는 코드는 "환불 시도가 실패한 예매"라는 예외를 기억할 필요가 없다.
 - **사용자가 왜 예매가 유지됐는지 알 수 있다.** `BookingSummaryResponse`에 `refundFailedAt`이 실려, 취소를 눌렀는데 예매가 `CONFIRMED`로 남은 이유를 클라이언트가 표시할 수 있다.
-- (트레이드오프) **결정적 거절 건을 사용자가 반복 시도할 수 있다.** PG 호출이 낭비될 수 있으나, 흡수 상태를 되살리지 않는 편이 낫다고 판단했다. 실측상 문제가 되면 `refundFailedAt` 기반 쿨다운을 추가한다(#397).
+- (트레이드오프) **결정적 거절 건을 사용자가 반복 시도할 수 있다.** PG 호출이 낭비될 수 있으나, 흡수 상태를 되살리지 않는 편이 낫다고 판단했다. #397에서 쿨다운 도입 여부를 검토했고 **실측 전 미도입으로 결정했다** — 고착이 없어 사용자 피해가 없고 비용은 PG 호출뿐이므로, PG 호출량이 실측상 문제가 되면 그때 `refundFailedAt` 기반 쿨다운(시간제한이어야 하며 영구 차단이면 흡수 상태의 부활이다)을 재검토한다.
 - (트레이드오프) **관리자가 재환불을 처리하기 전에 사용자가 입장할 수 있다.** 입장한 뒤 재환불이 성공하면 `TicketCancelUseCase`는 `USED` 티켓을 전이시키지 않지만, `SeatReleaseSoldSeatUseCase`는 티켓 사용 여부를 보지 않고 좌석을 `SOLD → AVAILABLE`로 반환한다 — 실제로 착석한 좌석이 재판매 가능해진다. 이 갭은 이 결정이 만든 것이 아니라(입장한 예매를 사용자가 취소해도 동일하다) 재환불 경로가 늘어 도달성이 넓어졌을 뿐이다. 입장 후 환불을 허용할지는 운영 정책이며, 좌석 반환 차단은 후속 과제로 분리한다. 다만 그 반대(환불도 못 받고 입장도 못 하는 상태)보다는 낫다.
 - (마이그레이션) 마이그레이션 도구가 없고 prod는 `ddl-auto: validate`이므로(ADR [3](0003-shared-database-with-service-boundaries.md)), `infra/mysql/init/01-schema.sql` 갱신과 함께 기존 DB에는 수동 `ALTER`가 필요하다. 작성 시점 기준 아직 프로덕션 배포 전이라 `REFUND_FAILED` 행이 존재하지 않으므로 데이터 변환이 필요 없다. **먼저 그 전제를 확인한다.**
 
@@ -83,6 +83,9 @@ payment-service는 손대지 않는다. `RefundFailedEvent`는 Javadoc만 정정
   ALTER TABLE booking ADD COLUMN refund_failed_at datetime(6) DEFAULT NULL;
   ALTER TABLE booking MODIFY booking_status
     enum('CANCELED','CONFIRMED','EXPIRED','PENDING','REFUNDED','REFUNDING') NOT NULL;
+
+  -- #397 낙관적 락. 배포 전에 실행하지 않으면 ddl-auto: validate가 기동을 실패시킨다.
+  ALTER TABLE booking ADD COLUMN version bigint NOT NULL DEFAULT 0;
   ```
 
   **0단계가 0이 아니면 enum을 먼저 축소해선 안 된다.** MySQL이 제거된 enum 값을 빈 문자열로 만든다. 그리고 남은 행을 일괄 `CONFIRMED`로 밀어서도 안 된다 — 위 §맥락 결함 1이 말하듯 그중 일부는 결제 취소 API로 **우회 환불이 실제로 성사된 뒤 booking만 고착된 건**이라(payment=CANCELED, 좌석은 이미 반환·재판매됐을 수 있음), `CONFIRMED`로 되살리면 입장이 허용되고 좌석이 이중 보유된다. 그 경우에만 아래를 enum 축소 **앞에** 끼워 넣는다.
@@ -102,7 +105,7 @@ payment-service는 손대지 않는다. `RefundFailedEvent`는 Javadoc만 정정
 
   로컬은 `ddl-auto: update`가 enum 값 축소를 반영하지 않으므로 컨테이너 볼륨을 재생성하거나 위 `ALTER`를 직접 실행한다.
 - (알려진 한계 · 이벤트 재생) `recordRefundFailure`는 `failedAt`이 기록된 `refundFailedAt`보다 나중일 때만 복원한다. 이 가드가 없으면, Inbox retention(기본 30일)이 만료된 뒤 DLT/토픽을 재생해 **옛 `RefundFailedEvent`가 새 재환불 시도(REFUNDING) 도중 도착**할 때 진행 중인 시도를 조용히 중단시킨다. 가드는 동일 시각 이벤트를 무시하므로 이 창을 닫는다. 다만 시도 식별자(예: `refundId`)로 매칭하는 편이 더 견고하며, 이벤트 계약을 바꿔야 하므로 후속 과제로 남긴다.
-- (알려진 한계 · 동시성) `Booking`에는 `@Version`이 없다. `requestRefund()`가 check-then-act이므로 사용자 취소와 관리자 재환불이 동시에 같은 `CONFIRMED` 예매를 읽으면 둘 다 `REFUNDING`을 쓰고 `RefundRequestedEvent`를 두 번 발행할 수 있다. 이중 PG 환불은 payment의 unique 제약(#296)과 멱등 키가 막으므로 금전 피해는 없으나, booking 계층 자체의 방어는 없다. 낙관적 락 도입은 이 변경의 범위를 넘으므로 후속 과제다(#397).
-- (후속 과제 · #397) **REFUNDING에서 멈춘 예매는 이 조회로 보이지 않는다.** payment 통신 실패로 DLT에 빠져 종결 이벤트가 끝내 오지 않으면 예매는 `REFUNDING`으로 남는다 — 돈도 못 받고, 좌석은 SOLD로 묶이고, 입장까지 차단되는(REFUNDING은 통과 불가) 더 급한 상태다. 이 사각지대를 덮는 리컨실 수단이 필요하다.
+- (해소됨 · #397) ~~`Booking`에는 `@Version`이 없다~~ — `Booking`에 낙관적 락(`@Version`)을 도입했다. `requestRefund()`가 check-then-act이므로 사용자 취소와 관리자 재환불이 동시에 같은 `CONFIRMED` 예매를 읽으면 둘 다 검증을 통과했었는데, 이제 늦은 쪽 커밋이 버전 충돌로 실패한다. 이벤트 발행이 afterCommit이므로 실패한 커밋의 `RefundRequestedEvent`는 발행되지 않는다 — 이중 발행이 booking 계층에서 차단된다(그 아래 payment의 unique 제약 #296과 멱등 키는 그대로 2차 방어로 남는다). 충돌은 HTTP에서 `COMMON_409`로 응답하고, Kafka 리스너에서는 transient로 분류돼 재시도로 수렴한다. 낙관적 락은 `Booking`에만 둔다 — 베이스 엔티티로 확대하면 14개 엔티티 전체의 스키마·리스너 거동이 한꺼번에 바뀌므로 필요가 실증될 때 확대한다. 주의: 벌크 UPDATE(`expirePendingBookingById`)는 version을 증가시키지도 검사하지도 않으므로 confirm-vs-expire 경합(만료 벌크 UPDATE가 EXPIRED로 민 행을 진행 중이던 confirm 커밋이 덮는 lost update)은 이 락의 보호 밖이다 — #397 이전부터 있던 한계이며, 필요해지면 JPQL `UPDATE VERSIONED` 적용을 검토한다.
+- (해소됨 · #397) ~~REFUNDING에서 멈춘 예매는 이 조회로 보이지 않는다~~ — payment 통신 실패로 DLT에 빠져 종결 이벤트가 끝내 오지 않으면 예매는 `REFUNDING`으로 남는다(돈도 못 받고, 좌석은 SOLD로 묶이고, 입장까지 차단). 이 사각지대에 두 수단을 추가했다. **식별**: `GET /api/v1/booking/admin/bookings/refunding-stuck`가 `REFUNDING`에서 임계 시간(기본 30분, `app.booking.refunding-stuck-threshold-minutes`) 이상 멈춘 예매를 오래된 순으로 노출한다. `REFUNDING` 진입 후 엔티티가 갱신되지 않으므로 `updatedAt`이 곧 진입 시각이다. 임계는 Kafka 재시도 소진(약 31초)보다 훨씬 길어 컨슈머 랙·재배포 지연을 오탐하지 않는다. **복구**: 환불 재시도 API가 고착 건(임계 초과 REFUNDING)이면 상태 전이 없이 `RefundRequestedEvent`만 재발행한다. booking이 자체 판단으로 `CONFIRMED` 복원하는 방식은 채택하지 않았다 — 통신 실패는 환불이 실제 성공했을 수도 있는 상태라, 재발행이 payment의 self-heal(COMPLETED면 PG 재실행, CANCELED면 `PaymentCanceledEvent` 재발행)과 맞물려 `REFUNDED` 또는 `CONFIRMED+refundFailedAt`로 안전하게 수렴하는 유일한 경로다. 임계 미달의 신선한 `REFUNDING`은 정상 진행 중이므로 여전히 거절한다. 재발행은 엔티티를 건드리지 않아 관리자 중복 호출을 낙관적 락이 막지 못하지만, payment 멱등성이 이중 환불을 막으므로 감사 로그로만 추적한다. 리컨실 스케줄러·메트릭 자동화는 도입하지 않았다 — DLT 적재 시 Slack 알림이 이미 1차 신호이고, 사람 판단 없는 자동 재발행은 무한 PG 재시도 위험이 있다.
 - (후속 과제 · #399) **입장 완료(ticket=USED) 예매의 환불 시 좌석 재판매를 막을지 결정해야 한다.** 위 트레이드오프 참고. 기존 결함이나 이 변경으로 도달 경로가 늘었다.
 - (후속 과제) payment-service의 결제 취소 API가 booking 상태를 고려하지 않는 문제와 관리자용 재환불 수단은 별도 이슈로 분리돼 있다.

--- a/docs/adr/0005-refund-state-machine-and-recovery.md
+++ b/docs/adr/0005-refund-state-machine-and-recovery.md
@@ -86,6 +86,10 @@ payment-service는 손대지 않는다. `RefundFailedEvent`는 Javadoc만 정정
 
   -- #397 낙관적 락. 배포 전에 실행하지 않으면 ddl-auto: validate가 기동을 실패시킨다.
   ALTER TABLE booking ADD COLUMN version bigint NOT NULL DEFAULT 0;
+
+  -- #397 REFUNDING 고착 조회용 인덱스(장애 대응 중 반복 조회 경로). validate 대상은 아니라 배포 후에 넣어도 되지만,
+  -- 없으면 booking 풀스캔 + filesort가 된다.
+  ALTER TABLE booking ADD INDEX idx_booking_status_updated_at (booking_status, updated_at);
   ```
 
   **0단계가 0이 아니면 enum을 먼저 축소해선 안 된다.** MySQL이 제거된 enum 값을 빈 문자열로 만든다. 그리고 남은 행을 일괄 `CONFIRMED`로 밀어서도 안 된다 — 위 §맥락 결함 1이 말하듯 그중 일부는 결제 취소 API로 **우회 환불이 실제로 성사된 뒤 booking만 고착된 건**이라(payment=CANCELED, 좌석은 이미 반환·재판매됐을 수 있음), `CONFIRMED`로 되살리면 입장이 허용되고 좌석이 이중 보유된다. 그 경우에만 아래를 enum 축소 **앞에** 끼워 넣는다.

--- a/infra/mysql/init/01-schema.sql
+++ b/infra/mysql/init/01-schema.sql
@@ -22,6 +22,7 @@ CREATE TABLE `booking` (
   `performance_id` bigint NOT NULL,
   `seat_id` bigint NOT NULL,
   `user_id` bigint NOT NULL,
+  `version` bigint NOT NULL DEFAULT '0',
   PRIMARY KEY (`booking_id`),
   UNIQUE KEY `UK6j74n7w8mp19sixr5272028mk` (`booking_number`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;

--- a/infra/mysql/init/01-schema.sql
+++ b/infra/mysql/init/01-schema.sql
@@ -24,7 +24,8 @@ CREATE TABLE `booking` (
   `user_id` bigint NOT NULL,
   `version` bigint NOT NULL DEFAULT '0',
   PRIMARY KEY (`booking_id`),
-  UNIQUE KEY `UK6j74n7w8mp19sixr5272028mk` (`booking_number`)
+  UNIQUE KEY `UK6j74n7w8mp19sixr5272028mk` (`booking_number`),
+  KEY `idx_booking_status_updated_at` (`booking_status`,`updated_at`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;


### PR DESCRIPTION
## 🔗 관련 이슈

- close #397

---

## 📌 주요 변경 사항

- `REFUNDING`에서 임계 시간(기본 30분) 이상 멈춘 고착 예매를 식별하는 관리자 조회 API 신설
- 환불 재시도 API 가드 확장 — 고착 예매는 상태 전이 없이 `RefundRequestedEvent`만 재발행해 복구
- `Booking`에 `@Version` 낙관적 락 도입 — 동시 환불 요청의 이벤트 중복 발행 차단 (스키마 변경 동반)
- 셀프 재시도 쿨다운은 실측 전 미도입으로 결정하고 ADR 0005에 기록

---

## 🛠 상세 구현 내용

- **고착 식별** (`GET /api/v1/booking/admin/bookings/refunding-stuck`)
  - payment의 PG 통신 실패가 DLT로 빠지면 종결 이벤트가 오지 않아 예매가 `REFUNDING`에 영구 고착됨(#391 조회의 사각지대). `updatedAt`(=REFUNDING 진입 시각) 기준 임계 초과 건을 오래된 순으로 노출.
  - 임계는 `app.booking.refunding-stuck-threshold-minutes`(기본 30분) — Kafka 재시도 소진(약 31초)보다 훨씬 길게 잡아 컨슈머 랙·재배포 오탐 방지. 식별·복구가 같은 임계를 보도록 `STUCK_THRESHOLD_PROPERTY` 상수로 단일 출처화.
  - `BookingSummaryResponse`에 `updatedAt` 필드 추가(말단 추가라 하위호환).
- **고착 복구** (`BookingAdminRetryRefundUseCase` 가드 확장)
  - 고착 REFUNDING이면 상태 전이 없이 이벤트만 재발행. booking이 임의로 CONFIRMED 복원하지 않는 이유: 통신 실패는 환불이 실제 성공했을 수 있는 상태라, payment의 멱등 self-heal(COMPLETED면 PG 재실행, CANCELED면 `PaymentCanceledEvent` 재발행)과 맞물려 REFUNDED 또는 CONFIRMED+refundFailedAt로 수렴하는 재발행이 유일한 안전 경로.
  - 임계 미달의 신선한 REFUNDING은 기존대로 `BOOKING_409_005` 거절. 관리자 행위는 ADMIN-AUDIT 로그로 추적.
- **낙관적 락**
  - `requestRefund()`가 check-then-act라 사용자 취소·관리자 재환불 동시 실행 시 이벤트 이중 발행 가능했음. `@Version` 도입으로 늦은 커밋이 실패하고, 발행이 afterCommit이라 실패한 커밋의 이벤트는 나가지 않음.
  - 충돌은 `GlobalExceptionHandler`에서 공용 `COMMON_409`로 변환(기존엔 500). Kafka 리스너 경로는 transient 재시도로 수렴.
  - `Booking`에만 적용(베이스 확대 시 14개 엔티티 전파 — 범위 초과). 스키마 스냅샷 2벌에 `version` 컬럼 추가.
  - 알려진 한계: 벌크 UPDATE(`expirePendingBookingById`)는 version 미검사 — confirm-vs-expire 경합은 기존 한계로 ADR에 명시.
- **ADR 0005 갱신**: 후속 과제(#397) 2건 해소, 쿨다운 미도입 결정, version 수동 ALTER 절차 기록.

---

## ✅ 테스트

### 테스트 방법

- `./gradlew test` (common 변경 포함 → 전체 모듈 실행) + `./gradlew spotlessCheck`
- 추가·수정한 테스트:
  - `BookingGetRefundingStuckBookingsUseCaseTest` (신규): cutoff 계산·페이징 위임
  - `BookingAdminRetryRefundUseCaseTest`: 고착 REFUNDING 재발행(상태 전이 없음) / 임계 미달 REFUNDING 거절
  - `BookingRepositoryTest` (`@DataJpaTest`): 고착 파생 쿼리 / stale 버전 저장 시 `ObjectOptimisticLockingFailureException`
  - `BookingAdminControllerTest`: 신규 엔드포인트 응답(`updated_at` 포함)
  - `BookingFacadeTest`: 위임

### 테스트 결과

- 전 모듈 590건 통과 / 0 실패 (common 88, booking 112, payment 154, seat 85, ticket 68, performance 47, user 17, auth 18, gateway 1) ✅
- `spotlessCheck` 통과 ✅
<!--
### 📸 스크린샷

- (작성 필요)
-->
---

## 👀 리뷰 요청 사항

- 고착 복구를 별도 API가 아니라 기존 refund-retry 가드 확장으로 처리한 결정(새 표면 없음 vs 계약 혼합)에 대한 의견
- `COMMON_409` 공용 에러 코드 도입(booking 전용 코드 대신)이 적절한지

---

## ⚠️ 배포 시 주의사항

- **prod 배포 전 수동 ALTER 필수** (`ddl-auto: validate`라 누락 시 기동 실패):
  `ALTER TABLE booking ADD COLUMN version bigint NOT NULL DEFAULT 0;`
- 고착 조회용 인덱스도 함께 추가해 주세요(validate 대상은 아니라 배포 후에도 되지만, 없으면 풀스캔+filesort):
  `ALTER TABLE booking ADD INDEX idx_booking_status_updated_at (booking_status, updated_at);`
- 로컬은 `ddl-auto: update`가 컬럼을 자동 추가하나, 볼륨 재생성 대비 init SQL 2벌도 함께 갱신됨

