### PR TITLE
[Fix] #416 결제 취소 시 입장(USED) 예매 차단으로 착석 좌석 재판매 방지

### DIFF
--- a/common/src/main/java/com/ticketrush/global/status/ErrorStatus.java
+++ b/common/src/main/java/com/ticketrush/global/status/ErrorStatus.java
@@ -174,6 +174,8 @@ public enum ErrorStatus {
   // Payment 409
   PAYMENT_ALREADY_COMPLETED(HttpStatus.CONFLICT, "PAYMENT_409_001", "이미 결제가 완료된 예매입니다."),
   PAYMENT_NOT_CANCELABLE(HttpStatus.CONFLICT, "PAYMENT_409_002", "환불 가능한 결제 상태가 아닙니다."),
+  PAYMENT_CANCEL_NOT_ALLOWED_TICKET_USED(
+      HttpStatus.CONFLICT, "PAYMENT_409_003", "이미 입장한 예매는 환불할 수 없습니다."),
 
   // Payment 500
   PAYMENT_REFUND_INCONSISTENT(
@@ -190,6 +192,8 @@ public enum ErrorStatus {
   // Payment 503
   PAYMENT_PG_COMMUNICATION_FAILED(
       HttpStatus.SERVICE_UNAVAILABLE, "PAYMENT_503_001", "PG사와 통신에 실패했습니다."),
+  PAYMENT_TICKET_COMMUNICATION_FAILED(
+      HttpStatus.SERVICE_UNAVAILABLE, "PAYMENT_503_002", "입장권 정보 조회에 실패했습니다. 잠시 후 다시 시도해 주세요."),
 
   // Ticket 400
   TICKET_QR_INVALID(HttpStatus.BAD_REQUEST, "TICKET_400_001", "유효하지 않은 QR입니다."),

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentCancelUseCase.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentCancelUseCase.java
@@ -12,6 +12,7 @@ import com.ticketrush.boundedcontext.payment.domain.types.RefundStatus;
 import com.ticketrush.boundedcontext.payment.out.apiclient.PaymentCancelClientRouter;
 import com.ticketrush.boundedcontext.payment.out.apiclient.PaymentCancelCommand;
 import com.ticketrush.boundedcontext.payment.out.apiclient.PaymentCancelResult;
+import com.ticketrush.boundedcontext.payment.out.apiclient.TicketRestClient;
 import com.ticketrush.boundedcontext.payment.out.repository.PaymentRepository;
 import com.ticketrush.boundedcontext.payment.out.repository.RefundRepository;
 import com.ticketrush.global.exception.BusinessException;
@@ -42,6 +43,7 @@ public class PaymentCancelUseCase {
   private final PaymentCancelPersister paymentCancelPersister;
   private final FailedRefundRecorder failedRefundRecorder;
   private final PaymentEventPublisher paymentEventPublisher;
+  private final TicketRestClient ticketRestClient;
   private final PaymentMapper paymentMapper;
 
   public PaymentCancelResponse execute(Long userId, Long paymentId, PaymentCancelRequest request) {
@@ -57,6 +59,12 @@ public class PaymentCancelUseCase {
 
     if (payment.getStatus() != PaymentStatus.COMPLETED) {
       throw new BusinessException(ErrorStatus.PAYMENT_NOT_CANCELABLE);
+    }
+
+    // 이미 입장(ticket=USED)한 예매는 환불을 막는다 (#416). 이 검증이 없으면 결제 취소가 booking을 우회해 착석한 좌석이
+    // 환불 이벤트로 AVAILABLE 반환되어 재판매된다(#399가 세운 정책의 우회). PG 왕복과 마찬가지로 트랜잭션 밖에서 조회한다.
+    if (ticketRestClient.isTicketUsed(payment.getBookingId())) {
+      throw new BusinessException(ErrorStatus.PAYMENT_CANCEL_NOT_ALLOWED_TICKET_USED);
     }
 
     // PG 취소는 트랜잭션 밖에서 호출한다(외부 왕복 동안 DB 커넥션을 점유하지 않기 위함).

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/out/apiclient/TicketRestClient.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/out/apiclient/TicketRestClient.java
@@ -1,0 +1,134 @@
+package com.ticketrush.boundedcontext.payment.out.apiclient;
+
+import com.ticketrush.boundedcontext.payment.out.apiclient.dto.TicketApiResponse;
+import com.ticketrush.global.config.CustomSecurityProperties;
+import com.ticketrush.global.exception.BusinessException;
+import com.ticketrush.global.status.ErrorStatus;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
+
+/**
+ * 결제 취소 경로에서 입장권 사용 여부를 판정하는 클라이언트 (#416).
+ *
+ * <p>결제 취소 API는 booking을 통과하지 않아, #399가 booking 경로(자가 취소·관리자 재환불)에 세운 "입장 완료 예매 환불 차단" 정책을 그대로
+ * 우회한다. booking의 동명 클라이언트와 같은 계약(엔드포인트·헤더·fail-closed 판정)으로 ticket-service를 동기 조회해, payment 취소 경로에도
+ * 동일한 규율을 적용한다.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class TicketRestClient {
+
+  private static final String INTERNAL_TOKEN_HEADER = "X-Internal-Token";
+
+  /** ticket-service TicketStatus의 이름. 문자열로 건너오므로 컴파일러가 지켜주지 못한다. */
+  private static final String STATUS_USED = "USED";
+
+  private static final String STATUS_UNUSED = "UNUSED";
+  private static final String STATUS_CANCELED = "CANCELED";
+
+  private final RestClient ticketServiceRestClient;
+  private final CustomSecurityProperties customSecurityProperties;
+
+  /**
+   * 예매에 발급된 입장권이 사용(입장 완료)됐는지 ticket-service에 동기 조회한다 (#416).
+   *
+   * <p><b>알 수 없으면 막는다.</b> 조회 실패에도 환불을 진행시키면 착석한 좌석이 반환될 수 있으므로, 판정할 수 없는 응답은 모두 {@code
+   * PAYMENT_TICKET_COMMUNICATION_FAILED}(503)로 수렴시켜 좌석을 SOLD로 남기는 안전한 방향(취소 거부)으로 전파한다. 이 클래스에서
+   * {@code false}(환불 허용)를 반환하는 분기는 아래 둘뿐이며, 나머지는 전부 막는다.
+   *
+   * <ul>
+   *   <li><b>입장권 미발급</b> — ticket-service가 {@code TICKET_404_001}로 응답한 404. 티켓 발급은 결제 완료 이벤트 이후라
+   *       CONFIRMED이면서 티켓 행이 아직 없는 상태가 실재하고(발급 이벤트 DLT 등), 그 예매는 입장이 불가능하므로 취소를 막아선 안 된다. <b>그 밖의
+   *       404는 미입장으로 해석하지 않는다</b> — 경로 오설정·라우팅 오류로 나는 404까지 통과시키면 정책이 조용히 무력화된다.
+   *   <li><b>UNUSED / CANCELED</b> — 입장하지 않은 입장권.
+   * </ul>
+   *
+   * <p>알 수 없는 상태 문자열도 막는다. ticket-service가 {@code TicketStatus}에 값을 추가하거나 이름을 바꿔도 payment는 컴파일 에러
+   * 없이 이 코드를 통과하므로, 모르는 값을 "미입장"으로 낙관하면 정책이 소리 없이 뚫린다.
+   */
+  public boolean isTicketUsed(Long bookingId) {
+    TicketApiResponse response;
+    try {
+      response =
+          ticketServiceRestClient
+              .get()
+              .uri("/api/v1/internal/ticket/bookings/{bookingId}", bookingId)
+              .header(INTERNAL_TOKEN_HEADER, customSecurityProperties.getInternalToken())
+              .retrieve()
+              .onStatus(
+                  status -> status.isError() && status.value() != 404,
+                  (request, clientResponse) -> {
+                    log.warn(
+                        "[TicketRestClient] ticket-service 비정상 응답 status={}, bookingId={}",
+                        clientResponse.getStatusCode(),
+                        bookingId);
+                    throw new BusinessException(ErrorStatus.PAYMENT_TICKET_COMMUNICATION_FAILED);
+                  })
+              .body(TicketApiResponse.class);
+    } catch (HttpClientErrorException.NotFound e) {
+      return handleNotFound(e, bookingId);
+    } catch (RestClientException e) {
+      // 연결 실패·타임아웃(ResourceAccessException), 본문이 JSON이 아닌 경우(UnknownContentTypeException) 등
+      // 남은 통신 실패 전반. 하나라도 새어 나가면 사용자에게 원시 500이 노출되므로 여기서 모두 503으로 수렴시킨다.
+      log.warn("[TicketRestClient] ticket-service 통신 실패 bookingId={}", bookingId, e);
+      throw new BusinessException(ErrorStatus.PAYMENT_TICKET_COMMUNICATION_FAILED);
+    }
+
+    if (response == null || response.result() == null) {
+      log.warn(
+          "[TicketRestClient] ticket-service 200 응답이나 result 본문이 비어 있음 bookingId={}", bookingId);
+      throw new BusinessException(ErrorStatus.PAYMENT_TICKET_COMMUNICATION_FAILED);
+    }
+
+    return isUsed(response.result().ticketStatus(), bookingId);
+  }
+
+  /** ticket-service가 의도적으로 낸 404(입장권 미발급)만 미입장으로 해석한다. */
+  private boolean handleNotFound(HttpClientErrorException.NotFound e, Long bookingId) {
+    String code = errorCodeOf(e);
+
+    if (ErrorStatus.TICKET_NOT_FOUND.getCode().equals(code)) {
+      log.info("[TicketRestClient] 발급된 입장권이 없어 미입장으로 판단합니다. bookingId={}", bookingId);
+      return false;
+    }
+
+    // 핸들러가 없는 경로(오타·매핑 변경)나 라우팅 오설정도 404다. 이를 미입장으로 통과시키면 정책이 사일런트로 무력화된다.
+    log.warn(
+        "[TicketRestClient] 입장권 미발급(TICKET_404_001)이 아닌 404입니다. 경로·배포 설정을 확인하세요. "
+            + "bookingId={}, code={}",
+        bookingId,
+        code);
+    throw new BusinessException(ErrorStatus.PAYMENT_TICKET_COMMUNICATION_FAILED);
+  }
+
+  /** 에러 응답 본문에서 code를 꺼낸다. 본문이 없거나 파싱되지 않으면 null(= 의도된 404가 아님)로 본다. */
+  private String errorCodeOf(HttpClientErrorException.NotFound e) {
+    try {
+      TicketApiResponse body = e.getResponseBodyAs(TicketApiResponse.class);
+      return (body != null) ? body.code() : null;
+    } catch (RestClientException parseFailure) {
+      return null;
+    }
+  }
+
+  /** 알 수 없는 상태 문자열은 통과시키지 않는다(fail-closed). */
+  private boolean isUsed(String ticketStatus, Long bookingId) {
+    if (STATUS_USED.equals(ticketStatus)) {
+      return true;
+    }
+    if (STATUS_UNUSED.equals(ticketStatus) || STATUS_CANCELED.equals(ticketStatus)) {
+      return false;
+    }
+
+    log.warn(
+        "[TicketRestClient] 알 수 없는 입장권 상태라 판정할 수 없습니다. bookingId={}, ticketStatus={}",
+        bookingId,
+        ticketStatus);
+    throw new BusinessException(ErrorStatus.PAYMENT_TICKET_COMMUNICATION_FAILED);
+  }
+}

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/out/apiclient/dto/TicketApiResponse.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/out/apiclient/dto/TicketApiResponse.java
@@ -1,0 +1,16 @@
+package com.ticketrush.boundedcontext.payment.out.apiclient.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * ticket-service의 공통 ApiResponse 래퍼 중 payment-service가 사용하는 필드만 매핑한다.
+ *
+ * <p>{@code code}는 성공 응답뿐 아니라 <b>에러 응답 본문</b>에도 실린다. 404를 "입장권 미발급"으로 해석해도 되는지 가리는 데 쓴다 — 경로 오설정
+ * 등으로 발생한 404는 이 코드가 없거나 다르다.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record TicketApiResponse(
+    @JsonProperty("is_success") boolean isSuccess,
+    @JsonProperty("code") String code,
+    @JsonProperty("result") TicketInfoResponse result) {}

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/out/apiclient/dto/TicketInfoResponse.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/out/apiclient/dto/TicketInfoResponse.java
@@ -1,0 +1,15 @@
+package com.ticketrush.boundedcontext.payment.out.apiclient.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * ticket-service internal 조회 API 응답의 result 본문(snake_case JSON)을 매핑한다.
+ *
+ * <p>{@code ticketStatus}는 ticket-service {@code TicketStatus}의 이름이 문자열로 건너온 값이다. 무엇을 "입장했다"로 볼지는
+ * 정책이므로 여기서 판정하지 않는다({@code TicketRestClient}가 판정한다).
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record TicketInfoResponse(
+    @JsonProperty("booking_id") Long bookingId,
+    @JsonProperty("ticket_status") String ticketStatus) {}

--- a/payment-service/src/main/java/com/ticketrush/global/config/RestClientConfig.java
+++ b/payment-service/src/main/java/com/ticketrush/global/config/RestClientConfig.java
@@ -51,4 +51,19 @@ public class RestClientConfig {
         .defaultHeader(HttpHeaders.AUTHORIZATION, basicAuth)
         .build();
   }
+
+  /**
+   * 취소 경로의 입장권 판정 전용 클라이언트 (#416). 공용/PG 타임아웃이 아니라 훨씬 짧은 예산을 쓴다 — 판정에 필요한 건 단일 행 조회 하나인데,
+   * ticket-service가 느려질 때 취소 요청 하나가 톰캣 스레드를 오래 붙잡으면 결제 경로 전체가 함께 마른다.
+   */
+  @Bean
+  public RestClient ticketServiceRestClient(
+      @Value("${service.ticket.url}") String ticketServiceUrl,
+      @Value("${service.ticket.connect-timeout-ms:1000}") long connectTimeoutMs,
+      @Value("${service.ticket.read-timeout-ms:2000}") long readTimeoutMs) {
+    return RestClient.builder()
+        .baseUrl(ticketServiceUrl)
+        .requestFactory(RestClientFactorySupport.withTimeouts(connectTimeoutMs, readTimeoutMs))
+        .build();
+  }
 }

--- a/payment-service/src/main/resources/application-prod.yml
+++ b/payment-service/src/main/resources/application-prod.yml
@@ -18,8 +18,17 @@ gateway:
   # 운영은 게이트웨이 내부 토큰을 반드시 주입(base의 test-token 기본값 오버라이드, 미주입 시 fail-fast).
   internal-token: ${GATEWAY_INTERNAL_TOKEN}
 
+service:
+  ticket:
+    # 결제 취소 경로의 입장권 판정 대상 (#416). 운영은 기본값 없이 반드시 주입(미주입 시 fail-fast).
+    # 반드시 ticket-service '직접' 주소를 주입한다 — 내부 API는 게이트웨이 미라우팅(#367)이라
+    # 게이트웨이 주소로 오설정하면 404가 나 취소가 조용히 전건 503 거부된다.
+    url: ${TICKET_SERVICE_URL}
+
 custom:
   security:
+    # 서비스 간 내부 API 호출 토큰. 운영은 base의 test 기본값을 오버라이드해 반드시 주입(미주입 시 ticket 조회 401 → 취소 전건 거부).
+    internal-token: ${INTERNAL_API_TOKEN}
     permit-urls:
       - /swagger-ui/**
       - /v3/api-docs/**

--- a/payment-service/src/main/resources/application.yml
+++ b/payment-service/src/main/resources/application.yml
@@ -14,12 +14,27 @@ app:
   event-publisher:
     type: kafka
 
+service:
+  ticket:
+    # 결제 취소 경로의 입장권 사용 여부 판정 전용 (#416).
+    # 내부 API(/api/v1/internal/ticket/**)는 게이트웨이가 라우팅하지 않으므로(#367),
+    # ticket-service '직접' 주소여야 한다. 게이트웨이 주소로 넣으면 라우트 없음 404가 나
+    # 미발급(TICKET_404_001)이 아닌 404로 취소가 전건 503 거부된다.
+    url: ${TICKET_SERVICE_URL:http://localhost:8087}
+    # 단일 행 조회이므로 공용 예산(3s/10s)을 쓰지 않는다 —
+    # ticket-service가 느려질 때 취소 요청이 톰캣 스레드를 오래 붙잡아 결제 경로까지 마르는 것을 막는다.
+    connect-timeout-ms: ${TICKET_HTTP_CONNECT_TIMEOUT_MS:1000}
+    read-timeout-ms: ${TICKET_HTTP_READ_TIMEOUT_MS:2000}
+
 custom:
   global:
     internalBackUrl: ${INTERNAL_BACK_URL:http://localhost:${server.port:8085}}
   swagger:
     serverUrl: ${SWAGGER_SERVER_URL:http://localhost:8080}
   security:
+    # 서비스 간 내부 API 호출에 사용하는 전용 토큰
+    # (게이트웨이↔서비스 공유 시크릿 재사용, booking/performance/user/auth 서비스와 동일).
+    internal-token: ${INTERNAL_API_TOKEN:test-internal-token}
     permit-all: false
     permit-urls:
       # ========== 개발 도구 ==========

--- a/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentCancelUseCaseTest.java
+++ b/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentCancelUseCaseTest.java
@@ -3,6 +3,7 @@ package com.ticketrush.boundedcontext.payment.app.usecase;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.BDDMockito.given;
@@ -22,6 +23,7 @@ import com.ticketrush.boundedcontext.payment.domain.types.RefundStatus;
 import com.ticketrush.boundedcontext.payment.out.apiclient.PaymentCancelClientRouter;
 import com.ticketrush.boundedcontext.payment.out.apiclient.PaymentCancelCommand;
 import com.ticketrush.boundedcontext.payment.out.apiclient.PaymentCancelResult;
+import com.ticketrush.boundedcontext.payment.out.apiclient.TicketRestClient;
 import com.ticketrush.boundedcontext.payment.out.repository.PaymentRepository;
 import com.ticketrush.boundedcontext.payment.out.repository.RefundRepository;
 import com.ticketrush.global.exception.BusinessException;
@@ -50,6 +52,7 @@ class PaymentCancelUseCaseTest {
   @Mock private PaymentCancelPersister paymentCancelPersister;
   @Mock private FailedRefundRecorder failedRefundRecorder;
   @Mock private PaymentEventPublisher paymentEventPublisher;
+  @Mock private TicketRestClient ticketRestClient;
 
   @Spy private PaymentMapper paymentMapper = Mappers.getMapper(PaymentMapper.class);
 
@@ -70,6 +73,7 @@ class PaymentCancelUseCaseTest {
 
     Payment payment = completedPayment(paymentId, userId, bookingId, seatId, amount);
     given(paymentRepository.findByIdAndUserId(paymentId, userId)).willReturn(Optional.of(payment));
+    given(ticketRestClient.isTicketUsed(bookingId)).willReturn(false);
     given(paymentCancelClientRouter.cancel(any()))
         .willReturn(new PaymentCancelResult("PG-REFUND-1", amount, canceledAt));
 
@@ -167,6 +171,60 @@ class PaymentCancelUseCaseTest {
     verify(paymentCancelPersister, never()).persist(any(), any(Refund.class));
     verify(paymentEventPublisher, never())
         .publishCanceled(any(), any(), any(), any(), any(), any(), any(), any());
+    // 이미 취소된 건은 가드 앞에서 조기 반환되므로 입장권 조회를 하지 않는다 (#416).
+    verify(ticketRestClient, never()).isTicketUsed(any());
+  }
+
+  @Test
+  @DisplayName("입장(ticket=USED)한 예매는 PG 취소 없이 PAYMENT_409_003 으로 거절한다 (#416)")
+  void execute_fail_when_ticket_used() throws Exception {
+    // given
+    Long userId = 10L;
+    Long paymentId = 1L;
+    Long bookingId = 100L;
+    PaymentCancelRequest request = new PaymentCancelRequest("단순 변심");
+
+    Payment payment = completedPayment(paymentId, userId, bookingId, 200L, 55_000L);
+    given(paymentRepository.findByIdAndUserId(paymentId, userId)).willReturn(Optional.of(payment));
+    given(ticketRestClient.isTicketUsed(bookingId)).willReturn(true);
+
+    // when & then
+    assertThatThrownBy(() -> paymentCancelUseCase.execute(userId, paymentId, request))
+        .isInstanceOf(BusinessException.class)
+        .extracting("errorStatus")
+        .isEqualTo(ErrorStatus.PAYMENT_CANCEL_NOT_ALLOWED_TICKET_USED);
+
+    // 착석한 좌석이 환불 이벤트로 반환되지 않도록 PG 취소·영속화·이벤트 발행을 모두 하지 않는다.
+    verify(paymentCancelClientRouter, never()).cancel(any());
+    verify(paymentCancelPersister, never()).persist(any(), any(Refund.class));
+    verify(paymentEventPublisher, never())
+        .publishCanceled(any(), any(), any(), any(), any(), any(), any(), any());
+  }
+
+  @Test
+  @DisplayName("입장권 조회가 통신 실패(503)면 PG 취소 이전에 예외가 전파되고 PG를 호출하지 않는다 (#416)")
+  void execute_fail_when_ticket_lookup_communication_fails() throws Exception {
+    // given: fail-closed — 판정할 수 없으면 PG 취소로 넘어가지 않고 취소를 거부해야 한다.
+    Long userId = 10L;
+    Long paymentId = 1L;
+    Long bookingId = 100L;
+    PaymentCancelRequest request = new PaymentCancelRequest("단순 변심");
+
+    Payment payment = completedPayment(paymentId, userId, bookingId, 200L, 55_000L);
+    given(paymentRepository.findByIdAndUserId(paymentId, userId)).willReturn(Optional.of(payment));
+    given(ticketRestClient.isTicketUsed(bookingId))
+        .willThrow(new BusinessException(ErrorStatus.PAYMENT_TICKET_COMMUNICATION_FAILED));
+
+    // when & then
+    assertThatThrownBy(() -> paymentCancelUseCase.execute(userId, paymentId, request))
+        .isInstanceOf(BusinessException.class)
+        .extracting("errorStatus")
+        .isEqualTo(ErrorStatus.PAYMENT_TICKET_COMMUNICATION_FAILED);
+
+    verify(paymentCancelClientRouter, never()).cancel(any());
+    verify(paymentCancelPersister, never()).persist(any(), any(Refund.class));
+    verify(paymentEventPublisher, never())
+        .publishCanceled(any(), any(), any(), any(), any(), any(), any(), any());
   }
 
   @Test
@@ -253,6 +311,7 @@ class PaymentCancelUseCaseTest {
 
     Payment payment = completedPayment(paymentId, userId, 100L, 200L, 55_000L);
     given(paymentRepository.findByIdAndUserId(paymentId, userId)).willReturn(Optional.of(payment));
+    given(ticketRestClient.isTicketUsed(anyLong())).willReturn(false);
     given(paymentCancelClientRouter.cancel(any()))
         .willThrow(new BusinessException(ErrorStatus.PAYMENT_REFUND_FAILED));
 
@@ -278,6 +337,7 @@ class PaymentCancelUseCaseTest {
 
     Payment payment = completedPayment(paymentId, userId, 100L, 200L, 55_000L);
     given(paymentRepository.findByIdAndUserId(paymentId, userId)).willReturn(Optional.of(payment));
+    given(ticketRestClient.isTicketUsed(anyLong())).willReturn(false);
     given(paymentCancelClientRouter.cancel(any()))
         .willReturn(new PaymentCancelResult("PG-REFUND-1", 55_000L, LocalDateTime.now()));
     given(paymentCancelPersister.persist(eq(paymentId), any(Refund.class)))
@@ -332,6 +392,7 @@ class PaymentCancelUseCaseTest {
     final PaymentCancelRequest request = new PaymentCancelRequest("단순 변심");
     Payment payment = completedPayment(paymentId, userId, 100L, 200L, 55_000L);
     given(paymentRepository.findByIdAndUserId(paymentId, userId)).willReturn(Optional.of(payment));
+    given(ticketRestClient.isTicketUsed(anyLong())).willReturn(false);
     BusinessException rejected = new BusinessException(ErrorStatus.PAYMENT_REFUND_FAILED);
     given(paymentCancelClientRouter.cancel(any())).willThrow(rejected);
 

--- a/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/out/apiclient/TicketRestClientTest.java
+++ b/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/out/apiclient/TicketRestClientTest.java
@@ -1,0 +1,248 @@
+package com.ticketrush.boundedcontext.payment.out.apiclient;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.header;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withServerError;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withStatus;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+import com.ticketrush.global.config.CustomSecurityProperties;
+import com.ticketrush.global.exception.BusinessException;
+import com.ticketrush.global.status.ErrorStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestClient;
+
+class TicketRestClientTest {
+
+  private static final String BASE_URL = "http://localhost:8087";
+  private static final String INTERNAL_TOKEN = "test-token";
+  private static final long BOOKING_ID = 100L;
+  private static final String REQUEST_URL =
+      BASE_URL + "/api/v1/internal/ticket/bookings/" + BOOKING_ID;
+
+  private MockRestServiceServer mockServer;
+  private TicketRestClient client;
+
+  @BeforeEach
+  void setUp() {
+    RestClient.Builder builder = RestClient.builder().baseUrl(BASE_URL);
+    mockServer = MockRestServiceServer.bindTo(builder).build();
+
+    CustomSecurityProperties customSecurityProperties = new CustomSecurityProperties();
+    customSecurityProperties.setInternalToken(INTERNAL_TOKEN);
+
+    client = new TicketRestClient(builder.build(), customSecurityProperties);
+  }
+
+  private static String successBody(String ticketStatus) {
+    return String.join(
+        "\n",
+        "{",
+        "  \"is_success\": true,",
+        "  \"code\": \"COMMON_200\",",
+        "  \"message\": \"성공입니다.\",",
+        "  \"result\": {",
+        "    \"booking_id\": 100,",
+        "    \"ticket_status\": \"" + ticketStatus + "\"",
+        "  }",
+        "}");
+  }
+
+  /** ticket-service가 입장권 미발급 시 내려주는 에러 본문(공통 ApiResponse 형식). */
+  private static String ticketNotFoundBody() {
+    return String.join(
+        "\n",
+        "{",
+        "  \"is_success\": false,",
+        "  \"code\": \"TICKET_404_001\",",
+        "  \"message\": \"입장권을 찾을 수 없습니다.\"",
+        "}");
+  }
+
+  private void expectGetAndRespondWith(String ticketStatus) {
+    mockServer
+        .expect(requestTo(REQUEST_URL))
+        .andExpect(method(HttpMethod.GET))
+        .andExpect(header("X-Internal-Token", INTERNAL_TOKEN))
+        .andRespond(withSuccess(successBody(ticketStatus), MediaType.APPLICATION_JSON));
+  }
+
+  private void expectGetAndRespondWithStatus(HttpStatus status, String body) {
+    mockServer
+        .expect(requestTo(REQUEST_URL))
+        .andExpect(method(HttpMethod.GET))
+        .andExpect(header("X-Internal-Token", INTERNAL_TOKEN))
+        .andRespond(withStatus(status).contentType(MediaType.APPLICATION_JSON).body(body));
+  }
+
+  @Test
+  @DisplayName("성공: USED 입장권은 사용됨(true)으로 판정하고 X-Internal-Token을 전송한다")
+  void isTicketUsed_returns_true_for_used_ticket() {
+    expectGetAndRespondWith("USED");
+
+    assertThat(client.isTicketUsed(BOOKING_ID)).isTrue();
+
+    mockServer.verify();
+  }
+
+  @Test
+  @DisplayName("성공: UNUSED 입장권은 미사용(false)으로 판정한다")
+  void isTicketUsed_returns_false_for_unused_ticket() {
+    expectGetAndRespondWith("UNUSED");
+
+    assertThat(client.isTicketUsed(BOOKING_ID)).isFalse();
+
+    mockServer.verify();
+  }
+
+  @Test
+  @DisplayName("성공: CANCELED 입장권은 미사용(false)으로 판정한다 — 입장하지 않은 채 취소된 예매다")
+  void isTicketUsed_returns_false_for_canceled_ticket() {
+    expectGetAndRespondWith("CANCELED");
+
+    assertThat(client.isTicketUsed(BOOKING_ID)).isFalse();
+
+    mockServer.verify();
+  }
+
+  @Test
+  @DisplayName("실패: 알 수 없는 입장권 상태는 통과시키지 않는다 — 모르는 값을 미입장으로 낙관하면 정책이 뚫린다")
+  void isTicketUsed_rejects_unknown_status() {
+    expectGetAndRespondWith("CHECKED_IN");
+
+    assertThatThrownBy(() -> client.isTicketUsed(BOOKING_ID))
+        .isInstanceOf(BusinessException.class)
+        .hasFieldOrPropertyWithValue(
+            "errorStatus", ErrorStatus.PAYMENT_TICKET_COMMUNICATION_FAILED);
+
+    mockServer.verify();
+  }
+
+  @Test
+  @DisplayName("성공: TICKET_404_001(입장권 미발급)만 미입장(false)으로 해석한다")
+  void isTicketUsed_returns_false_when_ticket_not_issued() {
+    expectGetAndRespondWithStatus(HttpStatus.NOT_FOUND, ticketNotFoundBody());
+
+    assertThat(client.isTicketUsed(BOOKING_ID)).isFalse();
+
+    mockServer.verify();
+  }
+
+  @Test
+  @DisplayName("실패: 본문 없는 404(경로·라우팅 오설정)는 미입장으로 해석하지 않는다 — 정책이 조용히 무력화되면 안 된다")
+  void isTicketUsed_rejects_404_without_body() {
+    mockServer
+        .expect(requestTo(REQUEST_URL))
+        .andExpect(method(HttpMethod.GET))
+        .andExpect(header("X-Internal-Token", INTERNAL_TOKEN))
+        .andRespond(withStatus(HttpStatus.NOT_FOUND));
+
+    assertThatThrownBy(() -> client.isTicketUsed(BOOKING_ID))
+        .isInstanceOf(BusinessException.class)
+        .hasFieldOrPropertyWithValue(
+            "errorStatus", ErrorStatus.PAYMENT_TICKET_COMMUNICATION_FAILED);
+
+    mockServer.verify();
+  }
+
+  @Test
+  @DisplayName("실패: 다른 code의 404도 미입장으로 해석하지 않는다")
+  void isTicketUsed_rejects_404_with_other_code() {
+    expectGetAndRespondWithStatus(
+        HttpStatus.NOT_FOUND, "{\"is_success\": false, \"code\": \"COMMON_404\"}");
+
+    assertThatThrownBy(() -> client.isTicketUsed(BOOKING_ID))
+        .isInstanceOf(BusinessException.class)
+        .hasFieldOrPropertyWithValue(
+            "errorStatus", ErrorStatus.PAYMENT_TICKET_COMMUNICATION_FAILED);
+
+    mockServer.verify();
+  }
+
+  @Test
+  @DisplayName("실패: 토큰 불일치(403)는 통신 실패로 매핑해 취소를 거부한다(알 수 없으면 막는다)")
+  void isTicketUsed_maps_403_to_communication_failed() {
+    mockServer
+        .expect(requestTo(REQUEST_URL))
+        .andExpect(method(HttpMethod.GET))
+        .andExpect(header("X-Internal-Token", INTERNAL_TOKEN))
+        .andRespond(withStatus(HttpStatus.FORBIDDEN));
+
+    assertThatThrownBy(() -> client.isTicketUsed(BOOKING_ID))
+        .isInstanceOf(BusinessException.class)
+        .hasFieldOrPropertyWithValue(
+            "errorStatus", ErrorStatus.PAYMENT_TICKET_COMMUNICATION_FAILED);
+
+    mockServer.verify();
+  }
+
+  @Test
+  @DisplayName("실패: ticket-service 5xx는 통신 실패로 매핑한다")
+  void isTicketUsed_maps_5xx_to_communication_failed() {
+    mockServer
+        .expect(requestTo(REQUEST_URL))
+        .andExpect(method(HttpMethod.GET))
+        .andExpect(header("X-Internal-Token", INTERNAL_TOKEN))
+        .andRespond(withServerError());
+
+    assertThatThrownBy(() -> client.isTicketUsed(BOOKING_ID))
+        .isInstanceOf(BusinessException.class)
+        .hasFieldOrPropertyWithValue(
+            "errorStatus", ErrorStatus.PAYMENT_TICKET_COMMUNICATION_FAILED);
+
+    mockServer.verify();
+  }
+
+  @Test
+  @DisplayName("실패: 200이지만 본문이 JSON이 아니면 원시 500이 아니라 통신 실패로 매핑한다")
+  void isTicketUsed_maps_unparsable_body_to_communication_failed() {
+    mockServer
+        .expect(requestTo(REQUEST_URL))
+        .andExpect(method(HttpMethod.GET))
+        .andExpect(header("X-Internal-Token", INTERNAL_TOKEN))
+        .andRespond(withSuccess("<html>gateway error</html>", MediaType.TEXT_HTML));
+
+    assertThatThrownBy(() -> client.isTicketUsed(BOOKING_ID))
+        .isInstanceOf(BusinessException.class)
+        .hasFieldOrPropertyWithValue(
+            "errorStatus", ErrorStatus.PAYMENT_TICKET_COMMUNICATION_FAILED);
+
+    mockServer.verify();
+  }
+
+  @Test
+  @DisplayName("실패: 200이지만 result 본문이 비어 있으면 통신 실패로 매핑한다")
+  void isTicketUsed_maps_empty_result_to_communication_failed() {
+    String responseBody =
+        String.join(
+            "\n",
+            "{",
+            "  \"is_success\": true,",
+            "  \"code\": \"COMMON_200\",",
+            "  \"message\": \"성공입니다.\",",
+            "  \"result\": null",
+            "}");
+
+    mockServer
+        .expect(requestTo(REQUEST_URL))
+        .andExpect(method(HttpMethod.GET))
+        .andExpect(header("X-Internal-Token", INTERNAL_TOKEN))
+        .andRespond(withSuccess(responseBody, MediaType.APPLICATION_JSON));
+
+    assertThatThrownBy(() -> client.isTicketUsed(BOOKING_ID))
+        .isInstanceOf(BusinessException.class)
+        .hasFieldOrPropertyWithValue(
+            "errorStatus", ErrorStatus.PAYMENT_TICKET_COMMUNICATION_FAILED);
+
+    mockServer.verify();
+  }
+}


### PR DESCRIPTION
## 🔗 관련 이슈

- close #416

---

## 📌 주요 변경 사항

- 결제 취소 API(`POST /api/v1/payment/{paymentId}/cancel`)가 PG 취소 전 입장권 사용 여부(ticket=USED)를 확인해, 입장 완료한 예매의 환불을 거절하도록 보강
- 결제 취소가 booking을 우회해 #399의 "입장 완료 예매 환불 차단" 정책이 뚫리던 문제 해소 — 착석한 좌석(`ticket=USED`)이 환불 이벤트로 `seat=AVAILABLE` 반환되어 재판매되던 정합성 버그 차단
- 사용자용 API로 확정하고 booking 경로(#399)와 동일 규율(fail-closed) 적용

---

## 🛠 상세 구현 내용

- **`TicketRestClient` 신설**(payment `out/apiclient`): booking #399 동명 클라이언트를 이식. `GET /api/v1/internal/ticket/bookings/{bookingId}`를 `X-Internal-Token` 헤더로 동기 조회. **fail-closed("알 수 없으면 막는다")** — `USED`만 차단, `TICKET_404_001`(미발급)·`UNUSED`·`CANCELED`만 취소 허용, 그 외 404/5xx/타임아웃/비-JSON/미지 상태는 모두 `PAYMENT_503_002`로 수렴
- **`PaymentCancelUseCase` 가드 삽입**: COMPLETED 확정 직후·PG 취소 직전에 USED 차단(PG 왕복과 동일하게 트랜잭션 밖 조회). CANCELED 멱등 조기반환이 가드보다 앞이라 이미 취소된 건은 ticket을 조회하지 않음
- **`ErrorStatus` 신규 2건**: `PAYMENT_409_003`(입장 예매 환불 거절), `PAYMENT_503_002`(입장권 조회 통신 실패)
- **`ticketServiceRestClient` Bean**: 단일 행 조회 전용으로 짧은 예산(connect 1s / read 2s) — ticket-service 지연 시 취소 요청이 톰캣 스레드를 오래 붙잡아 결제 경로까지 마르는 것을 방지
- **yml**: `service.ticket.*` + `custom.security.internal-token` 추가(base 기본값 有 / prod fail-fast). 내부 API는 게이트웨이 미라우팅(#367)이라 URL은 ticket-service **직접 주소**여야 함을 주석 명시

---

## ✅ 테스트

### 테스트 방법

- `./gradlew :payment-service:test`
- 신설 `TicketRestClientTest`(HTTP 계약, MockRestServiceServer): USED/UNUSED/CANCELED, TICKET_404_001 미발급, 본문없는 404·다른 code 404, 403/5xx/비-JSON/빈 result/미지 상태 → 503 매핑
- 보강 `PaymentCancelUseCaseTest`: USED 차단 시 PG 취소 `never()`, 통신실패(503) 시 PG 미호출, CANCELED 멱등 시 ticket 미조회

### 테스트 결과

- payment-service: 171 통과 / 0 실패 ✅

### 📸 스크린샷

- 

---

## 👀 리뷰 요청 사항

- fail-closed 트레이드오프: ticket-service 다운/지연 시 정상 환불까지 503으로 거부됩니다. "좌석 재판매 방지 > 일시적 취소 불가"로 의도한 설계이며, 짧은 타임아웃(1s/2s)으로 스레드 고갈을 완화했습니다. 모니터링/억제 메트릭·관리자 강제환불 우회 경로는 이슈 범위 밖으로 후속 논의 대상입니다(리뷰 이월).
- booking과 `TicketRestClient`/DTO ~130줄 중복은 이슈 본문이 "동명 클라이언트 같은 계약이면 된다"로 용인한 부분입니다. 공통화(booking까지 포함)는 별도 리팩토링 이슈로 이월했습니다.

---

## ⚠️ 배포 시 주의사항

- **prod 환경변수 필수 주입**: `TICKET_SERVICE_URL`(ticket-service **직접 주소** — 게이트웨이 주소 금지), `INTERNAL_API_TOKEN`(booking/performance/user/auth와 공유하는 내부 토큰). 미주입 시 부팅 실패(URL) 또는 ticket 조회 401 → **결제 취소 전건 503 거부**로 이어집니다.
- 스키마 변경 없음(ticket 조회만 추가) — DB 마이그레이션 불필요.
