### PR TITLE
[Feat] #298 예매 오픈 시각 기반 공연 상태 자동 전환 스케줄러 추가

### DIFF
--- a/deploy/mysql/init/001-ticket-rush-schema.sql
+++ b/deploy/mysql/init/001-ticket-rush-schema.sql
@@ -140,6 +140,7 @@ CREATE TABLE `performance` (
   `created_at` datetime(6) DEFAULT NULL,
   `updated_at` datetime(6) DEFAULT NULL,
   `address` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `booking_open_at` datetime(6) DEFAULT NULL,
   `deleted_at` datetime(6) DEFAULT NULL,
   `description` text COLLATE utf8mb4_unicode_ci,
   `duration_minutes` int NOT NULL,

--- a/performance-service/build.gradle
+++ b/performance-service/build.gradle
@@ -54,6 +54,10 @@ dependencies {
     // MapStruct
     implementation 'org.mapstruct:mapstruct:1.5.5.Final'
 
+    // ShedLock (스케줄러 분산 락)
+    implementation 'net.javacrumbs.shedlock:shedlock-spring:5.13.0'
+    implementation 'net.javacrumbs.shedlock:shedlock-provider-redis-spring:5.13.0'
+
     // AWS S3
     implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3:4.0.0'
 

--- a/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/app/dto/request/PerformanceCreateRequest.java
+++ b/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/app/dto/request/PerformanceCreateRequest.java
@@ -7,6 +7,7 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
 import lombok.Builder;
@@ -49,5 +50,11 @@ public record PerformanceCreateRequest(
     @Schema(description = "공연장 주소", example = "서울특별시 송파구 올림픽로 25 잠실종합운동장")
         @NotBlank(message = "공연장 주소는 필수입니다.")
         String address,
+    @Schema(
+            description = "예매 오픈 시각 (yyyy-MM-dd HH:mm:ss, 선택 — 미설정 시 자동 오픈 없이 수동 전환만 가능)",
+            example = "2027-08-01 20:00:00",
+            nullable = true)
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
+        LocalDateTime bookingOpenAt,
     @Schema(description = "편의시설 목록 (선택)", example = "[\"주차장\", \"수유실\", \"장애인석\"]", nullable = true)
         List<String> facilities) {}

--- a/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/app/dto/request/PerformancePatchRequest.java
+++ b/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/app/dto/request/PerformancePatchRequest.java
@@ -7,6 +7,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.Size;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 
 @Schema(description = "공연 정보 수정 요청 (null 필드는 수정하지 않음)")
@@ -39,4 +40,9 @@ public record PerformancePatchRequest(
     @Schema(description = "공연장 주소", example = "서울특별시 송파구 올림픽로 25 잠실종합운동장")
         @NullOrNotBlank
         @Size(max = 255, message = "주소는 255자를 초과할 수 없습니다.")
-        String address) {}
+        String address,
+    @Schema(
+            description = "예매 오픈 시각 (yyyy-MM-dd HH:mm:ss, null=수정 안 함 — 한 번 설정하면 해제 불가, 변경만 가능)",
+            example = "2027-08-01 20:00:00")
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
+        LocalDateTime bookingOpenAt) {}

--- a/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/app/dto/response/PerformanceDetailResponse.java
+++ b/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/app/dto/response/PerformanceDetailResponse.java
@@ -3,6 +3,7 @@ package com.ticketrush.boundedcontext.performance.app.dto.response;
 import com.ticketrush.boundedcontext.performance.domain.types.Genre;
 import com.ticketrush.boundedcontext.performance.domain.types.PerformanceStatus;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
 
@@ -19,6 +20,7 @@ public record PerformanceDetailResponse(
     Integer totalSeats,
     String address,
     PerformanceStatus performanceStatus,
+    LocalDateTime bookingOpenAt,
     String imageMainUrl,
     String image3dUrl,
     List<String> imageGalleryUrls,

--- a/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/app/scheduler/PerformanceStatusScheduler.java
+++ b/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/app/scheduler/PerformanceStatusScheduler.java
@@ -1,0 +1,30 @@
+package com.ticketrush.boundedcontext.performance.app.scheduler;
+
+import com.ticketrush.boundedcontext.performance.app.usecase.PerformanceOpenBookingUseCase;
+import lombok.RequiredArgsConstructor;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(
+    name = "app.scheduler.enabled",
+    havingValue = "true",
+    matchIfMissing = true) // test 프로파일은 Redis가 없어 false로 끈다
+public class PerformanceStatusScheduler {
+
+  private final PerformanceOpenBookingUseCase performanceOpenBookingUseCase;
+
+  // 정각 티켓 오픈 체감 지연을 줄이기 위해 10초 주기로 실행
+  @Scheduled(fixedDelay = 10000)
+  @SchedulerLock(
+      name = "schedulePerformanceOpenBookingLock",
+      lockAtLeastFor = "9s", // 서버 간 시계 오차(Clock Skew)로 인한 즉각적인 중복 실행 방지
+      lockAtMostFor = "1m" // 노드가 죽었을 때 락이 자동으로 풀리는 최대 시간
+      )
+  public void schedulePerformanceOpenBooking() {
+    performanceOpenBookingUseCase.execute();
+  }
+}

--- a/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/app/usecase/PerformanceOpenBookingUseCase.java
+++ b/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/app/usecase/PerformanceOpenBookingUseCase.java
@@ -1,0 +1,29 @@
+package com.ticketrush.boundedcontext.performance.app.usecase;
+
+import com.ticketrush.boundedcontext.performance.domain.types.PerformanceStatus;
+import com.ticketrush.boundedcontext.performance.out.repository.PerformanceRepository;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PerformanceOpenBookingUseCase {
+
+  private final PerformanceRepository performanceRepository;
+
+  @Transactional
+  public int execute() {
+    int openedCount =
+        performanceRepository.bulkTransitionStatusByBookingOpenAtDue(
+            PerformanceStatus.UPCOMING, PerformanceStatus.ON_SALE, LocalDateTime.now());
+
+    if (openedCount > 0) {
+      log.info("예매 오픈 시각 도래 공연 {}건을 ON_SALE 상태로 전환했습니다.", openedCount);
+    }
+    return openedCount;
+  }
+}

--- a/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/app/usecase/PerformancePatchUseCase.java
+++ b/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/app/usecase/PerformancePatchUseCase.java
@@ -32,6 +32,7 @@ public class PerformancePatchUseCase {
         request.durationMinutes(),
         request.price(),
         request.totalSeats(),
-        request.address());
+        request.address(),
+        request.bookingOpenAt());
   }
 }

