### PR TITLE
[Infra] #408 엔티티↔스키마 스냅샷 drift를 CI가 감지하게 한다

### DIFF
--- a/.github/workflows/schema-validate.yml
+++ b/.github/workflows/schema-validate.yml
@@ -1,0 +1,139 @@
+name: Schema Validate
+
+# 엔티티와 초기 스키마 스냅샷(deploy/mysql/init/001-ticket-rush-schema.sql)의 drift를 PR 단계에서 잡는다 (#408).
+# local 프로파일은 ddl-auto=update라 로컬에선 증상이 없고, ./gradlew test는 H2를 쓴다.
+# prod(validate)에서만 부팅 실패로 터지므로, 여기서 prod와 동일한 validate 부팅을 재현해 미리 떨어뜨린다.
+#
+# 동작: 빈 MySQL에 스냅샷을 로드한 뒤, 엔티티(테이블 매핑)를 가진 서비스를 ddl-auto=validate 로 부팅한다.
+#   - 스키마가 엔티티와 정합하면 "Started ...Application" 도달 → 통과
+#   - 어긋나면 Hibernate가 SchemaManagementException("missing column [x] in table [y]")으로 조기 실패 → 잡힘
+# gateway(DB 미사용)와 auth(@Entity 0개, 테이블은 user-service 소유)는 검증 대상이 아니라 제외한다.
+# 아래 env 는 부팅에 필요한 더미 시크릿일 뿐 실제 값이 아니다(검증은 스키마 정합성뿐, 외부 연동 없음).
+# 한계: validate 는 컬럼 존재/타입은 잡지만 컬럼 길이·인덱스·유니크/FK·nullable 차이는 검출하지 않는다.
+
+on:
+  pull_request:
+    branches: [ "develop" ]
+    types: [opened, synchronize, reopened]
+
+concurrency:
+  group: schema-validate-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  schema-validate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    services:
+      mysql:
+        image: mysql:8.0
+        env:
+          MYSQL_ROOT_PASSWORD: ci-root-pw
+          MYSQL_DATABASE: ticket_rush
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping -h 127.0.0.1 -uroot -pci-root-pw"
+          --health-interval=5s
+          --health-timeout=5s
+          --health-retries=20
+      redis:
+        image: redis:7-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd="redis-cli ping"
+          --health-interval=5s
+          --health-timeout=5s
+          --health-retries=20
+
+    # 부팅에 필요한 더미 시크릿(실제 값 아님). local 프로파일이 localhost:3306 MySQL / localhost:6379 Redis 를 가리키므로
+    # 그대로 재사용하고, ddl-auto 만 validate 로 덮어쓴다. Kafka 는 validate(EMF 초기화)가 리스너 기동보다 앞서 도달하므로 불필요.
+    env:
+      SPRING_PROFILES_ACTIVE: local
+      SPRING_JPA_HIBERNATE_DDL_AUTO: validate
+      MYSQL_USERNAME: root
+      MYSQL_PASSWORD: ci-root-pw
+      INTERNAL_API_TOKEN: ci-dummy-internal-token
+      GATEWAY_INTERNAL_TOKEN: ci-dummy-gateway-token
+      TICKET_QR_SECRET: ci-dummy-ticket-qr-secret-value-0123456789
+
+    steps:
+      - name: 코드 가져오기
+        uses: actions/checkout@v4
+
+      - name: JDK 21 설치
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+          cache: 'gradle'
+
+      - name: Gradle 권한 부여
+        run: chmod +x gradlew
+
+      - name: MySQL 클라이언트 설치
+        # 러너 이미지 버전에 따라 mysql CLI 사전설치 여부가 흔들리므로 명시 설치한다.
+        run: sudo apt-get update && sudo apt-get install -y default-mysql-client
+
+      - name: 스키마 스냅샷 로드
+        # GitHub Actions service 컨테이너는 initdb 볼륨 마운트가 제약이 크므로, mysql 클라이언트로 직접 적재한다.
+        run: |
+          mysql -h 127.0.0.1 -P 3306 -uroot -pci-root-pw ticket_rush \
+            < deploy/mysql/init/001-ticket-rush-schema.sql
+          echo "로드된 테이블 수:"
+          mysql -h 127.0.0.1 -P 3306 -uroot -pci-root-pw -N \
+            -e "SELECT COUNT(*) FROM information_schema.tables WHERE table_schema='ticket_rush';"
+
+      - name: bootJar 빌드
+        run: ./gradlew bootJar
+
+      - name: validate 부팅 검증 (엔티티 보유 서비스)
+        run: |
+          set -u
+          # "서비스:포트" 목록. 엔티티(테이블 매핑)를 가진 서비스만. 새 DB 서비스 추가 시 여기에 함께 추가해야 한다.
+          SERVICES="user:18081 performance:18083 seat:18086 booking:18084 payment:18085 ticket:18087"
+          mkdir -p schema-validate-logs
+          FAIL=0
+          for pair in $SERVICES; do
+            svc="${pair%%:*}"
+            port="${pair##*:}"
+            log="schema-validate-logs/${svc}.log"
+            java -jar "${svc}-service/build/libs/${svc}-service-0.0.1-SNAPSHOT.jar" \
+              --server.port="${port}" > "$log" 2>&1 &
+            pid=$!
+            for _ in $(seq 1 120); do
+              if grep -qE "Started .*Application|SchemaManagementException|APPLICATION FAILED TO START" "$log"; then break; fi
+              if ! kill -0 "$pid" 2>/dev/null; then break; fi
+              sleep 1
+            done
+            kill "$pid" 2>/dev/null || true
+            wait "$pid" 2>/dev/null || true
+
+            if grep -qE "Started .*Application" "$log"; then
+              echo "✅ ${svc}: 스키마 검증 통과"
+            elif grep -qE "SchemaManagementException|Schema validation|missing (column|table)|wrong column type" "$log"; then
+              echo "❌ ${svc}: 스키마 drift — 엔티티와 스냅샷(deploy/mysql/init/001-ticket-rush-schema.sql)이 어긋났습니다."
+              grep -nE "SchemaManagementException|Schema validation|missing (column|table)|wrong column type" "$log" | head -20 || true
+              FAIL=1
+            else
+              echo "❌ ${svc}: 부팅 실패(스키마 무관 원인일 수 있음) — 아래 로그 확인."
+              grep -nE "Could not resolve placeholder|APPLICATION FAILED TO START|Caused by:" "$log" | head -20 || true
+              echo "---- ${svc} 로그 tail ----"
+              tail -20 "$log" || true
+              FAIL=1
+            fi
+          done
+          if [ "$FAIL" -ne 0 ]; then
+            echo "스키마 스냅샷이 엔티티를 따라가지 못했거나 검증 부팅이 실패했습니다. 엔티티 변경 시 스냅샷 재생성이 필요합니다(infra/mysql/README.md 절차)."
+            exit 1
+          fi
+          echo "모든 대상 서비스가 스냅샷 스키마로 validate 부팅에 성공했습니다."
+
+      - name: 검증 로그 업로드
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: schema-validate-logs
+          path: schema-validate-logs/

