### PR TITLE
[Fix] #450 Prometheus 배포 검증 로직 수정

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -428,30 +428,82 @@ jobs:
 
           # 컨테이너가 떴다고 지표가 수집되는 것은 아니다. 타깃 주소가 틀리면 up=0인 채로
           # 배포가 초록불로 끝난다. 실제로 스크랩되는지 확인한다(이슈 #380 완료 조건).
-          EXPECTED_TARGETS=9   # 앱 8 + prometheus 자기 자신 1
+          EXPECTED_TARGETS=10
+          PROMETHEUS_READY=false
 
           for ATTEMPT in $(seq 1 12); do
-            UP_COUNT="$(
-              curl --fail --silent \
-                'http://127.0.0.1:9090/api/v1/query?query=up' \
-                | jq '[.data.result[] | select(.value[1] == "1")] | length'
-            )" || UP_COUNT=0
+            TARGETS_RESPONSE="$(
+              curl \
+                --fail \
+                --silent \
+                --show-error \
+                http://127.0.0.1:9090/api/v1/targets
+            )" || TARGETS_RESPONSE=""
 
-            if [[ "${UP_COUNT}" == "${EXPECTED_TARGETS}" ]]; then
-              echo "Prometheus targets UP: ${UP_COUNT}/${EXPECTED_TARGETS}"
+            if [[ -z "${TARGETS_RESPONSE}" ]]; then
+              echo \
+                "Prometheus targets request failed " \
+                "(${ATTEMPT}/12, retrying)"
+
+              sleep 10
+              continue
+            fi
+
+            TOTAL_COUNT="$(
+              jq '.data.activeTargets | length' \
+                <<< "${TARGETS_RESPONSE}"
+            )"
+
+            UP_COUNT="$(
+              jq '
+                [
+                  .data.activeTargets[]
+                  | select(.health == "up")
+                ]
+                | length
+              ' <<< "${TARGETS_RESPONSE}"
+            )"
+
+            DOWN_COUNT="$(
+              jq '
+                [
+                  .data.activeTargets[]
+                  | select(.health != "up")
+                ]
+                | length
+              ' <<< "${TARGETS_RESPONSE}"
+            )"
+
+            echo \
+              "Prometheus targets: " \
+              "total=${TOTAL_COUNT}/${EXPECTED_TARGETS} " \
+              "up=${UP_COUNT} down=${DOWN_COUNT}"
+
+            if (( TOTAL_COUNT == EXPECTED_TARGETS )) \
+              && (( UP_COUNT == EXPECTED_TARGETS )) \
+              && (( DOWN_COUNT == 0 )); then
+              PROMETHEUS_READY=true
               break
             fi
 
-            echo "Prometheus targets UP: ${UP_COUNT}/${EXPECTED_TARGETS} (retrying)"
+            jq -r '
+              .data.activeTargets[]
+              | select(.health != "up")
+              | "\(.scrapeUrl) health=\(.health) error=\(.lastError)"
+            ' <<< "${TARGETS_RESPONSE}"
+
             sleep 10
           done
 
-          if [[ "${UP_COUNT}" != "${EXPECTED_TARGETS}" ]]; then
-            echo "Prometheus is not scraping all targets."
+          if [[ "${PROMETHEUS_READY}" != "true" ]]; then
+            echo "Prometheus targets did not become fully healthy."
 
-            curl --silent 'http://127.0.0.1:9090/api/v1/targets' \
-              | jq -r '.data.activeTargets[]
-                  | "\(.scrapeUrl) health=\(.health) \(.lastError)"'
+            if [[ -n "${TARGETS_RESPONSE:-}" ]]; then
+              jq -r '
+                .data.activeTargets[]
+                | "\(.scrapeUrl) health=\(.health) error=\(.lastError)"
+              ' <<< "${TARGETS_RESPONSE}"
+            fi
 
             exit 1
           fi


### PR DESCRIPTION
## 🔗 관련 이슈

* close #450

---

## 📌 주요 변경 사항

* Prometheus 배포 검증의 예상 타깃 수를 실제 운영 구성에 맞게 수정
* 단순 UP 개수 비교를 전체·정상·비정상 타깃 검증 방식으로 개선
* Prometheus 타깃 검증 실패 시 원인 확인을 위한 상세 로그 출력 추가

---

## 🛠 상세 구현 내용

* Redis Exporter를 포함한 실제 Prometheus 타깃 구성에 맞춰 `EXPECTED_TARGETS`를 9개에서 10개로 변경
* `/api/v1/query?query=up`의 UP 개수만 확인하던 기존 로직을 `/api/v1/targets` 기반 검증으로 변경
* 전체 타깃 수가 10개인지, 모든 타깃이 UP인지, DOWN 타깃이 0개인지 함께 확인하도록 수정
* Prometheus API 응답 실패 또는 타깃 준비 지연에 대비해 최대 12회 재시도하도록 구성
* 검증 실패 시 각 타깃의 스크랩 URL, 상태 및 마지막 오류 메시지를 출력하도록 개선
* `actionlint`와 `git diff --check`를 통해 GitHub Actions 문법 및 공백 오류 검증 완료
