### PR TITLE
[Infra] #426 Redis SPOF 수용 결정 및 전제 조건 확보 (fail-closed + ADR 기록)

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -226,6 +226,7 @@ jobs:
           EXPECTED_SERVICES=(
             mysql
             redis
+            redis-exporter
             kafka
             gateway-service
             auth-service

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,8 +84,14 @@ jobs:
           expected = {f"{name}:{MGMT_PORT}" for name in deployed}
           for miss in sorted(expected - scraped):
               errors.append(f"배포되는데 스크랩하지 않는다: {miss}")
+
+          # 앱이 아닌 타깃(redis-exporter 등)도 스크랩한다. 이 검증의 목적은 up=0 인 타깃을 막는 것이므로,
+          # 앱처럼 :8090 을 강제하는 대신 compose 에 그 서비스가 실제로 있는지만 본다.
+          # (exporter 는 SERVER_PORT 가 없어 deployed 에 잡히지 않고, 포트도 앱과 다르다.)
+          services = set(comp["services"])
           for extra in sorted(scraped - expected):
-              errors.append(f"스크랩하는데 배포되지 않는다 (up=0 이 된다): {extra}")
+              if extra.split(":")[0] not in services:
+                  errors.append(f"스크랩하는데 배포되지 않는다 (up=0 이 된다): {extra}")
 
           # 타깃 포트가 각 서비스의 실제 management.server.port 와 같은가
           for name in sorted(deployed):

--- a/auth-service/src/main/resources/application-prod.yml
+++ b/auth-service/src/main/resources/application-prod.yml
@@ -13,6 +13,8 @@ spring:
     redis:
       host: ${REDIS_HOST}
       port: ${REDIS_PORT:6379}
+      # local은 무인증 Redis라 prod 프로파일에만 둔다(ADR 0008).
+      password: ${REDIS_PASSWORD}
 
 oauth:
   kakao:

--- a/booking-service/src/main/resources/application-prod.yml
+++ b/booking-service/src/main/resources/application-prod.yml
@@ -13,6 +13,8 @@ spring:
     redis:
       host: ${REDIS_HOST}
       port: ${REDIS_PORT:6379}
+      # local은 무인증 Redis라 prod 프로파일에만 둔다(ADR 0008).
+      password: ${REDIS_PASSWORD}
 
 service:
   ticket:

--- a/common/src/main/java/com/ticketrush/global/exception/GlobalExceptionHandler.java
+++ b/common/src/main/java/com/ticketrush/global/exception/GlobalExceptionHandler.java
@@ -9,6 +9,7 @@ import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.core.convert.ConversionFailedException;
 import org.springframework.dao.OptimisticLockingFailureException;
+import org.springframework.data.redis.RedisConnectionFailureException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.authorization.AuthorizationDeniedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -72,6 +73,35 @@ public class GlobalExceptionHandler {
     log.warn("Optimistic locking conflict: {}", e.getMessage());
 
     return ApiResponse.onFailure(ErrorStatus.CONFLICT);
+  }
+
+  /*
+   * Redis 불가 = fail-closed로 요청을 거절한다(ADR 0008). 재시도하면 되는 일시 장애인데
+   * 아래 Exception 핸들러에 걸려 500 "관리자에게 문의"로 나가면 사용자를 오도한다.
+   *
+   * 여기서 잡는 것은 Lettuce 계열(RedisTemplate·캐시)뿐이다. Spring이 RedisConnectionFailureException으로
+   * 변환해주며, hang형(연결은 살아있고 응답만 없음)은 RedisCommandTimeoutException이 원인으로 감싸여 온다.
+   *
+   * Redisson(좌석 락)은 Spring 예외 변환을 타지 않아 RedisException(RuntimeException)을 그대로 던지므로
+   * 이 핸들러에 걸리지 않는다. 그러나 Redisson 의존성은 seat-service에만 있어 common에서 등록하면
+   * 나머지 서비스가 클래스 로딩에 실패한다 — 그래서 seat-service의 SeatRedissonExceptionHandler가 맡는다.
+   *
+   * QueryTimeoutException은 일부러 잡지 않는다. Redis 전용이 아니라 JDBC·JPA 쿼리 타임아웃도
+   * 여기로 변환되므로, 등록하면 common을 쓰는 전 서비스의 DB 타임아웃 응답까지 조용히 503으로 바뀐다.
+   * DB 타임아웃의 처리 방침은 ADR 0008의 범위가 아니다.
+   *
+   * NOAUTH(비밀번호 오설정)도 잡지 않는다. RedisSystemException으로 도착해 500이 되는데,
+   * 그건 일시 장애가 아니라 설정 버그이므로 500이 옳다.
+   *
+   * 좌석 락의 Kafka 경로는 이 핸들러를 타지 않는다 — KafkaConsumerErrorPolicy가 Redis 예외를
+   * 일시로 분류해 재시도·DLT로 보존한다.
+   */
+  @ExceptionHandler(RedisConnectionFailureException.class)
+  public ResponseEntity<ApiResponse<?>> handleTransientInfraException(RuntimeException e) {
+    storeException(e);
+    log.error("인프라 일시 장애로 요청을 거절했습니다.", e);
+
+    return ApiResponse.onFailure(ErrorStatus.INFRA_TRANSIENT_UNAVAILABLE);
   }
 
   @ExceptionHandler(Exception.class)

--- a/common/src/main/java/com/ticketrush/global/status/ErrorStatus.java
+++ b/common/src/main/java/com/ticketrush/global/status/ErrorStatus.java
@@ -25,6 +25,12 @@ public enum ErrorStatus {
   INFRA_KAFKA_PUBLISH_FAILED(
       HttpStatus.INTERNAL_SERVER_ERROR, "INFRA_500_001", "카프카 메시지 발행 중 인프라 오류가 발생했습니다."),
 
+  // Infra 503
+  // Redis 불가 시 fail-closed로 요청을 거절한다(ADR 0008). 재시도하면 되는 일시 장애이므로
+  // 500("관리자에게 문의")이 아니라 503 + 재시도 안내로 내보낸다. 내부 구현어(Redis)는 노출하지 않는다.
+  INFRA_TRANSIENT_UNAVAILABLE(
+      HttpStatus.SERVICE_UNAVAILABLE, "INFRA_503_001", "일시적으로 요청을 처리할 수 없습니다. 잠시 후 다시 시도해 주세요."),
+
   // Auth 400
   AUTH_PROVIDER_NOT_SUPPORT(HttpStatus.BAD_REQUEST, "AUTH_400_001", "지원하지 않는 소셜로그인입니다."),
   AUTH_KAKAO_TOKEN_FAILED(HttpStatus.BAD_REQUEST, "AUTH_400_002", "잘못된 카카오 토큰입니다."),

--- a/common/src/test/java/com/ticketrush/global/exception/GlobalExceptionHandlerTest.java
+++ b/common/src/test/java/com/ticketrush/global/exception/GlobalExceptionHandlerTest.java
@@ -1,0 +1,72 @@
+package com.ticketrush.global.exception;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.ticketrush.global.dto.response.ApiResponse;
+import com.ticketrush.global.status.ErrorStatus;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.dao.QueryTimeoutException;
+import org.springframework.data.redis.RedisConnectionFailureException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+/**
+ * Redis 장애가 500 "관리자에게 문의"로 뭉개지지 않고 503 + 재시도 안내로 나가는지 검증한다(ADR 0008).
+ *
+ * <p>MockMvc를 쓰지 않는 이유: common은 Jackson 3(tools.jackson)를 쓰는데 MockMvc의 기본 메시지 컨버터가 Jackson 2를 찾아
+ * 클래스패스에서 깨진다. 대신 핸들러의 반환값과 {@code @ExceptionHandler} 등록 예외 타입을 함께 검증해, "어떤 예외가 이 핸들러로 라우팅되는가"와 "그때
+ * 무엇을 반환하는가"를 모두 덮는다.
+ */
+class GlobalExceptionHandlerTest {
+
+  private final GlobalExceptionHandler handler = new GlobalExceptionHandler();
+
+  @Test
+  @DisplayName("Redis 연결 실패는 503 INFRA_503_001로 나간다")
+  void redisConnectionFailureReturns503() {
+    ResponseEntity<ApiResponse<?>> response =
+        handler.handleTransientInfraException(new RedisConnectionFailureException("refused"));
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);
+    assertThat(response.getBody().getCode())
+        .isEqualTo(ErrorStatus.INFRA_TRANSIENT_UNAVAILABLE.getCode());
+  }
+
+  @Test
+  @DisplayName("Lettuce 예외만 등록한다 — Redisson 예외는 seat-service의 어드바이스가 맡는다")
+  void onlyLettuceExceptionIsRoutedHere() throws NoSuchMethodException {
+    ExceptionHandler annotation =
+        GlobalExceptionHandler.class
+            .getMethod("handleTransientInfraException", RuntimeException.class)
+            .getAnnotation(ExceptionHandler.class);
+
+    List<Class<? extends Throwable>> registered = Arrays.asList(annotation.value());
+
+    assertThat(registered).containsExactly(RedisConnectionFailureException.class);
+  }
+
+  @Test
+  @DisplayName("QueryTimeoutException은 잡지 않는다 — 잡으면 전 서비스의 DB 타임아웃까지 503이 된다")
+  void queryTimeoutIsNotRoutedHere() throws NoSuchMethodException {
+    ExceptionHandler annotation =
+        GlobalExceptionHandler.class
+            .getMethod("handleTransientInfraException", RuntimeException.class)
+            .getAnnotation(ExceptionHandler.class);
+
+    assertThat(Arrays.asList(annotation.value())).doesNotContain(QueryTimeoutException.class);
+  }
+
+  @Test
+  @DisplayName("일시 장애가 아닌 예외는 종전대로 500이다 — 503으로 넓게 삼키지 않는다")
+  void otherExceptionStillReturns500() {
+    ResponseEntity<ApiResponse<?>> response =
+        handler.handleException(new IllegalStateException("boom"));
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
+    assertThat(response.getBody().getCode()).isEqualTo(ErrorStatus.INTERNAL_SERVER_ERROR.getCode());
+  }
+}

--- a/deploy/.env.prod.example
+++ b/deploy/.env.prod.example
@@ -18,8 +18,10 @@ MYSQL_ROOT_PASSWORD=__REQUIRED__
 # Kafka (MSK 등)
 KAFKA_BOOTSTRAP_SERVERS=
 # Redis (ElastiCache 등)
+# REDIS_PASSWORD는 Redis(requirepass)·앱 4개·redis-exporter가 함께 쓴다. 미설정 시 배포가 멈춘다(ADR 0008).
 REDIS_HOST=
 REDIS_PORT=6379
+REDIS_PASSWORD=__REQUIRED__
 # 게이트웨이 내부 호출 토큰(전 서비스 공유, 반드시 오버라이드)
 GATEWAY_INTERNAL_TOKEN=
 # 서비스 간 내부 API 호출 전용 토큰
@@ -41,6 +43,8 @@ TICKET_SERVICE_URL=
 # ==================================================
 GRAFANA_ADMIN_USER=admin
 GRAFANA_ADMIN_PASSWORD=__REQUIRED__
+# Redis 다운 알림(ADR 0008)은 아래 booking-service 섹션의 SLACK_WEBHOOK_URL을 그대로 쓴다.
+# 채널을 나눠야 할 이유가 생기면 그때 별도 키로 분리한다.
 
 # ===== gateway-service =====
 JWT_SECRET=
@@ -92,6 +96,8 @@ TICKET_QR_SECRET=
 DLT_MONITOR_ENABLED=true
 # DLT_RETENTION_DAYS=30
 SLACK_ENABLED=true
-SLACK_WEBHOOK_URL=
+# booking-service DLT 알림과 Grafana의 Redis 다운 알림(ADR 0008)이 함께 쓴다.
+# Grafana가 이 값 없이는 기동하지 않으므로 빈 값을 둘 수 없다.
+SLACK_WEBHOOK_URL=__REQUIRED__
 INBOX_RETENTION_ENABLED=true
 # INBOX_RETENTION_DAYS=30

--- a/deploy/docker-compose.prod.yml
+++ b/deploy/docker-compose.prod.yml
@@ -34,21 +34,69 @@ services:
   redis:
     image: redis:7-alpine
     container_name: ticketrush-redis
+    # 실측 최대 4.1 MiB / 상한의 3.20%로 여유가 30배다(ADR 0006). 상향 근거가 없어 유지한다.
     mem_limit: 128m
     restart: unless-stopped
+    # healthcheck가 `redis-cli -a <비밀번호>`를 쓰지 않아도 되게 한다. redis-cli가 이 값을 자동으로 읽으므로
+    # healthcheck 프로세스 인자에는 비밀번호가 실리지 않고, `-a`가 매번 뱉는 경고도 없다.
+    # (아래 --requirepass는 redis-server의 인자라 `ps`·`docker inspect`에 그대로 보인다. 그걸 없애려면
+    #  redis.conf 마운트가 필요한데, 같은 호스트에서 그 파일을 읽을 수 있는 주체는 어차피 .env도 읽는다.)
+    environment:
+      REDISCLI_AUTH: ${REDIS_PASSWORD:?deploy/.env에 REDIS_PASSWORD를 설정하세요}
     command:
       - redis-server
+      # Redis는 포트를 publish 하지 않아 노출면이 같은 compose 네트워크로 한정되지만,
+      # 컨테이너 하나만 뚫려도 락·토큰·캐시가 통째로 무방비가 된다(ADR 0008).
+      - --requirepass
+      - ${REDIS_PASSWORD:?deploy/.env에 REDIS_PASSWORD를 설정하세요}
       - --appendonly
       - "yes"
       - --notify-keyspace-events
       - Ex
+      # mem_limit(128m)만 있으면 Redis는 자기 상한을 모른 채 커널에 OOMKill 당한다.
+      # SPOF를 수용하기로 한 이상(ADR 0008) 가장 흔한 사망 원인을 방치할 수 없어 스스로 방어하게 한다.
+      #
+      # 64mb인 이유(= 상한의 50%): appendonly가 켜져 있어 AOF rewrite는 fork를 하고 최악의 CoW는
+      # 데이터셋 전체 복사다. 상한에 가깝게 잡으면(예: 96mb) 정작 가득 찬 순간 데이터+CoW+출력 버퍼가
+      # 128m을 넘겨, noeviction이 거절을 시작하기 전에 커널이 먼저 죽인다 — 막으려던 실패 모드가 그대로 남는다.
+      - --maxmemory
+      - 64mb
+      # noeviction이어야 한다. allkeys-lru였다면 좌석 락 키가 evict돼 중복 HOLD 경로가 열린다.
+      # 한도 초과 시 쓰기를 거절하는 편이 fail-closed 원칙과 일치한다.
+      - --maxmemory-policy
+      - noeviction
     volumes:
       - redis-data:/data
     healthcheck:
-      test: ["CMD", "redis-cli", "ping"]
+      # 무인증 ping은 NOAUTH 에러를 "응답"으로 받는다. 종료코드에만 기대면 false-healthy가 될 수 있고,
+      # 그러면 앱 4개가 붙지도 못할 Redis를 향해 기동한다. 응답 문자열을 직접 확인한다.
+      test: ["CMD-SHELL", "redis-cli ping | grep -q PONG"]
       interval: 10s
       timeout: 5s
       retries: 5
+    networks:
+      - ticketrush-network
+
+  # Redis 지표 수집 경로가 없어 장애를 사후에 500 로그로만 인지했다(ADR 0008).
+  # SPOF를 수용하는 이상 죽었을 때 즉시 아는 것이 유일한 대응책이므로 redis_up을 Grafana 알림에 물린다.
+  redis-exporter:
+    image: oliver006/redis_exporter:v1.62.0-alpine
+    container_name: ticketrush-redis-exporter
+    mem_limit: 32m
+    restart: unless-stopped
+    # 관측 포트는 인터넷에 열지 않는다(ADR 0007). Prometheus가 같은 네트워크에서 서비스명으로 스크랩한다.
+    #
+    # 주소는 앱 4개와 같은 ${REDIS_HOST}/${REDIS_PORT}를 쓴다. 여기만 redis:6379로 고정하면
+    # ElastiCache로 옮겼을 때(ADR 0008 재평가 트리거) 앱은 따라가지만 exporter는 사라진 컨테이너를
+    # 계속 보며 redis_up=0을 내고, 알림이 실제 다운을 알리는 신호가 아니게 된다.
+    environment:
+      REDIS_ADDR: redis://${REDIS_HOST}:${REDIS_PORT:-6379}
+      REDIS_PASSWORD: ${REDIS_PASSWORD:?deploy/.env에 REDIS_PASSWORD를 설정하세요}
+    # service_healthy가 아니다. Redis가 죽어 있을 때 redis_up=0을 보고하는 것이 이 컨테이너의 존재
+    # 이유인데, healthy를 조건으로 걸면 정작 감지해야 할 상황에서 exporter 자신이 뜨지 못한다.
+    depends_on:
+      redis:
+        condition: service_started
     networks:
       - ticketrush-network
 
@@ -337,9 +385,25 @@ services:
       GF_SECURITY_ADMIN_USER: ${GRAFANA_ADMIN_USER:?deploy/.env에 GRAFANA_ADMIN_USER를 설정하세요}
       GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_ADMIN_PASSWORD:?deploy/.env에 GRAFANA_ADMIN_PASSWORD를 설정하세요}
       GF_USERS_ALLOW_SIGN_UP: "false"
