### PR TITLE
[Fix] #409 준비 체크가 크래시 루프를 정상으로 판정한다

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -223,10 +223,6 @@ jobs:
             -f deploy/docker-compose.prod.yml
           )
 
-          "${COMPOSE[@]}" config -q
-          "${COMPOSE[@]}" pull
-          "${COMPOSE[@]}" up -d --remove-orphans
-
           EXPECTED_SERVICES=(
             mysql
             redis
@@ -255,27 +251,43 @@ jobs:
           )
 
           declare -A APPLICATION_SERVICE_SET
+          declare -A PREVIOUS_CONTAINER_IDS
           declare -A BASE_RESTART_COUNTS
 
           for SERVICE in "${APPLICATION_SERVICES[@]}"; do
             APPLICATION_SERVICE_SET["${SERVICE}"]=true
           done
 
+          "${COMPOSE[@]}" config -q
+
+          echo "Snapshotting container restart counts before deployment."
+
           for SERVICE in "${EXPECTED_SERVICES[@]}"; do
-            CONTAINER_ID="$("${COMPOSE[@]}" ps -q "${SERVICE}")"
-
-            if [[ -z "${CONTAINER_ID}" ]]; then
-              echo "${SERVICE}: container not created"
-              "${COMPOSE[@]}" ps --all
-              exit 1
-            fi
-
-            BASE_RESTART_COUNTS["${SERVICE}"]="$(
-              docker inspect \
-                --format '{{.RestartCount}}' \
-                "${CONTAINER_ID}"
+            CONTAINER_ID="$(
+              "${COMPOSE[@]}" ps --all -q "${SERVICE}" 2>/dev/null || true
             )"
+
+            if [[ -n "${CONTAINER_ID}" ]] \
+              && docker inspect "${CONTAINER_ID}" > /dev/null 2>&1; then
+              PREVIOUS_CONTAINER_IDS["${SERVICE}"]="${CONTAINER_ID}"
+              BASE_RESTART_COUNTS["${SERVICE}"]="$(
+                docker inspect \
+                  --format '{{.RestartCount}}' \
+                  "${CONTAINER_ID}"
+              )"
+
+              echo \
+                "${SERVICE}: previous container=${CONTAINER_ID}, baseline RestartCount=${BASE_RESTART_COUNTS[$SERVICE]}"
+            else
+              PREVIOUS_CONTAINER_IDS["${SERVICE}"]=""
+              BASE_RESTART_COUNTS["${SERVICE}"]=0
+
+              echo "${SERVICE}: no previous container, baseline RestartCount=0"
+            fi
           done
+
+          "${COMPOSE[@]}" pull
+          "${COMPOSE[@]}" up -d --remove-orphans
 
           READY=false
           STABLE_PASSES=0
@@ -321,7 +333,14 @@ jobs:
                   "${CONTAINER_ID}"
               )"
 
-              BASE_RESTART_COUNT="${BASE_RESTART_COUNTS[$SERVICE]}"
+              PREVIOUS_CONTAINER_ID="${PREVIOUS_CONTAINER_IDS[$SERVICE]:-}"
+
+              if [[ -n "${PREVIOUS_CONTAINER_ID}" ]] \
+                && [[ "${CONTAINER_ID}" == "${PREVIOUS_CONTAINER_ID}" ]]; then
+                BASE_RESTART_COUNT="${BASE_RESTART_COUNTS[$SERVICE]:-0}"
+              else
+                BASE_RESTART_COUNT=0
+              fi
 
               if [[ "${STATUS}" != "running" ]]; then
                 echo "${SERVICE}: status=${STATUS}"
@@ -339,7 +358,11 @@ jobs:
               fi
 
               if (( RESTART_COUNT > BASE_RESTART_COUNT )); then
-                echo "${SERVICE}: restart count increased from ${BASE_RESTART_COUNT} to ${RESTART_COUNT}"
+                RESTART_DELTA=$((RESTART_COUNT - BASE_RESTART_COUNT))
+
+                echo \
+                  "::error::${SERVICE}: RestartCount=${RESTART_COUNT}, baseline=${BASE_RESTART_COUNT}, increased=${RESTART_DELTA} during deployment"
+
                 ALL_READY=false
                 RESTART_DETECTED=true
               fi


### PR DESCRIPTION
## 🔗 관련 이슈

- close #409

---

## 📌 주요 변경 사항

- GitHub Actions CD의 컨테이너 준비 상태 검사에 배포 중 컨테이너 재시작 감지 로직을 추가했습니다.
- 배포 전 컨테이너 ID와 `RestartCount`를 저장하고, 배포 후 값과 비교하도록 변경했습니다.
- 컨테이너가 배포 도중 한 번이라도 재시작하면 순간적으로 `running` 상태이더라도 정상으로 판정하지 않고 배포를 실패 처리합니다.
- 기존 컨테이너에 누적된 `RestartCount`는 배포 전 기준값으로 사용하여 정상 재배포가 오탐으로 실패하지 않도록 처리했습니다.
- 이미지 변경 등으로 새 컨테이너가 생성된 경우에는 기준 `RestartCount`를 `0`으로 적용합니다.
- 재시작이 감지된 경우 서비스명, 배포 전 기준값, 현재값, 증가량을 GitHub Actions 로그에 출력하도록 개선했습니다.
- 모든 컨테이너가 준비된 이후에도 연속 6회 안정 상태를 유지해야 배포 성공으로 처리하도록 준비 상태 검사를 강화했습니다.

