### PR TITLE
[Chore] #433 version 컬럼의 DEFAULT를 columnDefinition으로 선언한다

### DIFF
--- a/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/domain/entity/Booking.java
+++ b/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/domain/entity/Booking.java
@@ -52,9 +52,14 @@ public class Booking extends AutoIdBaseEntity {
    * RefundRequestedEvent가 이중 발행된다. 이벤트 발행은 afterCommit이므로 늦은 커밋이 버전 충돌로 실패하면 이벤트도 나가지 않는다.
    * 단, expirePendingBookingById 벌크 UPDATE는 version을 증가시키지도 검사하지도 않는다 — PENDING 전용이라 환불
    * 경로(CONFIRMED/REFUNDING)와는 겹치지 않지만, confirm-vs-expire 경합은 이 락의 보호 밖이다(기존 한계, ADR 0005).
+   *
+   * columnDefinition으로 DEFAULT 0을 명시하는 이유는 스키마 스냅샷 때문이다(#433). Hibernate는 DEFAULT를 만들지
+   * 않는데, version을 명시하지 않는 시딩 SQL은 DEFAULT가 없으면 ERROR 1364로 깨진다. 매핑에 넣지 않으면 스냅샷을
+   * 재생성할 때마다 사람이 수동으로 넣어줘야 하고, validate CI는 DEFAULT 차이를 검출하지 못해 빠뜨려도 조용히
+   * 통과한다. 새 @Version 엔티티도 같은 방식으로 선언한다.
    */
   @Version
-  @Column(nullable = false)
+  @Column(nullable = false, columnDefinition = "bigint NOT NULL DEFAULT 0")
   private Long version;
 
   @Builder

--- a/booking-service/src/test/java/com/ticketrush/boundedcontext/booking/domain/entity/BookingVersionDefaultTest.java
+++ b/booking-service/src/test/java/com/ticketrush/boundedcontext/booking/domain/entity/BookingVersionDefaultTest.java
@@ -1,0 +1,34 @@
+package com.ticketrush.boundedcontext.booking.domain.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+
+/**
+ * {@code Booking.version}의 {@code columnDefinition}이 실제로 DDL에 {@code DEFAULT 0}을 만드는지 검증한다(#433).
+ *
+ * <p>이 보장이 깨지면 {@code version}을 명시하지 않는 시딩 SQL이 {@code ERROR 1364}로 깨진다. {@code schema-validate}
+ * CI의 {@code ddl-auto=validate}는 DEFAULT 차이를 검출하지 못하므로 여기서 잡는다.
+ */
+@DataJpaTest
+class BookingVersionDefaultTest {
+
+  @Autowired private EntityManager entityManager;
+
+  @Test
+  @DisplayName("Hibernate가 생성한 booking.version 컬럼에 DEFAULT 0이 붙는다 (#433)")
+  void versionColumn_HasDefaultZero() {
+    Object columnDefault =
+        entityManager
+            .createNativeQuery(
+                "SELECT column_default FROM information_schema.columns "
+                    + "WHERE table_name = 'BOOKING' AND column_name = 'VERSION'")
+            .getSingleResult();
+
+    assertThat(columnDefault).asString().contains("0");
+  }
+}

--- a/deploy/mysql/README.md
+++ b/deploy/mysql/README.md
@@ -69,21 +69,7 @@ init SQL은 **빈 DB의 최초 기동에만** 실행된다. 이미 데이터가 
 
    (gateway는 datasource가 없어 제외한다.)
 
-4. **낙관적 락 컬럼의 `DEFAULT`를 넣는다.** Hibernate DDL은 `DEFAULT`를 만들지 않지만, 스냅샷의
-   `version` 컬럼에는 `DEFAULT '0'`이 있어야 한다 — `version`을 명시하지 않는 시딩 SQL
-   (`load-test/seed/seed_load.sql`, `load-tests/fixtures/seat-layouts-120.sql`)이 없으면 `ERROR 1364`로
-   깨진다. 이 값은 ADR의 운영 `ALTER`(`... ADD COLUMN version bigint NOT NULL DEFAULT 0`)를 친 prod DB
-   형태를 반영한 것이므로, 덤프 전에 임시 DB에도 같은 상태를 만든다.
-
-   ```sh
-   docker exec -e MYSQL_PWD=snapshot mysql-snapshot mysql -uroot ticket_rush -e "
-     ALTER TABLE booking MODIFY version bigint NOT NULL DEFAULT 0;
-     ALTER TABLE seat    MODIFY version bigint NOT NULL DEFAULT 0;"
-   ```
-
-   > `@Version` 엔티티를 새로 추가했다면 여기에도 함께 추가한다. 현재 대상은 `Booking`(#397)·`Seat`(#427)뿐이다.
-
-5. 덤프한다. `--skip-comments`는 버전·타임스탬프 헤더를 지운다.
+4. 덤프한다. `--skip-comments`는 버전·타임스탬프 헤더를 지운다.
    `sed`는 테이블별 `AUTO_INCREMENT=<n>` 시작값을 지운다 — 덤프를 뜬 DB에 몇 행이 있었는지가
    그대로 굳어 재현이 깨지기 때문이다(컬럼의 `AUTO_INCREMENT` 속성 자체는 남는다).
    `DROP TABLE IF EXISTS`는 **지우지 않는다**(mysqldump 기본) — 현재 스냅샷이 그 형태다.
@@ -95,14 +81,17 @@ init SQL은 **빈 DB의 최초 기동에만** 실행된다. 이미 데이터가 
      > deploy/mysql/init/001-ticket-rush-schema.sql
    ```
 
-6. 인덱스·제약·`DEFAULT`가 들어갔는지 확인한다.
+5. 인덱스·제약·`DEFAULT`가 들어갔는지 확인한다.
+
+   `version` 컬럼의 `DEFAULT 0`은 엔티티의 `columnDefinition`이 만들어주므로(#433) 수동 작업이 필요 없다.
+   다만 빠지면 시딩 SQL이 `ERROR 1364`로 깨지고 `validate` CI는 이를 검출하지 못하므로, 여기서 눈으로 확인한다.
 
    ```sh
    grep -E "idx_seat_performance_id|uk_seat_layout_performance_id" deploy/mysql/init/001-ticket-rush-schema.sql
    grep -c "NOT NULL DEFAULT '0'" deploy/mysql/init/001-ticket-rush-schema.sql   # @Version 엔티티 수와 일치해야 한다
    ```
 
-7. 정리한다.
+6. 정리한다.
 
    ```sh
    docker rm -f mysql-snapshot

--- a/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/domain/entity/Seat.java
+++ b/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/domain/entity/Seat.java
@@ -104,9 +104,14 @@ public class Seat extends AutoIdBaseEntity {
    * 이 불변식이 깨지면(= HOLD 좌석을 더티 체킹으로 고치는 UseCase를 추가하거나, 위 두 곳의 clearAutomatically를 끄거나,
    * AVAILABLE/SOLD 행에 발화하는 벌크 UPDATE를 추가하면) stale 엔티티가 충돌 없이 덮어써 버전 검사가 조용히 무력화된다.
    * 그때는 JPQL UPDATE VERSIONED를 검토한다(booking도 같은 한계를 안고 있다 — ADR 0005).
+   *
+   * columnDefinition으로 DEFAULT 0을 명시하는 이유는 스키마 스냅샷 때문이다(#433). Hibernate는 DEFAULT를 만들지
+   * 않는데, version을 명시하지 않는 시딩 SQL(load-test/seed/seed_load.sql 등)은 DEFAULT가 없으면 ERROR 1364로
+   * 깨진다. 매핑에 넣지 않으면 스냅샷을 재생성할 때마다 사람이 수동으로 DEFAULT를 넣어줘야 하고, validate CI는
+   * DEFAULT 차이를 검출하지 못해 빠뜨려도 조용히 통과한다. 새 @Version 엔티티도 같은 방식으로 선언한다.
    */
   @Version
-  @Column(nullable = false)
+  @Column(nullable = false, columnDefinition = "bigint NOT NULL DEFAULT 0")
   private Long version;
 
   @Builder

--- a/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/domain/entity/SeatVersionDefaultTest.java
+++ b/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/domain/entity/SeatVersionDefaultTest.java
@@ -1,0 +1,34 @@
+package com.ticketrush.boundedcontext.seat.domain.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+
+/**
+ * {@code Seat.version}의 {@code columnDefinition}이 실제로 DDL에 {@code DEFAULT 0}을 만드는지 검증한다(#433).
+ *
+ * <p>이 보장이 깨지면 {@code version}을 명시하지 않는 시딩 SQL(load-test/seed/seed_load.sql 등)이 {@code ERROR 1364}로
+ * 깨진다. {@code schema-validate} CI의 {@code ddl-auto=validate}는 DEFAULT 차이를 검출하지 못하므로 여기서 잡는다.
+ */
+@DataJpaTest
+class SeatVersionDefaultTest {
+
+  @Autowired private EntityManager entityManager;
+
+  @Test
+  @DisplayName("Hibernate가 생성한 seat.version 컬럼에 DEFAULT 0이 붙는다 (#433)")
+  void versionColumn_HasDefaultZero() {
+    Object columnDefault =
+        entityManager
+            .createNativeQuery(
+                "SELECT column_default FROM information_schema.columns "
+                    + "WHERE table_name = 'SEAT' AND column_name = 'VERSION'")
+            .getSingleResult();
+
+    assertThat(columnDefault).asString().contains("0");
+  }
+}


### PR DESCRIPTION
## 🔗 관련 이슈

- close #433

---

## 📌 주요 변경 사항

- `Booking.version`·`Seat.version`에 `columnDefinition = "bigint NOT NULL DEFAULT 0"` 추가 — Hibernate가 `DEFAULT`를 직접 생성하게 한다
- `deploy/mysql/README.md`의 "덤프 전 `DEFAULT` 수동 삽입" 단계 제거 (불필요해짐)
- 두 엔티티가 생성한 DDL의 `column_default`를 실제로 확인하는 테스트 추가

---

## 🛠 상세 구현 내용

**무엇이 문제였나.** 스냅샷의 `version bigint NOT NULL DEFAULT '0'`에서 그 `DEFAULT '0'`은 **Hibernate가 만든 게 아니다.** ADR 0005와 #427의 운영 `ALTER`(`... ADD COLUMN version bigint NOT NULL DEFAULT 0`)를 친 DB에서 덤프했기 때문에 남아 있던 값이다. 매핑은 `@Version @Column(nullable = false)`뿐이라 `ddl-auto`는 `version bigint not null`까지만 만든다.

**무엇이 깨지나.** 빈 DB에 `ddl-auto: update`로 스냅샷을 재생성하면 `DEFAULT`가 조용히 사라진다. 그러면 `version`을 명시하지 않는 시딩 SQL이 `ERROR 1364 (Field 'version' doesn't have a default value)`로 실패한다.

- `load-test/seed/seed_load.sql:77`
- `load-tests/fixtures/seat-layouts-120.sql:80`

**CI도 못 잡는다.** `schema-validate`(#408)의 `ddl-auto=validate`는 컬럼 존재·타입만 검사하고 `DEFAULT` 차이는 검출하지 않는다(워크플로 주석에 명시된 한계).

**왜 문서로는 부족한가.** #430에서 재생성 절차에 "덤프 전에 `DEFAULT`를 수동으로 넣어라"를 추가했지만, 이건 사람이 절차를 정확히 따를 때만 유지된다. 한 번 빠뜨리면 **CI가 통과한 채로 시딩만 조용히 깨지고** 원인을 찾기 어렵다. 매핑에 넣으면 Hibernate가 매번 만들어주므로 절차 의존이 사라진다.

**Booking과 Seat를 함께 바꿨다.** 한쪽만 바꾸면 두 `@Version` 엔티티의 매핑 패턴이 갈린다.

---

## ✅ 테스트

### 테스트 방법

- `SeatVersionDefaultTest`·`BookingVersionDefaultTest` 추가 — Hibernate가 생성한 DDL의 `column_default`를 `information_schema`로 직접 조회해 확인한다. **`validate` CI가 `DEFAULT` 차이를 못 잡으므로 이 테스트가 유일한 자동 방어선이다.**
- **역검증**: `columnDefinition`을 다시 빼고 돌려 테스트가 실제로 실패하는지 확인했다(무의미한 통과가 아님을 확인).
- `./gradlew build` (전체 모듈 + spotless + checkstyle)

### 테스트 결과

- `SeatVersionDefaultTest` 통과 / `BookingVersionDefaultTest` 통과
- 역검증: `columnDefinition` 제거 시 두 테스트 모두 `failures="1"`로 실패 → 매핑이 실제로 DDL을 바꾸고 있음이 확인됨
- `./gradlew build` — BUILD SUCCESSFUL (seat 92개, booking 138개 테스트 전부 통과, 실패·에러 0)
- 스냅샷 파일 자체는 변경하지 않았다 — 엔티티↔스냅샷 정합성은 `schema-validate` CI가 검증한다

### 📸 스크린샷

- (작성 필요)

---

## 👀 리뷰 요청 사항

- `columnDefinition`은 **DB 방언에 종속되는 문자열**입니다. 현재 prod·CI·로컬이 MySQL 8이고 테스트는 H2인데 `bigint NOT NULL DEFAULT 0`은 양쪽 다 유효한 문법입니다. 방언이 갈릴 계획이 있다면 알려주세요.
- 검증은 H2로 했습니다(로컬 Docker 미가동). MySQL에서도 같은 DDL이 나가지만 실제 확인은 못 했습니다 — 다음에 스냅샷을 재생성하는 분이 `DEFAULT`가 살아 있는지 봐주시면 좋겠습니다.

---

## ⚠️ 배포 시 주의사항

- **운영 DB에 실행할 DDL이 없습니다.** prod의 두 `version` 컬럼에는 이미 `DEFAULT 0`이 들어 있습니다(ADR 0005의 `ALTER`, #427의 `ALTER`). 이 변경은 앞으로 Hibernate가 만드는 DDL만 바꿉니다.
- 스키마 스냅샷도 변경하지 않았습니다 — 이미 `DEFAULT '0'`이 들어 있어 정합합니다.