+      # Redis 다운 알림의 Slack contact point가 프로비저닝 파일에서 $SLACK_WEBHOOK_URL로 참조한다(ADR 0008).
+      # booking-service DLT 알림과 같은 webhook을 재사용한다.
+      SLACK_WEBHOOK_URL: ${SLACK_WEBHOOK_URL:?deploy/.env에 SLACK_WEBHOOK_URL을 설정하세요}
+    # 로컬(docker-compose.yml)은 provisioning 디렉토리를 통째로 마운트하지만, 배포본은 하위 디렉토리별로
+    # 나눠 마운트한다. 알림만 배포본 전용 소스(provisioning-aws)에서 가져와야 하기 때문이다.
+    #
+    # 알림을 provisioning/ 공용 디렉토리에 두면 로컬 compose가 그것까지 마운트하는데, 로컬 스택에는
+    # redis-exporter가 없어 redis_up 자체가 없다 → noDataState=Alerting → 모든 개발자 로컬에서
+    # "Redis 다운"이 영구 발화한다. prometheus.yml / prometheus.aws.yml 로 로컬·배포본을 나누는
+    # 기존 관행과 같은 이유다.
+    #
+    # 부모(/etc/grafana/provisioning)를 :ro로 통째 마운트한 뒤 그 안에 alerting을 겹쳐 마운트하는 방식은
+    # 쓸 수 없다 — 읽기 전용이라 마운트포인트를 만들지 못해 컨테이너가 기동에 실패한다.
+    # 하위별 마운트는 이미지에 이미 있는 디렉토리를 그대로 쓰므로 그 문제가 없다.
     volumes:
       # datasource url이 http://prometheus:9090(서비스명)이라 로컬과 같은 파일을 그대로 쓴다.