---

## 🛠 상세 구현 내용

### 배포 전 컨테이너 상태 저장

`docker compose pull`과 `docker compose up`을 실행하기 전에 애플리케이션 서비스별로 다음 정보를 저장합니다.

- 기존 컨테이너 ID
- 기존 `RestartCount`

기존 컨테이너가 존재하지 않는 서비스는 기준값을 `0`으로 설정합니다.

### 컨테이너 교체 여부에 따른 기준값 적용

배포 후 컨테이너 ID를 다시 확인하여 배포 전후 컨테이너가 동일한지 비교합니다.

- 배포 전후 컨테이너 ID가 동일한 경우  
  → 기존에 저장한 `RestartCount`를 기준값으로 사용

- 배포 전후 컨테이너 ID가 다른 경우  
  → 새로 생성된 컨테이너이므로 기준값을 `0`으로 사용

이를 통해 이전 장애로 누적된 재시작 횟수와 이번 배포 도중 새로 발생한 재시작을 구분합니다.

### 배포 중 RestartCount 증가 감지

컨테이너 준비 상태 검사에서 서비스별로 다음 값을 확인합니다.

- 컨테이너 실행 상태
- Health 상태
- `OOMKilled` 여부
- 현재 `RestartCount`
- Spring Boot 시작 완료 로그

현재 `RestartCount`가 배포 전 기준값보다 증가한 경우 해당 컨테이너가 배포 도중 종료 후 다시 시작된 것으로 판단합니다.

재시작이 감지되면 다음 형식으로 오류를 출력합니다.

> `<service>: RestartCount=<current>, baseline=<baseline>, increased=<difference> during deployment`

출력 예시:

> `booking-service: RestartCount=1, baseline=0, increased=1 during deployment`

재시작이 확인되면 컨테이너가 현재 `running` 상태이더라도 준비 완료로 판정하지 않고 배포를 실패 처리합니다.

### 크래시 루프의 running 상태 오판 방지

기존 방식에서는 컨테이너가 반복적으로 종료되고 재시작하는 과정에서 잠시 `running` 상태가 되면 정상으로 오판할 가능성이 있었습니다.

변경 후에는 다음 조건을 모두 만족해야 준비 완료로 판단합니다.

- 컨테이너가 생성되어 있음
- 컨테이너 상태가 `running`
- Healthcheck가 있는 경우 `healthy`
- `OOMKilled=false`
- 배포 중 `RestartCount` 증가 없음
- Spring Boot 시작 완료 로그 확인
- 모든 서비스가 연속 6회 안정 상태 유지

### Spring Boot 시작 완료 확인

다음 애플리케이션 서비스는 Docker 실행 상태뿐 아니라 Spring Boot의 시작 완료 로그도 확인합니다.

- gateway-service
- auth-service
- user-service
- booking-service
- payment-service
- performance-service
- ticket-service
- seat-service

확인하는 로그 형식은 다음과 같습니다.

> `Started *Application in * seconds`

컨테이너가 `running` 상태이더라도 Spring Boot 시작 완료가 확인되지 않으면 준비 완료로 처리하지 않습니다.

### 연속 안정 상태 검사

모든 컨테이너가 한 번 준비 완료로 확인됐다고 즉시 배포 성공으로 처리하지 않습니다.

전체 서비스가 연속 6회의 준비 상태 검사를 통과해야 최종 준비 완료로 판단합니다.

> `Stable readiness pass 1/6`  
> `Stable readiness pass 2/6`  
> `Stable readiness pass 3/6`  
> `Stable readiness pass 4/6`  
> `Stable readiness pass 5/6`  
> `Stable readiness pass 6/6`

검사 도중 하나의 서비스라도 준비되지 않은 상태가 되면 연속 성공 횟수를 초기화합니다.

### 배포 실패 시 진단 정보 출력

컨테이너 재시작이 감지되거나 제한 시간 내에 준비되지 않은 경우 다음 정보를 출력합니다.

- 재시작한 서비스명
- 배포 전 기준 `RestartCount`
- 현재 `RestartCount`
- 배포 중 증가한 재시작 횟수
- Spring Boot 시작 미확인 서비스
- 전체 Docker Compose 컨테이너 상태
- 각 서비스의 최근 로그

이를 통해 GitHub Actions 로그에서 배포 실패 서비스를 바로 확인할 수 있도록 했습니다.

### 변경 범위

이번 이슈에서는 다음 파일만 수정했습니다.

- `.github/workflows/cd.yml`

각 서비스의 비즈니스 로직, 엔티티 및 DB 스키마는 수정하지 않았습니다.

검증 과정에서 확인된 `seat-service`, `booking-service`의 스키마 검증 실패는 기존 운영 DB와 현재 애플리케이션 스키마 사이의 불일치 문제이며, 본 PR의 변경 범위에는 포함하지 않습니다.

