### PR TITLE
[Refactor] #412 payment.booking_id 인덱스 추가로 bookingId 조회 최적화

### DIFF
--- a/deploy/mysql/init/001-ticket-rush-schema.sql
+++ b/deploy/mysql/init/001-ticket-rush-schema.sql
@@ -125,7 +125,8 @@ CREATE TABLE `payment` (
   `status` enum('CANCELED','COMPLETED','FAILED','PENDING') COLLATE utf8mb4_unicode_ci NOT NULL,
   `user_id` bigint DEFAULT NULL,
   PRIMARY KEY (`payment_id`),
-  UNIQUE KEY `UK6vew52c3hm7vwaiwfvt498x3` (`payment_key`)
+  UNIQUE KEY `UK6vew52c3hm7vwaiwfvt498x3` (`payment_key`),
+  KEY `idx_payment_booking_id` (`booking_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `performance`;

--- a/infra/mysql/init/01-schema.sql
+++ b/infra/mysql/init/01-schema.sql
@@ -119,7 +119,8 @@ CREATE TABLE `payment` (
   `status` enum('CANCELED','COMPLETED','FAILED','PENDING') NOT NULL,
   `user_id` bigint DEFAULT NULL,
   PRIMARY KEY (`payment_id`),
-  UNIQUE KEY `UK6vew52c3hm7vwaiwfvt498x3` (`payment_key`)
+  UNIQUE KEY `UK6vew52c3hm7vwaiwfvt498x3` (`payment_key`),
+  KEY `idx_payment_booking_id` (`booking_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/domain/entity/Payment.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/domain/entity/Payment.java
@@ -8,6 +8,7 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.Index;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
@@ -16,12 +17,24 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@Table(name = "payment")
+@Table(
+    name = "payment",
+    indexes = @Index(name = "idx_payment_booking_id", columnList = "booking_id"))
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AttributeOverride(name = "id", column = @Column(name = "payment_id"))
 public class Payment extends AutoIdBaseEntity {
 
+  /* bookingId 조건 조회(exists/findFirst/count By BookingId And Status)가 confirm hot path에서 매 요청
+   * 실행되므로 idx_payment_booking_id 인덱스를 둔다(#412). 세 조회 모두 (booking_id, status) 복합 조건이지만,
+   * booking당 payment row가 유계(COMPLETED 최대 1건 + FAILED 상한 #333)라 booking_id 단일 인덱스로 seek하면
+   * status는 소수 잔여 row 필터라 복합 인덱스 실익이 없어 단일로 둔다.
+   *
+   * @Table의 @Index는 ddl-auto=update인 로컬/신규 초기화 DB(init SQL)에서만 생성되고, prod(validate)는 인덱스
+   * 부재를 검출하지 못한다. 따라서 이미 가동 중인 기존 DB에는 배포 전 수동 DDL이 필요하다(#296 수동 DDL 관행과 동일).
+   * 아래 ALTER는 인덱스가 없는 기존 DB에만 실행한다(신규 초기화 DB는 init SQL이 이미 만들어 Duplicate key name 실패):
+   *   ALTER TABLE payment
+   *     ADD INDEX idx_payment_booking_id (booking_id), ALGORITHM=INPLACE, LOCK=NONE; */
   @Column(nullable = false)
   private Long bookingId;
 


### PR DESCRIPTION
## 🔗 관련 이슈

- close #412

---

## 📌 주요 변경 사항

- `payment` 테이블 `booking_id` 컬럼에 인덱스 `idx_payment_booking_id`를 추가해, confirm hot path의 bookingId 기준 조회 3종을 최적화했습니다.
- 엔티티 `@Table(indexes = @Index(...))`와 두 스키마 스냅샷(`infra`/`deploy`)에 인덱스를 반영했습니다.
- 애플리케이션 로직·쿼리 메서드 변경은 없습니다(옵티마이저가 인덱스를 자동 선택).

---

## 🛠 상세 구현 내용

- **대상 조회**: `PaymentRepository`의 `existsByBookingIdAndStatus`, `findFirstByBookingIdAndStatus`, `countByBookingIdAndStatus`(#333 FAILED 상한 판정) — 모두 confirm 경로에서 매 요청 실행. 기존엔 PK와 `payment_key` unique만 있어 `booking_id` 조건이 인덱스를 타지 못했습니다.
- **단일 vs 복합**: 3종 모두 `(booking_id, status)` 복합 조건이지만, booking당 payment row가 유계(COMPLETED 최대 1건 + FAILED 상한 #333)라 `booking_id` 단일 인덱스로 seek 후 status는 소수 잔여 필터 → 복합 인덱스 실익이 없어 단일로 결정. 네이밍은 기존 선례(`idx_seat_performance_id`)와 동일한 `idx_{table}_{column}`.
- **스냅샷 2개 반영**: prod가 실제 마운트하는 `deploy/mysql/init/001-ticket-rush-schema.sql`과 SSOT 문서가 지목하는 `infra/mysql/init/01-schema.sql` 양쪽에 `KEY idx_payment_booking_id (booking_id)` 추가(신규 초기화 DB 반영 + 드리프트 억제).

---

## ✅ 테스트

### 테스트 방법

- `./gradlew :payment-service:test` (엔티티 변경 회귀 확인)
- **인덱스 사용 실측(완료조건②)**: 로컬 MySQL에 스냅샷과 동일한 payment 스키마(+본 인덱스)를 임시 구성하고 1,000행 적재 후, 3종 조회를 `EXPLAIN`으로 확인.

### 테스트 결과

- payment-service: 159 통과 / 0 실패 ✅
- `EXPLAIN` 결과 — 3종 조회 전부 인덱스 사용 확인:
  - `existsByBookingIdAndStatus` → `Index lookup on payment using idx_payment_booking_id (booking_id = ?)`
  - `findFirstByBookingIdAndStatus` → `Index lookup on payment using idx_payment_booking_id`
  - `countByBookingIdAndStatus` → `Index lookup on payment using idx_payment_booking_id`
  - (status는 인덱스 후 잔여 필터 — 유계 카디널리티 설계와 일치)

### 📸 스크린샷

- 

---

## 👀 리뷰 요청 사항

- 단일 `booking_id` 인덱스 결정(복합 대신)에 대한 판단이 타당한지 봐주세요.
- 스냅샷 두 파일 동시 갱신 방식에 이견 없는지 확인 부탁드립니다.

---

## ⚠️ 배포 시 주의사항

- **⚠️ prod는 `ddl-auto: validate`라 인덱스를 자동 생성하지 않으며, validate는 인덱스 부재를 검출하지도 못합니다.** 스냅샷/앱 배포만으로는 **이미 가동 중인 기존 prod DB에 인덱스가 반영되지 않습니다.**
- **기존 prod DB에 배포 담당이 수동 DDL을 실행해야 합니다** (신규 초기화 DB는 init SQL이 자동 생성하므로 실행 금지 — `Duplicate key name` 실패):
  ```sql
  ALTER TABLE payment
    ADD INDEX idx_payment_booking_id (booking_id), ALGORITHM=INPLACE, LOCK=NONE;
  ```
  `ALGORITHM=INPLACE, LOCK=NONE`은 hot 테이블 쓰기 차단 없이 온라인으로 인덱스를 추가하기 위함입니다.
- **적용 확인**: `SHOW INDEX FROM payment;`에 `idx_payment_booking_id`가 보이는지 확인.
- 롤백: `ALTER TABLE payment DROP INDEX idx_payment_booking_id, ALGORITHM=INPLACE, LOCK=NONE;` (부작용 없는 세컨더리 인덱스).
- 스키마 스냅샷 SSOT 일원화(infra vs deploy)는 본 범위 밖 — #408과 함께 별도 처리.