-      - ./monitoring/grafana/provisioning:/etc/grafana/provisioning:ro
+      - ./monitoring/grafana/provisioning/datasources:/etc/grafana/provisioning/datasources:ro
+      - ./monitoring/grafana/provisioning/dashboards:/etc/grafana/provisioning/dashboards:ro
+      - ./monitoring/grafana/provisioning-aws/alerting:/etc/grafana/provisioning/alerting:ro
       - ./monitoring/grafana/dashboards:/var/lib/grafana/dashboards:ro
       - grafana-data:/var/lib/grafana
     depends_on:

--- a/docs/adr/0008-accept-redis-spof-with-fail-closed.md
+++ b/docs/adr/0008-accept-redis-spof-with-fail-closed.md
@@ -1,0 +1,156 @@
+# 8. Redis 단일 인스턴스 SPOF를 수용하고, 장애 시 전면 차단(fail-closed)한다
+
+날짜: 2026-07-16
+
+## 상태
+
+승인됨
+
+[ADR 0006](0006-eight-gib-container-memory-limits.md)의 메모리 예산과 [ADR 0007](0007-observability-stack-colocation.md)의 관측 스택 배치를 전제로 한다.
+
+## 맥락
+
+`deploy/docker-compose.prod.yml`의 Redis는 컨테이너 **1개**다. 복제도, Sentinel도, Cluster도 없다. 단일 장애점(SPOF)이다.
+
+**Redis가 떠받치는 것**은 캐시만이 아니다.
+
+| 용도 | 위치 | 성격 |
+|---|---|---|
+| 좌석 Redisson 락 | `SeatLockUseCase.java:28-32` | 정합성 자산 |
+| 예매번호 SETNX 멱등키 | `BookingIssueNumberUseCase.java:32` | 정합성 자산 |
+| RefreshToken | auth-service | 정합성 자산 |
+| 공연 목록 캐시 · ShedLock | performance-service | 최적화 |
+
+앞의 셋이 인메모리 스토어 위에 있다는 것이 문제의 핵심이었다. 특히 prod Redis는 `appendonly yes`이지만 fsync 기본 정책이 `everysec`이라 **크래시 시 최대 1초치 쓰기가 유실된다.** 그 사이 걸린 락 키가 사라진 채 재시작되면 같은 좌석에 두 개의 HOLD가 성립할 수 있었다 — 좌석 중복 판매.
+
+작용한 힘은 다음과 같다.
+
+- **비용 제약.** [ADR 0006](0006-eight-gib-container-memory-limits.md)이 정한 8 GiB 단일 인스턴스 예산 안에서 운영한다. Sentinel HA는 최소 컨테이너 4개에 수백 MiB로 예산 밖이고, ElastiCache Multi-AZ는 인스턴스 비용이 별도로 붙는다.
+- **장애 시에만 도는 코드는 검증되지 않는다.** 락 획득 실패 시 DB 낙관적 락으로 degradation하는 안이 논의됐다. 그러나 평소에 한 번도 실행되지 않는 경로는 정작 장애 순간에 두 번째 장애를 만든다.
+- **정합성은 DB가 보장해야 한다.** 최종 방어선이 인메모리 스토어에 있는 구조 자체가 잘못이었다.
+
+### 결정을 가능하게 한 전제 — #427
+
+`Seat` 엔티티에 `@Version`을 추가하는 [#427](https://github.com/TicketRush/TicketRush-backend/pull/431)이 **이 결정의 전제 조건**이었고, 먼저 완료됐다(`Seat.java:113-115`).
+
+이제 DB가 최종 방어선이므로 **Redis 상태와 무관하게 좌석 중복 판매가 불가능하다.** 컬럼 하나를 추가하는 비용으로 Redis HA보다 확실한 안전을 얻었다. 이 전제가 없었다면 SPOF 수용은 정합성 포기와 같은 말이었다.
+
+### 검토한 대안
+
+1. **Redis HA 도입(Sentinel / Cluster / ElastiCache Multi-AZ)** — 기각. 비용·예산 제약. 그리고 #427 이후로는 HA가 막아주는 것이 "가용성"뿐이며, 그 대가가 이 프로젝트 단계에서 균형이 맞지 않는다.
+2. **락 실패 시 DB 낙관적 락으로 degradation(fail-open)** — 기각. 위에 적은 대로 검증되지 않는 경로이며, 이중 선점을 허용하는 순간 락의 존재 이유가 사라진다.
+3. **SPOF 수용 + fail-closed + 값싼 완화책** — 채택.
+
+## 결정
+
+**Redis SPOF를 수용한다. 대신 Redis 장애 시 전면 차단(fail-closed)하고, 정합성은 DB로 내린다.**
+
+Redis 장애의 결과는 **가용성 손실(예매 거절)이지 정합성 손실(중복 판매)이 아니다.** #427이 그것을 보장한다.
+
+### 1. 락·멱등 경로는 fail-closed
+
+Redis 불가 = 요청 거절 + 재시도 유도. degradation 경로를 만들지 않는다.
+
+**예외는 공연 목록 캐시 하나뿐이다**(`CacheConfig.java`의 `FailOpenCacheErrorHandler`). 캐시는 정합성 자산이 아니라 지연 최적화이므로 fail-open이 맞다. 이 비대칭은 의도된 것이다.
+
+### 2. HA는 도입하지 않는다
+
+전 서비스가 단일 Redis 인스턴스를 공유한다.
+
+### 3. 인증은 password만. TLS는 도입하지 않는다
+
+`requirepass`를 적용하고 Redis 사용 4개 서비스(auth/booking/performance/seat)와 redis-exporter가 같은 `REDIS_PASSWORD`를 쓴다. Redisson은 별도 설정 없이 `spring.data.redis`를 그대로 물려받으므로 락 경로도 함께 인증된다.
+
+**TLS 미도입 근거**: Redis는 `ports`를 publish하지 않아 단일 EC2의 docker bridge 네트워크 밖에서 도달할 수 없다. 이 위협 모델에서 통신을 도청할 수 있는 주체는 같은 호스트의 root뿐이고, **root라면 TLS 개인키도 함께 읽는다** — 실질 이득이 0이다. 반면 `requirepass`는 다르다. 같은 네트워크의 다른 컨테이너가 실수나 침해로 붙는 것을 막는 실질 이득이 있고, 비용은 설정 한 줄이다.
+
+**password는 `ps`에 노출된다.** `--requirepass`가 `command`에 있어 redis-server의 프로세스 인자로 `ps`·`docker inspect`에 그대로 보인다. 없애려면 `redis.conf` 마운트가 필요한데, 같은 호스트에서 그 파일을 읽을 수 있는 주체는 어차피 `.env`도 읽으므로 위 위협 모델 안에서는 이득이 없다. 다만 "password를 걸었으니 호스트 접근자에게도 가려진다"는 뜻은 아니다. healthcheck는 예외로 `REDISCLI_AUTH` 환경변수를 써서 인자 노출과 경고를 함께 피한다.
+
+`.env`에 `REDIS_PASSWORD`가 없으면 compose의 `:?` 보간이 **배포를 멈춘다.** 무인증 Redis가 조용히 뜨는 것이 가장 나쁜 실패 모드이기 때문이다. healthcheck도 종료코드가 아니라 `PONG` 응답 문자열을 확인해 false-healthy를 막는다. 다만 `:?`는 unset·빈 값만 거른다 — `.env.prod.example`의 `__REQUIRED__`를 **그대로 복사하면 배포는 성공한다.** 플레이스홀더 값을 실제 값으로 바꾸는 것은 여전히 사람의 몫이다.
+
+### 4. `maxmemory 64mb` + `noeviction`을 명시한다
+
+`mem_limit: 128m`만 있으면 **Redis는 자기 상한을 모른 채 커널 OOM killer에 프로세스째 죽는다.** 장애가 "명시적 거절"이 아니라 "돌연사"가 된다. SPOF를 수용하기로 한 이상 가장 흔한 사망 원인을 방치할 수 없다.
+
+`maxmemory`가 있으면 상한 도달 시 `noeviction`이 **쓰기에 OOM 에러를 응답**하고 읽기는 계속된다 — 이 문서가 정한 fail-closed와 정확히 일치한다.
+
+`noeviction`은 Redis 7 기본값이지만 **명시한다.** Redis가 들고 있는 것은 전부 정합성 자산이라 evict 대상이 될 수 없는데, 명시하지 않으면 "캐시니까 LRU 아니냐"가 리뷰마다 재발하고 누군가 바꿔도 근거가 남지 않는다. 설정 두 줄이 문서 역할을 한다.
+
+**값은 상한의 50%인 `64mb`다.** `appendonly`가 켜져 있어 AOF rewrite는 fork를 하고, 최악의 CoW는 데이터셋 전체 복사다. 상한에 가깝게 잡으면(예: 96mb) 정작 데이터가 가득 찬 순간 데이터 + CoW + 클라이언트 출력 버퍼가 128m을 넘겨 **noeviction이 거절을 시작하기 전에 커널이 먼저 죽인다** — 이 결정이 없애려던 바로 그 실패 모드가 그대로 남는다. 여유를 절반 남기는 통상 권고를 따른다.
+
+**`mem_limit: 128m`은 유지한다** — [ADR 0006](0006-eight-gib-container-memory-limits.md)의 실측 최대 사용량이 4.1 MiB(상한의 3.20%)로, 64mb 기준으로도 여유가 15배다.
+
+**한도 임박도 알린다.** 한도에 닿아도 Redis는 살아 있어 `redis_up`은 1이다. 즉 다운 알림만으로는 "예매가 실패하는데 아무도 모르는" 상태가 새로 생긴다. exporter가 이미 내보내는 `redis_memory_used_bytes / redis_memory_max_bytes`로 80% 초과 5분 지속 시 별도 경고를 보낸다. 정상 트래픽에서 도달할 값은 아니다(RefreshToken은 사용자당 1키 + TTL, 예매번호 키는 10분 TTL이라 상한이 사용자 수에 묶인다) — 사고·버그 시나리오를 위한 그물이다.
+
+### 5. 감지는 redis_exporter + Grafana Alerting → Slack
+
+SPOF를 수용하는 이상 **죽었을 때 즉시 아는 것이 유일한 대응책이다.** 그런데 지금까지 Redis 지표를 긁는 주체가 없어 장애를 사후에 500 로그로만 인지했다.
+
+`redis-exporter` 컨테이너(32 MiB)를 추가해 `redis_up`을 수집하고, Grafana Alerting이 `redis_up == bool 0`을 1분 유지 시 Slack으로 보낸다. exporter는 포트를 publish하지 않는다([ADR 0007](0007-observability-stack-colocation.md)). `depends_on`은 `service_started`다 — `service_healthy`로 걸면 정작 감지해야 할 상황(Redis 다운)에서 exporter 자신이 뜨지 못한다.
+
+**`noDataState: Alerting`인 이유**: Redis가 죽으면 지표가 `redis_up=0`으로 오리라 기대하기 쉽지만, 실제로는 exporter가 죽은 Redis에 붙느라 느려져 **Prometheus 스크랩이 타임아웃하고 지표 자체가 사라지는** 경우가 있다(검증 중 관찰). 그때는 `NoData`가 되므로, 이 값이 `OK`였다면 정작 Redis가 죽은 순간에 침묵한다. exporter 자신이 죽어 지표가 끊기는 것도 "Redis 상태를 모르는" 상황이고, SPOF를 수용한 이상 모르는 것이 곧 위험이다.
+
+**`== bool 0`인 이유**(실기기 검증에서 잡았다): 직관적인 `redis_up == 0`은 **정확히 뒤집혀 동작한다.** 필터형 표현식은 Redis 다운 시 값 `0`을 반환하는데 Grafana는 0을 "조건 거짓"으로 읽어 영영 발화하지 않고, 정상일 때는 결과가 비어 `NoData`로 오히려 깨운다. `bool` 수식어는 다운 시 `1`, 정상 시 `0`을 주므로 의도대로 동작한다. 파일만 읽고 통과시켰다면 "알림을 붙였다"고 믿은 채 실제로는 침묵하는 규칙을 배포할 뻔했다 — 알림 규칙은 반드시 실제로 죽여서 울리는 것까지 확인한다.
+
+**Alertmanager 미도입 근거**: 규칙이 1개고 Grafana는 이미 떠 있다. Alertmanager가 주는 그룹핑·억제·silence는 규칙 1개에 가치가 없고, 대가는 컨테이너 하나와 라우팅 설정이다. 알림은 booking-service DLT가 쓰는 `SLACK_WEBHOOK_URL`을 재사용한다.
+
+### 6. 사용자 안내는 경로별로 다르다
+
+| 경로 | 클라이언트 | 동작 |
+|---|---|---|
+| HTTP (예매번호 발급 · 로그인 · 토큰 재발급) | Lettuce | `INFRA_503_001` **503 + "일시적으로 요청을 처리할 수 없습니다. 잠시 후 다시 시도해 주세요."** 종전에는 `Exception` 핸들러에 걸려 500 "관리자에게 문의"로 나갔다 |
+| HTTP (좌석 확정 `SeatInternalController`) | Redisson | 같은 503. 단 **핸들러가 다르다**(아래) |
+| HTTP (공연 목록) | Lettuce | 캐시 fail-open → 정상 응답 |
+| Kafka (좌석 락) | Redisson | `@RestControllerAdvice`를 타지 않는다. `KafkaConsumerErrorPolicy`가 Redis 예외를 일시로 분류 → 재시도 → DLT → Slack. 사용자 측은 `BookingExpirationScheduler`의 기존 만료 안내를 탄다 |
+
+**핸들러가 둘로 나뉜 이유**: Lettuce 예외는 Spring이 `RedisConnectionFailureException`(`DataAccessException` 계열)으로 변환해주지만, **Redisson은 Spring 예외 변환을 타지 않고 `RedisException`(단순 `RuntimeException`)을 그대로 던진다.** 하나의 핸들러로 둘 다 잡으려면 common에 Redisson 예외를 등록해야 하는데, **Redisson 의존성은 seat-service에만 있어** common에 등록하면 나머지 6개 서비스가 어드바이스 로딩에 실패해 기동하지 못한다. 그래서 Lettuce는 common의 `GlobalExceptionHandler`가, Redisson은 seat-service의 `SeatRedissonExceptionHandler`가 맡는다.
+
+Kafka 경로에 별도 안내를 넣지 않은 것은 **메시지 보존(DLT) + 운영자 알림 + 사용자 측 자동 만료가 이미 붙어 있기 때문이다.**
+
+`QueryTimeoutException`은 잡지 않는다. Redis 전용이 아니라 JDBC·JPA 쿼리 타임아웃도 이 예외로 변환되므로, 등록하면 common을 쓰는 **전 서비스의 DB 타임아웃 응답까지 조용히 503으로 바뀐다.** DB 타임아웃의 처리 방침은 이 문서의 범위가 아니다.
+
+NOAUTH(비밀번호 오설정)도 503으로 잡지 않는다. `RedisSystemException`으로 도착해 500이 되는데, 그건 일시 장애가 아니라 설정 버그이므로 500이 옳다.
+
+### 7. Lettuce 타임아웃을 1초로 자른다
+
+**fail-closed는 '거절'이지 '무한 대기'가 아니다.** seat-service는 Lettuce 기본 60초를 그대로 쓰고 있었다. 좌석 락 경로는 Kafka 리스너 스레드에서 도므로, hang형 장애에 60초씩 물리면 poll이 밀려 **컨슈머 리밸런싱 루프**로 장애가 번진다. Redis 장애가 Redis에 머물지 않고 Kafka로 전이되는 것이다.
+
+performance-service가 같은 이유로 이미 1초를 적용해뒀다(`application.yml:16-20`). seat-service에 같은 값을 넣는다.
+
+**단, 이 값이 곧 실패까지의 벽시계 시간은 아니다.** Redisson 스타터는 `spring.data.redis.timeout`을 응답 타임아웃으로 매핑하지만 자체 `retryAttempts`(기본 3)·`retryInterval`(기본 1.5s)을 별도로 갖는다. 최악은 1초가 아니라 수 초다. 60초보다 훨씬 낫지만 "1초에 차단된다"고 읽으면 안 되며, 리밸런싱을 실제로 막는지는 hang형 장애를 재현해 리스너 체류 시간을 재봐야 확정된다 — 이번 검증에는 그 측정이 없다.
+
+**트레이드오프**: 응답 타임아웃이 짧으면 부하·GC 스파이크에 unlock이 타임아웃날 수 있고, 그러면 좌석 락이 `LOCK_TTL_MINUTES`(5분)까지 잔존해 그 좌석이 5분간 잠긴다. performance-service가 ShedLock(1분) 기준으로 수용한 것과 같은 성질이되 잔존 시간이 5배다. 정합성은 깨지지 않고(#427의 DB `@Version`) 가용성만 손해라 수용한다.
+
+## 결과
+
+### 얻는 것
+
+- **Redis가 죽거나 락 키를 잃어도 좌석 중복 판매가 없다.** #427의 DB `@Version`이 최종 방어선이고, Redis 락은 경쟁을 앞단에서 걸러 DB까지 안 가게 하는 **성능 최적화**로 역할이 정리됐다.
+- 무인증 Redis가 사라졌다. password 누락 시 배포가 조용히 성공하지 못한다.
+- 상한 도달이 돌연사(OOMKill)가 아니라 명시적 쓰기 거절이 된다.
+- hang형 장애가 60초에서 1초로 잘려 Kafka 리밸런싱으로 번지지 않는다.
+- Redis 다운을 1분 내 Slack으로 안다. 비용은 컨테이너 1개(32 MiB).
+- Redis 장애 시 사용자가 "서버 에러, 관리자에게 문의"가 아니라 재시도 안내를 받는다.
+
+### 감수하는 것
+
+- **Redis 다운 = 예매 생성 전면 중단.** `BookingIssueNumberUseCase`가 Redis에 의존하므로 멈추는 것은 부가 기능이 아니라 핵심 기능이다. 이것이 수용한 가용성 손실의 정확한 범위다.
+- **복구는 사람이 한다.** 자동 페일오버가 없다. 목표 복구 경로는 Slack 알림(1분 이내) + 수동 재시작이다.
+- **replica가 없고 AOF뿐이다.** 컨테이너나 EBS가 손실되면 진행 중인 락이 전부 사라진다. 그래도 최악은 "사용자가 재시도해야 함"이다.
+- **password 무중단 rotate가 불가능하다.** `requirepass`가 `command`에 있어 컨테이너 재생성이 필요하다.
+- **네트워크 내부 통신은 평문이다.** 위 결정 3의 위협 모델 안에서만 유효하다.
+- **인증 경로가 처음 실행되는 곳이 운영이다.** 로컬 Redis는 무인증이고 CI(`schema-validate.yml`)도 `local` 프로파일이라, prod yml의 password 배선은 **어떤 자동 검증도 통과하지 않는다.** 이번에는 수동 실기기 검증으로 메웠지만, 다음에 누가 `password` 키를 빠뜨려도 CI는 초록이다. `:?` 보간과 healthcheck가 배포 시점에 잡아주는 것이 유일한 그물이다.
+- **알림 설정은 로컬에서 검증되지 않는다.** 로컬 스택에는 exporter가 없어 알림 프로비저닝을 `provisioning-aws/`로 분리했다(로컬에 두면 `redis_up`이 없어 상시 오탐한다). 대가로 이 파일은 배포본에서만 로드되므로, 문법 오류는 배포 시점에야 드러난다.
+- **최초 적용 시 수동 선행 단계가 있다.** EC2의 `deploy/.env`는 리포에서 오지 않고 사람이 관리한다. 이 변경이 담긴 배포 **이전에** 운영자가 `REDIS_PASSWORD`를 추가하고, `SLACK_WEBHOOK_URL`이 비어 있지 않은지 확인해야 한다(Grafana가 이 값을 요구하게 됐다). 누락 시 `:?`가 배포를 중단시키므로 부분 적용 없이 깨끗하게 실패한다.
+- **메모리 예산 영향**: 컨테이너 `mem_limit` 합계가 [ADR 0006](0006-eight-gib-container-memory-limits.md)의 6,528 MiB에서 **6,560 MiB**로 늘어난다(redis-exporter +32 MiB). 실측 인스턴스 메모리 약 7.6 GiB 대비 여유는 유지된다. ADR 0006 본문의 표는 그 시점의 기록이므로 수정하지 않고, 델타를 이 문서에 남긴다.
+
+### 향후 주의점 — ElastiCache 전환 시
+
+`SeatLockExpirationListener`는 Redis keyspace 만료 이벤트에 의존하는데, Spring의 `KeyspaceEventMessageListener`는 기동 시 `CONFIG SET`으로 `notify-keyspace-events`를 자동 설정한다. **관리형 Redis에서는 `CONFIG SET`이 막혀 있어 조용히 실패할 수 있으므로** 파라미터 그룹에서 미리 설정해야 한다.
+
+### 재평가 트리거
+
+| 트리거 | 재검토 대상 |
+|---|---|
+| Redis를 EC2 밖(ElastiCache 등)으로 이동 | TLS 도입 (위협 모델이 바뀐다) |
+| 알림 규칙이 3개를 넘어 알림 피로 발생 | Alertmanager 도입 |
+| 예매 중단의 실측 손실 > HA 비용 | Sentinel / ElastiCache Multi-AZ |

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -13,6 +13,7 @@ TicketRush의 아키텍처 결정을 번호 매긴 Markdown으로 축적하는 �
 - [5. 환불 실패를 예매 상태가 아니라 타임스탬프로 기록한다](0005-refund-state-machine-and-recovery.md)
 - [6. 8 GiB 단일 인스턴스에서 컨테이너별 메모리 상한을 적용한다](0006-eight-gib-container-memory-limits.md)
 - [7. 관측 스택을 측정 대상과 같은 EC2에 두고, 관측 포트는 SSH 터널로만 연다](0007-observability-stack-colocation.md)
+- [8. Redis 단일 인스턴스 SPOF를 수용하고, 장애 시 전면 차단(fail-closed)한다](0008-accept-redis-spof-with-fail-closed.md)
 
 ## 사용법
 

--- a/monitoring/grafana/provisioning-aws/alerting/redis-spof.yml
+++ b/monitoring/grafana/provisioning-aws/alerting/redis-spof.yml
@@ -1,0 +1,100 @@
+# Redis SPOF를 수용한 이상, 죽었을 때 즉시 아는 것이 유일한 대응책이다(ADR 0008).
+#
+# 대시보드와 마찬가지로 SSOT는 이 파일이다. 프로비저닝된 알림은 Grafana UI에서 수정할 수 없다.
+# 파일이 유효하지 않으면 Grafana가 기동에 실패하므로, 변경 후에는 반드시 기동 로그를
+# `Failed to provision alerting` 문자열로 확인한다.
+apiVersion: 1
+
+groups:
+  - orgId: 1
+    name: infra-health
+    # provisioning/dashboards/dashboards.yml 의 folder와 같은 폴더에 모은다.
+    folder: TicketRush
+    interval: 1m
+    rules:
+      - uid: redis-down
+        title: Redis 다운
+        # instant 쿼리라 reduce/threshold expression 없이 쿼리의 refId를 그대로 조건으로 쓴다.
+        condition: A
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 600
+              to: 0
+            # datasources/datasource.yml 이 고정한 uid.
+            datasourceUid: prometheus
+            model:
+              refId: A
+              editorMode: code
+              # `redis_up == 0`이 아니라 `== bool 0`이다. 필터 형태(`== 0`)는 Redis 다운 시 값 0을
+              # 반환하는데 Grafana는 0을 '조건 거짓'으로 읽어 영영 발화하지 않고, 정상일 때는 빈 결과가 돼
+              # NoData로 오히려 깨운다 — 정확히 뒤집힌다. bool 수식어는 다운 시 1, 정상 시 0을 준다.
+              expr: redis_up == bool 0
+              instant: true
+              range: false
+              datasource:
+                type: prometheus
+                uid: prometheus
+        # 스크랩 1회 실패로 깨우지 않는다. 1분을 유지해야 진짜 다운이다.
+        for: 1m
+        # NoData도 알린다. redis-exporter 자신이 죽어 지표가 끊긴 것도 "Redis 상태를 모르는" 상황이고,
+        # SPOF를 수용한 이상 모르는 것이 곧 위험이다.
+        noDataState: Alerting
+        execErrState: Alerting
+        labels:
+          severity: critical
+        annotations:
+          summary: "Redis 다운 — 예매 생성이 전면 거절된다(fail-closed, ADR 0008)"
+          description: "redis_up 이 0인 상태가 1분 이상 지속. 좌석 중복 판매는 DB @Version이 막지만(#427) 예매는 멈춘다. Redis 컨테이너 상태를 확인할 것."
+
+      # 위 규칙만으로는 maxmemory 도달을 잡지 못한다. 한도에 닿아도 Redis는 살아 있어 redis_up=1이고,
+      # noeviction이 쓰기를 거절하기 시작하면 예매는 실패하는데 알림은 울리지 않는다 —
+      # "죽었을 때 즉시 안다"는 결정(ADR 0008)에 구멍이 난다. 그래서 사용률을 따로 본다.
+      - uid: redis-memory-high
+        title: Redis 메모리 한도 임박
+        condition: A
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 600
+              to: 0
+            datasourceUid: prometheus
+            model:
+              refId: A
+              editorMode: code
+              # maxmemory 대비 사용률. 80%를 넘으면 거절이 시작되기 전에 손 쓸 시간을 준다.
+              # maxmemory가 설정돼 있어야 분모가 0이 아니다(compose에서 64mb로 고정).
+              expr: redis_memory_used_bytes / redis_memory_max_bytes > bool 0.8
+              instant: true
+              range: false
+              datasource:
+                type: prometheus
+                uid: prometheus
+        for: 5m
+        # 여기서는 NoData를 알리지 않는다. 지표 부재는 위 redis-down 규칙이 이미 담당하므로
+        # 같은 사건으로 두 번 깨우지 않는다.
+        noDataState: OK
+        execErrState: Alerting
+        labels:
+          severity: warning
+        annotations:
+          summary: "Redis 메모리가 maxmemory의 80%를 넘었다 — 한도 도달 시 쓰기가 거절된다(ADR 0008)"
+          description: "noeviction이라 한도에 닿으면 예매번호 발급·토큰 저장이 실패하기 시작한다. 키 증가 원인(TTL 누락·비정상 적재)을 확인할 것."
+
+contactPoints:
+  - orgId: 1
+    name: slack
+    receivers:
+      - uid: slack-webhook
+        type: slack
+        settings:
+          # webhook URL은 커밋하지 않는다. compose가 grafana 컨테이너에 주입한 환경변수를 참조한다.
+          # 환경변수 확장은 settings 같은 필드에서만 동작하고 annotations·model·시간범위에서는 안 된다.
+          url: $SLACK_WEBHOOK_URL
+
+# 정책 트리는 통째로 대체된다(부분 병합이 아니다). 현재 알림 규칙이 이 파일의 1개뿐이라
+# 루트에서 바로 Slack으로 보낸다. 규칙이 늘어 라우팅이 필요해지면 그때 하위 route를 만든다.
+policies:
+  - orgId: 1
+    receiver: slack
+    group_by: ['alertname']

--- a/monitoring/prometheus.aws.yml
+++ b/monitoring/prometheus.aws.yml
@@ -33,6 +33,15 @@ scrape_configs:
         labels:
           stack: mvc
 
+  # Redis SPOF를 수용한 이상 죽었을 때 즉시 아는 것이 유일한 대응책이다(ADR 0008).
+  # redis_up 이 0이면 Grafana Alerting → Slack으로 나간다. exporter는 포트를 publish 하지 않는다.
+  - job_name: 'redis'
+    static_configs:
+      - targets:
+          - 'redis-exporter:9121'
+        labels:
+          stack: observability
+
   # 자기 자신. ADR 0007이 "전환 시점"의 기준으로 삼은 '부하 중 Prometheus의 CPU·메모리 점유'를
   # 재려면 prometheus_* 자기 지표가 필요하다. mem_limit(384m) 재평가 근거도 여기서 나온다.
   - job_name: 'prometheus'

--- a/performance-service/src/main/resources/application-prod.yml
+++ b/performance-service/src/main/resources/application-prod.yml
@@ -13,6 +13,8 @@ spring:
     redis:
       host: ${REDIS_HOST}
       port: ${REDIS_PORT:6379}
+      # local은 무인증 Redis라 prod 프로파일에만 둔다(ADR 0008).
+      password: ${REDIS_PASSWORD}
   cloud:
     aws:
       # 운영은 IAM 인스턴스 롤 사용 권장(access/secret 미주입 시 DefaultCredentialsProvider로 폴백).

--- a/seat-service/src/main/java/com/ticketrush/global/exception/SeatRedissonExceptionHandler.java
+++ b/seat-service/src/main/java/com/ticketrush/global/exception/SeatRedissonExceptionHandler.java
@@ -1,0 +1,41 @@
+package com.ticketrush.global.exception;
+
+import com.ticketrush.global.dto.response.ApiResponse;
+import com.ticketrush.global.status.ErrorStatus;
+import lombok.extern.slf4j.Slf4j;
+import org.redisson.client.RedisException;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+/**
+ * Redisson 장애를 500이 아니라 503 + 재시도 안내로 내보낸다(ADR 0008).
+ *
+ * <p>common의 {@code GlobalExceptionHandler}가 아니라 여기 있는 이유: Redisson 의존성은 seat-service에만 있다. common에
+ * {@code @ExceptionHandler(RedisException.class)}를 두면 Redisson이 없는 나머지 서비스가 어드바이스를 로딩할 때 클래스를 찾지 못해
+ * 기동에 실패한다.
+ *
+ * <p>Redisson은 Spring의 예외 변환을 타지 않아 {@code DataAccessException}이 아닌 {@link RedisException}을 그대로
+ * 던진다. 그래서 common의 Lettuce용 핸들러에 걸리지 않고, 이것이 없으면 {@code Exception} 핸들러의 500 "관리자에게 문의"로 샌다.
+ *
+ * <p>{@code @Order}로 common의 어드바이스보다 먼저 평가되게 한다. 양쪽이 겹치는 예외는 없지만, 순서를 명시하지 않으면 등록 순서가 클래스패스 스캔에 의존해
+ * 재현되지 않는다.
+ *
+ * <p>좌석 락의 Kafka 경로(BookingCreatedEventListener)는 HTTP가 아니라 이 어드바이스를 타지 않는다 — {@code
+ * KafkaConsumerErrorPolicy}가 Redis 예외를 일시로 분류해 재시도·DLT로 보존한다. 이 어드바이스가 실제로 담당하는 것은 {@code
+ * SeatInternalController}의 확정(confirmSold) 같은 HTTP 진입점이다.
+ */
+@Slf4j
+@Order(Ordered.HIGHEST_PRECEDENCE)
+@RestControllerAdvice
+public class SeatRedissonExceptionHandler {
+
+  @ExceptionHandler(RedisException.class)
+  public ResponseEntity<ApiResponse<?>> handleRedissonException(RedisException e) {
+    log.error("Redisson 장애로 요청을 거절했습니다.", e);
+
+    return ApiResponse.onFailure(ErrorStatus.INFRA_TRANSIENT_UNAVAILABLE);
+  }
+}

--- a/seat-service/src/main/resources/application-prod.yml
+++ b/seat-service/src/main/resources/application-prod.yml
@@ -13,6 +13,8 @@ spring:
     redis:
       host: ${REDIS_HOST}
       port: ${REDIS_PORT:6379}
+      # local은 무인증 Redis라 prod 프로파일에만 둔다(ADR 0008). Redisson 락도 이 설정을 물려받는다.
+      password: ${REDIS_PASSWORD}
 
 gateway:
   # 운영은 게이트웨이 내부 토큰을 반드시 주입(base의 test-token 기본값 오버라이드, 미주입 시 fail-fast).

--- a/seat-service/src/main/resources/application.yml
+++ b/seat-service/src/main/resources/application.yml
@@ -9,6 +9,23 @@ spring:
     name: seat-service
   jpa:
     open-in-view: false
+  data:
+    redis:
+      # Lettuce 기본 커맨드 타임아웃(60s)은 hang형 Redis 장애 시 좌석 락 경로를 60초 물린다.
+      # fail-closed는 '거절'이지 '무한 대기'가 아니다(ADR 0008) — 이 경로는 Kafka 리스너 스레드를
+      # 잡으므로, 물려 있는 동안 poll이 밀려 컨슈머 리밸런싱으로 장애가 번진다. 짧게 자른다.
+      # performance-service(application.yml:16-20)가 같은 이유로 먼저 적용한 값이다.
+      #
+      # 주의 — 이 값이 곧 실패까지의 벽시계 시간은 아니다. Redisson 스타터는 이 timeout을 응답
+      # 타임아웃으로 매핑하지만 자체 retryAttempts(기본 3)·retryInterval(기본 1.5s)을 별도로 갖는다.
+      # 즉 최악은 1초가 아니라 수 초다. 60초보다 훨씬 낫지만 "1초 차단"으로 읽으면 안 된다.
+      #
+      # 트레이드오프: 응답 타임아웃이 짧으면 부하·GC 스파이크에 unlock이 타임아웃날 수 있고,
+      # 그러면 좌석 락이 SeatLockUseCase.LOCK_TTL_MINUTES(5분)까지 잔존해 그 좌석이 5분간 잠긴다.
+      # performance-service가 ShedLock(1분) 기준으로 수용한 것과 같은 성질이되 잔존 시간이 5배다.
+      # 정합성은 깨지지 않고(#427의 DB @Version) 가용성만 손해라 수용한다.
+      timeout: 1s
+      connect-timeout: 1s
 
 custom:
   global:

--- a/seat-service/src/test/java/com/ticketrush/global/exception/SeatRedissonExceptionHandlerTest.java
+++ b/seat-service/src/test/java/com/ticketrush/global/exception/SeatRedissonExceptionHandlerTest.java
@@ -1,0 +1,50 @@
+package com.ticketrush.global.exception;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.ticketrush.global.dto.response.ApiResponse;
+import com.ticketrush.global.status.ErrorStatus;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.redisson.client.RedisConnectionException;
+import org.redisson.client.RedisTimeoutException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+/**
+ * Redisson 장애가 503으로 나가는지 검증한다(ADR 0008).
+ *
+ * <p>이 테스트의 존재 이유는 "Redisson 예외가 common의 핸들러에 걸리지 않는다"는 사실이다. Redisson은 Spring 예외 변환을 타지 않아
+ * DataAccessException이 아니므로, 이 어드바이스가 없으면 좌석 확정 API가 조용히 500으로 샌다.
+ */
+class SeatRedissonExceptionHandlerTest {
+
+  private final SeatRedissonExceptionHandler handler = new SeatRedissonExceptionHandler();
+
+  @Test
+  @DisplayName("Redisson 연결 실패는 503 INFRA_503_001로 나간다")
+  void redissonConnectionFailureReturns503() {
+    ResponseEntity<ApiResponse<?>> response =
+        handler.handleRedissonException(new RedisConnectionException("connection refused"));
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);
+    assertThat(response.getBody().getCode())
+        .isEqualTo(ErrorStatus.INFRA_TRANSIENT_UNAVAILABLE.getCode());
+  }
+
+  @Test
+  @DisplayName("Redisson 타임아웃(hang형)도 같은 503으로 나간다")
+  void redissonTimeoutReturns503() {
+    ResponseEntity<ApiResponse<?>> response =
+        handler.handleRedissonException(new RedisTimeoutException("command timed out"));
+
+    assertThat(response.getStatusCode()).isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);
+  }
+
+  @Test
+  @DisplayName("Redisson 예외는 Spring의 DataAccessException이 아니다 — common 핸들러가 못 잡는 근거")
+  void redissonExceptionIsNotSpringDataAccessException() {
+    assertThat(new RedisConnectionException("x"))
+        .isNotInstanceOf(org.springframework.dao.DataAccessException.class);
+  }
+}