--- a/deploy/mysql/init/001-ticket-rush-schema.sql
+++ b/deploy/mysql/init/001-ticket-rush-schema.sql
@@ -21,7 +21,6 @@ CREATE TABLE `booking` (
   `confirmed_at` datetime(6) DEFAULT NULL,
   `refund_failed_at` datetime(6) DEFAULT NULL,
   `performance_id` bigint NOT NULL,
-  `refund_failed_at` datetime(6) DEFAULT NULL,
   `seat_id` bigint NOT NULL,
   `user_id` bigint NOT NULL,
   `version` bigint NOT NULL DEFAULT '0',
@@ -257,7 +256,6 @@ CREATE TABLE `ticket` (
   `ticket_status` enum('CANCELED','UNUSED','USED') COLLATE utf8mb4_unicode_ci NOT NULL,
   `ticket_token_hash` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL,
   `used_at` datetime(6) DEFAULT NULL,
-  `user_id` bigint DEFAULT NULL,
   PRIMARY KEY (`ticket_id`),
   UNIQUE KEY `UKgco27k8cbs8j67db3oadbna6o` (`booking_id`),
   UNIQUE KEY `UKgbou3cclxytcn7k5xlag9s0n8` (`ticket_token_hash`)


### PR DESCRIPTION
## 🔗 관련 이슈

- close #408

---

## 📌 주요 변경 사항

- 엔티티와 초기 스키마 스냅샷(`deploy/mysql/init/001-ticket-rush-schema.sql`)이 어긋나면 **PR 단계 CI가 실패**하도록 `schema-validate.yml` 워크플로우 추가
- 지금은 drift를 CI가 못 잡고 **prod(`ddl-auto: validate`)에서만 부팅 실패로 터진다**(#380 재발 방지)
- 착수 중 발견한 **스냅샷 자체 결함**(중복 컬럼 2건)도 함께 제거 — 이대로면 빈 MySQL 로드가 "Duplicate column"으로 실패해 신규 배포·CI 검증 자체가 불가능했음

---

## 🛠 상세 구현 내용

**1) 스냅샷 중복 컬럼 제거** (`9e8bfa2`)
- `booking.refund_failed_at`(22·24행 중복 → 1개), `ticket.user_id`(256·260행 중복 → 1개). #380 수동 편집 때 삽입된 중복. 엔티티는 각 1개만 매핑하므로 제거만으로 정합. prod는 기존 data dir이라 init 미재실행 → 영향 없음

**2) drift 감지 워크플로우** (`ac70c85`, `.github/workflows/schema-validate.yml`)
- `pull_request → develop` 트리거, 기존 `ci.yml`과 concurrency 그룹 분리(무충돌)
- service 컨테이너 `mysql:8.0` + `redis:7`. 스냅샷을 `mysql` 클라이언트로 로드(Actions initdb 마운트 제약 회피)
- `./gradlew bootJar` 후, **엔티티 보유 6개 서비스**(user/performance/seat/booking/payment/ticket)를 `ddl-auto=validate`로 부팅
  - 정합 → `Started …Application` 도달 = 통과
  - drift → `SchemaManagementException`으로 조기 실패, **어느 테이블/컬럼**인지 로그·아티팩트로 노출
- `local` 프로파일 재사용(localhost mysql/redis) + `SPRING_JPA_HIBERNATE_DDL_AUTO=validate` override. 부팅용 더미 시크릿만 env로 주입(실값 아님)
- **Kafka 미포함**: validate(EMF 초기화)가 Kafka 리스너 기동보다 앞서 도달 → 브로커 없이도 검증 성립(로컬 실측)
- **auth 제외**: `@Entity` 0개(social_account/user_account 등 테이블은 user-service 소유)라 검증 이득 0 + OAuth/JWT/MAIL 더미 표면만 커짐 → 대상에서 제외
- 실패 시 **스키마 drift vs 비-스키마 부팅 실패를 분리 표기**(신호 오도 방지)

---

## ✅ 테스트

### 테스트 방법

- 자동화 단위/통합 테스트 대상 코드(서비스 모듈) 변경 없음(SQL·워크플로우 YAML만) → `./gradlew test` 대상 아님
- 대신 **로컬 MySQL로 워크플로우 로직을 그대로 프로토타입**해 검증:
  1. 중복 제거한 스냅샷을 빈 MySQL에 로드 → 16테이블 정상 생성(로드 성공)
  2. 6개 서비스를 `SPRING_PROFILES_ACTIVE=local SPRING_JPA_HIBERNATE_DDL_AUTO=validate`로 부팅 (Kafka 미기동)
  3. (음성) 스냅샷 DB에서 컬럼 DROP 후 재부팅

### 테스트 결과

- **완료조건 ②** 현재 develop 스냅샷: user/performance/seat/booking/payment/ticket **6/6 validate 통과**(Started 도달) ✅
- **완료조건 ①③** 음성 테스트: `ALTER TABLE ticket DROP COLUMN user_id` → `SchemaManagementException: Schema validation: missing column [user_id] in table [ticket]`로 실패 / `booking.refund_failed_at` DROP → `missing column [refund_failed_at] in table [booking]` 지목하며 `SCHEMA_DRIFT`로 분류 ✅
- Kafka 미기동 상태에서도 validate 도달 확인(브로커 불필요 실증)

### 📸 스크린샷

- 

---

## 👀 리뷰 요청 사항

- **validate 스코프 한계**: 컬럼 **존재/타입**은 검출하지만 **컬럼 길이·인덱스·유니크/FK·nullable 차이는 검출하지 않습니다**. 이 이슈 범위(컬럼 drift)와는 일치하나 "스키마 완전 일치"를 보장하진 않습니다(예: `varchar(50)↔varchar(200)`은 통과). 인덱스 drift(#412 류)는 별도 수단 필요
- **SSOT 일원화는 범위 밖**: 고아본 `infra/mysql/init/01-schema.sql`·`infra/mysql/README.md`·ADR 0003의 낡은 경로 참조 정리는 이 이슈 범위("스냅샷이 엔티티를 따라가는지 검사만")를 벗어나 **후속 이슈로 분리** 예정

---

## ⚠️ 배포 시 주의사항

- 프로덕션 런타임/스키마 변경 없음. 스냅샷 SQL은 중복 컬럼 제거뿐이라 기존 prod DB(기존 data dir, init 미재실행)에 영향 없음
- 신규 워크플로우는 PR 검증 전용 — 오탐 발생 시 워크플로우 파일 삭제만으로 기존 `ci.yml` 파이프라인 무영향
