### PR TITLE
[Chore] #425 Redis 운영 위생 정리 (설정 불일치·키 컨벤션·미사용 설정)

### DIFF
--- a/auth-service/src/main/java/com/ticketrush/boundedcontext/auth/out/repository/RedisRepository.java
+++ b/auth-service/src/main/java/com/ticketrush/boundedcontext/auth/out/repository/RedisRepository.java
@@ -13,13 +13,16 @@ public class RedisRepository {
 
   private final RedisTemplate<String, String> redisTemplate;
 
-  private static final String REFRESH_TOKEN_PREFIX = "RT:";
+  // Redis 키 컨벤션: {도메인}:{엔티티}[:{식별자}] 소문자 콜론 (docs/backend-convention.md §4)
+  private static final String REFRESH_TOKEN_PREFIX = "auth:refresh-token:";
 
-  private static final String SIGNUP_EMAIL_AUTH_NUMBER_PREFIX = "SIGNUP:EMAIL:AUTH_NUMBER:";
-  private static final String SIGNUP_EMAIL_AUTH_COOLDOWN_PREFIX = "SIGNUP:EMAIL:AUTH_COOLDOWN:";
-  private static final String SIGNUP_EMAIL_AUTH_VERIFIED_PREFIX = "SIGNUP:EMAIL:AUTH_VERIFIED:";
+  private static final String SIGNUP_EMAIL_AUTH_NUMBER_PREFIX = "auth:signup:email:auth-number:";
+  private static final String SIGNUP_EMAIL_AUTH_COOLDOWN_PREFIX =
+      "auth:signup:email:auth-cooldown:";
+  private static final String SIGNUP_EMAIL_AUTH_VERIFIED_PREFIX =
+      "auth:signup:email:auth-verified:";
   private static final String SIGNUP_EMAIL_AUTH_VERIFY_ATTEMPT_PREFIX =
-      "SIGNUP:EMAIL:AUTH_VERIFY_ATTEMPT:";
+      "auth:signup:email:auth-verify-attempt:";
 
   // 인증번호 유효시간 = 5분
   private static final Duration SIGNUP_EMAIL_AUTH_NUMBER_TTL = Duration.ofMinutes(5);

--- a/common/src/main/java/com/ticketrush/global/config/RedisConfig.java
+++ b/common/src/main/java/com/ticketrush/global/config/RedisConfig.java
@@ -1,10 +1,14 @@
 package com.ticketrush.global.config;
 
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.listener.RedisMessageListenerContainer;
 
+// 이 설정은 전 서비스에 컴포넌트 스캔된다. Redis를 안 쓰는 서비스(user/payment/ticket)는
+// spring.data.redis.host를 두지 않으므로 이 조건으로 빈 로드를 건너뛰어 불필요한 커넥션을 막는다.
+@ConditionalOnProperty(prefix = "spring.data.redis", name = "host")
 @Configuration
 public class RedisConfig {
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,9 @@ services:
   redis:
     image: redis:7-alpine
     container_name: redis
+    # prod(deploy/docker-compose.prod.yml)와 동일하게 keyspace 만료 이벤트(Ex) 활성화.
+    # 없으면 SeatLockExpirationListener가 안 뜨고 1분 주기 스케줄러 fallback에만 의존한다.
+    command: ["redis-server", "--notify-keyspace-events", "Ex"]
     ports:
       - "127.0.0.1:6379:6379"
     networks:

--- a/docs/backend-convention.md
+++ b/docs/backend-convention.md
@@ -342,3 +342,13 @@ class SeatControllerTest {
 * **DLT 자동 보존/삭제** — `dead_letter_record`는 기본 **30일** 보존 후 retention 배치가 자동 삭제합니다.
   보존 기간은 `app.dlt.monitor.retention-days`(환경변수 `DLT_RETENTION_DAYS`)로 조정합니다.
 * **Kafka .DLT 토픽 잔존 주의** — DB 저장값은 마스킹되지만 원본 메시지는 Kafka `.DLT` 토픽에 해당 토픽의 retention 기간 동안 잔존합니다. 운영 환경에서는 Kafka 토픽 retention 설정도 함께 관리하세요.
+
+### 🔑 Redis 키 컨벤션
+
+* **키 포맷** — `{도메인}:{엔티티}[:{식별자}]`, **전부 소문자**, 세그먼트 구분자는 콜론(`:`), 세그먼트 내 멀티워드는 케밥(`-`).
+  * 예: `seat:lock:{seatId}`, `booking:number:{예매번호}`, `auth:refresh-token:{userId}`, `auth:signup:email:auth-number:{email}`
+* **prefix 상수화** — 키 prefix는 도메인별 상수(예: `SeatLockKey`) 또는 Repository 상수 한 곳에서 관리하고, 여러 클래스에 리터럴을 하드코딩하지 않습니다.
+* **예외** — ShedLock 락 네임스페이스는 `{applicationName}-{profile}`(케밥, 예: `seat-service-local`) 형태입니다. 이는 `RedisLockProvider` 라이브러리 규약이라 위 콜론 컨벤션의 예외로 둡니다.
+* **DB 인덱스** — 현재 전 서비스가 단일 Redis 인스턴스의 **DB 0을 공유**하며, 충돌은 위 키 prefix로만 논리 분리합니다. 서비스별 `spring.data.redis.database` 분리는 실익(FLUSHDB 격리) 대비 기존 DB 0 키 마이그레이션·무중단 배포 순서 설계 비용이 커, 현재는 **보류**합니다(#425). 분리가 필요해지면 마이그레이션 절차부터 설계합니다.
+* **미사용 서비스** — Redis를 쓰지 않는 서비스(현재 user/payment/ticket)는 `spring.data.redis` 설정을 두지 않고 `RedisAutoConfiguration`을 exclude합니다. `common`의 `RedisConfig`는 `@ConditionalOnProperty("spring.data.redis.host")`로 게이트되어 host가 없으면 로드되지 않습니다.
+* **인프라 전제** — 좌석 락 만료 즉시 해제(`SeatLockExpirationListener`)는 Redis keyspace 만료 이벤트에 의존합니다. `--notify-keyspace-events Ex`가 로컬(`docker-compose.yml`)·운영(`deploy/docker-compose.prod.yml`) 양쪽에 켜져 있어야 하며, 없으면 1분 주기 `SeatStatusScheduler` fallback에만 의존하게 됩니다.

--- a/payment-service/src/main/resources/application-local.yml
+++ b/payment-service/src/main/resources/application-local.yml
@@ -9,7 +9,3 @@ spring:
       ddl-auto: ${SPRING_JPA_HIBERNATE_DDL_AUTO:update}
   kafka:
     bootstrap-servers: localhost:29092
-  data:
-    redis:
-      host: ${REDIS_HOST:localhost}
-      port: ${REDIS_PORT:6379}

--- a/payment-service/src/main/resources/application-prod.yml
+++ b/payment-service/src/main/resources/application-prod.yml
@@ -9,10 +9,6 @@ spring:
       ddl-auto: validate
   kafka:
     bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS}
-  data:
-    redis:
-      host: ${REDIS_HOST}
-      port: ${REDIS_PORT:6379}
 
 gateway:
   # 운영은 게이트웨이 내부 토큰을 반드시 주입(base의 test-token 기본값 오버라이드, 미주입 시 fail-fast).

--- a/payment-service/src/main/resources/application.yml
+++ b/payment-service/src/main/resources/application.yml
@@ -7,6 +7,10 @@ spring:
     active: ${SPRING_PROFILES_ACTIVE:local}
   application:
     name: payment-service
+  # payment-service는 Redis를 쓰지 않는다. common의 redis 스타터가 전이돼 오토컨피그가 뜨는 것을 막는다(#425).
+  autoconfigure:
+    exclude:
+      - org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration
   jpa:
     open-in-view: false
 

--- a/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/app/usecase/SeatLockUseCase.java
+++ b/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/app/usecase/SeatLockUseCase.java
@@ -1,5 +1,6 @@
 package com.ticketrush.boundedcontext.seat.app.usecase;
 
+import com.ticketrush.boundedcontext.seat.domain.constant.SeatLockKey;
 import com.ticketrush.global.constants.MetricNames;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
@@ -20,11 +21,10 @@ public class SeatLockUseCase {
   private final RedissonClient redissonClient;
   private final MeterRegistry meterRegistry;
 
-  private static final String SEAT_LOCK_PREFIX = "seat:lock:";
   private static final int LOCK_TTL_MINUTES = 5;
 
   public Optional<LocalDateTime> execute(Long seatId, Long userId) {
-    String lockKey = SEAT_LOCK_PREFIX + seatId;
+    String lockKey = SeatLockKey.of(seatId);
     RLock lock = redissonClient.getLock(lockKey);
 
     try {

--- a/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/app/usecase/SeatUnlockUseCase.java
+++ b/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/app/usecase/SeatUnlockUseCase.java
@@ -1,5 +1,6 @@
 package com.ticketrush.boundedcontext.seat.app.usecase;
 
+import com.ticketrush.boundedcontext.seat.domain.constant.SeatLockKey;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.redisson.api.RLock;
@@ -13,10 +14,9 @@ import org.springframework.stereotype.Service;
 public class SeatUnlockUseCase {
 
   private final RedissonClient redissonClient;
-  private static final String SEAT_LOCK_PREFIX = "seat:lock:";
 
   public void execute(Long seatId) {
-    String lockKey = SEAT_LOCK_PREFIX + seatId;
+    String lockKey = SeatLockKey.of(seatId);
     RLock lock = redissonClient.getLock(lockKey);
 
     /*
@@ -34,7 +34,7 @@ public class SeatUnlockUseCase {
   }
 
   public void forceRelease(Long seatId) {
-    String lockKey = SEAT_LOCK_PREFIX + seatId;
+    String lockKey = SeatLockKey.of(seatId);
     RLock lock = redissonClient.getLock(lockKey);
 
     if (lock.forceUnlock()) {

--- a/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/domain/constant/SeatLockKey.java
+++ b/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/domain/constant/SeatLockKey.java
@@ -1,0 +1,16 @@
+package com.ticketrush.boundedcontext.seat.domain.constant;
+
+/**
+ * 좌석 선점 Redisson 락의 Redis 키. prefix가 여러 곳(락 획득/해제, 만료 리스너)에 흩어져 하드코딩되던 것을 한 곳으로 모은다. 포맷: {@code
+ * seat:lock:{seatId}} — 소문자 콜론 컨벤션(docs/backend-convention.md §4 Redis 키 컨벤션).
+ */
+public final class SeatLockKey {
+
+  public static final String PREFIX = "seat:lock:";
+
+  private SeatLockKey() {}
+
+  public static String of(Long seatId) {
+    return PREFIX + seatId;
+  }
+}

--- a/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/in/eventlistener/SeatLockExpirationListener.java
+++ b/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/in/eventlistener/SeatLockExpirationListener.java
@@ -1,6 +1,7 @@
 package com.ticketrush.boundedcontext.seat.in.eventlistener;
 
 import com.ticketrush.boundedcontext.seat.app.usecase.SeatReleaseSingleUseCase;
+import com.ticketrush.boundedcontext.seat.domain.constant.SeatLockKey;
 import java.nio.charset.StandardCharsets;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.connection.Message;
@@ -12,7 +13,6 @@ import org.springframework.stereotype.Component;
 @Component
 public class SeatLockExpirationListener extends KeyExpirationEventMessageListener {
 
-  private static final String SEAT_LOCK_PREFIX = "seat:lock:";
   private final SeatReleaseSingleUseCase seatReleaseSingleUseCase;
 
   public SeatLockExpirationListener(
@@ -27,10 +27,10 @@ public class SeatLockExpirationListener extends KeyExpirationEventMessageListene
     String expiredKey = new String(message.getBody(), StandardCharsets.UTF_8);
 
     // 만료된 키가 좌석 락(seat:lock:)인지 확인
-    if (expiredKey.startsWith(SEAT_LOCK_PREFIX)) {
+    if (expiredKey.startsWith(SeatLockKey.PREFIX)) {
       try {
         // "seat:lock:123" 형태에서 "123" 추출
-        String seatIdStr = expiredKey.replace(SEAT_LOCK_PREFIX, "");
+        String seatIdStr = expiredKey.replace(SeatLockKey.PREFIX, "");
         Long seatId = Long.valueOf(seatIdStr);
 
         log.debug("Redis 락 만료 감지됨. seatId: {}", seatId);

--- a/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/app/usecase/SeatLockUseCaseTest.java
+++ b/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/app/usecase/SeatLockUseCaseTest.java
@@ -5,6 +5,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
+import com.ticketrush.boundedcontext.seat.domain.constant.SeatLockKey;
 import com.ticketrush.global.constants.MetricNames;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.time.LocalDateTime;
@@ -41,7 +42,7 @@ class SeatLockUseCaseTest {
     // given
     Long seatId = 100L;
     Long userId = 1L;
-    String expectedKey = "seat:lock:" + seatId;
+    String expectedKey = SeatLockKey.of(seatId);
 
     given(redissonClient.getLock(expectedKey)).willReturn(redissonLock);
     // tryLock(waitTime, leaseTime, TimeUnit) 성공(true) 시뮬레이션

--- a/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/in/eventlistener/SeatLockExpirationListenerTest.java
+++ b/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/in/eventlistener/SeatLockExpirationListenerTest.java
@@ -5,6 +5,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 import com.ticketrush.boundedcontext.seat.app.usecase.SeatReleaseSingleUseCase;
+import com.ticketrush.boundedcontext.seat.domain.constant.SeatLockKey;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -28,7 +29,7 @@ class SeatLockExpirationListenerTest {
   @DisplayName("올바른 키(seat:lock:) 만료 이벤트 수신 시 useCase를 호출한다")
   void onMessage_WithValidKey_CallsUseCase() {
     // given
-    String expiredKey = "seat:lock:123";
+    String expiredKey = SeatLockKey.of(123L);
     Message message = new DefaultMessage(new byte[0], expiredKey.getBytes());
 
     // when

--- a/ticket-service/src/main/resources/application-local.yml
+++ b/ticket-service/src/main/resources/application-local.yml
@@ -9,7 +9,3 @@ spring:
       ddl-auto: ${SPRING_JPA_HIBERNATE_DDL_AUTO:update}
   kafka:
     bootstrap-servers: localhost:29092
-  data:
-    redis:
-      host: ${REDIS_HOST:localhost}
-      port: ${REDIS_PORT:6379}

--- a/ticket-service/src/main/resources/application-prod.yml
+++ b/ticket-service/src/main/resources/application-prod.yml
@@ -9,10 +9,6 @@ spring:
       ddl-auto: validate
   kafka:
     bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS}
-  data:
-    redis:
-      host: ${REDIS_HOST}
-      port: ${REDIS_PORT:6379}
 
 gateway:
   # 운영은 게이트웨이 내부 토큰을 반드시 주입(base의 test-token 기본값 오버라이드, 미주입 시 fail-fast).

--- a/ticket-service/src/main/resources/application.yml
+++ b/ticket-service/src/main/resources/application.yml
@@ -7,6 +7,10 @@ spring:
     active: ${SPRING_PROFILES_ACTIVE:local}
   application:
     name: ticket-service
+  # ticket-service는 Redis를 쓰지 않는다. common의 redis 스타터가 전이돼 오토컨피그가 뜨는 것을 막는다(#425).
+  autoconfigure:
+    exclude:
+      - org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration
   jpa:
     open-in-view: false
 

--- a/user-service/src/main/resources/application-local.yml
+++ b/user-service/src/main/resources/application-local.yml
@@ -9,7 +9,3 @@ spring:
       ddl-auto: ${SPRING_JPA_HIBERNATE_DDL_AUTO:update}
   kafka:
     bootstrap-servers: localhost:29092
-  data:
-    redis:
-      host: ${REDIS_HOST:localhost}
-      port: ${REDIS_PORT:6379}

--- a/user-service/src/main/resources/application-prod.yml
+++ b/user-service/src/main/resources/application-prod.yml
@@ -9,10 +9,6 @@ spring:
       ddl-auto: validate
   kafka:
     bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS}
-  data:
-    redis:
-      host: ${REDIS_HOST}
-      port: ${REDIS_PORT:6379}
 
 gateway:
   # 운영은 게이트웨이 내부 토큰을 반드시 주입(base의 test-token 기본값 오버라이드, 미주입 시 fail-fast).

--- a/user-service/src/main/resources/application.yml
+++ b/user-service/src/main/resources/application.yml
@@ -7,6 +7,10 @@ spring:
     active: ${SPRING_PROFILES_ACTIVE:local}
   application:
     name: user-service
+  # user-service는 Redis를 쓰지 않는다. common의 redis 스타터가 전이돼 오토컨피그가 뜨는 것을 막는다(#425).
+  autoconfigure:
+    exclude:
+      - org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration
   jpa:
     open-in-view: false
 


### PR DESCRIPTION
## 🔗 관련 이슈

- close #425

---

## 📌 주요 변경 사항

- 로컬/prod Redis 설정 불일치 해소 — 로컬 compose에 `--notify-keyspace-events Ex` 추가
- `seat:lock:` 3중 하드코딩을 `SeatLockKey` 공유 상수로 추출
- Redis 키 prefix 컨벤션 통일 + auth 키 실제 리네임 + `docs/backend-convention.md` 기록
- Redis 미사용 서비스(user/payment/ticket)의 설정 안전 제거
- DB 인덱스 분리는 보류 결정, 근거를 문서화

---

## 🛠 상세 구현 내용

- **item 1 (설정 불일치)**: `docker-compose.yml` redis에 `command: ["redis-server", "--notify-keyspace-events", "Ex"]` 추가. 로컬에서도 `SeatLockExpirationListener`가 동작해 좌석 락 만료 즉시 해제(기존엔 1분 주기 `SeatStatusScheduler` fallback에만 의존).
- **item 4 (상수화)**: `SeatLockKey`(신규, `domain/constant`) 도입. `SeatLockUseCase`·`SeatUnlockUseCase`·`SeatLockExpirationListener`의 리터럴을 `SeatLockKey.of(seatId)`/`SeatLockKey.PREFIX`로 통합, 관련 테스트도 상수 참조로 갱신.
- **item 3 (키 컨벤션)**: 표준 `{도메인}:{엔티티}[:{식별자}]`(소문자 콜론, 멀티워드 kebab) 정의. `RedisRepository`의 auth 키 리네임(`RT:`→`auth:refresh-token:`, `SIGNUP:EMAIL:*`→`auth:signup:email:*`). `docs/backend-convention.md` §4에 "Redis 키 컨벤션" 섹션 신설.
- **item 5 (미사용 설정 제거)**: user/payment/ticket의 `application-local/prod.yml`에서 `spring.data.redis` 제거 + `application.yml`에 `RedisAutoConfiguration` exclude. common `RedisConfig`에 `@ConditionalOnProperty(spring.data.redis.host)` 게이트를 추가해, redis 미설정 서비스에서 `RedisMessageListenerContainer` 빈이 로드되지 않도록(전 서비스 컴포넌트 스캔 구조에서 기동 실패 방지). performance-service는 ShedLock으로 Redis 실사용 → 유지.
- **item 2 (DB 인덱스 분리)**: prefix로 이미 논리 분리되어 있고 기존 DB0 키 마이그레이션/무중단 배포 비용 대비 실익이 작아 **보류 결정**, 근거를 컨벤션 문서에 기록.

---

## ✅ 테스트

### 테스트 방법

- `./gradlew :common:compileJava :seat-service:compileTestJava :auth-service:compileTestJava :user-service:compileJava :payment-service:compileJava :ticket-service:compileJava` — 변경 모듈 전체 컴파일
- `./gradlew :seat-service:test --tests "*SeatLockUseCaseTest" --tests "*SeatLockExpirationListenerTest"` — 상수화 회귀
- `./gradlew :user-service:test :payment-service:test :ticket-service:test --tests "*ApplicationTests"` — 미사용 서비스 컨텍스트 로드(부팅) 검증

### 테스트 결과

- 전체 컴파일 `BUILD SUCCESSFUL`
- seat 락 단위 테스트 통과 (`SeatLockKey` 상수 경유 후에도 동일 키/동작)
- user/payment/ticket 컨텍스트 로드 테스트 통과 — 실제 Hikari/Kafka 부팅되면서 **Redis 커넥션 오류 0**, redis 제거 후 정상 기동/종료 확인
<!--
### 📸 스크린샷

- (작성 필요 — 로컬 좌석 5분 만료 실시간 해제 수동 시연)
-->
---

## 👀 리뷰 요청 사항

- item 5: common `RedisConfig`를 `@ConditionalOnProperty`로 게이트한 접근이 전 서비스 공통 변경입니다. redis 사용 서비스(auth/seat/booking/performance)의 리스너 컨테이너 로드에 영향 없는지 봐주세요.
- item 3: auth 키 리네임 범위(리프레시 토큰 + 회원가입 이메일 인증 키)가 적절한지 확인 부탁드립니다.

---

## ⚠️ 배포 시 주의사항

- **auth `RT:` → `auth:refresh-token:` 리네임**으로 배포 순간 기존 리프레시 토큰이 orphan 처리됩니다(재로그인 필요). 현재 프리런치 단계라 실사용자 영향은 사실상 없음.
- 운영 Redis는 이미 `--notify-keyspace-events Ex`가 켜져 있어 추가 조치 불필요(이번 변경은 로컬 compose 정합).
