### PR TITLE
[Refactor] #221 공연 목록 조회 API 커서 페이징 전환

### DIFF
--- a/common/src/main/java/com/ticketrush/global/dto/request/CursorPageRequest.java
+++ b/common/src/main/java/com/ticketrush/global/dto/request/CursorPageRequest.java
@@ -1,13 +1,28 @@
 package com.ticketrush.global.dto.request;
 
 import static com.ticketrush.global.constants.PaginationConstants.DEFAULT_PAGE_SIZE;
+import static com.ticketrush.global.constants.PaginationConstants.MAX_PAGE_SIZE;
 
-public record CursorPageRequest(Long cursorId, Integer size) implements PaginationRequest {
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "커서 기반 페이징 요청 (무한 스크롤)")
+public record CursorPageRequest(
+    @Schema(description = "이전 응답의 nextCursor 값 (첫 페이지는 생략, 1 미만 값은 첫 페이지로 취급)", example = "42")
+        Long cursorId,
+    @Schema(description = "페이지 크기 (기본 10, 최대 50 — 초과 시 50으로 보정)", example = "10") Integer size)
+    implements PaginationRequest {
 
   // 컴팩트 생성자를 통한 기본값 설정
   public CursorPageRequest {
+    // 유효하지 않은 커서는 첫 페이지 요청으로 취급
+    if (cursorId != null && cursorId < 1) {
+      cursorId = null;
+    }
     if (size == null || size < 1) {
       size = DEFAULT_PAGE_SIZE;
+    }
+    if (size > MAX_PAGE_SIZE) {
+      size = MAX_PAGE_SIZE;
     }
   }
 }

