### PR TITLE
[Fix] #422 동시 confirm 시 COMPLETED 중복 생성 방지 unique 제약 스냅샷 복구

### DIFF
--- a/deploy/mysql/README.md
+++ b/deploy/mysql/README.md
@@ -29,7 +29,7 @@ prod MySQL이 **최초 기동할 때 1회** 실행한다.
 
 init SQL은 **빈 DB의 최초 기동에만** 실행된다. 이미 데이터가 있는 prod DB에는 수동 `ALTER`가 따로 필요하다.
 컬럼 추가·타입 변경은 `validate`가 검출하므로 **배포 전에 실행하지 않으면 기동이 실패한다.**
-수동 DDL은 관례상 해당 엔티티의 javadoc(예: `Seat`) 또는 ADR(예:
+수동 DDL은 관례상 해당 엔티티의 javadoc(예: `Seat`, `Payment.completedBookingId`) 또는 ADR(예:
 [ADR 0005](../../docs/adr/0005-refund-state-machine-and-recovery.md))에 적어둔다.
 
 ## 재생성 절차
@@ -69,7 +69,21 @@ init SQL은 **빈 DB의 최초 기동에만** 실행된다. 이미 데이터가 
 
    (gateway는 datasource가 없어 제외한다.)
 
-4. 덤프한다. `--skip-comments`는 버전·타임스탬프 헤더를 지운다.
+4. **수동 DDL을 재적용한다.** `ddl-auto=update`는 generated 컬럼을 만들지 못하므로, 이 단계를 빠뜨리면
+   덤프에서 수동 DDL분이 빠진 스냅샷이 만들어진다 — #422가 실제로 그렇게 유실됐던 사례다.
+   이 DDL의 SSOT는 `Payment.completedBookingId` javadoc 런북이다. 운영 런북의 `ALGORITHM`/`LOCK` 옵션은
+   일회용 임시 컨테이너라 여기서는 생략했다.
+
+   ```sh
+   docker exec -e MYSQL_PWD=snapshot mysql-snapshot mysql -uroot ticket_rush -e "
+     ALTER TABLE payment MODIFY COLUMN completed_booking_id BIGINT
+       GENERATED ALWAYS AS (CASE WHEN status = 'COMPLETED' THEN booking_id END) STORED;
+     ALTER TABLE payment ADD CONSTRAINT uk_payment_completed_booking UNIQUE (completed_booking_id);"
+   ```
+
+   수동 DDL이 새로 생기면 여기와 6번(아래) grep에도 추가한다. 현재 목록은 위 ⚠️ 절의 javadoc/ADR 관례를 따른다.
+
+5. 덤프한다. `--skip-comments`는 버전·타임스탬프 헤더를 지운다.
    `sed`는 테이블별 `AUTO_INCREMENT=<n>` 시작값을 지운다 — 덤프를 뜬 DB에 몇 행이 있었는지가
    그대로 굳어 재현이 깨지기 때문이다(컬럼의 `AUTO_INCREMENT` 속성 자체는 남는다).
    `DROP TABLE IF EXISTS`는 **지우지 않는다**(mysqldump 기본) — 현재 스냅샷이 그 형태다.
@@ -81,7 +95,7 @@ init SQL은 **빈 DB의 최초 기동에만** 실행된다. 이미 데이터가 
      > deploy/mysql/init/001-ticket-rush-schema.sql
    ```
 
-5. 인덱스·제약·`DEFAULT`가 들어갔는지 확인한다.
+6. 인덱스·제약·`DEFAULT`가 들어갔는지 확인한다.
 
    `version` 컬럼의 `DEFAULT 0`은 엔티티의 `columnDefinition`이 만들어주므로(#433) 수동 작업이 필요 없다.
    다만 빠지면 시딩 SQL이 `ERROR 1364`로 깨지고 `validate` CI는 이를 검출하지 못하므로, 여기서 눈으로 확인한다.
@@ -89,9 +103,10 @@ init SQL은 **빈 DB의 최초 기동에만** 실행된다. 이미 데이터가 
    ```sh
    grep -E "idx_seat_performance_id|uk_seat_layout_performance_id" deploy/mysql/init/001-ticket-rush-schema.sql
    grep -c "NOT NULL DEFAULT '0'" deploy/mysql/init/001-ticket-rush-schema.sql   # @Version 엔티티 수와 일치해야 한다
+   grep -E "uk_payment_completed_booking|GENERATED ALWAYS" deploy/mysql/init/001-ticket-rush-schema.sql  # #422 수동 DDL
    ```
 
-6. 정리한다.
+7. 정리한다.
 
    ```sh
    docker rm -f mysql-snapshot

--- a/deploy/mysql/init/001-ticket-rush-schema.sql
+++ b/deploy/mysql/init/001-ticket-rush-schema.sql
@@ -115,7 +115,7 @@ CREATE TABLE `payment` (
   `amount` bigint NOT NULL,
   `approval_number` varchar(100) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `booking_id` bigint NOT NULL,
-  `completed_booking_id` bigint DEFAULT NULL,
+  `completed_booking_id` bigint GENERATED ALWAYS AS ((case when (`status` = _utf8mb4'COMPLETED') then `booking_id` end)) STORED,
   `failure_code` varchar(50) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `failure_reason` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `paid_at` datetime(6) DEFAULT NULL,
@@ -128,6 +128,7 @@ CREATE TABLE `payment` (
   `user_id` bigint DEFAULT NULL,
   PRIMARY KEY (`payment_id`),
   UNIQUE KEY `UK6vew52c3hm7vwaiwfvt498x3` (`payment_key`),
+  UNIQUE KEY `uk_payment_completed_booking` (`completed_booking_id`),
   KEY `idx_payment_booking_id` (`booking_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;

--- a/payment-service/build.gradle
+++ b/payment-service/build.gradle
@@ -53,6 +53,11 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-kafka-test'
 
 	testImplementation 'com.h2database:h2'
+	// Testcontainers — uk_payment_completed_booking(generated 컬럼) 실 MySQL 검증 (#422)
+	// 버전은 Boot BOM(testcontainers-bom 2.x)이 관리한다. 1.x(구 좌표 org.testcontainers:mysql)는
+	// docker-java가 구식 Docker API(1.32)를 요구해 최신 Docker 데몬(최소 1.40)과 호환되지 않는다.
+	testImplementation 'org.testcontainers:testcontainers-junit-jupiter'
+	testImplementation 'org.testcontainers:testcontainers-mysql'
 	testImplementation 'org.springframework.boot:spring-boot-starter-actuator-test'
 	testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
 	testImplementation 'org.springframework.boot:spring-boot-starter-security-test'

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/domain/entity/Payment.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/domain/entity/Payment.java
@@ -85,7 +85,33 @@ public class Payment extends AutoIdBaseEntity {
    * unique 제약(uk_payment_completed_booking)으로 동일 booking에 서로 다른 paymentKey를 가진 confirm이 동시에 들어와도
    * COMPLETED 결제가 2건 생성되지 못하게 DB 레벨에서 막는다(#296, TOCTOU 최종 방어선). MySQL은 NULL을 unique 중복으로 보지 않으므로
    * CANCELED/FAILED 후 재결제는 허용된다. 값 계산과 unique 제약은 수동 DDL로만 관리하고(ddl-auto=update가 generated 컬럼을
-   * 만들지 못한다) 애플리케이션은 읽기만 하므로, insertable=false·updatable=false로 매핑한다. */
+   * 만들지 못한다) 애플리케이션은 읽기만 하므로, insertable=false·updatable=false로 매핑한다.
+   *
+   * 이 수동 DDL이 스키마 스냅샷(deploy/mysql/init)에서 누락돼 신규 초기화 DB에 방어선이 빠져 있던 것을
+   * 스냅샷에 복구했다(#422). 신규 초기화 DB는 init SQL이 만들어주므로, 아래 런북은 스냅샷 복구 전에
+   * 초기화된 기존 DB에만 사람이 직접 실행한다. 실행 전 점검 3가지:
+   *   -- ① EXTRA='STORED GENERATED'가 나오면 이미 적용된 DB다. (1)을 생략한다:
+   *   SELECT EXTRA FROM information_schema.COLUMNS WHERE TABLE_SCHEMA='ticket_rush'
+   *     AND TABLE_NAME='payment' AND COLUMN_NAME='completed_booking_id';
+   *   -- ② 인덱스가 나오면 (2)를 생략한다:
+   *   SELECT INDEX_NAME FROM information_schema.STATISTICS WHERE TABLE_SCHEMA='ticket_rush'
+   *     AND TABLE_NAME='payment' AND INDEX_NAME='uk_payment_completed_booking';
+   *   -- ③ 결과가 있으면 (2)가 ERROR 1062로 실패한다. 중복 COMPLETED 정리(어느 건이 진짜인지 CS 판단) 후 진행:
+   *   SELECT booking_id, COUNT(*) FROM payment WHERE status='COMPLETED'
+   *     GROUP BY booking_id HAVING COUNT(*) > 1;
+   *
+   *   -- (1) 일반 컬럼 → STORED generated 전환. MySQL 8.0에서 이 방향 MODIFY는 허용되지만 ALGORITHM=COPY
+   *   --     (테이블 리빌드)라 리빌드 동안 payment 쓰기가 차단된다 → 저트래픽 창에 실행.
+   *   --     기존 COMPLETED row의 값은 전환 시 자동 backfill된다.
+   *   ALTER TABLE payment MODIFY COLUMN completed_booking_id BIGINT
+   *     GENERATED ALWAYS AS (CASE WHEN status = 'COMPLETED' THEN booking_id END) STORED;
+   *   -- (2) unique 제약 추가. 보조 인덱스 생성이라 온라인(INPLACE·LOCK=NONE) 가능:
+   *   ALTER TABLE payment
+   *     ADD CONSTRAINT uk_payment_completed_booking UNIQUE (completed_booking_id),
+   *     ALGORITHM=INPLACE, LOCK=NONE;
+   *   -- 롤백: DROP INDEX uk_payment_completed_booking 후 MODIFY ... BIGINT NULL(일반 컬럼 전환, 무손실).
+   *   --     단 롤백 MODIFY도 generated↔일반 전환이라 (1)과 동일하게 ALGORITHM=COPY(쓰기 차단) —
+   *   --     장애 대응 중이라도 저트래픽 창에 실행한다. */
   @Column(name = "completed_booking_id", insertable = false, updatable = false)
   private Long completedBookingId;
 

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/out/repository/PaymentRepository.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/out/repository/PaymentRepository.java
@@ -14,7 +14,8 @@ public interface PaymentRepository extends JpaRepository<Payment, Long> {
   /*
    * 멱등 fallback에서 "먼저 확정된 COMPLETED 결제"를 조회한다. uk_payment_completed_booking 제약이 정상 적용된 환경에서는
    * booking당 COMPLETED가 최대 1건이지만, 제약이 누락된 비정상 환경에서도 IncorrectResultSizeDataAccessException으로
-   * 깨지지 않도록 findFirst(LIMIT 1)로 조회한다(#296).
+   * 깨지지 않도록 findFirst(LIMIT 1)로 조회한다(#296). 실제로 스키마 스냅샷에서 제약이 누락된 채 초기화될 수 있었던
+   * 사례가 있었고(#422) validate·CI 모두 unique 부재를 검출하지 못하므로, 이 방어는 유지한다.
    */
   Optional<Payment> findFirstByBookingIdAndStatus(Long bookingId, PaymentStatus status);
 

--- a/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/out/repository/PaymentCompletedBookingUniqueTest.java
+++ b/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/out/repository/PaymentCompletedBookingUniqueTest.java
@@ -1,0 +1,187 @@
+package com.ticketrush.boundedcontext.payment.out.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.ticketrush.boundedcontext.payment.domain.entity.Payment;
+import com.ticketrush.boundedcontext.payment.domain.types.PaymentProvider;
+import com.ticketrush.boundedcontext.payment.domain.types.PaymentStatus;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import javax.sql.DataSource;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.mysql.MySQLContainer;
+
+/**
+ * uk_payment_completed_booking(STORED generated 컬럼 + unique 제약)이 실제 MySQL에서 동일 booking의 COMPLETED
+ * 중복 생성을 막는지 검증한다(#422). 이 방어선은 수동 DDL로만 존재해 H2(ddl-auto)로는 재현되지 않으므로, #296 당시 예외 주입 단위 테스트({@code
+ * PaymentFacadeTest})로 대체했던 실 DB 검증을 Testcontainers로 보강한다.
+ *
+ * <p>적용하는 DDL은 {@link Payment#getCompletedBookingId()} javadoc 런북(DDL의 SSOT)과 동일한 문장이므로, 이 테스트 통과가
+ * 곧 운영 마이그레이션 런북의 MySQL 8.0 문법 검증을 겸한다. 런북이 바뀌면 이 테스트의 DDL도 함께 바꾼다.
+ *
+ * <p>Docker가 없는 환경에서는 이 테스트가 컨테이너 기동 실패로 깨진다. 의도된 fail-closed다 — silent skip을 허용하면 이 방어선이 CI에서 조용히
+ * 사라져도 아무도 모른다(#422가 잡은 스냅샷 누락과 같은 패턴).
+ */
+@DataJpaTest(properties = "spring.jpa.hibernate.ddl-auto=update")
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Testcontainers
+@Transactional(propagation = Propagation.NOT_SUPPORTED) // 스레드별 커밋이 필요해 테스트 트랜잭션을 끈다
+class PaymentCompletedBookingUniqueTest {
+
+  /* prod(deploy/docker-compose.prod.yml)와 동일한 mysql:8.0 + utf8mb4_unicode_ci로 맞춘다. */
+  @Container
+  private static final MySQLContainer MYSQL =
+      new MySQLContainer("mysql:8.0")
+          .withDatabaseName("ticket_rush")
+          .withCommand("--character-set-server=utf8mb4", "--collation-server=utf8mb4_unicode_ci");
+
+  @DynamicPropertySource
+  static void datasourceProperties(DynamicPropertyRegistry registry) {
+    registry.add("spring.datasource.url", MYSQL::getJdbcUrl);
+    registry.add("spring.datasource.username", MYSQL::getUsername);
+    registry.add("spring.datasource.password", MYSQL::getPassword);
+  }
+
+  @Autowired private PaymentRepository paymentRepository;
+  @Autowired private DataSource dataSource;
+
+  /* ddl-auto=update가 만든 일반 bigint 컬럼을 운영 런북과 동일한 DDL로 generated+unique 전환한다.
+   * (운영 기존 DB와 같은 출발 상태 → 같은 마이그레이션 경로를 그대로 검증)
+   * 적용 여부 판정도 런북 사전 점검 ②와 동일하게 information_schema로 한다 — JVM 상태(static 가드)에
+   * 의존하면 클래스 재실행 시 새 컨테이너에 DDL이 누락되는 footgun이 생긴다. @BeforeAll을 쓰지 않는 이유:
+   * @TestInstance(PER_CLASS)에서는 인스턴스 생성(=컨텍스트 로드)이 컨테이너 기동보다 먼저 일어난다. */
+  @BeforeEach
+  void applyManualDdlRunbook() {
+    JdbcTemplate jdbc = new JdbcTemplate(dataSource);
+    Integer constraintCount =
+        jdbc.queryForObject(
+            "SELECT COUNT(*) FROM information_schema.STATISTICS WHERE TABLE_SCHEMA = DATABASE() "
+                + "AND TABLE_NAME = 'payment' AND INDEX_NAME = 'uk_payment_completed_booking'",
+            Integer.class);
+    if (constraintCount != null && constraintCount > 0) {
+      return;
+    }
+    jdbc.execute(
+        "ALTER TABLE payment MODIFY COLUMN completed_booking_id BIGINT "
+            + "GENERATED ALWAYS AS (CASE WHEN status = 'COMPLETED' THEN booking_id END) STORED");
+    jdbc.execute(
+        "ALTER TABLE payment ADD CONSTRAINT uk_payment_completed_booking "
+            + "UNIQUE (completed_booking_id), ALGORITHM=INPLACE, LOCK=NONE");
+  }
+
+  @Test
+  @DisplayName("동일 booking에 COMPLETED 결제가 이미 있으면 두 번째 COMPLETED 저장은 unique 제약으로 거부된다")
+  void second_completed_payment_for_same_booking_is_rejected_by_unique_constraint() {
+    Long bookingId = 100L;
+    paymentRepository.saveAndFlush(completedPayment(bookingId, "pk-first-100"));
+
+    assertThatThrownBy(
+            () -> paymentRepository.saveAndFlush(completedPayment(bookingId, "pk-second-100")))
+        .isInstanceOf(DataIntegrityViolationException.class)
+        .hasMessageContaining("uk_payment_completed_booking");
+
+    assertThat(paymentRepository.countByBookingIdAndStatus(bookingId, PaymentStatus.COMPLETED))
+        .isEqualTo(1);
+  }
+
+  @Test
+  @DisplayName("동일 booking에 서로 다른 paymentKey로 동시 confirm 저장 시 COMPLETED는 1건만 생성된다")
+  void concurrent_completed_payments_for_same_booking_only_one_succeeds() throws Exception {
+    Long bookingId = 200L;
+    int threads = 2;
+    CyclicBarrier barrier = new CyclicBarrier(threads);
+    CountDownLatch done = new CountDownLatch(threads);
+    AtomicInteger success = new AtomicInteger();
+    AtomicInteger uniqueViolation = new AtomicInteger();
+    AtomicReference<Exception> unexpected = new AtomicReference<>();
+
+    ExecutorService executor = Executors.newFixedThreadPool(threads);
+    try {
+      for (int i = 0; i < threads; i++) {
+        String paymentKey = "pk-concurrent-200-" + i;
+        executor.submit(
+            () -> {
+              try {
+                barrier.await(); // 두 스레드가 동시에 INSERT를 시도하도록 정렬
+                paymentRepository.saveAndFlush(completedPayment(bookingId, paymentKey));
+                success.incrementAndGet();
+              } catch (DataIntegrityViolationException e) {
+                uniqueViolation.incrementAndGet();
+              } catch (Exception e) {
+                unexpected.compareAndSet(null, e); // 원인 진단용으로 보존해 아래 단언 메시지에 노출한다
+              } finally {
+                done.countDown();
+              }
+            });
+      }
+      assertThat(done.await(10, TimeUnit.SECONDS)).isTrue();
+    } finally {
+      executor.shutdownNow();
+    }
+
+    assertThat(unexpected.get()).as("unique 위반 외의 예기치 못한 예외").isNull();
+    assertThat(success.get()).isEqualTo(1);
+    assertThat(uniqueViolation.get()).isEqualTo(1);
+    assertThat(paymentRepository.countByBookingIdAndStatus(bookingId, PaymentStatus.COMPLETED))
+        .isEqualTo(1);
+  }
+
+  @Test
+  @DisplayName("FAILED는 completed_booking_id가 NULL이라 동일 booking에 여러 건 누적돼도 제약에 걸리지 않는다")
+  void failed_payments_do_not_collide_with_unique_constraint() {
+    Long bookingId = 300L;
+    paymentRepository.saveAndFlush(completedPayment(bookingId, "pk-completed-300"));
+    paymentRepository.saveAndFlush(failedPayment(bookingId));
+    paymentRepository.saveAndFlush(failedPayment(bookingId));
+
+    List<Payment> payments =
+        paymentRepository.findAll().stream()
+            .filter(p -> p.getBookingId().equals(bookingId))
+            .toList();
+    assertThat(payments).hasSize(3);
+    // generated 컬럼 값 검증: COMPLETED만 booking_id, FAILED는 NULL
+    assertThat(payments)
+        .filteredOn(p -> p.getStatus() == PaymentStatus.COMPLETED)
+        .allSatisfy(p -> assertThat(p.getCompletedBookingId()).isEqualTo(bookingId));
+    assertThat(payments)
+        .filteredOn(p -> p.getStatus() == PaymentStatus.FAILED)
+        .allSatisfy(p -> assertThat(p.getCompletedBookingId()).isNull());
+  }
+
+  private Payment completedPayment(Long bookingId, String paymentKey) {
+    return Payment.builder()
+        .bookingId(bookingId)
+        .userId(1L)
+        .seatId(1L)
+        .provider(PaymentProvider.TOSS)
+        .amount(10_000L)
+        .status(PaymentStatus.COMPLETED)
+        .paymentKey(paymentKey)
+        .build();
+  }
+
+  private Payment failedPayment(Long bookingId) {
+    return Payment.failed(
+        bookingId, 1L, 1L, PaymentProvider.TOSS, 10_000L, "PAYMENT_400_001", "PG 거절", null, null);
+  }
+}


### PR DESCRIPTION
## 🔗 관련 이슈

- close #422

---

## 📌 주요 변경 사항

- 스키마 스냅샷(`deploy/mysql/init/001-ticket-rush-schema.sql`)에 누락돼 있던 `completed_booking_id` STORED generated 컬럼 정의와 `uk_payment_completed_booking` unique 제약을 복구
- 기존 운영 DB용 마이그레이션 런북(사전 점검 3종 + ALTER 2건 + 롤백)을 `Payment.completedBookingId` javadoc에 기록 (DDL의 SSOT)
- 실 MySQL(Testcontainers, 팀 첫 도입)에서 동일 booking 동시 confirm 시 COMPLETED가 1건만 생성됨을 검증하는 통합 테스트 추가
- 스냅샷 재생성 절차(`deploy/mysql/README.md`)에 "수동 DDL 재적용" 단계를 삽입해 재생성 시 동일 drift가 재발하는 구조적 원인 차단

---

## 🛠 상세 구현 내용

- **스냅샷 복구**: 실제 MySQL 8.0에 현 스냅샷 적재 → 마이그레이션 DDL 적용 → `SHOW CREATE TABLE`/`mysqldump` 실측 문법을 그대로 반영(재생성 diff 노이즈 방지). 빈 DB 재적재 + 중복 COMPLETED 거부(ERROR 1062)/FAILED 누적 허용을 SQL로 검증함
- **마이그레이션 런북** (`Payment.java` javadoc): ① 컬럼 EXTRA 점검(#301 기적용 판별) ② 제약 존재 점검 ③ 중복 COMPLETED 사전 검출 → (1) 일반→STORED generated `MODIFY`(MySQL 8.0 허용, ALGORITHM=COPY라 쓰기 차단 → 저트래픽 창) (2) unique 추가(INPLACE·LOCK=NONE). 롤백도 COPY임을 경고 포함
- **통합 테스트** (`PaymentCompletedBookingUniqueTest`): `@DataJpaTest` + `@AutoConfigureTestDatabase(NONE)` + Testcontainers mysql:8.0(prod와 동일 collation). `ddl-auto=update`가 만든 일반 컬럼에 런북과 동일한 DDL을 적용해 **운영 기존 DB와 같은 마이그레이션 경로를 그대로 검증**. 순차 중복 거부 / 2스레드 동시 INSERT 1건만 성공 / FAILED 누적 비충돌 3케이스. Docker 부재 시 silent skip 대신 실패(fail-closed, 의도 javadoc 명시)
- **Testcontainers 좌표**: Boot 4.0.3 BOM이 관리하는 2.x(`testcontainers-junit-jupiter`/`testcontainers-mysql`, 버전 미명시). 1.x는 docker-java가 구식 Docker API(1.32)를 요구해 최신 Docker 데몬(최소 1.40)에서 실행 불가함을 실측 확인
- **`PaymentRepository.findFirst` 존치 재검토(이슈 완료조건)**: 존치 확정 — validate·CI 모두 unique 부재를 못 잡는다는 게 이번에 실증됐고 비용이 없음. 주석에 #422 이력 보강

---

## ✅ 테스트

### 테스트 방법

- `./gradlew :payment-service:test` (신규 `PaymentCompletedBookingUniqueTest` 3케이스 포함, 실 MySQL 8.0 컨테이너에서 실행)
- `./gradlew :payment-service:checkstyleMain :payment-service:checkstyleTest` + spotlessApply

### 테스트 결과

- payment-service: **175 통과 / 0 실패 / 0 스킵** ✅ (신규 3케이스 실 MySQL에서 실행 확인 — skip 아님)
- 동시 confirm 케이스: 성공 1 + `DataIntegrityViolationException` 1 + COMPLETED count=1 확인

### 📸 스크린샷

---

## 👀 리뷰 요청 사항

- Testcontainers **팀 첫 도입**입니다. fail-closed 방침(Docker 없으면 테스트 실패, silent skip 거부)이 팀 로컬 환경과 맞는지 봐주세요
- 시니어 셀프 리뷰 8건 중 7건 반영 완료(혼합 클래스패스 정렬, 롤백 경고, information_schema 멱등 가드 등). 스냅샷 재생성 완주 요구 1건은 실측 dump 검증으로 대체하고 거절

---

## ⚠️ 배포 시 주의사항

- **기존 운영 DB에는 수동 DDL 필수** (`Payment.completedBookingId` javadoc 런북 참조). 특히 (1) MODIFY는 ALGORITHM=COPY(리빌드 중 payment 쓰기 차단) → 저트래픽 창에 실행
- 실행 전 **#301 수동 DDL 기적용 여부**(점검 ①②)와 **중복 COMPLETED 존재 여부**(점검 ③) 확인 — 중복이 있으면 unique 추가가 실패하므로 정리 후 진행
- schema-validate CI는 이 제약의 부재를 검출하지 못함(validate 한계) — 런북·README grep이 유일한 방어