### PR DESCRIPTION
## 🔗 관련 이슈

- close #426

---

## 📌 주요 변경 사항

- Redis에 `requirepass` 적용 — Redis·앱 4개·exporter가 `REDIS_PASSWORD`를 공유하고, 미설정 시 배포가 멈춘다.
- `maxmemory 64mb` + `noeviction` 명시 — 상한을 모른 채 커널에 OOMKill 당하던 것을 스스로 방어하게 한다.
- `redis-exporter` + Grafana Alerting → Slack — Redis 다운·메모리 한도 임박을 1분 내 알린다.
- Redis 장애 시 500 "관리자에게 문의" → **503 + 재시도 안내**(`INFRA_503_001`).
- seat-service Lettuce 타임아웃 1초 — hang형 장애가 Kafka 컨슈머로 번지는 것을 줄인다.
- ADR 0008에 SPOF 수용 결정과 전제 조건·감수하는 비용 기록.

전제 조건인 #427(Seat `@Version`)은 PR #431로 선행 완료됐다. DB가 정합성의 최종 방어선이 된 덕분에 Redis 장애의 결과가 "가용성 손실"이지 "정합성 손실"이 아니게 됐고, 그 위에서만 SPOF 수용이 성립한다.

---

## 🛠 상세 구현 내용

