### PR TITLE
[Feat] #177 공연 목록 조회 API Redis 캐싱 적용

### DIFF
--- a/performance-service/build.gradle
+++ b/performance-service/build.gradle
@@ -36,6 +36,9 @@ dependencies {
 
     implementation 'org.springframework.data:spring-data-commons'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    // 공연 목록 캐싱 (#177) — data-redis는 shedlock 전이 의존에 기대지 않도록 명시 선언
+    implementation 'org.springframework.boot:spring-boot-starter-cache'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-security'
@@ -73,6 +76,8 @@ dependencies {
     annotationProcessor 'org.mapstruct:mapstruct-processor:1.5.5.Final'
 
     testImplementation 'com.h2database:h2'
+    // Testcontainers — 공연 목록 캐싱 실 Redis 검증 (#177). 버전은 Boot BOM(testcontainers-bom 2.x) 관리 (payment #422 선례)
+    testImplementation 'org.testcontainers:testcontainers-junit-jupiter'
     testImplementation 'org.springframework.boot:spring-boot-starter-actuator-test'
     testImplementation 'org.springframework.boot:spring-boot-starter-data-jpa-test'
     testImplementation 'org.springframework.boot:spring-boot-starter-security-test'

--- a/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/app/dto/response/PerformanceListSlice.java
+++ b/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/app/dto/response/PerformanceListSlice.java
@@ -1,0 +1,21 @@
+package com.ticketrush.boundedcontext.performance.app.dto.response;
+
+import java.util.List;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+
+/**
+ * 공연 목록 조회 결과의 Redis 캐시 값. {@link SliceImpl}은 Jackson 역직렬화가 불가능해 캐시에 저장 가능한 형태(content + hasNext)로
+ * 평탄화한다.
+ */
+public record PerformanceListSlice(List<PerformanceListResponse> content, boolean hasNext) {
+
+  public static PerformanceListSlice from(Slice<PerformanceListResponse> slice) {
+    return new PerformanceListSlice(slice.getContent(), slice.hasNext());
+  }
+
+  public Slice<PerformanceListResponse> toSlice(int size) {
+    return new SliceImpl<>(content, PageRequest.of(0, size), hasNext);
+  }
+}

--- a/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/app/facade/PerformanceFacade.java
+++ b/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/app/facade/PerformanceFacade.java
@@ -49,7 +49,9 @@ public class PerformanceFacade {
       Long maxPrice,
       PerformanceStatus status,
       CursorPageRequest pageRequest) {
-    return performanceGetListUseCase.execute(genre, minPrice, maxPrice, status, pageRequest);
+    return performanceGetListUseCase
+        .execute(genre, minPrice, maxPrice, status, pageRequest)
+        .toSlice(pageRequest.size());
   }
 
   public PerformanceDetailResponse getPerformanceDetail(Long performanceId) {

--- a/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/app/usecase/PerformanceChangeStatusUseCase.java
+++ b/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/app/usecase/PerformanceChangeStatusUseCase.java
@@ -3,9 +3,11 @@ package com.ticketrush.boundedcontext.performance.app.usecase;
 import com.ticketrush.boundedcontext.performance.app.dto.request.PerformanceChangeStatusRequest;
 import com.ticketrush.boundedcontext.performance.domain.entity.Performance;
 import com.ticketrush.boundedcontext.performance.out.repository.PerformanceRepository;
+import com.ticketrush.global.constants.CacheConstants;
 import com.ticketrush.global.exception.BusinessException;
 import com.ticketrush.global.status.ErrorStatus;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -15,6 +17,7 @@ public class PerformanceChangeStatusUseCase {
 
   private final PerformanceRepository performanceRepository;
 
+  @CacheEvict(cacheNames = CacheConstants.PERFORMANCE_LIST_CACHE, allEntries = true)
   @Transactional
   public void execute(Long performanceId, PerformanceChangeStatusRequest request) {
     Performance performance =

--- a/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/app/usecase/PerformanceCreateUseCase.java
+++ b/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/app/usecase/PerformanceCreateUseCase.java
@@ -5,6 +5,7 @@ import com.ticketrush.boundedcontext.performance.app.dto.response.PerformanceCre
 import com.ticketrush.boundedcontext.performance.app.mapper.PerformanceMapper;
 import com.ticketrush.boundedcontext.performance.domain.entity.Performance;
 import com.ticketrush.boundedcontext.performance.out.repository.PerformanceRepository;
+import com.ticketrush.global.constants.CacheConstants;
 import com.ticketrush.global.eventpublisher.EventPublisher;
 import com.ticketrush.global.exception.BusinessException;
 import com.ticketrush.global.status.ErrorStatus;
@@ -12,6 +13,7 @@ import com.ticketrush.global.util.S3UploadUtils;
 import com.ticketrush.shared.performance.event.PerformanceCreatedEvent;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -26,6 +28,7 @@ public class PerformanceCreateUseCase {
   private final EventPublisher eventPublisher;
 
   /** 공연 정보와 파일들을 받아 S3 업로드 후 DB에 저장 */
+  @CacheEvict(cacheNames = CacheConstants.PERFORMANCE_LIST_CACHE, allEntries = true)
   @Transactional
   public PerformanceCreateResponse execute(
       PerformanceCreateRequest request,

--- a/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/app/usecase/PerformanceDeleteUseCase.java
+++ b/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/app/usecase/PerformanceDeleteUseCase.java
@@ -2,9 +2,11 @@ package com.ticketrush.boundedcontext.performance.app.usecase;
 
 import com.ticketrush.boundedcontext.performance.domain.entity.Performance;
 import com.ticketrush.boundedcontext.performance.out.repository.PerformanceRepository;
+import com.ticketrush.global.constants.CacheConstants;
 import com.ticketrush.global.exception.BusinessException;
 import com.ticketrush.global.status.ErrorStatus;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -14,6 +16,7 @@ public class PerformanceDeleteUseCase {
 
   private final PerformanceRepository performanceRepository;
 
+  @CacheEvict(cacheNames = CacheConstants.PERFORMANCE_LIST_CACHE, allEntries = true)
   @Transactional
   public void execute(Long performanceId) {
     Performance performance =

--- a/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/app/usecase/PerformanceGetListUseCase.java
+++ b/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/app/usecase/PerformanceGetListUseCase.java
@@ -1,15 +1,16 @@
 package com.ticketrush.boundedcontext.performance.app.usecase;
 
-import com.ticketrush.boundedcontext.performance.app.dto.response.PerformanceListResponse;
+import com.ticketrush.boundedcontext.performance.app.dto.response.PerformanceListSlice;
 import com.ticketrush.boundedcontext.performance.app.mapper.PerformanceMapper;
 import com.ticketrush.boundedcontext.performance.domain.types.Genre;
 import com.ticketrush.boundedcontext.performance.domain.types.PerformanceStatus;
 import com.ticketrush.boundedcontext.performance.out.repository.PerformanceRepository;
+import com.ticketrush.global.constants.CacheConstants;
 import com.ticketrush.global.dto.request.CursorPageRequest;
 import com.ticketrush.global.exception.BusinessException;
 import com.ticketrush.global.status.ErrorStatus;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Slice;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -20,8 +21,18 @@ public class PerformanceGetListUseCase {
   private final PerformanceRepository performanceRepository;
   private final PerformanceMapper performanceMapper;
 
+  /**
+   * 캐싱 대상은 메인 화면 트래픽이 집중되는 <b>무필터 + 첫 페이지</b> 조합만으로 제한한다 — minPrice/maxPrice/cursorId가 자유값이라 전 조합
+   * 캐싱은 키 카디널리티가 무한하기 때문(키는 size별 최대 {@code MAX_PAGE_SIZE}개).
+   */
+  @Cacheable(
+      cacheNames = CacheConstants.PERFORMANCE_LIST_CACHE,
+      key = "'size=' + #pageRequest.size()",
+      condition =
+          "#genre == null && #minPrice == null && #maxPrice == null && #status == null"
+              + " && #pageRequest.cursorId() == null")
   @Transactional(readOnly = true)
-  public Slice<PerformanceListResponse> execute(
+  public PerformanceListSlice execute(
       Genre genre,
       Long minPrice,
       Long maxPrice,
@@ -30,10 +41,11 @@ public class PerformanceGetListUseCase {
 
     validatePriceRange(minPrice, maxPrice);
 
-    return performanceRepository
-        .findByFilters(
-            genre, minPrice, maxPrice, status, pageRequest.cursorId(), pageRequest.size())
-        .map(performanceMapper::toListResponse);
+    return PerformanceListSlice.from(
+        performanceRepository
+            .findByFilters(
+                genre, minPrice, maxPrice, status, pageRequest.cursorId(), pageRequest.size())
+            .map(performanceMapper::toListResponse));
   }
 
   private void validatePriceRange(Long minPrice, Long maxPrice) {

--- a/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/app/usecase/PerformanceOpenBookingUseCase.java
+++ b/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/app/usecase/PerformanceOpenBookingUseCase.java
@@ -2,11 +2,16 @@ package com.ticketrush.boundedcontext.performance.app.usecase;
 
 import com.ticketrush.boundedcontext.performance.domain.types.PerformanceStatus;
 import com.ticketrush.boundedcontext.performance.out.repository.PerformanceRepository;
+import com.ticketrush.global.constants.CacheConstants;
 import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 @Slf4j
 @Service
@@ -14,6 +19,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class PerformanceOpenBookingUseCase {
 
   private final PerformanceRepository performanceRepository;
+  private final CacheManager cacheManager;
 
   @Transactional
   public int execute() {
@@ -23,7 +29,34 @@ public class PerformanceOpenBookingUseCase {
 
     if (openedCount > 0) {
       log.info("예매 오픈 시각 도래 공연 {}건을 ON_SALE 상태로 전환했습니다.", openedCount);
+      registerCacheEvictionAfterCommit();
     }
     return openedCount;
+  }
+
+  /**
+   * 상태 전환은 목록 응답 필드이자 필터 조건인 status를 바꾸므로 캐시를 무효화한다. {@code @CacheEvict}는 결과값(전환 건수) 조건을 걸 수 없어 직접
+   * 호출하되, 커밋 전에 비우면 다른 요청이 커밋 전 스냅샷을 재적재할 수 있어 <b>커밋 이후</b>로 미룬다.
+   */
+  private void registerCacheEvictionAfterCommit() {
+    TransactionSynchronizationManager.registerSynchronization(
+        new TransactionSynchronization() {
+          @Override
+          public void afterCommit() {
+            evictPerformanceListCache();
+          }
+        });
+  }
+
+  /** 무효화 실패가 스케줄러를 죽이지 않도록 예외를 삼킨다(TTL 안전망으로 정리됨). */
+  private void evictPerformanceListCache() {
+    try {
+      Cache cache = cacheManager.getCache(CacheConstants.PERFORMANCE_LIST_CACHE);
+      if (cache != null) {
+        cache.clear();
+      }
+    } catch (RuntimeException e) {
+      log.warn("공연 목록 캐시 무효화 실패 — TTL 만료로 정리됩니다.", e);
+    }
   }
 }

--- a/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/app/usecase/PerformancePatchUseCase.java
+++ b/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/app/usecase/PerformancePatchUseCase.java
@@ -3,9 +3,11 @@ package com.ticketrush.boundedcontext.performance.app.usecase;
 import com.ticketrush.boundedcontext.performance.app.dto.request.PerformancePatchRequest;
 import com.ticketrush.boundedcontext.performance.domain.entity.Performance;
 import com.ticketrush.boundedcontext.performance.out.repository.PerformanceRepository;
+import com.ticketrush.global.constants.CacheConstants;
 import com.ticketrush.global.exception.BusinessException;
 import com.ticketrush.global.status.ErrorStatus;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -15,6 +17,7 @@ public class PerformancePatchUseCase {
 
   private final PerformanceRepository performanceRepository;
 
+  @CacheEvict(cacheNames = CacheConstants.PERFORMANCE_LIST_CACHE, allEntries = true)
   @Transactional
   public void execute(Long performanceId, PerformancePatchRequest request) {
     Performance performance =

--- a/performance-service/src/main/java/com/ticketrush/global/config/CacheConfig.java
+++ b/performance-service/src/main/java/com/ticketrush/global/config/CacheConfig.java
@@ -1,0 +1,102 @@
+package com.ticketrush.global.config;
+
+import com.ticketrush.boundedcontext.performance.app.dto.response.PerformanceListSlice;
+import com.ticketrush.global.constants.CacheConstants;
+import java.time.Duration;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.cache.autoconfigure.RedisCacheManagerBuilderCustomizer;
+import org.springframework.cache.Cache;
+import org.springframework.cache.annotation.CachingConfigurer;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.interceptor.CacheErrorHandler;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.Ordered;
+import org.springframework.data.redis.cache.BatchStrategies;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheWriter;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.JacksonJsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+
+/**
+ * 공연 목록 조회 캐시 설정 (#177).
+ *
+ * <p>수동 {@code @Bean CacheManager} 대신 auto-configuration 커스터마이저를 사용한다 — test 프로파일의 {@code
+ * spring.cache.type: none}이 그대로 동작해야 하기 때문.
+ *
+ * <p>{@code order = HIGHEST_PRECEDENCE}로 캐시 어드바이저를 트랜잭션 어드바이저 바깥에 고정한다 — 캐시 히트 시 불필요한 트랜잭션 진입을 막고,
+ * {@code @CacheEvict}가 커밋 이후에 실행되어 커밋 전 stale 재적재 경합을 줄인다.
+ */
+@Slf4j
+@Configuration
+@EnableCaching(order = Ordered.HIGHEST_PRECEDENCE)
+public class CacheConfig implements CachingConfigurer {
+
+  /**
+   * TTL은 evict 누락·경합(리더가 커밋 전 데이터를 evict 후 재적재하는 read-then-put)에 대비한 안전망. 갱신 경로 5곳(어드민 4종 + 예매 오픈
+   * 스케줄러)이 모두 evict를 수행하므로 평상시 정합성은 evict가 보장한다.
+   */
+  private static final Duration PERFORMANCE_LIST_TTL = Duration.ofSeconds(30);
+
+  /** clear 시 SCAN 배치 크기 — 기본 전략(KEYS)은 공유 Redis를 블로킹하므로 쓰지 않는다. */
+  private static final int CLEAR_SCAN_BATCH_SIZE = 100;
+
+  /**
+   * spring-data-redis 4.0부터 캐시 쓰기·무효화가 기본 비동기(fire-and-forget)라, 뮤테이션 API가 응답한 뒤에도 잠깐 stale이 노출되고
+   * evict 실패가 {@link CacheErrorHandler}에 잡히지 않는다. 무효화 즉시 반영(#177 완료 조건)을 위해 immediateWrites(동기 쓰기)로
+   * 전환하고, 히트율 관측을 위해 통계 수집을 켠다.
+   */
+  @Bean
+  public RedisCacheManagerBuilderCustomizer performanceListCacheCustomizer(
+      RedisConnectionFactory connectionFactory) {
+    return builder ->
+        builder
+            .cacheWriter(
+                RedisCacheWriter.create(
+                    connectionFactory,
+                    config ->
+                        config
+                            .batchStrategy(BatchStrategies.scan(CLEAR_SCAN_BATCH_SIZE))
+                            .immediateWrites()
+                            .collectStatistics()))
+            .withCacheConfiguration(
+                CacheConstants.PERFORMANCE_LIST_CACHE,
+                RedisCacheConfiguration.defaultCacheConfig()
+                    .entryTtl(PERFORMANCE_LIST_TTL)
+                    .disableCachingNullValues()
+                    .serializeValuesWith(
+                        RedisSerializationContext.SerializationPair.fromSerializer(
+                            new JacksonJsonRedisSerializer<>(PerformanceListSlice.class))));
+  }
+
+  /** Redis 장애 시 목록 API가 죽지 않도록 캐시 예외를 삼키고 미스로 취급한다(fail-open). */
+  @Override
+  public CacheErrorHandler errorHandler() {
+    return new FailOpenCacheErrorHandler();
+  }
+
+  private static final class FailOpenCacheErrorHandler implements CacheErrorHandler {
+
+    @Override
+    public void handleCacheGetError(RuntimeException exception, Cache cache, Object key) {
+      log.warn("캐시 조회 실패 — 미스로 취급합니다. cache={}, key={}", cache.getName(), key, exception);
+    }
+
+    @Override
+    public void handleCachePutError(
+        RuntimeException exception, Cache cache, Object key, Object value) {
+      log.warn("캐시 저장 실패 — 무시합니다. cache={}, key={}", cache.getName(), key, exception);
+    }
+
+    @Override
+    public void handleCacheEvictError(RuntimeException exception, Cache cache, Object key) {
+      log.warn("캐시 무효화 실패 — TTL 만료로 정리됩니다. cache={}, key={}", cache.getName(), key, exception);
+    }
+
+    @Override
+    public void handleCacheClearError(RuntimeException exception, Cache cache) {
+      log.warn("캐시 전체 무효화 실패 — TTL 만료로 정리됩니다. cache={}", cache.getName(), exception);
+    }
+  }
+}

--- a/performance-service/src/main/java/com/ticketrush/global/constants/CacheConstants.java
+++ b/performance-service/src/main/java/com/ticketrush/global/constants/CacheConstants.java
@@ -1,0 +1,9 @@
+package com.ticketrush.global.constants;
+
+/** performance-service 캐시 이름 상수. 키 네이밍은 Redis 키 컨벤션 통일(#425) 확정 전 임시이며, 확정 시 이관한다. */
+public final class CacheConstants {
+
+  public static final String PERFORMANCE_LIST_CACHE = "performance:list";
+
+  private CacheConstants() {}
+}

--- a/performance-service/src/main/resources/application-test.yml
+++ b/performance-service/src/main/resources/application-test.yml
@@ -22,6 +22,10 @@ spring:
     console:
       enabled: false
 
+  # test 프로파일은 Redis가 없어 캐시를 끈다 (캐시 검증은 Testcontainers 테스트가 redis로 오버라이드)
+  cache:
+    type: none
+
 app:
   event-publisher:
     type: kafka

--- a/performance-service/src/main/resources/application.yml
+++ b/performance-service/src/main/resources/application.yml
@@ -9,6 +9,15 @@ spring:
     name: performance-service
   jpa:
     open-in-view: false
+  cache:
+    type: redis
+  data:
+    redis:
+      # Lettuce 기본 커맨드 타임아웃(60s)은 hang형 Redis 장애 시 캐시 fail-open을 무력화한다 — 짧게 자른다.
+      # 같은 ConnectionFactory를 쓰는 ShedLock에도 적용됨: Redis 지연 스파이크 시 unlock 타임아웃으로
+      # 락이 lockAtMostFor(1m)까지 잔존할 빈도가 소폭 늘 수 있는 트레이드오프를 수용한 값이다.
+      timeout: 1s
+      connect-timeout: 1s
   servlet:
     multipart:
       enabled: true

--- a/performance-service/src/test/java/com/ticketrush/boundedcontext/performance/in/api/v1/PerformanceGetListTest.java
+++ b/performance-service/src/test/java/com/ticketrush/boundedcontext/performance/in/api/v1/PerformanceGetListTest.java
@@ -57,7 +57,9 @@ class PerformanceGetListTest {
 
   private Slice<PerformanceListResponse> execute(
       Genre genre, Long minPrice, Long maxPrice, PerformanceStatus status, CursorPageRequest req) {
-    return performanceGetListUseCase.execute(genre, minPrice, maxPrice, status, req);
+    return performanceGetListUseCase
+        .execute(genre, minPrice, maxPrice, status, req)
+        .toSlice(req.size());
   }
 
   private CursorPageRequest firstPage(int size) {

--- a/performance-service/src/test/java/com/ticketrush/boundedcontext/performance/in/api/v1/PerformanceListCacheTest.java
+++ b/performance-service/src/test/java/com/ticketrush/boundedcontext/performance/in/api/v1/PerformanceListCacheTest.java
@@ -1,0 +1,261 @@
+package com.ticketrush.boundedcontext.performance.in.api.v1;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+import com.ticketrush.boundedcontext.performance.app.dto.request.PerformanceChangeStatusRequest;
+import com.ticketrush.boundedcontext.performance.app.dto.request.PerformanceCreateRequest;
+import com.ticketrush.boundedcontext.performance.app.dto.request.PerformancePatchRequest;
+import com.ticketrush.boundedcontext.performance.app.dto.response.PerformanceListResponse;
+import com.ticketrush.boundedcontext.performance.app.facade.PerformanceFacade;
+import com.ticketrush.boundedcontext.performance.app.usecase.PerformanceOpenBookingUseCase;
+import com.ticketrush.boundedcontext.performance.domain.entity.Performance;
+import com.ticketrush.boundedcontext.performance.domain.types.Genre;
+import com.ticketrush.boundedcontext.performance.domain.types.PerformanceStatus;
+import com.ticketrush.boundedcontext.performance.out.repository.PerformanceRepository;
+import com.ticketrush.global.constants.CacheConstants;
+import com.ticketrush.global.dto.request.CursorPageRequest;
+import com.ticketrush.global.eventpublisher.EventPublisher;
+import com.ticketrush.global.util.S3UploadUtils;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+/**
+ * 공연 목록 조회 Redis 캐싱(#177)을 실제 Redis(Testcontainers)로 검증한다. test 프로파일은 {@code spring.cache.type:
+ * none}으로 캐시를 끄므로, 이 테스트만 redis로 오버라이드한다.
+ *
+ * <p>테스트 트랜잭션 롤백과 캐시(비트랜잭셔널)의 시점이 얽히지 않도록 {@code @Transactional}을 쓰지 않고 직접 정리한다.
+ *
+ * <p>Docker가 없는 환경에서는 컨테이너 기동 실패로 깨진다 — 의도된 fail-closed(payment #422 선례).
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+@EnableAutoConfiguration(
+    exclude = {
+      io.awspring.cloud.autoconfigure.s3.S3AutoConfiguration.class,
+      io.awspring.cloud.autoconfigure.core.AwsAutoConfiguration.class
+    })
+@Testcontainers
+class PerformanceListCacheTest {
+
+  /** prod(deploy/docker-compose.prod.yml)와 동일한 redis:7-alpine. */
+  @Container
+  private static final GenericContainer<?> REDIS =
+      new GenericContainer<>("redis:7-alpine").withExposedPorts(6379);
+
+  private static final int PAGE_SIZE = 10;
+  private static final String FIRST_PAGE_KEY =
+      CacheConstants.PERFORMANCE_LIST_CACHE + "::size=" + PAGE_SIZE;
+
+  @DynamicPropertySource
+  static void redisCacheProperties(DynamicPropertyRegistry registry) {
+    registry.add("spring.cache.type", () -> "redis");
+    registry.add("spring.data.redis.host", REDIS::getHost);
+    registry.add("spring.data.redis.port", () -> REDIS.getMappedPort(6379));
+    // 다른 테스트 컨텍스트와 공유 mem DB(testdb)를 create-drop으로 서로 갈아엎지 않도록 이 컨텍스트만 분리
+    registry.add(
+        "spring.datasource.url", () -> "jdbc:h2:mem:cachetestdb;MODE=MySQL;DB_CLOSE_DELAY=-1");
+  }
+
+  @MockitoBean private S3UploadUtils s3UploadUtils;
+  @MockitoBean private EventPublisher eventPublisher;
+
+  @Autowired private PerformanceFacade performanceFacade;
+  @Autowired private PerformanceOpenBookingUseCase performanceOpenBookingUseCase;
+  @Autowired private PerformanceRepository performanceRepository;
+  @Autowired private StringRedisTemplate redisTemplate;
+  @Autowired private CacheManager cacheManager;
+
+  @AfterEach
+  void tearDown() {
+    performanceRepository.deleteAll();
+    Cache cache = cacheManager.getCache(CacheConstants.PERFORMANCE_LIST_CACHE);
+    assertThat(cache).as("performance:list 캐시가 설정되어 있어야 한다").isNotNull();
+    cache.clear();
+  }
+
+  @Test
+  @DisplayName("무필터 첫 페이지 조회는 Redis에 캐시되고, 두 번째 호출은 캐시에서 반환된다")
+  void unfilteredFirstPage_secondCallServedFromCache() {
+    savePerformance(Genre.CONCERT, null);
+
+    Slice<PerformanceListResponse> first = getUnfilteredFirstPage();
+
+    assertThat(first.getContent()).hasSize(1);
+    assertThat(redisTemplate.hasKey(FIRST_PAGE_KEY)).isTrue();
+
+    // 캐시 무효화 경로를 우회해 DB에만 새 공연을 넣는다 — 두 번째 응답이 DB가 아닌 캐시에서 왔음을 증명
+    savePerformance(Genre.MUSICAL, null);
+
+    Slice<PerformanceListResponse> second = getUnfilteredFirstPage();
+
+    assertThat(second.getContent()).hasSize(1);
+    // record equals로 전 필드(LocalDate/LocalTime 포함) 직렬화 왕복 동등성까지 단언
+    assertThat(second.getContent().getFirst()).isEqualTo(first.getContent().getFirst());
+  }
+
+  @Test
+  @DisplayName("필터 또는 커서가 있는 조회는 캐시하지 않는다")
+  void filteredOrCursorRequests_notCached() {
+    Performance saved = savePerformance(Genre.CONCERT, null);
+
+    performanceFacade.getPerformances(
+        Genre.CONCERT, null, null, null, new CursorPageRequest(null, PAGE_SIZE));
+    performanceFacade.getPerformances(null, 10000L, 90000L, null, firstPage());
+    performanceFacade.getPerformances(
+        null, null, null, null, new CursorPageRequest(saved.getId() + 1, PAGE_SIZE));
+
+    assertThat(redisTemplate.keys(CacheConstants.PERFORMANCE_LIST_CACHE + "*")).isEmpty();
+  }
+
+  @Test
+  @DisplayName("공연 등록 시 캐시가 무효화되어 다음 조회에 즉시 반영된다")
+  void create_evictsCache() {
+    savePerformance(Genre.CONCERT, null);
+    warmCache();
+
+    given(s3UploadUtils.uploadFile(any())).willReturn("https://example.com/file");
+    performanceFacade.createPerformance(
+        buildCreateRequest("신규 공연"), mockFile("mainImage"), mockFile("model3d"), null);
+
+    assertThat(redisTemplate.hasKey(FIRST_PAGE_KEY)).isFalse();
+    assertThat(getUnfilteredFirstPage().getContent())
+        .hasSize(2)
+        .anyMatch(p -> p.title().equals("신규 공연"));
+  }
+
+  @Test
+  @DisplayName("공연 수정 시 캐시가 무효화되어 다음 조회에 즉시 반영된다")
+  void patch_evictsCache() {
+    Performance saved = savePerformance(Genre.CONCERT, null);
+    warmCache();
+
+    performanceFacade.patchPerformance(
+        saved.getId(),
+        new PerformancePatchRequest(
+            "수정된 제목", null, null, null, null, null, null, null, null, null, null));
+
+    assertThat(redisTemplate.hasKey(FIRST_PAGE_KEY)).isFalse();
+    assertThat(getUnfilteredFirstPage().getContent()).anyMatch(p -> p.title().equals("수정된 제목"));
+  }
+
+  @Test
+  @DisplayName("공연 상태 변경 시 캐시가 무효화되어 다음 조회에 즉시 반영된다")
+  void changeStatus_evictsCache() {
+    Performance saved = savePerformance(Genre.CONCERT, null);
+    warmCache();
+
+    performanceFacade.changePerformanceStatus(
+        saved.getId(), new PerformanceChangeStatusRequest(PerformanceStatus.ON_SALE));
+
+    assertThat(redisTemplate.hasKey(FIRST_PAGE_KEY)).isFalse();
+    assertThat(getUnfilteredFirstPage().getContent())
+        .anyMatch(p -> p.performanceStatus() == PerformanceStatus.ON_SALE);
+  }
+
+  @Test
+  @DisplayName("공연 삭제 시 캐시가 무효화되어 다음 조회에 즉시 반영된다")
+  void delete_evictsCache() {
+    Performance saved = savePerformance(Genre.CONCERT, null);
+    warmCache();
+
+    performanceFacade.deletePerformance(saved.getId());
+
+    assertThat(redisTemplate.hasKey(FIRST_PAGE_KEY)).isFalse();
+    assertThat(getUnfilteredFirstPage().getContent()).isEmpty();
+  }
+
+  @Test
+  @DisplayName("예매 오픈 스케줄러가 상태를 전환하면 캐시가 무효화된다")
+  void openBooking_transitioned_evictsCache() {
+    savePerformance(Genre.CONCERT, LocalDateTime.now().minusMinutes(1));
+    warmCache();
+
+    int openedCount = performanceOpenBookingUseCase.execute();
+
+    assertThat(openedCount).isEqualTo(1);
+    assertThat(redisTemplate.hasKey(FIRST_PAGE_KEY)).isFalse();
+    assertThat(getUnfilteredFirstPage().getContent())
+        .anyMatch(p -> p.performanceStatus() == PerformanceStatus.ON_SALE);
+  }
+
+  @Test
+  @DisplayName("예매 오픈 스케줄러가 전환한 공연이 없으면 캐시를 유지한다")
+  void openBooking_nothingTransitioned_keepsCache() {
+    savePerformance(Genre.CONCERT, LocalDateTime.now().plusHours(1));
+    warmCache();
+
+    int openedCount = performanceOpenBookingUseCase.execute();
+
+    assertThat(openedCount).isZero();
+    assertThat(redisTemplate.hasKey(FIRST_PAGE_KEY)).isTrue();
+  }
+
+  private Slice<PerformanceListResponse> getUnfilteredFirstPage() {
+    return performanceFacade.getPerformances(null, null, null, null, firstPage());
+  }
+
+  private void warmCache() {
+    getUnfilteredFirstPage();
+    assertThat(redisTemplate.hasKey(FIRST_PAGE_KEY)).isTrue();
+  }
+
+  private CursorPageRequest firstPage() {
+    return new CursorPageRequest(null, PAGE_SIZE);
+  }
+
+  private Performance savePerformance(Genre genre, LocalDateTime bookingOpenAt) {
+    return performanceRepository.save(
+        Performance.builder()
+            .title("공연명")
+            .performer("출연진")
+            .genre(genre)
+            .description("설명")
+            .showDate(LocalDate.now().plusDays(30))
+            .showTime(LocalTime.of(19, 0))
+            .durationMinutes(120)
+            .price(50000L)
+            .totalSeats(100)
+            .address("서울")
+            .bookingOpenAt(bookingOpenAt)
+            .build());
+  }
+
+  private PerformanceCreateRequest buildCreateRequest(String title) {
+    return PerformanceCreateRequest.builder()
+        .title(title)
+        .performer("출연진")
+        .genre(Genre.CONCERT)
+        .showDate(LocalDate.now().plusDays(30))
+        .showTime(LocalTime.of(19, 0))
+        .durationMinutes(120)
+        .price(50000L)
+        .totalSeats(100)
+        .address("서울")
+        .build();
+  }
+
+  private MockMultipartFile mockFile(String name) {
+    return new MockMultipartFile(name, name + ".bin", "application/octet-stream", new byte[] {1});
+  }
+}


### PR DESCRIPTION
## 🔗 관련 이슈

- close #177

---

## 📌 주요 변경 사항

- performance-service에 팀 최초로 Spring Cache + Redis(RedisCacheManager) 도입
- 공연 목록 조회(`GET /api/v1/performance`)의 **무필터 + 첫 페이지** 응답을 Redis에 캐싱 (TTL 30초)
- 공연 변경 경로 5곳(어드민 등록/수정/삭제/상태변경 + 예매 오픈 스케줄러)에서 캐시 무효화 — 쓰기 후 즉시 반영 보장
- Redis 장애 시 목록 API가 죽지 않는 fail-open(`CacheErrorHandler` + Lettuce 타임아웃 1s)
- 스키마·외부 API 계약 무변경

---

## 🛠 상세 구현 내용

- **캐시 대상 제한**: minPrice/maxPrice/cursorId가 자유값이라 전 조합 캐싱은 키 카디널리티가 무한 → `@Cacheable`의 `condition`으로 무필터+첫 페이지(cursorId=null)만 캐싱. 키는 `performance:list::size={n}` (size 캡 50 → 최대 50키)
- **직렬화**: `SliceImpl`은 Jackson 역직렬화 불가 → UseCase 반환형을 `PerformanceListSlice`(content+hasNext record)로 평탄화, Facade에서 `SliceImpl` 복원 — 컨트롤러·`ApiResponse` 커서 오버로드 무변경
- **CacheConfig**: 수동 `@Bean CacheManager` 대신 `RedisCacheManagerBuilderCustomizer` 사용 (test 프로파일 `spring.cache.type: none` 동작 보장)
  - **immediateWrites**: spring-data-redis 4.0부터 캐시 쓰기·clear가 기본 비동기(fire-and-forget)라 evict 즉시성이 깨짐 → 동기 쓰기로 전환 (실측: 비동기 기본값에서 evict 직후에도 키 잔존, 테스트 5건 실패 → 전환 후 통과)
  - **BatchStrategies.scan(100)**: clear 기본 전략(KEYS)은 공유 prod Redis를 블로킹 → SCAN으로 교체
  - **collectStatistics()**: 히트율 메트릭 수집 (prometheus 기노출)
  - **`@EnableCaching(order = HIGHEST_PRECEDENCE)`**: 캐시 어드바이저를 tx 어드바이저 바깥에 고정 — 캐시 히트 시 불필요한 트랜잭션 진입 방지 + `@CacheEvict`가 커밋 이후 실행
- **무효화**: 어드민 4 UseCase `@CacheEvict(allEntries=true)`, 예매 오픈 스케줄러(#298)는 전환 건수 >0일 때만 `TransactionSynchronization.afterCommit`으로 evict (커밋 전 evict 시 stale 재적재 경합 방지, `@CacheEvict`는 결과값 조건 불가)
- **fail-open**: get/put/evict 예외를 warn 로그 후 캐시 미스 취급. hang형 장애 대비 `spring.data.redis.timeout/connect-timeout: 1s` (Lettuce 기본 60s)
- 캐시명 상수는 `global/constants/CacheConstants`로 분리 (app↔global.config 패키지 순환 방지)
- build.gradle: `starter-cache`/`starter-data-redis` 명시 선언 (기존 shedlock 전이 의존에 컴파일이 기대던 상태 해소)

---

## ✅ 테스트

### 테스트 방법

- `./gradlew :performance-service:test` (Docker 필수 — Testcontainers Redis)
- 신규 `PerformanceListCacheTest` 8건 (redis:7-alpine 컨테이너, prod와 동일 이미지):
  - 무필터 첫 페이지 캐시 히트 + 직렬화 왕복 필드 동등성 / 필터·커서 요청 미캐싱
  - 등록·수정·상태변경·삭제 각각 evict 후 즉시 반영
  - 오픈 스케줄러 전환 시 evict / 전환 0건 시 캐시 유지
- 기존 `PerformanceGetListTest` 13건·`PerformanceGetListCursorTest` 3건 회귀 확인 (test 프로파일 `cache.type: none`)

### 테스트 결과

- performance-service: **67 통과 / 0 실패** ✅

### 📸 스크린샷

- (작성 필요)

---

## 👀 리뷰 요청 사항

- **잔여 경합 수용 여부**: 리더가 커밋 전 스냅샷을 읽고 evict 직후 재적재하는 read-then-put 경합은 구조적으로 남음 → TTL 30초 안전망으로 수용했습니다 (목록 표시용 데이터, 좌석/예매 정합성과 무관)
- **캐시 키 네이밍**(`performance:list`)은 #425(Redis 키 컨벤션 통일) 확정 전 임시입니다 — 확정 시 이관 예정
- `global.constants`가 common과 split package가 됐습니다 — #425/#439에서 common 승격 시 이 파일 삭제 선행 필요 (CacheConstants Javadoc에 명시)

---

## ⚠️ 배포 시 주의사항

- **신규 환경변수·수동 DDL 없음** — REDIS_HOST/PORT는 #298(ShedLock)부터 기주입, prod compose에 performance-service→redis 연결 기존재
- 배포 후 Redis에서 `performance:list::*` 키 생성·TTL 소멸 및 캐시 히트율 메트릭(prometheus `cache_*`) 확인 권장
- Redis 커맨드 타임아웃 1s가 ShedLock에도 적용됨 — 지연 스파이크 시 unlock 실패로 락이 최대 1분 잔존할 빈도가 소폭 증가하는 트레이드오프 수용