---

## ✅ 테스트

### 테스트 방법

#### 1. 원격 배포 스크립트 문법 검사

GitHub Actions의 EC2 원격 실행 스크립트를 추출하여 Bash 5.2 환경에서 문법 검사를 수행했습니다.

- `bash -n` 실행
- `git diff --check` 실행

#### 2. 배포 중 재시작 감지 테스트

EC2에서 테스트 대상 컨테이너의 호스트 PID를 강제 종료하여 Docker 재시작 정책에 따른 실제 컨테이너 재시작을 발생시켰습니다.

테스트 순서:

1. 배포 전 `RestartCount=0` 저장
2. 컨테이너의 호스트 PID 강제 종료
3. Docker의 자동 재시작 확인
4. 현재 `RestartCount=1` 확인
5. 배포 전 기준값과 현재값 비교
6. 증가량 감지 후 실패 처리 확인

#### 3. 기존 누적 RestartCount 오탐 방지 테스트

이전 테스트로 `RestartCount=1`이 누적된 컨테이너를 그대로 사용하여 정상 상태 검사를 다시 수행했습니다.

테스트 순서:

1. 기존 누적 `RestartCount=1`을 배포 전 기준값으로 저장
2. 추가 재시작 없이 컨테이너 정상 상태 유지
3. 현재 `RestartCount=1` 확인
4. 기준값과 현재값이 동일하므로 재시작으로 판단하지 않는지 확인
5. 연속 6회 안정 상태 검사 통과 확인

#### 4. 실제 GitHub Actions CD 테스트

`feature/409` 브랜치에서 실제 GitHub Actions CD를 실행했습니다.

배포 중 애플리케이션의 스키마 검증 실패로 컨테이너가 반복 재시작하는 상황에서 변경된 CD가 해당 재시작을 감지하고 배포를 실패 처리하는지 확인했습니다.

---

### 테스트 결과

#### 원격 스크립트 문법 검사

> `REMOTE_SCRIPT syntax OK`

`git diff --check`도 오류 없이 통과했습니다.

#### 배포 중 재시작 감지

> `baseline RestartCount=0`  
> `RestartCount=1`  
> `increased=1`  
> `::error::user-service: RestartCount=1, baseline=0, increased=1 during deployment`  
> `PASS 1`

배포 중 컨테이너가 한 번이라도 재시작하면 현재 상태가 `running`이어도 정상으로 판정하지 않고 실패 처리하는 것을 확인했습니다.

#### 기존 누적 RestartCount 오탐 방지

> `new baseline RestartCount=1`  
> `Stable readiness pass 1/6`  
> `Stable readiness pass 2/6`  
> `Stable readiness pass 3/6`  
> `Stable readiness pass 4/6`  
> `Stable readiness pass 5/6`  
> `Stable readiness pass 6/6`  
> `PASS 2`  
> `FEATURE 409 FAST TEST PASSED`

기존에 누적된 `RestartCount`만으로 정상 컨테이너를 재시작 발생으로 오판하지 않는 것을 확인했습니다.

#### 실제 GitHub Actions CD 재시작 감지

`seat-service` 재시작 감지 결과:

> `seat-service: RestartCount=1, baseline=0, increased=1 during deployment`  
> `seat-service: Spring Boot startup not confirmed`  
> `A container restarted during deployment.`  
> `Containers did not become ready and remain stable.`

`booking-service` 재시작 감지 결과:

> `booking-service: RestartCount=1, baseline=0, increased=1 during deployment`  
> `booking-service: Spring Boot startup not confirmed`  
> `A container restarted during deployment.`  
> `Containers did not become ready and remain stable.`

실제 크래시 루프 상황에서 재시작한 서비스와 증가한 횟수를 로그에 출력하고 CD를 실패 처리하는 것을 확인했습니다.

---

## 완료 조건

- [x] 배포 도중 컨테이너가 재시작한 경우 CD가 실패한다.
- [x] 컨테이너가 재시작 직후 `running` 상태여도 정상으로 판정하지 않는다.
- [x] 재시작한 서비스명을 GitHub Actions 로그에서 확인할 수 있다.
- [x] 배포 전 기준 `RestartCount`를 로그에서 확인할 수 있다.
- [x] 현재 `RestartCount`를 로그에서 확인할 수 있다.
- [x] 배포 중 증가한 재시작 횟수를 로그에서 확인할 수 있다.
- [x] 기존에 누적된 `RestartCount` 때문에 정상 배포가 실패하지 않는다.
- [x] 새 컨테이너가 생성된 경우 기준 `RestartCount`를 `0`으로 처리한다.
- [x] Spring Boot 시작 완료 여부를 함께 확인한다.
- [x] 모든 서비스가 연속된 안정 상태 검사를 통과해야 배포 성공으로 처리한다.
- [x] 크래시 루프 상태의 배포를 성공으로 오판하지 않는다.
- [x] 실패 시 전체 컨테이너 상태와 서비스 로그를 출력한다.
- [x] 프로덕션 애플리케이션 코드 변경 없이 CD Workflow 범위에서 구현한다.