**인증** — `:?` 보간으로 `REDIS_PASSWORD` 누락 시 배포를 중단시킨다(무인증 Redis가 조용히 뜨는 것이 가장 나쁜 실패 모드). healthcheck는 종료코드가 아니라 `PONG` 응답을 확인한다 — NOAUTH는 에러를 "응답"으로 받아 false-healthy가 될 수 있고, 그러면 앱 4개가 붙지도 못할 Redis를 향해 기동한다. Redisson은 별도 설정 없이 `spring.data.redis`를 물려받아 락 경로도 함께 인증된다. 로컬은 무인증 유지(`application-local.yml` 무수정).

**메모리** — `64mb`는 상한의 50%다. AOF rewrite fork의 CoW 때문에 상한에 가깝게 잡으면 가득 찬 순간 `noeviction`이 거절을 시작하기 전에 커널이 먼저 죽인다. `noeviction`은 기본값이지만 명시했다 — 락 키가 evict되면 중복 HOLD 경로가 열린다.

**알림** — 규칙은 `redis_up == bool 0`이다. 직관적인 `== 0`은 **정확히 뒤집혀 동작한다**: 다운 시 값 `0`을 반환하는데 Grafana가 이를 "조건 거짓"으로 읽어 영영 발화하지 않고, 정상 시엔 빈 결과가 NoData로 오히려 깨운다. `noDataState: Alerting`인 이유는 Redis가 죽으면 exporter가 느려져 스크랩이 타임아웃하고 지표 자체가 사라지는 경우가 있어서다. 한도 도달은 `redis_up=1`이라 다운 알림이 침묵하므로 메모리 사용률 규칙을 따로 뒀다. 알림 파일은 `provisioning-aws/`로 분리했다 — 공용 디렉토리에 두면 로컬 compose도 마운트하는데 로컬엔 exporter가 없어 모든 개발자 로컬에서 상시 오탐한다.

