### PR TITLE
[Refactor] #413 paymentKey 형식 검증 공용화 및 confirm 앞단 검증 추가

### DIFF
--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/dto/request/PaymentConfirmRequest.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/dto/request/PaymentConfirmRequest.java
@@ -1,9 +1,11 @@
 package com.ticketrush.boundedcontext.payment.app.dto.request;
 
+import com.ticketrush.boundedcontext.payment.app.support.PaymentKeyFormat;
 import com.ticketrush.boundedcontext.payment.domain.types.PaymentProvider;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Positive;
 
 @Schema(description = "결제 Confirm 요청 DTO")
@@ -18,4 +20,5 @@ public record PaymentConfirmRequest(
         Long amount,
     @Schema(description = "PG사가 발급한 결제 키", example = "tossKey_xxxxxxxx")
         @NotBlank(message = "결제 키는 필수입니다.")
+        @Pattern(regexp = PaymentKeyFormat.REGEX, message = "결제 키 형식이 올바르지 않습니다.")
         String paymentKey) {}

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/support/PaymentKeyFormat.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/support/PaymentKeyFormat.java
@@ -1,0 +1,30 @@
+package com.ticketrush.boundedcontext.payment.app.support;
+
+import java.util.regex.Pattern;
+
+/**
+ * PG {@code paymentKey}의 형식 검증 규칙(SSOT).
+ *
+ * <p>비인증 webhook 엔드포인트가 요청마다 Toss 조회 API를 호출하는 증폭(amplification) 벡터를 완화하고(#357), confirm 요청의 무의미한
+ * 입력을 앞단에서 거르기 위한(#413) 공용 형식 필터다. Toss는 paymentKey 최대 길이를 200자로 규정하지만 문자셋은 공식 규정이 없어(orderId만 규정),
+ * 좁은 화이트리스트는 정상 요청을 오탐 기각할 수 있다. 따라서 제어문자/공백/멀티바이트만 배제하는 넓은 인쇄가능 ASCII(0x21~0x7E, 1~200자)로 잡아 실제
+ * Toss 키는 모두 통과시키고 가비지만 거른다.
+ *
+ * <p>webhook(UseCase)은 {@link #PATTERN}으로 요청마다 매칭하고, confirm DTO는 {@code @Pattern(regexp = REGEX)}로
+ * 검증한다. {@code @Pattern}의 인자는 컴파일타임 상수 문자열이어야 하므로 {@link #REGEX}가 원본이고 {@link #PATTERN}은 이를 프리컴파일한
+ * 파생값이다(값 이중 정의 방지).
+ *
+ * <p>주의: 상한(200자·인쇄가능 ASCII)의 근거는 Toss 스펙이다. 현재 실제 결제 승인 구현체는 Toss뿐이라(다른 provider는 라우터에서 {@code
+ * PAYMENT_PROVIDER_NOT_SUPPORTED}로 선차단) confirm에 이 규칙을 적용해도 정상 결제가 오탐 기각될 여지가 없다. 향후 Toss 외 PG 승인
+ * 연동이 추가되면, 해당 PG의 paymentKey 형식이 이 화이트리스트에 부합하는지 재검토해야 한다.
+ */
+public final class PaymentKeyFormat {
+
+  /** 인쇄가능 ASCII(0x21~0x7E) 1~200자. {@code @Pattern(regexp = ...)}에 그대로 쓰이는 원본 정규식. */
+  public static final String REGEX = "[\\x21-\\x7E]{1,200}";
+
+  /** {@link #REGEX}를 프리컴파일한 패턴. 요청마다 매칭하는 호출부(webhook)에서 재컴파일을 피하기 위해 노출한다. */
+  public static final Pattern PATTERN = Pattern.compile(REGEX);
+
+  private PaymentKeyFormat() {}
+}

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentWebhookUseCase.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentWebhookUseCase.java
@@ -1,6 +1,7 @@
 package com.ticketrush.boundedcontext.payment.app.usecase;
 
 import com.ticketrush.boundedcontext.payment.app.dto.request.PaymentWebhookRequest;
+import com.ticketrush.boundedcontext.payment.app.support.PaymentKeyFormat;
 import com.ticketrush.boundedcontext.payment.domain.types.PaymentProvider;
 import com.ticketrush.boundedcontext.payment.out.apiclient.PaymentInquiryClientRouter;
 import com.ticketrush.boundedcontext.payment.out.apiclient.PaymentInquiryResult;
@@ -8,7 +9,6 @@ import com.ticketrush.boundedcontext.payment.out.repository.PaymentRepository;
 import com.ticketrush.global.exception.BusinessException;
 import com.ticketrush.global.status.ErrorStatus;
 import java.util.Optional;
