### PR TITLE
[Fix] #447 외부 헬스체크를 별도 CD 잡으로 분리

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -456,36 +456,32 @@ jobs:
             exit 1
           fi
 
-          echo "Checking external HTTPS health..."
+          echo "Checking local Nginx HTTPS route..."
 
-          if ! EXTERNAL_HEALTH_RESPONSE="$(
+          NGINX_HEALTH_RESPONSE="$(
             curl \
               --fail \
               --silent \
               --show-error \
-              --connect-timeout 10 \
-              --max-time 30 \
+              --location \
+              --resolve api.ticketrush.store:443:127.0.0.1 \
+              --connect-timeout 5 \
+              --max-time 15 \
               --retry 6 \
               --retry-delay 5 \
               --retry-all-errors \
-              https://api.ticketrush.store/actuator/health \
-              2>&1
-          )"; then
-            echo "${EXTERNAL_HEALTH_RESPONSE}"
-            echo "External HTTPS health request failed."
-            echo "Check DNS, TLS certificate, Nginx, and public network reachability."
-            exit 1
-          fi
+              https://api.ticketrush.store/actuator/health
+          )"
 
-          echo "${EXTERNAL_HEALTH_RESPONSE}"
+          echo "${NGINX_HEALTH_RESPONSE}"
 
           if ! grep -Eq '"status"[[:space:]]*:[[:space:]]*"UP"' \
-            <<< "${EXTERNAL_HEALTH_RESPONSE}"; then
-            echo "External HTTPS health status is not UP."
+            <<< "${NGINX_HEALTH_RESPONSE}"; then
+            echo "Local Nginx HTTPS health status is not UP."
             exit 1
           fi
 
-          echo "External HTTPS health check passed."
+          echo "Local Nginx HTTPS health check passed."
 
 
           PREVIOUS_RELEASE=""
@@ -520,3 +516,58 @@ jobs:
             echo "- Registry: \`${ECR_REGISTRY}\`"
             echo "- Result: success"
           } >> "${GITHUB_STEP_SUMMARY}"
+
+  external-health:
+    name: External HTTPS health
+    needs: deploy
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Check public HTTPS health
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+
+          EXTERNAL_URL="https://api.ticketrush.store/actuator/health"
+          MAX_ATTEMPTS=12
+          SLEEP_SECONDS=10
+
+          for ATTEMPT in $(seq 1 "${MAX_ATTEMPTS}"); do
+            echo "External health check ${ATTEMPT}/${MAX_ATTEMPTS}"
+
+            RESPONSE_FILE="$(mktemp)"
+
+            HTTP_CODE="$(
+              curl \
+                --silent \
+                --show-error \
+                --location \
+                --connect-timeout 5 \
+                --max-time 15 \
+                --output "${RESPONSE_FILE}" \
+                --write-out '%{http_code}' \
+                "${EXTERNAL_URL}"
+            )" && CURL_EXIT=0 || CURL_EXIT=$?
+
+            RESPONSE="$(cat "${RESPONSE_FILE}")"
+            rm -f "${RESPONSE_FILE}"
+
+            echo "curl_exit=${CURL_EXIT}, http_code=${HTTP_CODE:-none}"
+            echo "${RESPONSE}"
+
+            if [[ "${CURL_EXIT}" -eq 0 ]] \
+              && [[ "${HTTP_CODE}" == "200" ]] \
+              && grep -Eq '"status"[[:space:]]*:[[:space:]]*"UP"' \
+                <<< "${RESPONSE}"; then
+              echo "External HTTPS health check passed."
+              exit 0
+            fi
+
+            if (( ATTEMPT < MAX_ATTEMPTS )); then
+              sleep "${SLEEP_SECONDS}"
+            fi
+          done
+
+          echo "::error::External HTTPS health did not become UP."
+          exit 1


### PR DESCRIPTION
## 🔗 관련 이슈

- close #447

---

## 📌 주요 변경 사항

- EC2 내부에서 수행하던 공개 도메인 헬스체크를 로컬 Nginx HTTPS 경로 검사로 변경
- 공개 HTTPS 헬스체크를 별도의 `external-health` Job으로 분리
- 외부 헬스체크 실패 시 curl 종료 코드와 HTTP 상태 코드를 로그에 출력하도록 개선

---

## 🛠 상세 구현 내용

- 기존 배포 Job의 `https://api.ticketrush.store/actuator/health` 호출을
  `--resolve api.ticketrush.store:443:127.0.0.1` 기반 검사로 변경
- EC2 내부에서는 로컬 Nginx, TLS 인증서, Gateway 연결 상태까지만 검증하도록 구성
- 내부 컨테이너 상태, Gateway Actuator, Prometheus 타깃 검사는 기존과 같이 배포 차단 조건으로 유지
- GitHub Actions Runner에서 공개 도메인을 검사하는 `external-health` Job 추가
- `external-health` Job이 배포 Job 성공 이후 실행되도록 `needs: deploy` 설정
- 공개 HTTPS 헬스체크를 최대 12회, 10초 간격으로 재시도하도록 구성
- 외부 검사 로그에 `curl_exit`과 `http_code`를 출력하여 DNS, 연결, TLS, HTTP 오류를 구분할 수 있도록 개선
- 외부 헬스체크만 실패한 경우 전체 이미지 빌드·배포가 아닌 해당 Job만 재실행할 수 있도록 Job 구조 분리
- 내부 배포 검증이 완료되면 외부 네트워크 검사와 관계없이 `CURRENT_RELEASE`가 정상 기록되도록 실행 순서 개선

---