**에러 응답** — 핸들러가 둘로 나뉜다. Lettuce는 Spring이 `RedisConnectionFailureException`으로 변환해주지만 **Redisson은 예외 변환을 타지 않아** `RedisException`을 그대로 던진다. 하나로 합치려면 common에 Redisson 예외를 등록해야 하는데 **Redisson 의존성은 seat-service에만 있어** 나머지 6개 서비스가 어드바이스 로딩에 실패해 기동하지 못한다. `QueryTimeoutException`은 일부러 제외했다 — Redis 전용이 아니라 JDBC·JPA 타임아웃까지 잡아 전 서비스의 DB 타임아웃 응답을 조용히 503으로 바꾼다.

**Kafka 좌석 락 경로는 손대지 않았다** — `KafkaConsumerErrorPolicy`가 Redis 예외를 이미 "일시"로 분류해 재시도→DLT→Slack으로 보존한다.

---

## ✅ 테스트

### 테스트 방법

**자동화 테스트**
- `./gradlew test` — 전체 모듈
- `./gradlew :common:test :seat-service:test`
- 작성한 테스트:
  - `common/.../GlobalExceptionHandlerTest` — Redis 연결 실패 → 503 `INFRA_503_001`, Lettuce 예외만 등록됨, `QueryTimeoutException` 미등록(전 서비스 DB 타임아웃 파급 방지), 그 밖의 예외는 종전대로 500
  - `seat-service/.../SeatRedissonExceptionHandlerTest` — Redisson 연결 실패·타임아웃 → 503, Redisson 예외가 Spring `DataAccessException`이 아님(common 핸들러가 못 잡는 근거)