-import java.util.regex.Pattern;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -34,14 +34,6 @@ import tools.jackson.databind.json.JsonMapper;
 @RequiredArgsConstructor
 public class PaymentWebhookUseCase {
 
-  /*
-   * 재조회(외부 호출) 전에 값싸게 거를 paymentKey 형식 필터. 비인증 webhook 엔드포인트가 요청마다 Toss 조회 API를
-   * 호출하는 증폭(amplification) 벡터를 완화한다(#357). Toss는 paymentKey 최대 길이를 200자로 규정하지만 문자셋은
-   * 공식 규정이 없어(orderId만 규정), 좁은 화이트리스트는 정상 요청을 오탐 기각할 수 있다. 따라서 제어문자/공백/멀티바이트만
-   * 배제하는 넓은 인쇄가능 ASCII(0x21~0x7E, 1~200자)로 잡아 실제 Toss 키는 모두 통과시키고 가비지만 거른다.
-   */
-  private static final Pattern PAYMENT_KEY_PATTERN = Pattern.compile("[\\x21-\\x7E]{1,200}");
-
   private final PaymentInquiryClientRouter inquiryClientRouter;
   private final PaymentRepository paymentRepository;
 
@@ -61,7 +53,7 @@ public class PaymentWebhookUseCase {
     // 사전 필터(#357): 형식상 성립 불가능한 paymentKey는 정상 Toss가 절대 보내지 않으므로, 재조회(외부 호출) 전에
     // 값싸게(CPU만으로) 거부해 비인증 webhook의 증폭(amplification) 공격 표면을 줄인다. 위조/무효로 취급해 재조회
     // 실패와 동일하게 401로 거부한다.
-    if (!PAYMENT_KEY_PATTERN.matcher(paymentKey).matches()) {
+    if (!PaymentKeyFormat.PATTERN.matcher(paymentKey).matches()) {
       // 형식 위반 값은 제어문자/CRLF를 담을 수 있어(마스킹은 새니타이즈가 아님) 로그에 내용을 찍지 않고 길이만 남긴다(로그 인젝션 방지).
       log.warn(
           "[PG-WEBHOOK] paymentKey 형식이 유효하지 않습니다. 재조회 없이 거부합니다. paymentKeyLength={}",

--- a/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/in/api/v1/PaymentControllerTest.java
+++ b/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/in/api/v1/PaymentControllerTest.java
@@ -144,6 +144,106 @@ class PaymentControllerTest {
   }
 
   @Test
+  @DisplayName("paymentKey가 200자를 초과하면 400 Bad Request로 앞단에서 거부한다")
+  void confirm_fails_when_payment_key_too_long() throws Exception {
+    // given - paymentKey 201자(형식 상한 200자 초과)
+    String tooLongKey = "a".repeat(201);
+    String requestBody =
+        """
+        {
+          "booking_id": 100,
+          "seat_id": 200,
+          "provider": "KAKAO",
+          "amount": 55000,
+          "payment_key": "%s"
+        }
+        """
+            .formatted(tooLongKey);
+
+    // when & then - VALIDATION_ERROR(@Pattern 위반)로 거부됨을 code까지 단언해 JSON 파싱 실패 등 다른 400과 구분한다.
+    mockMvc
+        .perform(
+            post("/api/v1/payment/confirm")
+                .header("X-Gateway-Token", INTERNAL_TOKEN)
+                .header("X-User-Id", 10L)
+                .header("X-User-Role", "USER")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestBody))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.is_success").value(false))
+        .andExpect(jsonPath("$.code").value(ErrorStatus.VALIDATION_ERROR.getCode()));
+
+    verifyNoInteractions(paymentFacade);
+  }
+
+  @Test
+  @DisplayName("paymentKey에 제어문자가 있으면 400 Bad Request로 앞단에서 거부한다")
+  void confirm_fails_when_payment_key_has_control_char() throws Exception {
+    // given - paymentKey에 제어문자(개행)가 포함되어 인쇄가능 ASCII 화이트리스트 위반
+    String requestBody =
+        """
+        {
+          "booking_id": 100,
+          "seat_id": 200,
+          "provider": "KAKAO",
+          "amount": 55000,
+          "payment_key": "pg\\nKey_xyz"
+        }
+        """;
+
+    // when & then - JSON 파싱 실패가 아니라 @Pattern(VALIDATION_ERROR) 위반으로 거부됨을 code로 특정한다.
+    mockMvc
+        .perform(
+            post("/api/v1/payment/confirm")
+                .header("X-Gateway-Token", INTERNAL_TOKEN)
+                .header("X-User-Id", 10L)
+                .header("X-User-Role", "USER")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestBody))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.is_success").value(false))
+        .andExpect(jsonPath("$.code").value(ErrorStatus.VALIDATION_ERROR.getCode()));
+
+    verifyNoInteractions(paymentFacade);
+  }
+
+  @Test
+  @DisplayName("paymentKey가 상한 200자면 검증을 통과해 confirm으로 전달된다")
+  void confirm_succeeds_when_payment_key_at_max_length() throws Exception {
+    // given - 형식 상한 정확히 200자(off-by-one 회귀 방어: {1,200}이 200자를 허용해야 함)
+    Long userId = 10L;
+    String maxLengthKey = "a".repeat(200);
+    LocalDateTime paidAt = LocalDateTime.of(2026, 5, 22, 10, 0);
+    PaymentConfirmResponse response = new PaymentConfirmResponse(1L, "COMPLETED", paidAt);
+    given(paymentFacade.confirm(eq(userId), any(PaymentConfirmRequest.class))).willReturn(response);
+
+    String requestBody =
+        """
+        {
+          "booking_id": 100,
+          "seat_id": 200,
+          "provider": "KAKAO",
+          "amount": 55000,
+          "payment_key": "%s"
+        }
+        """
+            .formatted(maxLengthKey);
+
+    // when & then
+    mockMvc
+        .perform(
+            post("/api/v1/payment/confirm")
+                .header("X-Gateway-Token", INTERNAL_TOKEN)
+                .header("X-User-Id", userId)
+                .header("X-User-Role", "USER")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestBody))
+        .andExpect(status().isOk());
+
+    verify(paymentFacade).confirm(eq(userId), any(PaymentConfirmRequest.class));
+  }
+
+  @Test
   @DisplayName("결제 금액 불일치 시 PAYMENT_400_001로 실패한다")
   void confirm_fails_when_amount_mismatch() throws Exception {
     // given


### PR DESCRIPTION
## 🔗 관련 이슈

- close #413

---

## 📌 주요 변경 사항

- #357에서 webhook UseCase 내부에 갇혀 있던 paymentKey 형식 정규식(`[\x21-\x7E]{1,200}`, 인쇄가능 ASCII 1~200자)을 payment-service 공용 상수 `PaymentKeyFormat`로 승격했습니다.
- confirm 요청 DTO(`PaymentConfirmRequest.paymentKey`)에 동일 형식 검증(`@Pattern`)을 추가해, 임의 길이·형식의 paymentKey를 컨트롤러 앞단(400)에서 거르도록 했습니다.
- webhook·confirm이 단일 규칙(SSOT)을 공유하게 되어 형식 필터가 두 진입점에서 동일하게 동작합니다.

---

## 🛠 상세 구현 내용

- **공용 상수 신규**: `app/support/PaymentKeyFormat`에 원본 정규식 `REGEX`(String) + 프리컴파일 `PATTERN`(Pattern)을 노출. `@Pattern`은 컴파일타임 String 상수를 요구하므로 `REGEX`가 SSOT이고 `PATTERN`은 이를 파생시켜 값 이중 정의를 차단.
- **webhook 리팩토링**: `PaymentWebhookUseCase`의 로컬 `PAYMENT_KEY_PATTERN`을 제거하고 `PaymentKeyFormat.PATTERN` 참조로 교체. 위반 시 예외(`PAYMENT_WEBHOOK_INVALID` 401)·로그·동작은 전부 유지, 정규식 값도 문자·이스케이프까지 동일해 리그레션 없음.
- **confirm 검증**: `paymentKey`에 `@Pattern(regexp = PaymentKeyFormat.REGEX)` 추가(`@NotBlank` 유지). 위반은 `MethodArgumentNotValidException` → `VALIDATION_ERROR`(400)로 자동 매핑. 정규식의 `{1,200}` + 전체일치 시맨틱으로 길이 상한까지 커버되어 `@Size`는 불필요.
- **적용 범위 근거**: 상한(200자·ASCII)의 근거는 Toss 스펙이며, 현재 실제 결제 승인 구현체는 Toss뿐(KAKAO/NAVER는 라우터에서 `PAYMENT_PROVIDER_NOT_SUPPORTED`로 선차단)이라 정상 결제가 오탐 기각될 여지가 없음. 향후 타 PG 연동 시 재검토하도록 상수 Javadoc에 명시.

---

## ✅ 테스트

### 테스트 방법

- `./gradlew :payment-service:test`
- 추가한 슬라이스 테스트(`PaymentControllerTest`, `@WebMvcSliceTest`):
  - `confirm_fails_when_payment_key_too_long`: paymentKey 201자 → 400(`code=VALID_400_001`) + `paymentFacade` 미호출
  - `confirm_fails_when_payment_key_has_control_char`: 제어문자(개행) 포함 → 400(`code=VALID_400_001`) + `paymentFacade` 미호출
  - `confirm_succeeds_when_payment_key_at_max_length`: 상한 정확히 200자 → 검증 통과 → confirm 전달(200 OK)
- 기존 webhook 형식 필터 테스트(`PaymentWebhookUseCaseTest`) 리그레션 무영향 확인.

### 테스트 결과

- payment-service: 159 통과 / 0 실패 ✅

### 📸 스크린샷

- 

---

## 👀 리뷰 요청 사항

- 공용 상수 배치 위치(`app/support/PaymentKeyFormat`)와 형태(정규식 String + 프리컴파일 Pattern 동시 노출)가 적절한지 봐주세요.
- confirm의 형식 검증 적용 범위(Toss 근거 상한을 멀티 provider enum 경로에 적용)에 대한 판단이 타당한지 확인 부탁드립니다.

---

## ⚠️ 배포 시 주의사항

- 스키마·설정 변경 없음(순수 코드 리팩토링). 별도 마이그레이션 불필요.
- 동작 변경: 형식상 성립 불가능한 paymentKey의 confirm 요청이 이제 400으로 거부됩니다. 정상 Toss 키(인쇄가능 ASCII ≤200자)는 전부 통과하므로 사용자 영향 없음.