--- a/common/src/main/java/com/ticketrush/global/status/ErrorStatus.java
+++ b/common/src/main/java/com/ticketrush/global/status/ErrorStatus.java
@@ -114,8 +114,7 @@ public enum ErrorStatus {
   PERFORMANCE_INVALID_STATUS_TRANSITION(
       HttpStatus.BAD_REQUEST, "PERFORMANCE_400_004", "유효하지 않은 공연 상태 전환입니다."),
   PERFORMANCE_NOT_ON_SALE(HttpStatus.BAD_REQUEST, "PERFORMANCE_400_005", "예매 가능한 공연이 아닙니다."),
-  PERFORMANCE_INVALID_SORT_PROPERTY(
-      HttpStatus.BAD_REQUEST, "PERFORMANCE_400_006", "허용되지 않은 정렬 필드입니다."),
+  // PERFORMANCE_400_006은 정렬 파라미터 제거(#221)로 결번
   PERFORMANCE_INVALID_PRICE_RANGE(
       HttpStatus.BAD_REQUEST, "PERFORMANCE_400_007", "최소 가격은 최대 가격보다 클 수 없습니다."),
 

--- a/common/src/test/java/com/ticketrush/global/dto/request/CursorPageRequestTest.java
+++ b/common/src/test/java/com/ticketrush/global/dto/request/CursorPageRequestTest.java
@@ -1,0 +1,45 @@
+package com.ticketrush.global.dto.request;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.ticketrush.global.constants.PaginationConstants;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class CursorPageRequestTest {
+
+  @Test
+  @DisplayName("size가 비어있거나 범위를 벗어나면 공통 기본값으로 보정한다")
+  void cursor_page_request_normalizes_invalid_size() {
+    CursorPageRequest request = new CursorPageRequest(1L, 0);
+
+    assertThat(request.cursorId()).isEqualTo(1L);
+    assertThat(request.size()).isEqualTo(PaginationConstants.DEFAULT_PAGE_SIZE);
+  }
+
+  @Test
+  @DisplayName("size가 공통 최대 크기를 초과하면 최대 크기로 보정한다")
+  void cursor_page_request_caps_size() {
+    CursorPageRequest request = new CursorPageRequest(1L, 1000);
+
+    assertThat(request.size()).isEqualTo(PaginationConstants.MAX_PAGE_SIZE);
+  }
+
+  @Test
+  @DisplayName("유효하지 않은 cursorId는 첫 페이지 요청(null)으로 보정한다")
+  void cursor_page_request_normalizes_invalid_cursor_id() {
+    CursorPageRequest request = new CursorPageRequest(0L, 10);
+
+    assertThat(request.cursorId()).isNull();
+    assertThat(request.size()).isEqualTo(10);
+  }
+
+  @Test
+  @DisplayName("cursorId가 없으면 첫 페이지 요청으로 유지한다")
+  void cursor_page_request_allows_null_cursor_id() {
+    CursorPageRequest request = new CursorPageRequest(null, 10);
+
+    assertThat(request.cursorId()).isNull();
+    assertThat(request.size()).isEqualTo(10);
+  }
+}

--- a/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/app/facade/PerformanceFacade.java
+++ b/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/app/facade/PerformanceFacade.java
@@ -15,10 +15,10 @@ import com.ticketrush.boundedcontext.performance.app.usecase.PerformancePatchUse
 import com.ticketrush.boundedcontext.performance.app.usecase.PerformanceValidateUseCase;
 import com.ticketrush.boundedcontext.performance.domain.types.Genre;
 import com.ticketrush.boundedcontext.performance.domain.types.PerformanceStatus;
+import com.ticketrush.global.dto.request.CursorPageRequest;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -43,9 +43,13 @@ public class PerformanceFacade {
     return performanceCreateUseCase.execute(request, mainImage, model3d, gallery);
   }
 
-  public Page<PerformanceListResponse> getPerformances(
-      Genre genre, Long minPrice, Long maxPrice, PerformanceStatus status, Pageable pageable) {
-    return performanceGetListUseCase.execute(genre, minPrice, maxPrice, status, pageable);
+  public Slice<PerformanceListResponse> getPerformances(
+      Genre genre,
+      Long minPrice,
+      Long maxPrice,
+      PerformanceStatus status,
+      CursorPageRequest pageRequest) {
+    return performanceGetListUseCase.execute(genre, minPrice, maxPrice, status, pageRequest);
   }
 
   public PerformanceDetailResponse getPerformanceDetail(Long performanceId) {

--- a/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/app/usecase/PerformanceGetListUseCase.java
+++ b/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/app/usecase/PerformanceGetListUseCase.java
@@ -5,11 +5,11 @@ import com.ticketrush.boundedcontext.performance.app.mapper.PerformanceMapper;
 import com.ticketrush.boundedcontext.performance.domain.types.Genre;
 import com.ticketrush.boundedcontext.performance.domain.types.PerformanceStatus;
 import com.ticketrush.boundedcontext.performance.out.repository.PerformanceRepository;
+import com.ticketrush.global.dto.request.CursorPageRequest;
 import com.ticketrush.global.exception.BusinessException;
 import com.ticketrush.global.status.ErrorStatus;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -21,13 +21,18 @@ public class PerformanceGetListUseCase {
   private final PerformanceMapper performanceMapper;
 
   @Transactional(readOnly = true)
-  public Page<PerformanceListResponse> execute(
-      Genre genre, Long minPrice, Long maxPrice, PerformanceStatus status, Pageable pageable) {
+  public Slice<PerformanceListResponse> execute(
+      Genre genre,
+      Long minPrice,
+      Long maxPrice,
+      PerformanceStatus status,
+      CursorPageRequest pageRequest) {
 
     validatePriceRange(minPrice, maxPrice);
 
     return performanceRepository
-        .findByFilters(genre, minPrice, maxPrice, status, pageable)
+        .findByFilters(
+            genre, minPrice, maxPrice, status, pageRequest.cursorId(), pageRequest.size())
         .map(performanceMapper::toListResponse);
   }
 

--- a/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/in/api/v1/PerformanceController.java
+++ b/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/in/api/v1/PerformanceController.java
@@ -5,6 +5,7 @@ import com.ticketrush.boundedcontext.performance.app.dto.response.PerformanceLis
 import com.ticketrush.boundedcontext.performance.app.facade.PerformanceFacade;
 import com.ticketrush.boundedcontext.performance.domain.types.Genre;
 import com.ticketrush.boundedcontext.performance.domain.types.PerformanceStatus;
+import com.ticketrush.global.dto.request.CursorPageRequest;
 import com.ticketrush.global.dto.response.ApiResponse;
 import com.ticketrush.global.status.SuccessStatus;
 import io.swagger.v3.oas.annotations.Operation;
@@ -15,13 +16,11 @@ import jakarta.validation.constraints.PositiveOrZero;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springdoc.core.annotations.ParameterObject;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
-import org.springframework.data.web.PageableDefault;
+import org.springframework.data.domain.Slice;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -44,6 +43,10 @@ public class PerformanceController {
 
           슬라이드 영역과 그리드 목록 모두 이 API를 사용합니다.
 
+          **커서 페이징(무한 스크롤):** 최신 등록순(performanceId 내림차순) 고정 정렬입니다.
+          첫 요청은 cursorId 없이 호출하고, 응답 `paginationInfo.nextCursor`를
+          다음 요청의 cursorId로 전달합니다. `hasNext=false`면 마지막 페이지입니다.
+
           **장르 코드:**
           | 코드 | 설명 |
           |------|------|
@@ -63,14 +66,13 @@ public class PerformanceController {
       @Parameter(description = "최대 가격") @PositiveOrZero @RequestParam(required = false)
           Long maxPrice,
       @Parameter(description = "공연 상태 필터") @RequestParam(required = false) PerformanceStatus status,
-      @ParameterObject
-          @PageableDefault(size = 8, sort = "createdAt", direction = Sort.Direction.DESC)
-          Pageable pageable) {
+      @ParameterObject @ModelAttribute CursorPageRequest pageRequest) {
 
-    Page<PerformanceListResponse> performances =
-        performanceFacade.getPerformances(genre, minPrice, maxPrice, status, pageable);
+    Slice<PerformanceListResponse> performances =
+        performanceFacade.getPerformances(genre, minPrice, maxPrice, status, pageRequest);
 
-    return ApiResponse.onSuccess(SuccessStatus.OK, performances);
+    return ApiResponse.onSuccess(
+        SuccessStatus.OK, performances, PerformanceListResponse::performanceId);
   }
 
   @Operation(summary = "공연 상세 조회", description = "공연 ID로 상세 정보를 조회합니다. 인증 없이 누구나 접근 가능합니다.")

--- a/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/out/repository/PerformanceRepositoryCustom.java
+++ b/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/out/repository/PerformanceRepositoryCustom.java
@@ -3,11 +3,10 @@ package com.ticketrush.boundedcontext.performance.out.repository;
 import com.ticketrush.boundedcontext.performance.domain.entity.Performance;
 import com.ticketrush.boundedcontext.performance.domain.types.Genre;
 import com.ticketrush.boundedcontext.performance.domain.types.PerformanceStatus;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 
 public interface PerformanceRepositoryCustom {
 
-  Page<Performance> findByFilters(
-      Genre genre, Long minPrice, Long maxPrice, PerformanceStatus status, Pageable pageable);
+  Slice<Performance> findByFilters(
+      Genre genre, Long minPrice, Long maxPrice, PerformanceStatus status, Long cursorId, int size);
 }

--- a/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/out/repository/PerformanceRepositoryCustom.java
+++ b/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/out/repository/PerformanceRepositoryCustom.java
@@ -7,6 +7,9 @@ import org.springframework.data.domain.Slice;
 
 public interface PerformanceRepositoryCustom {
 
+  /**
+   * 커서 기반 공연 목록 조회. size는 양수를 전제한다 — 정규화(기본값·상한 캡)는 웹 계층의 {@code CursorPageRequest} 컴팩트 생성자가 책임진다.
+   */
   Slice<Performance> findByFilters(
       Genre genre, Long minPrice, Long maxPrice, PerformanceStatus status, Long cursorId, int size);
 }

--- a/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/out/repository/PerformanceRepositoryImpl.java
+++ b/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/out/repository/PerformanceRepositoryImpl.java
@@ -1,22 +1,16 @@
 package com.ticketrush.boundedcontext.performance.out.repository;
 
 import com.querydsl.core.BooleanBuilder;
-import com.querydsl.core.types.Order;
-import com.querydsl.core.types.OrderSpecifier;
-import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.ticketrush.boundedcontext.performance.domain.entity.Performance;
 import com.ticketrush.boundedcontext.performance.domain.entity.QPerformance;
 import com.ticketrush.boundedcontext.performance.domain.types.Genre;
 import com.ticketrush.boundedcontext.performance.domain.types.PerformanceStatus;
-import com.ticketrush.global.exception.BusinessException;
-import com.ticketrush.global.status.ErrorStatus;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
-import org.springframework.data.support.PageableExecutionUtils;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -25,9 +19,17 @@ public class PerformanceRepositoryImpl implements PerformanceRepositoryCustom {
 
   private final JPAQueryFactory queryFactory;
 
+  /**
+   * 커서 기반 공연 목록 조회. size는 양수를 전제한다 — 정규화(기본값·상한 캡)는 웹 계층의 {@code CursorPageRequest} 컴팩트 생성자가 책임진다.
+   */
   @Override
-  public Page<Performance> findByFilters(
-      Genre genre, Long minPrice, Long maxPrice, PerformanceStatus status, Pageable pageable) {
+  public Slice<Performance> findByFilters(
+      Genre genre,
+      Long minPrice,
+      Long maxPrice,
+      PerformanceStatus status,
+      Long cursorId,
+      int size) {
 
     QPerformance performance = QPerformance.performance;
 
@@ -44,40 +46,23 @@ public class PerformanceRepositoryImpl implements PerformanceRepositoryCustom {
     if (status != null) {
       predicate.and(performance.performanceStatus.eq(status));
     }
+    if (cursorId != null) {
+      predicate.and(performance.id.lt(cursorId));
+    }
 
-    List<Performance> content =
+    // size + 1건을 조회해 다음 페이지 존재 여부를 count 쿼리 없이 판단한다
+    List<Performance> rows =
         queryFactory
             .selectFrom(performance)
             .where(predicate)
-            .offset(pageable.getOffset())
-            .limit(pageable.getPageSize())
-            .orderBy(toOrderSpecifiers(performance, pageable))
+            .orderBy(performance.id.desc())
+            .limit(size + 1L)
             .fetch();
 
-    JPAQuery<Long> countQuery =
-        queryFactory.select(performance.count()).from(performance).where(predicate);
+    boolean hasNext = rows.size() > size;
+    List<Performance> content = hasNext ? rows.subList(0, size) : rows;
 
-    return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
-  }
-
-  private OrderSpecifier<?>[] toOrderSpecifiers(QPerformance performance, Pageable pageable) {
-    if (!pageable.getSort().isSorted()) {
-      return new OrderSpecifier[] {performance.createdAt.desc()};
-    }
-
-    return pageable.getSort().stream()
-        .map(order -> toOrderSpecifier(performance, order))
-        .toArray(OrderSpecifier[]::new);
-  }
-
-  private OrderSpecifier<?> toOrderSpecifier(QPerformance performance, Sort.Order order) {
-    Order direction = order.isAscending() ? Order.ASC : Order.DESC;
-    return switch (order.getProperty()) {
-      case "createdAt" -> new OrderSpecifier<>(direction, performance.createdAt);
-      case "price" -> new OrderSpecifier<>(direction, performance.price);
-      case "title" -> new OrderSpecifier<>(direction, performance.title);
-      case "showDate" -> new OrderSpecifier<>(direction, performance.showDate);
-      default -> throw new BusinessException(ErrorStatus.PERFORMANCE_INVALID_SORT_PROPERTY);
-    };
+    // 커서 방식에서 page 번호는 무의미하므로 0으로 고정 (size 전달용)
+    return new SliceImpl<>(content, PageRequest.of(0, size), hasNext);
   }
 }

--- a/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/out/repository/PerformanceRepositoryImpl.java
+++ b/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/out/repository/PerformanceRepositoryImpl.java
@@ -19,9 +19,6 @@ public class PerformanceRepositoryImpl implements PerformanceRepositoryCustom {
 
   private final JPAQueryFactory queryFactory;
 
-  /**
-   * 커서 기반 공연 목록 조회. size는 양수를 전제한다 — 정규화(기본값·상한 캡)는 웹 계층의 {@code CursorPageRequest} 컴팩트 생성자가 책임진다.
-   */
   @Override
   public Slice<Performance> findByFilters(
       Genre genre,

--- a/performance-service/src/test/java/com/ticketrush/boundedcontext/performance/in/api/v1/PerformanceGetListCursorTest.java
+++ b/performance-service/src/test/java/com/ticketrush/boundedcontext/performance/in/api/v1/PerformanceGetListCursorTest.java
@@ -1,0 +1,106 @@
+package com.ticketrush.boundedcontext.performance.in.api.v1;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.ticketrush.boundedcontext.performance.app.dto.response.PerformanceListResponse;
+import com.ticketrush.boundedcontext.performance.app.facade.PerformanceFacade;
+import com.ticketrush.boundedcontext.performance.domain.types.Genre;
+import com.ticketrush.boundedcontext.performance.domain.types.PerformanceStatus;
+import com.ticketrush.global.config.CustomSecurityProperties;
+import com.ticketrush.global.config.SecurityConfig;
+import com.ticketrush.global.dto.request.CursorPageRequest;
+import com.ticketrush.support.WebMvcSliceTest;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcSliceTest(PerformanceController.class)
+@Import({CustomSecurityProperties.class, SecurityConfig.class})
+class PerformanceGetListCursorTest {
+
+  @Autowired private MockMvc mockMvc;
+
+  @MockitoBean private PerformanceFacade performanceFacade;
+
+  private PerformanceListResponse sampleResponse(Long performanceId) {
+    return new PerformanceListResponse(
+        performanceId,
+        "공연명",
+        "가수",
+        Genre.CONCERT,
+        LocalDate.of(2026, 9, 1),
+        LocalTime.of(19, 0),
+        "서울",
+        "https://s3.example.com/main.jpg",
+        PerformanceStatus.ON_SALE,
+        50000L);
+  }
+
+  @Test
+  @DisplayName("다음 페이지가 있으면 마지막 원소의 performanceId가 next_cursor로 반환된다")
+  void getPerformances_returnsNextCursorOfLastElement() throws Exception {
+    when(performanceFacade.getPerformances(
+            isNull(), isNull(), isNull(), isNull(), any(CursorPageRequest.class)))
+        .thenReturn(
+            new SliceImpl<>(
+                List.of(sampleResponse(10L), sampleResponse(9L)), PageRequest.of(0, 2), true));
+
+    mockMvc
+        .perform(get("/api/v1/performance").param("size", "2"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.is_success").value(true))
+        .andExpect(jsonPath("$.pagination_info.has_next").value(true))
+        .andExpect(jsonPath("$.pagination_info.next_cursor").value(9))
+        .andExpect(jsonPath("$.pagination_info.size").value(2))
+        .andExpect(jsonPath("$.result[0].performance_id").value(10))
+        .andExpect(jsonPath("$.result[1].performance_id").value(9));
+  }
+
+  @Test
+  @DisplayName("마지막 페이지면 has_next가 false이고 next_cursor는 반환되지 않는다")
+  void getPerformances_lastPage_noNextCursor() throws Exception {
+    when(performanceFacade.getPerformances(
+            isNull(), isNull(), isNull(), isNull(), any(CursorPageRequest.class)))
+        .thenReturn(new SliceImpl<>(List.of(sampleResponse(1L)), PageRequest.of(0, 10), false));
+
+    mockMvc
+        .perform(get("/api/v1/performance"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.pagination_info.has_next").value(false))
+        .andExpect(jsonPath("$.pagination_info.next_cursor").doesNotExist());
+  }
+
+  @Test
+  @DisplayName("cursorId와 size 쿼리 파라미터가 CursorPageRequest로 바인딩된다")
+  void getPerformances_bindsCursorPageRequest() throws Exception {
+    when(performanceFacade.getPerformances(
+            isNull(), isNull(), isNull(), isNull(), any(CursorPageRequest.class)))
+        .thenReturn(new SliceImpl<>(List.of(), PageRequest.of(0, 2), false));
+
+    mockMvc
+        .perform(get("/api/v1/performance").param("cursorId", "5").param("size", "2"))
+        .andExpect(status().isOk());
+
+    ArgumentCaptor<CursorPageRequest> captor = ArgumentCaptor.forClass(CursorPageRequest.class);
+    verify(performanceFacade)
+        .getPerformances(isNull(), isNull(), isNull(), isNull(), captor.capture());
+    assertThat(captor.getValue().cursorId()).isEqualTo(5L);
+    assertThat(captor.getValue().size()).isEqualTo(2);
+  }
+}

--- a/performance-service/src/test/java/com/ticketrush/boundedcontext/performance/in/api/v1/PerformanceGetListTest.java
+++ b/performance-service/src/test/java/com/ticketrush/boundedcontext/performance/in/api/v1/PerformanceGetListTest.java
@@ -9,12 +9,14 @@ import com.ticketrush.boundedcontext.performance.domain.entity.Performance;
 import com.ticketrush.boundedcontext.performance.domain.types.Genre;
 import com.ticketrush.boundedcontext.performance.domain.types.PerformanceStatus;
 import com.ticketrush.boundedcontext.performance.out.repository.PerformanceRepository;
+import com.ticketrush.global.dto.request.CursorPageRequest;
 import com.ticketrush.global.eventpublisher.EventPublisher;
 import com.ticketrush.global.exception.BusinessException;
 import com.ticketrush.global.status.ErrorStatus;
 import com.ticketrush.global.util.S3UploadUtils;
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.util.Comparator;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -22,10 +24,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Slice;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.transaction.annotation.Transactional;
@@ -56,78 +55,137 @@ class PerformanceGetListTest {
             buildPerformance(Genre.JAZZ, 90000L, PerformanceStatus.CLOSED)));
   }
 
+  private Slice<PerformanceListResponse> execute(
+      Genre genre, Long minPrice, Long maxPrice, PerformanceStatus status, CursorPageRequest req) {
+    return performanceGetListUseCase.execute(genre, minPrice, maxPrice, status, req);
+  }
+
+  private CursorPageRequest firstPage(int size) {
+    return new CursorPageRequest(null, size);
+  }
+
   @Test
   @DisplayName("장르를 지정하지 않으면 전체 공연 목록을 반환한다")
   void getAll_whenGenreIsNull() {
-    Pageable pageable = PageRequest.of(0, 10, Sort.by(Sort.Direction.DESC, "createdAt"));
-    Page<PerformanceListResponse> result =
-        performanceGetListUseCase.execute(null, null, null, null, pageable);
-    assertThat(result.getTotalElements()).isEqualTo(4);
+    Slice<PerformanceListResponse> result = execute(null, null, null, null, firstPage(10));
+
+    assertThat(result.getContent()).hasSize(4);
+    assertThat(result.hasNext()).isFalse();
+  }
+
+  @Test
+  @DisplayName("목록은 performanceId 내림차순(최신 등록순)으로 정렬된다")
+  void getAll_sortedByIdDesc() {
+    Slice<PerformanceListResponse> result = execute(null, null, null, null, firstPage(10));
+
+    assertThat(result.getContent())
+        .isSortedAccordingTo(
+            Comparator.comparing(PerformanceListResponse::performanceId).reversed());
   }
 
   @Test
   @DisplayName("장르를 지정하면 해당 장르 공연만 반환한다")
   void getByGenre_whenGenreIsGiven() {
-    Pageable pageable = PageRequest.of(0, 10, Sort.by(Sort.Direction.DESC, "createdAt"));
-    Page<PerformanceListResponse> result =
-        performanceGetListUseCase.execute(Genre.CONCERT, null, null, null, pageable);
-    assertThat(result.getTotalElements()).isEqualTo(2);
+    Slice<PerformanceListResponse> result = execute(Genre.CONCERT, null, null, null, firstPage(10));
+
+    assertThat(result.getContent()).hasSize(2);
     assertThat(result.getContent()).allMatch(p -> p.genre() == Genre.CONCERT);
   }
 
   @Test
-  @DisplayName("페이지 사이즈에 따라 결과가 올바르게 분할된다")
-  void pagination_splitsByPageSize() {
-    Pageable firstPage = PageRequest.of(0, 2, Sort.by(Sort.Direction.DESC, "createdAt"));
-    Pageable secondPage = PageRequest.of(1, 2, Sort.by(Sort.Direction.DESC, "createdAt"));
+  @DisplayName("첫 페이지는 size만큼 반환하고 남은 데이터가 있으면 hasNext가 true다")
+  void cursorPaging_firstPage_hasNext() {
+    Slice<PerformanceListResponse> firstPage = execute(null, null, null, null, firstPage(2));
 
-    Page<PerformanceListResponse> page1 =
-        performanceGetListUseCase.execute(null, null, null, null, firstPage);
-    Page<PerformanceListResponse> page2 =
-        performanceGetListUseCase.execute(null, null, null, null, secondPage);
+    assertThat(firstPage.getContent()).hasSize(2);
+    assertThat(firstPage.hasNext()).isTrue();
+  }
 
-    assertThat(page1.getContent()).hasSize(2);
-    assertThat(page2.getContent()).hasSize(2);
-    assertThat(page1.getTotalPages()).isEqualTo(2);
+  @Test
+  @DisplayName("마지막 원소 id를 커서로 넘기면 중복·누락 없이 다음 페이지를 반환한다")
+  void cursorPaging_nextPage_noOverlapOrGap() {
+    Slice<PerformanceListResponse> firstPage = execute(null, null, null, null, firstPage(2));
+    Long nextCursor = firstPage.getContent().getLast().performanceId();
+
+    Slice<PerformanceListResponse> secondPage =
+        execute(null, null, null, null, new CursorPageRequest(nextCursor, 2));
+
+    List<Long> firstIds =
+        firstPage.getContent().stream().map(PerformanceListResponse::performanceId).toList();
+    List<Long> secondIds =
+        secondPage.getContent().stream().map(PerformanceListResponse::performanceId).toList();
+
+    assertThat(secondIds).hasSize(2).doesNotContainAnyElementsOf(firstIds);
+    assertThat(secondIds).allMatch(id -> id < nextCursor);
+    // 전체 4건 = 2 + 2, 정확히 size 배수여도 마지막 페이지의 hasNext는 false여야 한다
+    assertThat(secondPage.hasNext()).isFalse();
+  }
+
+  @Test
+  @DisplayName("잔여 데이터가 size보다 적으면 남은 만큼만 반환하고 hasNext가 false다")
+  void cursorPaging_lastPage_partial() {
+    Slice<PerformanceListResponse> firstPage = execute(null, null, null, null, firstPage(3));
+    Long nextCursor = firstPage.getContent().getLast().performanceId();
+
+    Slice<PerformanceListResponse> lastPage =
+        execute(null, null, null, null, new CursorPageRequest(nextCursor, 3));
+
+    assertThat(firstPage.hasNext()).isTrue();
+    assertThat(lastPage.getContent()).hasSize(1);
+    assertThat(lastPage.hasNext()).isFalse();
+  }
+
+  @Test
+  @DisplayName("필터 조건과 커서 조건이 함께 적용된다")
+  void cursorPaging_withFilter() {
+    Slice<PerformanceListResponse> firstPage =
+        execute(Genre.CONCERT, null, null, null, firstPage(1));
+    Long nextCursor = firstPage.getContent().getLast().performanceId();
+
+    Slice<PerformanceListResponse> secondPage =
+        execute(Genre.CONCERT, null, null, null, new CursorPageRequest(nextCursor, 1));
+
+    assertThat(firstPage.hasNext()).isTrue();
+    assertThat(secondPage.getContent()).hasSize(1);
+    assertThat(secondPage.hasNext()).isFalse();
+    assertThat(secondPage.getContent()).allMatch(p -> p.genre() == Genre.CONCERT);
+    assertThat(secondPage.getContent().getFirst().performanceId()).isLessThan(nextCursor);
   }
 
   @Test
   @DisplayName("최소 가격을 지정하면 해당 가격 이상의 공연만 반환한다")
   void filterByMinPrice() {
-    Pageable pageable = PageRequest.of(0, 10, Sort.by(Sort.Direction.DESC, "createdAt"));
-    Page<PerformanceListResponse> result =
-        performanceGetListUseCase.execute(null, 60000L, null, null, pageable);
-    assertThat(result.getTotalElements()).isEqualTo(2);
+    Slice<PerformanceListResponse> result = execute(null, 60000L, null, null, firstPage(10));
+
+    assertThat(result.getContent()).hasSize(2);
     assertThat(result.getContent()).allMatch(p -> p.price() >= 60000L);
   }
 
   @Test
   @DisplayName("최대 가격을 지정하면 해당 가격 이하의 공연만 반환한다")
   void filterByMaxPrice() {
-    Pageable pageable = PageRequest.of(0, 10, Sort.by(Sort.Direction.DESC, "createdAt"));
-    Page<PerformanceListResponse> result =
-        performanceGetListUseCase.execute(null, null, 50000L, null, pageable);
-    assertThat(result.getTotalElements()).isEqualTo(2);
+    Slice<PerformanceListResponse> result = execute(null, null, 50000L, null, firstPage(10));
+
+    assertThat(result.getContent()).hasSize(2);
     assertThat(result.getContent()).allMatch(p -> p.price() <= 50000L);
   }
 
   @Test
   @DisplayName("가격 범위를 지정하면 범위 내 공연만 반환한다")
   void filterByPriceRange() {
-    Pageable pageable = PageRequest.of(0, 10, Sort.by(Sort.Direction.DESC, "createdAt"));
-    Page<PerformanceListResponse> result =
-        performanceGetListUseCase.execute(null, 40000L, 80000L, null, pageable);
-    assertThat(result.getTotalElements()).isEqualTo(2);
+    Slice<PerformanceListResponse> result = execute(null, 40000L, 80000L, null, firstPage(10));
+
+    assertThat(result.getContent()).hasSize(2);
     assertThat(result.getContent()).allMatch(p -> p.price() >= 40000L && p.price() <= 80000L);
   }
 
   @Test
   @DisplayName("상태를 지정하면 해당 상태 공연만 반환한다")
   void filterByStatus() {
-    Pageable pageable = PageRequest.of(0, 10, Sort.by(Sort.Direction.DESC, "createdAt"));
-    Page<PerformanceListResponse> result =
-        performanceGetListUseCase.execute(null, null, null, PerformanceStatus.ON_SALE, pageable);
-    assertThat(result.getTotalElements()).isEqualTo(2);
+    Slice<PerformanceListResponse> result =
+        execute(null, null, null, PerformanceStatus.ON_SALE, firstPage(10));
+
+    assertThat(result.getContent()).hasSize(2);
     assertThat(result.getContent())
         .allMatch(p -> p.performanceStatus() == PerformanceStatus.ON_SALE);
   }
@@ -135,11 +193,10 @@ class PerformanceGetListTest {
   @Test
   @DisplayName("장르, 가격, 상태 복합 조건을 적용하면 모든 조건을 만족하는 공연만 반환한다")
   void filterByMultipleConditions() {
-    Pageable pageable = PageRequest.of(0, 10, Sort.by(Sort.Direction.DESC, "createdAt"));
-    Page<PerformanceListResponse> result =
-        performanceGetListUseCase.execute(
-            Genre.CONCERT, 40000L, 60000L, PerformanceStatus.ON_SALE, pageable);
-    assertThat(result.getTotalElements()).isEqualTo(1);
+    Slice<PerformanceListResponse> result =
+        execute(Genre.CONCERT, 40000L, 60000L, PerformanceStatus.ON_SALE, firstPage(10));
+
+    assertThat(result.getContent()).hasSize(1);
     PerformanceListResponse only = result.getContent().get(0);
     assertThat(only.genre()).isEqualTo(Genre.CONCERT);
     assertThat(only.price()).isBetween(40000L, 60000L);
@@ -149,9 +206,7 @@ class PerformanceGetListTest {
   @Test
   @DisplayName("최소 가격이 최대 가격보다 크면 PERFORMANCE_INVALID_PRICE_RANGE 예외가 발생한다")
   void invalidPriceRange_throwsException() {
-    Pageable pageable = PageRequest.of(0, 10, Sort.by(Sort.Direction.DESC, "createdAt"));
-    assertThatThrownBy(
-            () -> performanceGetListUseCase.execute(null, 80000L, 40000L, null, pageable))
+    assertThatThrownBy(() -> execute(null, 80000L, 40000L, null, firstPage(10)))
         .isInstanceOf(BusinessException.class)
         .hasFieldOrPropertyWithValue("errorStatus", ErrorStatus.PERFORMANCE_INVALID_PRICE_RANGE);
   }


### PR DESCRIPTION
## 🔗 관련 이슈

- close #221

---

## 📌 주요 변경 사항

- `GET /api/v1/performance` 목록 조회를 오프셋 페이징(`Pageable`/`Page`/count query) → **커서 기반 무한 스크롤**(`CursorPageRequest`/`Slice`/size+1 조회)로 전환
- 공통 `CursorPageRequest` 보완: `MAX_PAGE_SIZE`(50) 상한 캡 + `cursorId < 1` 첫 페이지 보정 + Swagger `@Schema` 문서화 (전사 최초 실사용)
- 미사용이 된 `ErrorStatus.PERFORMANCE_INVALID_SORT_PROPERTY` 제거 (PERFORMANCE_400_006 결번 처리)

---

## 🛠 상세 구현 내용

- **정렬/커서 정책**: `performanceId DESC` 고정 (id=IDENTITY라 최신 등록순과 동일). PK 커버로 인덱스 추가·수동 DDL 불필요. `createdAt` 복합 커서는 공통 계약(CursorInfo Long 단일 커서) 확장+복합 인덱스가 수반되어 채택하지 않음
- **Repository**: 기존 필터(장르·가격·상태 BooleanBuilder) 유지 + `id.lt(cursorId)` 커서 조건, `limit(size+1)` 조회로 count 쿼리 없이 `hasNext` 판단 → `SliceImpl` 반환. offset/count/정렬 화이트리스트 제거
- **Controller**: `@PageableDefault Pageable` → `@ParameterObject @ModelAttribute CursorPageRequest` (booking의 OffsetPageRequest 바인딩 선례와 동일 패턴). 응답은 `ApiResponse.onSuccess(SuccessStatus, Slice, PerformanceListResponse::performanceId)` — 공통 커서 오버로드 첫 실사용
- **UseCase/Facade**: 시그니처 `Page`→`Slice` 전파, 가격 범위 검증(`PERFORMANCE_INVALID_PRICE_RANGE`) 유지
- **Swagger**: @Operation에 커서 사용법(첫 요청 cursorId 생략 → 응답 `paginationInfo.nextCursor` 전달, `hasNext=false`=마지막) 명시

---

## ✅ 테스트

### 테스트 방법

- `./gradlew test` (common 변경 포함 → 전체 모듈 실행)
- `PerformanceGetListTest` 재작성: 기존 필터 케이스 유지 + 커서 케이스 5종(첫 페이지 hasNext / nextCursor 연쇄 중복·누락 없음 / size 정확 배수 경계 / 잔여 부분 페이지 / 필터+커서 병행) + id 내림차순 정렬 검증
- `PerformanceGetListCursorTest` 신규(@WebMvcSliceTest): next_cursor=마지막 원소 id, 마지막 페이지 next_cursor 미노출, cursorId/size 바인딩 검증
- `CursorPageRequestTest` 신규(common): 기본값/상한 캡/커서 보정 4케이스

### 테스트 결과

- 전 모듈 통과 ✅ (common 92 / performance-service 59 / booking 138 / payment 175 / seat 92 / ticket 75 / auth 18 / user 17 / gateway 1 — 실패 0)

### 📸 스크린샷

- (작성 필요)

---

## 👀 리뷰 요청 사항

- 커서 정책을 `performanceId DESC` 단순 커서로 고정한 판단 (createdAt 복합 커서 대비 트레이드오프)
- 공통 `CursorPageRequest` 보정 정책(조용히 캡/보정 vs 400 에러) — OffsetPageRequest와 일관성을 우선함

---

## ⚠️ 배포 시 주의사항

- **⚠️ Breaking Change — 프론트 전환 필수 (동시 배포 조율 필요)**:
  - 요청: `page`/`sort` 파라미터 제거 → `cursorId` 추가. 기존 `page=N` 호출은 에러 없이 첫 페이지만 반환됨
  - 응답: `pagination_info`가 `PageInfo`(total_elements/total_pages 포함) → `CursorInfo`(has_next/next_cursor/size). **전체 건수 미제공**
  - 기본 size 8 → 10 (공통 기본값), 정렬 createdAt DESC → performanceId DESC (체감 동일)
  - 비정상 타입 파라미터(`size=abc` 등)가 기존 "조용히 기본값" → `VALIDATION_ERROR` 400으로 변경
- DB 스키마 무변경 — 수동 DDL 없음
- 후속 후보: 데이터 증가 시 필터+커서 조합용 `(genre, performance_id)`류 복합 인덱스 검토 (#412 절차 참고)