**인프라 검증** (임시 스택으로 실제 기동)
- `cp deploy/.env.prod.example deploy/.env && docker compose -f deploy/docker-compose.prod.yml config -q` (CD의 검증 단계와 동일)
- Redis 인증/미인증 접근, healthcheck, `maxmemory`/`policy` 실제 값 조회
- Redis 컨테이너 정지 → Slack webhook 수신 서버로 알림 실제 수신 확인 → 복구 → 해제 확인
- 로컬 `docker-compose.yml`로 Grafana 기동해 알림 규칙이 로드되지 않는지 확인

### 테스트 결과

- `./gradlew test` — **BUILD SUCCESSFUL** (전체 통과)
- `compose config -q` — prod·로컬 모두 exit 0
- Redis 무인증 접근 → `NOAUTH Authentication required` / 인증 접근 → `PONG` / healthcheck → `healthy`
- `maxmemory` → `67108864`(64mb), `maxmemory-policy` → `noeviction`
- Redis 정지 → `[FIRING:1] Redis 다운` **Slack 실제 수신**, 복구 → `inactive`, NoData 오탐 **0회**
- 다운 시 "메모리 한도 임박"은 `inactive` 유지 — 같은 사건으로 중복 알림 없음
- 로컬 Grafana → 알림 규칙 `[]`, 프로비저닝 오류 0 (상시 오탐 없음)
- prod 마운트 구조 → 규칙 2개 로드, 기동 정상
<!--
### 📸 스크린샷