--- a/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/domain/entity/Performance.java
+++ b/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/domain/entity/Performance.java
@@ -69,6 +69,10 @@ public class Performance extends AutoIdBaseEntity {
   @Column(nullable = false)
   private PerformanceStatus performanceStatus;
 
+  // null이면 자동 전환 대상이 아니며 어드민 수동 전환만 가능하다
+  @Column(name = "booking_open_at")
+  private LocalDateTime bookingOpenAt;
+
   private String image3dUrl;
 
   private String imageMainUrl;
@@ -102,6 +106,7 @@ public class Performance extends AutoIdBaseEntity {
       Long price,
       Integer totalSeats,
       String address,
+      LocalDateTime bookingOpenAt,
       String image3dUrl,
       String imageMainUrl,
       List<String> imageGalleryUrls,
@@ -116,6 +121,7 @@ public class Performance extends AutoIdBaseEntity {
     this.price = price;
     this.totalSeats = totalSeats;
     this.address = address;
+    this.bookingOpenAt = bookingOpenAt;
     this.image3dUrl = image3dUrl;
     this.imageMainUrl = imageMainUrl;
     this.imageGalleryUrls = imageGalleryUrls != null ? imageGalleryUrls : new ArrayList<>();
@@ -141,7 +147,8 @@ public class Performance extends AutoIdBaseEntity {
       Integer durationMinutes,
       Long price,
       Integer totalSeats,
-      String address) {
+      String address,
+      LocalDateTime bookingOpenAt) {
     if (title != null) {
       this.title = title;
     }
@@ -171,6 +178,9 @@ public class Performance extends AutoIdBaseEntity {
     }
     if (address != null) {
       this.address = address;
+    }
+    if (bookingOpenAt != null) {
+      this.bookingOpenAt = bookingOpenAt;
     }
   }
 

--- a/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/out/repository/PerformanceRepository.java
+++ b/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/out/repository/PerformanceRepository.java
@@ -1,13 +1,39 @@
 package com.ticketrush.boundedcontext.performance.out.repository;
 
 import com.ticketrush.boundedcontext.performance.domain.entity.Performance;
+import com.ticketrush.boundedcontext.performance.domain.types.PerformanceStatus;
+import java.time.LocalDateTime;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface PerformanceRepository
     extends JpaRepository<Performance, Long>, PerformanceRepositoryCustom {
 
   @EntityGraph(attributePaths = {"imageGalleryUrls", "facilities"})
   Optional<Performance> findDetailById(Long id);
+
+  /**
+   * 예매 오픈 시각이 도래한 공연을 벌크 전환한다.
+   *
+   * <p>벌크 JPQL은 {@code @SQLRestriction}이 적용되지 않으므로 deletedAt 조건을 명시한다. WHERE의 from 상태 가드는 어드민 수동
+   * 전환이 먼저 커밋된 경우(예: CANCELED)의 lost update를 막는다. 단 역방향 — 어드민 PATCH가 UPCOMING으로 로드한 사이 벌크가 ON_SALE
+   * 커밋 — 은 {@code @Version} 부재로 stale 값이 덮어쓸 수 있으나, 스케줄러가 10초 주기로 재실행되며 다음 주기에 self-heal 된다.
+   *
+   * <p>{@code clearAutomatically = true}가 호출 트랜잭션의 영속성 컨텍스트 전체를 비우므로, 엔티티를 로드하는 다른 트랜잭션에서 재사용하지 말고
+   * 스케줄러 전용으로만 호출해야 한다.
+   */
+  @Modifying(clearAutomatically = true)
+  @Query(
+      "UPDATE Performance p SET p.performanceStatus = :to, p.updatedAt = :now "
+          + "WHERE p.performanceStatus = :from "
+          + "AND p.bookingOpenAt IS NOT NULL AND p.bookingOpenAt <= :now "
+          + "AND p.deletedAt IS NULL")
+  int bulkTransitionStatusByBookingOpenAtDue(
+      @Param("from") PerformanceStatus from,
+      @Param("to") PerformanceStatus to,
+      @Param("now") LocalDateTime now);
 }

--- a/performance-service/src/main/java/com/ticketrush/global/config/ShedLockConfig.java
+++ b/performance-service/src/main/java/com/ticketrush/global/config/ShedLockConfig.java
@@ -1,0 +1,40 @@
+package com.ticketrush.global.config;
+
+import net.javacrumbs.shedlock.core.LockProvider;
+import net.javacrumbs.shedlock.provider.redis.spring.RedisLockProvider;
+import net.javacrumbs.shedlock.spring.annotation.EnableSchedulerLock;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+@EnableSchedulerLock(defaultLockAtMostFor = "50s")
+public class ShedLockConfig {
+
+  @Value("${spring.application.name:performance-service}")
+  private String applicationName;
+
+  private final Environment env;
+
+  // Environment Bean 주입
+  public ShedLockConfig(Environment env) {
+    this.env = env;
+  }
+
+  @Bean
+  public LockProvider lockProvider(RedisConnectionFactory connectionFactory) {
+    String[] activeProfiles = env.getActiveProfiles();
+
+    // 활성화된 프로파일이 있으면 첫 번째 값을, 없으면 "default"를 사용
+    String profile = activeProfiles.length > 0 ? activeProfiles[0] : "default";
+
+    // "performance-service-local" 형태로 조합됨
+    String keyPrefix = applicationName + "-" + profile;
+
+    return new RedisLockProvider(connectionFactory, keyPrefix);
+  }
+}

--- a/performance-service/src/main/resources/application-test.yml
+++ b/performance-service/src/main/resources/application-test.yml
@@ -25,3 +25,5 @@ spring:
 app:
   event-publisher:
     type: kafka
+  scheduler:
+    enabled: false

--- a/performance-service/src/test/java/com/ticketrush/boundedcontext/performance/in/api/v1/PerformanceCreateTest.java
+++ b/performance-service/src/test/java/com/ticketrush/boundedcontext/performance/in/api/v1/PerformanceCreateTest.java
@@ -13,6 +13,7 @@ import com.ticketrush.global.eventpublisher.EventPublisher;
 import com.ticketrush.global.util.S3UploadUtils;
 import com.ticketrush.shared.performance.event.PerformanceCreatedEvent;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
@@ -59,6 +60,7 @@ class PerformanceCreateTest {
             .price(50000L)
             .totalSeats(100)
             .address("서울")
+            .bookingOpenAt(LocalDateTime.of(2025, 8, 1, 20, 0))
             .build();
 
     MockMultipartFile mainImage =
@@ -85,6 +87,7 @@ class PerformanceCreateTest {
     var savedPerformance = performanceRepository.findById(response.performanceId()).orElseThrow();
 
     assertThat(savedPerformance.getTitle()).isEqualTo(request.title());
+    assertThat(savedPerformance.getBookingOpenAt()).isEqualTo(request.bookingOpenAt());
 
     assertThat(savedPerformance.getImageMainUrl()).isEqualTo(expectedMainUrl);
     assertThat(savedPerformance.getImage3dUrl()).isEqualTo(expectedModelUrl);

--- a/performance-service/src/test/java/com/ticketrush/boundedcontext/performance/in/api/v1/PerformanceGetDetailTest.java
+++ b/performance-service/src/test/java/com/ticketrush/boundedcontext/performance/in/api/v1/PerformanceGetDetailTest.java
@@ -16,6 +16,7 @@ import com.ticketrush.global.config.SecurityConfig;
 import com.ticketrush.global.exception.BusinessException;
 import com.ticketrush.global.status.ErrorStatus;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
@@ -50,6 +51,7 @@ class PerformanceGetDetailTest {
         500,
         "서울특별시 중구 세종대로 110",
         PerformanceStatus.ON_SALE,
+        LocalDateTime.of(2025, 8, 1, 20, 0),
         "https://s3.example.com/main.jpg",
         "https://s3.example.com/model.glb",
         List.of("https://s3.example.com/gallery1.jpg"),

--- a/performance-service/src/test/java/com/ticketrush/boundedcontext/performance/in/api/v1/PerformanceOpenBookingTest.java
+++ b/performance-service/src/test/java/com/ticketrush/boundedcontext/performance/in/api/v1/PerformanceOpenBookingTest.java
@@ -1,0 +1,126 @@
+package com.ticketrush.boundedcontext.performance.in.api.v1;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.ticketrush.boundedcontext.performance.app.usecase.PerformanceOpenBookingUseCase;
+import com.ticketrush.boundedcontext.performance.domain.entity.Performance;
+import com.ticketrush.boundedcontext.performance.domain.types.Genre;
+import com.ticketrush.boundedcontext.performance.domain.types.PerformanceStatus;
+import com.ticketrush.boundedcontext.performance.out.repository.PerformanceRepository;
+import com.ticketrush.global.eventpublisher.EventPublisher;
+import com.ticketrush.global.util.S3UploadUtils;
+import jakarta.persistence.EntityManager;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@EnableAutoConfiguration(
+    exclude = {
+      io.awspring.cloud.autoconfigure.s3.S3AutoConfiguration.class,
+      io.awspring.cloud.autoconfigure.core.AwsAutoConfiguration.class
+    })
+@Transactional
+class PerformanceOpenBookingTest {
+
+  @MockitoBean private S3UploadUtils s3UploadUtils;
+  @MockitoBean private EventPublisher eventPublisher;
+
+  @Autowired private PerformanceOpenBookingUseCase performanceOpenBookingUseCase;
+  @Autowired private PerformanceRepository performanceRepository;
+  @Autowired private EntityManager em;
+
+  private Performance savePerformance(LocalDateTime bookingOpenAt) {
+    return performanceRepository.save(
+        Performance.builder()
+            .title("공연명")
+            .performer("출연진")
+            .genre(Genre.CONCERT)
+            .description("설명")
+            .showDate(LocalDate.now().plusDays(30))
+            .showTime(LocalTime.of(19, 0))
+            .durationMinutes(120)
+            .price(50000L)
+            .totalSeats(100)
+            .address("서울")
+            .bookingOpenAt(bookingOpenAt)
+            .build());
+  }
+
+  private Performance refetch(Long performanceId) {
+    em.flush();
+    em.clear();
+    return performanceRepository.findById(performanceId).orElseThrow();
+  }
+
+  @Test
+  @DisplayName("오픈 시각이 도래한 UPCOMING 공연은 ON_SALE로 전환된다")
+  void openBooking_dueUpcoming_transitionsToOnSale() {
+    Performance performance = savePerformance(LocalDateTime.now().minusMinutes(1));
+
+    int openedCount = performanceOpenBookingUseCase.execute();
+
+    assertThat(openedCount).isEqualTo(1);
+    assertThat(refetch(performance.getId()).getPerformanceStatus())
+        .isEqualTo(PerformanceStatus.ON_SALE);
+  }
+
+  @Test
+  @DisplayName("오픈 시각이 아직 도래하지 않은 공연은 전환되지 않는다")
+  void openBooking_futureOpenAt_notTransitioned() {
+    Performance performance = savePerformance(LocalDateTime.now().plusHours(1));
+
+    int openedCount = performanceOpenBookingUseCase.execute();
+
+    assertThat(openedCount).isZero();
+    assertThat(refetch(performance.getId()).getPerformanceStatus())
+        .isEqualTo(PerformanceStatus.UPCOMING);
+  }
+
+  @Test
+  @DisplayName("오픈 시각이 설정되지 않은 공연은 전환 대상이 아니다")
+  void openBooking_nullOpenAt_notTransitioned() {
+    Performance performance = savePerformance(null);
+
+    int openedCount = performanceOpenBookingUseCase.execute();
+
+    assertThat(openedCount).isZero();
+    assertThat(refetch(performance.getId()).getPerformanceStatus())
+        .isEqualTo(PerformanceStatus.UPCOMING);
+  }
+
+  @Test
+  @DisplayName("어드민이 취소한(CANCELED) 공연은 오픈 시각이 도래해도 전환되지 않는다")
+  void openBooking_canceled_notTransitioned() {
+    Performance performance = savePerformance(LocalDateTime.now().minusMinutes(1));
+    performance.changeStatus(PerformanceStatus.CANCELED);
+    em.flush();
+
+    int openedCount = performanceOpenBookingUseCase.execute();
+
+    assertThat(openedCount).isZero();
+    assertThat(refetch(performance.getId()).getPerformanceStatus())
+        .isEqualTo(PerformanceStatus.CANCELED);
+  }
+
+  @Test
+  @DisplayName("소프트 삭제된 공연은 오픈 시각이 도래해도 전환되지 않는다")
+  void openBooking_softDeleted_notTransitioned() {
+    Performance performance = savePerformance(LocalDateTime.now().minusMinutes(1));
+    performance.softDelete();
+    em.flush();
+
+    int openedCount = performanceOpenBookingUseCase.execute();
+
+    assertThat(openedCount).isZero();
+  }
+}

--- a/performance-service/src/test/java/com/ticketrush/boundedcontext/performance/in/api/v1/PerformancePatchTest.java
+++ b/performance-service/src/test/java/com/ticketrush/boundedcontext/performance/in/api/v1/PerformancePatchTest.java
@@ -14,6 +14,7 @@ import com.ticketrush.global.status.ErrorStatus;
 import com.ticketrush.global.util.S3UploadUtils;
 import jakarta.persistence.EntityManager;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -41,6 +42,8 @@ class PerformancePatchTest {
   @Autowired private PerformanceRepository performanceRepository;
   @Autowired private EntityManager em;
 
+  private static final LocalDateTime ORIGINAL_BOOKING_OPEN_AT = LocalDateTime.of(2025, 8, 1, 20, 0);
+
   private Performance savePerformance() {
     return performanceRepository.save(
         Performance.builder()
@@ -54,6 +57,7 @@ class PerformancePatchTest {
             .price(50000L)
             .totalSeats(100)
             .address("서울")
+            .bookingOpenAt(ORIGINAL_BOOKING_OPEN_AT)
             .build());
   }
 
@@ -63,6 +67,7 @@ class PerformancePatchTest {
     Performance performance = savePerformance();
     LocalDate newShowDate = LocalDate.now().plusDays(60);
     LocalTime newShowTime = LocalTime.of(20, 0);
+    LocalDateTime newBookingOpenAt = LocalDateTime.of(2025, 9, 1, 20, 0);
 
     performancePatchUseCase.execute(
         performance.getId(),
@@ -76,7 +81,8 @@ class PerformancePatchTest {
             150,
             80000L,
             200,
-            "부산"));
+            "부산",
+            newBookingOpenAt));
 
     em.flush();
     em.clear();
@@ -92,6 +98,7 @@ class PerformancePatchTest {
     assertThat(updated.getPrice()).isEqualTo(80000L);
     assertThat(updated.getTotalSeats()).isEqualTo(200);
     assertThat(updated.getAddress()).isEqualTo("부산");
+    assertThat(updated.getBookingOpenAt()).isEqualTo(newBookingOpenAt);
   }
 
   @Test
@@ -102,7 +109,7 @@ class PerformancePatchTest {
     performancePatchUseCase.execute(
         performance.getId(),
         new PerformancePatchRequest(
-            "새로운 공연명", null, null, null, null, null, null, null, null, null));
+            "새로운 공연명", null, null, null, null, null, null, null, null, null, null));
 
     em.flush();
     em.clear();
@@ -113,13 +120,15 @@ class PerformancePatchTest {
     assertThat(updated.getGenre()).isEqualTo(Genre.CONCERT);
     assertThat(updated.getDescription()).isEqualTo("원래 설명");
     assertThat(updated.getPrice()).isEqualTo(50000L);
+    assertThat(updated.getBookingOpenAt()).isEqualTo(ORIGINAL_BOOKING_OPEN_AT);
   }
 
   @Test
   @DisplayName("존재하지 않는 공연 ID로 수정 요청 시 예외 발생")
   void patchPerformance_notFound() {
     PerformancePatchRequest request =
-        new PerformancePatchRequest("새 제목", null, null, null, null, null, null, null, null, null);
+        new PerformancePatchRequest(
+            "새 제목", null, null, null, null, null, null, null, null, null, null);
 
     assertThatThrownBy(() -> performancePatchUseCase.execute(999L, request))
         .isInstanceOf(BusinessException.class)


### PR DESCRIPTION
## 🔗 관련 이슈

- close #298

---

## 📌 주요 변경 사항

- `Performance`에 예매 오픈 시각 `bookingOpenAt`(nullable) 필드 추가 및 등록/수정 API·상세 응답 반영
- `@Scheduled`(10초 주기) + ShedLock(Redis) 스케줄러가 오픈 시각이 도래한 UPCOMING 공연을 ON_SALE로 자동 전환
- 스키마 스냅샷(`deploy/mysql/init/001-ticket-rush-schema.sql`)에 `booking_open_at` 컬럼 추가

---

## 🛠 상세 구현 내용

- **엔티티/DTO**: `Performance.bookingOpenAt` 추가. `null` = 자동 전환 대상 아님(수동 전환만) — 기존 데이터·시드 완전 하위호환. `PerformanceCreateRequest`/`PerformancePatchRequest`(null=미수정)/`PerformanceDetailResponse` 반영, 포맷 `yyyy-MM-dd HH:mm:ss`
- **전환 방식**: 벌크 조건부 UPDATE (`WHERE performanceStatus = UPCOMING AND bookingOpenAt <= now AND deletedAt IS NULL`, `updatedAt` 함께 세팅)
  - from 상태 가드가 어드민 수동 전환(예: CANCELED) 선행 커밋과의 lost update를 원자적으로 차단
  - 벌크 JPQL엔 `@SQLRestriction` 미적용이라 `deletedAt IS NULL` 명시
  - 역방향(어드민 PATCH가 stale UPCOMING을 덮어쓰는 경우)은 `@Version` 부재로 이론상 가능하나 10초 주기 재실행으로 self-heal (Javadoc 명시)
- **스케줄러**: `PerformanceStatusScheduler` — seat/booking 팀 패턴 동일(얇은 `@Component` → `PerformanceOpenBookingUseCase` 위임). `@SchedulerLock(lockAtLeastFor=9s, lockAtMostFor=1m)`으로 멀티 인스턴스 중복 실행 방지 + 벌크 UPDATE 멱등성으로 2중 방어
- **ShedLock 도입**: `performance-service`에 shedlock 5.13.0 의존성 추가, `ShedLockConfig` 이식(락 키 프리픽스 `performance-service-{profile}`)
- **테스트 프로파일**: `@ConditionalOnProperty(app.scheduler.enabled)`로 test에서 스케줄러 비활성(Redis 부재 소음 제거)
- **전이 규칙 무변경**: `PerformanceStatus.canTransitionTo`가 UPCOMING→ON_SALE을 이미 허용하므로 기존 어드민 수동 변경(`PerformanceChangeStatusUseCase`)과 충돌 없음

---

## ✅ 테스트

### 테스트 방법

- `./gradlew :performance-service:test`
- 신규 `PerformanceOpenBookingTest` 5케이스: 오픈 시각 도래 UPCOMING→ON_SALE 전환 / 미래 시각 미전환 / null 미전환 / CANCELED 미전환(어드민 취소 우선) / soft delete 미전환
- 기존 `PerformanceCreateTest`·`PerformancePatchTest`에 `bookingOpenAt` 저장·수정·null 유지 검증 추가

### 테스트 결과

- performance-service: 52 통과 / 0 실패 ✅

### 📸 스크린샷

- (작성 필요)

---

## 👀 리뷰 요청 사항

- 벌크 조건부 UPDATE가 도메인 메서드(`changeStatus`)를 우회하는 트레이드오프 — 원자적 상태 가드를 위한 의도적 선택인데 괜찮은지
- 스케줄러 주기 10초(정각 오픈 체감 지연 최대 ~10초)가 적절한지

---

## ⚠️ 배포 시 주의사항

- **prod는 `ddl-auto: validate`이므로 배포 전 수동 DDL 필수** (미반영 시 기동 실패):
  ```sql
  ALTER TABLE performance ADD COLUMN booking_open_at datetime(6) DEFAULT NULL, ALGORITHM=INPLACE, LOCK=NONE;
  ```
- performance-service가 이번부터 Redis를 락 저장소로 사용(ShedLock) — prod Redis 접속 설정은 기존 `application-prod.yml`에 이미 존재
- 후속 이슈 후보(별도 생성 예정): ① bookingOpenAt 해제(null 복귀) 수단 — 현재는 변경만 가능, ② `ShedLockConfig` common 모듈 승격(seat/performance 중복 제거)