- (작성 필요)
-->
---

## 👀 리뷰 요청 사항

- **`SLACK_WEBHOOK_URL`이 이제 필수가 됩니다.** Grafana가 `:?`로 요구하므로 EC2 `.env`에 값이 없으면 배포가 멈춥니다. 기존에 이 값이 비어 있었다면 배포 전 채워야 합니다.
- **Lettuce 타임아웃 1초의 실효**: Redisson 자체 retry(3회 × 1.5초)가 별도로 있어 최악은 1초가 아니라 수 초입니다. "리밸런싱을 실제로 막는가"는 hang형 장애를 재현해 리스너 체류 시간을 재봐야 확정되며, 이번 검증에는 그 측정이 없습니다. 이 상태로 수용할지 봐주세요.
- **unlock 타임아웃 트레이드오프**: 응답 타임아웃이 짧으면 부하·GC 스파이크에 unlock이 타임아웃나 좌석이 `LOCK_TTL`(5분)까지 잠깁니다. 정합성은 `@Version`이 지키므로 가용성만 손해라 수용했는데, 5분이 과한지 봐주세요.
- **`maxmemory 64mb`** 값이 적절한지 (실측 최대 4.1 MiB, ADR 0006 기준 여유 15배).

---

## ⚠️ 배포 시 주의사항

- **배포 전에 EC2의 `deploy/.env`에 `REDIS_PASSWORD`를 추가하고, `SLACK_WEBHOOK_URL`이 비어 있지 않은지 확인해야 합니다.** 누락 시 compose `:?` 보간이 배포를 중단시킵니다(부분 적용 없이 깨끗하게 실패).
- Redis와 앱이 같은 `compose up`으로 함께 재시작되므로 인증 전환에 중간 상태는 없습니다.
- `redis-exporter` 컨테이너가 추가되어 메모리 예산이 6,528 MiB → **6,560 MiB**가 됩니다(+32 MiB). 인스턴스 실측 약 7.6 GiB 대비 여유는 유지됩니다.
- 알림 프로비저닝은 배포본에서만 로드되므로 문법 오류는 배포 시점에 드러납니다. 기동 후 Grafana 로그에 `Failed to provision alerting`이 없는지 확인해 주세요.
- `.env.prod.example`의 `__REQUIRED__`는 `:?`를 통과합니다 — 플레이스홀더를 실제 값으로 바꾸는 것은 사람의 몫입니다.
