### PR TITLE
[Fix] #453 CD 배포 시 monitoring bind mount 갱신 및 검증 보강

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -198,6 +198,43 @@ jobs:
             -xzf deploy-bundle.tar.gz \
             -C deploy
 
+          # 배포 번들에 monitoring 필수 파일이 정상적으로 포함됐는지 확인한다.
+          REQUIRED_MONITORING_FILES=(
+            deploy/monitoring/prometheus.aws.yml
+            deploy/monitoring/grafana/provisioning/dashboards/dashboards.yml
+          )
+
+          for REQUIRED_FILE in "${REQUIRED_MONITORING_FILES[@]}"; do
+            if [[ ! -f "${REQUIRED_FILE}" ]]; then
+              echo "::error::Required monitoring file is missing: ${REQUIRED_FILE}"
+              exit 1
+            fi
+          done
+
+          if [[ ! -d deploy/monitoring/grafana/dashboards ]]; then
+            echo "::error::Grafana dashboards directory is missing."
+            exit 1
+          fi
+
+          if ! find deploy/monitoring/grafana/dashboards \
+            -maxdepth 1 \
+            -type f \
+            -name '*.json' \
+            -print \
+            -quit \
+            | grep -q .; then
+            echo "::error::Grafana dashboard JSON files are missing."
+            exit 1
+          fi
+
+          echo "Monitoring deployment files validated successfully."
+
+          find deploy/monitoring/grafana/dashboards \
+            -maxdepth 1 \
+            -type f \
+            -name '*.json' \
+            -print
+
           rm -f deploy-bundle.tar.gz
 
           if [[ ! -f deploy/.env ]]; then
@@ -288,7 +325,65 @@ jobs:
           done
 
           "${COMPOSE[@]}" pull
+
+          # 전체 서비스에 변경된 이미지·Compose 설정 반영
           "${COMPOSE[@]}" up -d --remove-orphans
+
+          # 배포 과정에서 monitoring bind source를 교체했으므로
+          # 기존 마운트를 버리고 새 경로를 다시 마운트한다.
+          "${COMPOSE[@]}" up \
+            -d \
+            --force-recreate \
+            --no-deps \
+            prometheus \
+            grafana
+
+          # 호스트의 새 dashboards 디렉터리가 Grafana 컨테이너 안에 실제로
+          # 다시 마운트됐는지 확인한다.
+          GRAFANA_DASHBOARDS_MOUNTED=false
+
+          for ATTEMPT in $(seq 1 12); do
+            GRAFANA_CONTAINER_ID="$(
+              "${COMPOSE[@]}" ps -q grafana 2>/dev/null || true
+            )"
+
+            if [[ -n "${GRAFANA_CONTAINER_ID}" ]] \
+              && docker exec "${GRAFANA_CONTAINER_ID}" sh -c '
+                find /var/lib/grafana/dashboards \
+                  -maxdepth 1 \
+                  -type f \
+                  -name "*.json" \
+                  -print \
+                  -quit \
+                  | grep -q .
+              '; then
+              GRAFANA_DASHBOARDS_MOUNTED=true
+              break
+            fi
+
+            echo "Waiting for Grafana dashboard mount (${ATTEMPT}/12)"
+            sleep 5
+          done
+
+          if [[ "${GRAFANA_DASHBOARDS_MOUNTED}" != "true" ]]; then
+            echo "::error::Grafana dashboard JSON files are not visible inside the container."
+
+            GRAFANA_CONTAINER_ID="$(
+              "${COMPOSE[@]}" ps -q grafana 2>/dev/null || true
+            )"
+
+            if [[ -n "${GRAFANA_CONTAINER_ID}" ]]; then
+              docker inspect "${GRAFANA_CONTAINER_ID}" \
+                --format '{{range .Mounts}}{{println .Source "->" .Destination}}{{end}}'
+
+              docker exec "${GRAFANA_CONTAINER_ID}" \
+                sh -c 'ls -la /var/lib/grafana/dashboards || true'
+            fi
+
+            exit 1
+          fi
+
+          echo "Grafana dashboard mount validated successfully."
 
           READY=false
           STABLE_PASSES=0

--- a/.github/workflows/cd.yml.bak
+++ b/.github/workflows/cd.yml.bak
@@ -1,0 +1,625 @@
+name: CD - Deploy to EC2
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+concurrency:
+  group: ticketrush-production-deploy
+  cancel-in-progress: false
+
+env:
+  AWS_REGION: ${{ vars.AWS_REGION }}
+  ECR_REGISTRY: ${{ vars.ECR_REGISTRY }}
+  EC2_HOST: ${{ secrets.EC2_HOST }}
+  EC2_USER: ${{ vars.EC2_USER }}
+  IMAGE_TAG: ${{ github.sha }}
+
+jobs:
+  deploy:
+    name: Build, Push, Deploy
+    runs-on: ubuntu-latest
+    environment: production
+
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v7
+
+      - name: Set up Java 21
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: "21"
+          cache: gradle
+
+      - name: Validate deployment files
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+
+          test -f Dockerfile
+          test -f deploy/docker-compose.prod.yml
+          test -f deploy/.env.prod.example
+
+          if [[ -f deploy/.env ]]; then
+            echo "::error::deploy/.env must not be committed."
+            exit 1
+          fi
+
+          cp deploy/.env.prod.example deploy/.env
+          trap 'rm -f deploy/.env' EXIT
+
+          docker compose \
+            -f deploy/docker-compose.prod.yml \
+            config -q
+
+      - name: Run tests
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+
+          chmod +x gradlew
+          ./gradlew test
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v6
+        with:
+          role-to-assume: ${{ vars.AWS_DEPLOY_ROLE_ARN }}
+          role-session-name: ticketrush-cd-${{ github.run_id }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Login to Amazon ECR
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Build and push Docker images
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+
+          SERVICES=(
+            gateway-service
+            auth-service
+            user-service
+            booking-service
+            payment-service
+            performance-service
+            ticket-service
+            seat-service
+          )
+
+          for SERVICE in "${SERVICES[@]}"; do
+            REPOSITORY="ticketrush/${SERVICE}"
+            IMAGE="${ECR_REGISTRY}/${REPOSITORY}:${IMAGE_TAG}"
+
+            echo "Checking ECR repository: ${REPOSITORY}"
+
+            aws ecr describe-repositories \
+              --region "${AWS_REGION}" \
+              --repository-names "${REPOSITORY}" \
+              > /dev/null
+
+            echo "Building ${IMAGE}"
+
+            docker build \
+              --build-arg SERVICE="${SERVICE}" \
+              --tag "${IMAGE}" \
+              .
+
+            echo "Pushing ${IMAGE}"
+            docker push "${IMAGE}"
+          done
+
+      - name: Prepare SSH
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+
+          install -m 700 -d ~/.ssh
+
+          printf '%s\n' "${{ secrets.EC2_SSH_KEY }}" \
+            > ~/.ssh/ticketrush-key.pem
+
+          chmod 600 ~/.ssh/ticketrush-key.pem
+
+          printf '%s\n' "${{ secrets.EC2_KNOWN_HOSTS }}" \
+            > ~/.ssh/known_hosts
+
+          chmod 600 ~/.ssh/known_hosts
+
+      - name: Package deployment files
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+
+          # monitoring/ 은 로컬 스택과 공유하는 SSOT다. deploy/ 밑으로 복사하면 대시보드 JSON이
+          # 중복되므로, 번들에만 함께 담아 EC2에서 deploy/monitoring/** 으로 풀리게 한다.
+          # compose의 상대경로(./monitoring/...)가 그대로 이 위치를 가리킨다.
+          tar \
+            --exclude='.env' \
+            --exclude='.env.local' \
+            -czf deploy-bundle.tar.gz \
+            -C deploy . \
+            -C .. monitoring
+
+      - name: Copy deployment files to EC2
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+
+          SSH_OPTIONS=(
+            -i ~/.ssh/ticketrush-key.pem
+            -o BatchMode=yes
+            -o StrictHostKeyChecking=yes
+          )
+
+          ssh "${SSH_OPTIONS[@]}" \
+            "${EC2_USER}@${EC2_HOST}" \
+            "mkdir -p ~/ticketrush/deploy"
+
+          scp "${SSH_OPTIONS[@]}" \
+            deploy-bundle.tar.gz \
+            "${EC2_USER}@${EC2_HOST}:~/ticketrush/deploy-bundle.tar.gz"
+
+      - name: Deploy on EC2
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+
+          SSH_OPTIONS=(
+            -i ~/.ssh/ticketrush-key.pem
+            -o BatchMode=yes
+            -o StrictHostKeyChecking=yes
+          )
+
+          # shellcheck disable=SC2029
+          ssh "${SSH_OPTIONS[@]}" \
+            "${EC2_USER}@${EC2_HOST}" \
+            "AWS_REGION='${AWS_REGION}' ECR_REGISTRY='${ECR_REGISTRY}' IMAGE_TAG='${IMAGE_TAG}' bash -s" \
+            <<'REMOTE_SCRIPT'
+          set -Eeuo pipefail
+
+          cd "${HOME}/ticketrush"
+
+          mkdir -p deploy
+
+          # monitoring/ 은 항상 번들 것으로 갈아끼운다.
+          # compose 를 EC2 에서 수동으로 up 하면 bind 소스가 없는 경로를 dockerd 가 '디렉터리'로
+          # 자동 생성한다. 그 상태에서 tar 가 같은 경로에 '파일'을 풀려다 충돌해, 수동 개입 전까지
+          # 배포가 영구히 실패한다. 지워두면 오염된 상태에서도 자동 복구된다.
+          rm -rf deploy/monitoring
+
+          tar \
+            -xzf deploy-bundle.tar.gz \
+            -C deploy
+
+          rm -f deploy-bundle.tar.gz
+
+          if [[ ! -f deploy/.env ]]; then
+            echo "deploy/.env does not exist on EC2."
+            exit 1
+          fi
+
+          chmod 600 deploy/.env
+
+          aws ecr get-login-password \
+            --region "${AWS_REGION}" \
+            | docker login \
+                --username AWS \
+                --password-stdin "${ECR_REGISTRY}"
+
+          export AWS_REGION
+          export ECR_REGISTRY
+          export IMAGE_TAG
+
+          COMPOSE=(
+            docker compose
+            --env-file deploy/.env
+            -f deploy/docker-compose.prod.yml
+          )
+
+          EXPECTED_SERVICES=(
+            mysql
+            redis
+            redis-exporter
+            kafka
+            gateway-service
+            auth-service
+            user-service
+            booking-service
+            payment-service
+            performance-service
+            ticket-service
+            seat-service
+            prometheus
+            grafana
+          )
+
+          APPLICATION_SERVICES=(
+            gateway-service
+            auth-service
+            user-service
+            booking-service
+            payment-service
+            performance-service
+            ticket-service
+            seat-service
+          )
+
+          declare -A APPLICATION_SERVICE_SET
+          declare -A PREVIOUS_CONTAINER_IDS
+          declare -A BASE_RESTART_COUNTS
+
+          for SERVICE in "${APPLICATION_SERVICES[@]}"; do
+            APPLICATION_SERVICE_SET["${SERVICE}"]=true
+          done
+
+          "${COMPOSE[@]}" config -q
+
+          echo "Snapshotting container restart counts before deployment."
+
+          for SERVICE in "${EXPECTED_SERVICES[@]}"; do
+            CONTAINER_ID="$(
+              "${COMPOSE[@]}" ps --all -q "${SERVICE}" 2>/dev/null || true
+            )"
+
+            if [[ -n "${CONTAINER_ID}" ]] \
+              && docker inspect "${CONTAINER_ID}" > /dev/null 2>&1; then
+              PREVIOUS_CONTAINER_IDS["${SERVICE}"]="${CONTAINER_ID}"
+              BASE_RESTART_COUNTS["${SERVICE}"]="$(
+                docker inspect \
+                  --format '{{.RestartCount}}' \
+                  "${CONTAINER_ID}"
+              )"
+
+              echo \
+                "${SERVICE}: previous container=${CONTAINER_ID}, baseline RestartCount=${BASE_RESTART_COUNTS[$SERVICE]}"
+            else
+              PREVIOUS_CONTAINER_IDS["${SERVICE}"]=""
+              BASE_RESTART_COUNTS["${SERVICE}"]=0
+
+              echo "${SERVICE}: no previous container, baseline RestartCount=0"
+            fi
+          done
+
+          "${COMPOSE[@]}" pull
+          "${COMPOSE[@]}" up -d --remove-orphans
+
+          READY=false
+          STABLE_PASSES=0
+          REQUIRED_STABLE_PASSES=6
+          MAX_ATTEMPTS=60
+
+          for ATTEMPT in $(seq 1 "${MAX_ATTEMPTS}"); do
+            ALL_READY=true
+            RESTART_DETECTED=false
+
+            echo "Container readiness check ${ATTEMPT}/${MAX_ATTEMPTS}"
+
+            for SERVICE in "${EXPECTED_SERVICES[@]}"; do
+              CONTAINER_ID="$("${COMPOSE[@]}" ps -q "${SERVICE}")"
+
+              if [[ -z "${CONTAINER_ID}" ]]; then
+                echo "${SERVICE}: container not created"
+                ALL_READY=false
+                continue
+              fi
+
+              STATUS="$(
+                docker inspect \
+                  --format '{{.State.Status}}' \
+                  "${CONTAINER_ID}"
+              )"
+
+              HEALTH="$(
+                docker inspect \
+                  --format '{{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}' \
+                  "${CONTAINER_ID}"
+              )"
+
+              OOM_KILLED="$(
+                docker inspect \
+                  --format '{{.State.OOMKilled}}' \
+                  "${CONTAINER_ID}"
+              )"
+
+              RESTART_COUNT="$(
+                docker inspect \
+                  --format '{{.RestartCount}}' \
+                  "${CONTAINER_ID}"
+              )"
+
+              PREVIOUS_CONTAINER_ID="${PREVIOUS_CONTAINER_IDS[$SERVICE]:-}"
+
+              if [[ -n "${PREVIOUS_CONTAINER_ID}" ]] \
+                && [[ "${CONTAINER_ID}" == "${PREVIOUS_CONTAINER_ID}" ]]; then
+                BASE_RESTART_COUNT="${BASE_RESTART_COUNTS[$SERVICE]:-0}"
+              else
+                BASE_RESTART_COUNT=0
+              fi
+
+              if [[ "${STATUS}" != "running" ]]; then
+                echo "${SERVICE}: status=${STATUS}"
+                ALL_READY=false
+              fi
+
+              if [[ "${HEALTH}" == "starting" || "${HEALTH}" == "unhealthy" ]]; then
+                echo "${SERVICE}: health=${HEALTH}"
+                ALL_READY=false
+              fi
+
+              if [[ "${OOM_KILLED}" == "true" ]]; then
+                echo "${SERVICE}: OOMKilled=true"
+                ALL_READY=false
+              fi
+
+              if (( RESTART_COUNT > BASE_RESTART_COUNT )); then
+                RESTART_DELTA=$((RESTART_COUNT - BASE_RESTART_COUNT))
+
+                echo \
+                  "::error::${SERVICE}: RestartCount=${RESTART_COUNT}, baseline=${BASE_RESTART_COUNT}, increased=${RESTART_DELTA} during deployment"
+
+                ALL_READY=false
+                RESTART_DETECTED=true
+              fi
+
+              if [[ -n "${APPLICATION_SERVICE_SET[$SERVICE]:-}" ]]; then
+                if ! docker logs "${CONTAINER_ID}" 2>&1 \
+                  | grep -Eq 'Started .*Application in .* seconds'; then
+                  echo "${SERVICE}: Spring Boot startup not confirmed"
+                  ALL_READY=false
+                fi
+              fi
+            done
+
+            if [[ "${RESTART_DETECTED}" == "true" ]]; then
+              echo "A container restarted during deployment."
+              break
+            fi
+
+            if [[ "${ALL_READY}" == "true" ]]; then
+              STABLE_PASSES=$((STABLE_PASSES + 1))
+              echo "Stable readiness pass ${STABLE_PASSES}/${REQUIRED_STABLE_PASSES}"
+
+              if (( STABLE_PASSES >= REQUIRED_STABLE_PASSES )); then
+                READY=true
+                break
+              fi
+            else
+              STABLE_PASSES=0
+            fi
+
+            sleep 5
+          done
+
+          if [[ "${READY}" != "true" ]]; then
+            echo "Containers did not become ready and remain stable."
+
+            "${COMPOSE[@]}" ps --all
+            "${COMPOSE[@]}" logs --tail=100
+
+            exit 1
+          fi
+
+          # actuator는 prod 에서 8090(management.server.port)로 분리된다. 8080에는 없다.
+          HEALTH_RESPONSE="$(
+            curl \
+              --fail \
+              --silent \
+              --show-error \
+              --retry 12 \
+              --retry-delay 5 \
+              --retry-all-errors \
+              http://127.0.0.1:8090/actuator/health
+          )"
+
+          echo "${HEALTH_RESPONSE}"
+
+          if ! grep -Eq '"status"[[:space:]]*:[[:space:]]*"UP"' \
+            <<< "${HEALTH_RESPONSE}"; then
+            echo "Gateway health status is not UP."
+            exit 1
+          fi
+
+          # 컨테이너가 떴다고 지표가 수집되는 것은 아니다. 타깃 주소가 틀리면 up=0인 채로
+          # 배포가 초록불로 끝난다. 실제로 스크랩되는지 확인한다(이슈 #380 완료 조건).
+          EXPECTED_TARGETS=10
+          PROMETHEUS_READY=false
+          
+          for ATTEMPT in $(seq 1 12); do
+            TARGETS_RESPONSE="$(
+              curl \
+                --fail \
+                --silent \
+                --show-error \
+                http://127.0.0.1:9090/api/v1/targets
+            )" || TARGETS_RESPONSE=""
+        
+            if [[ -z "${TARGETS_RESPONSE}" ]]; then
+              echo \
+                "Prometheus targets request failed " \
+                "(${ATTEMPT}/12, retrying)"
+          
+              sleep 10
+              continue
+            fi
+        
+            TOTAL_COUNT="$(
+              jq '.data.activeTargets | length' \
+                <<< "${TARGETS_RESPONSE}"
+            )"
+        
+            UP_COUNT="$(
+              jq '
+                [
+                  .data.activeTargets[]
+                  | select(.health == "up")
+                ]
+                | length
+              ' <<< "${TARGETS_RESPONSE}"
+            )"
+                
+            DOWN_COUNT="$(
+              jq '
+                [
+                  .data.activeTargets[]
+                  | select(.health != "up")
+                ]
+                | length
+              ' <<< "${TARGETS_RESPONSE}"
+            )"
+          
+            echo \
+              "Prometheus targets: " \
+              "total=${TOTAL_COUNT}/${EXPECTED_TARGETS} " \
+              "up=${UP_COUNT} down=${DOWN_COUNT}"
+            
+            if (( TOTAL_COUNT == EXPECTED_TARGETS )) \
+              && (( UP_COUNT == EXPECTED_TARGETS )) \
+              && (( DOWN_COUNT == 0 )); then
+              PROMETHEUS_READY=true
+              break
+            fi
+          
+            jq -r '
+              .data.activeTargets[]
+              | select(.health != "up")
+              | "\(.scrapeUrl) health=\(.health) error=\(.lastError)"
+            ' <<< "${TARGETS_RESPONSE}"
+            
+            sleep 10
+          done
+        
+          if [[ "${PROMETHEUS_READY}" != "true" ]]; then
+            echo "Prometheus targets did not become fully healthy."
+        
+            if [[ -n "${TARGETS_RESPONSE:-}" ]]; then
+              jq -r '
+                .data.activeTargets[]
+                | "\(.scrapeUrl) health=\(.health) error=\(.lastError)"
+              ' <<< "${TARGETS_RESPONSE}"
+            fi
+      
+            exit 1
+          fi
+
+          echo "Checking local Nginx HTTPS route..."
+
+          NGINX_HEALTH_RESPONSE="$(
+            curl \
+              --fail \
+              --silent \
+              --show-error \
+              --location \
+              --resolve api.ticketrush.store:443:127.0.0.1 \
+              --connect-timeout 5 \
+              --max-time 15 \
+              --retry 6 \
+              --retry-delay 5 \
+              --retry-all-errors \
+              https://api.ticketrush.store/actuator/health
+          )"
+
+          echo "${NGINX_HEALTH_RESPONSE}"
+
+          if ! grep -Eq '"status"[[:space:]]*:[[:space:]]*"UP"' \
+            <<< "${NGINX_HEALTH_RESPONSE}"; then
+            echo "Local Nginx HTTPS health status is not UP."
+            exit 1
+          fi
+
+          echo "Local Nginx HTTPS health check passed."
+
+
+          PREVIOUS_RELEASE=""
+
+          if [[ -f deploy/CURRENT_RELEASE ]]; then
+            PREVIOUS_RELEASE="$(cat deploy/CURRENT_RELEASE)"
+          fi
+
+          if [[ -n "${PREVIOUS_RELEASE}" && "${PREVIOUS_RELEASE}" != "${IMAGE_TAG}" ]]; then
+            printf '%s\n' "${PREVIOUS_RELEASE}" \
+              > deploy/PREVIOUS_RELEASE
+          fi
+
+          printf '%s\n' "${IMAGE_TAG}" \
+            > deploy/CURRENT_RELEASE
+
+          echo "Deployment completed."
+          echo "Current release: ${IMAGE_TAG}"
+
+          "${COMPOSE[@]}" ps --all
+          REMOTE_SCRIPT
+
+      - name: Write deployment summary
+        shell: bash
+        run: |
+          {
+            echo "## TicketRush deployment"
+            echo
+            echo "- Branch: \`${GITHUB_REF_NAME}\`"
+            echo "- Commit: \`${IMAGE_TAG}\`"
+            echo "- Region: \`${AWS_REGION}\`"
+            echo "- Registry: \`${ECR_REGISTRY}\`"
+            echo "- Result: success"
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+  external-health:
+    name: External HTTPS health
+    needs: deploy
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Check public HTTPS health
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+
+          EXTERNAL_URL="https://api.ticketrush.store/actuator/health"
+          MAX_ATTEMPTS=12
+          SLEEP_SECONDS=10
+
+          for ATTEMPT in $(seq 1 "${MAX_ATTEMPTS}"); do
+            echo "External health check ${ATTEMPT}/${MAX_ATTEMPTS}"
+
+            RESPONSE_FILE="$(mktemp)"
+
+            HTTP_CODE="$(
+              curl \
+                --silent \
+                --show-error \
+                --location \
+                --connect-timeout 5 \
+                --max-time 15 \
+                --output "${RESPONSE_FILE}" \
+                --write-out '%{http_code}' \
+                "${EXTERNAL_URL}"
+            )" && CURL_EXIT=0 || CURL_EXIT=$?
+
+            RESPONSE="$(cat "${RESPONSE_FILE}")"
+            rm -f "${RESPONSE_FILE}"
+
+            echo "curl_exit=${CURL_EXIT}, http_code=${HTTP_CODE:-none}"
+            echo "${RESPONSE}"
+
+            if [[ "${CURL_EXIT}" -eq 0 ]] \
+              && [[ "${HTTP_CODE}" == "200" ]] \
+              && grep -Eq '"status"[[:space:]]*:[[:space:]]*"UP"' \
+                <<< "${RESPONSE}"; then
+              echo "External HTTPS health check passed."
+              exit 0
+            fi
+
+            if (( ATTEMPT < MAX_ATTEMPTS )); then
+              sleep "${SLEEP_SECONDS}"
+            fi
+          done
+
+          echo "::error::External HTTPS health did not become UP."
+          exit 1


### PR DESCRIPTION
## 🔗 관련 이슈

* close #453 

---

## 📌 주요 변경 사항

* CD 배포 번들에 monitoring 필수 설정 파일과 Grafana 대시보드 JSON이 포함됐는지 검증
* monitoring 디렉터리 교체 후 Prometheus와 Grafana 컨테이너 강제 재생성
* Grafana 컨테이너 내부에 대시보드 JSON이 정상적으로 마운트됐는지 검증

---

## 🛠 상세 구현 내용

### 1. monitoring 배포 파일 검증

배포 번들 압축 해제 후 아래 필수 파일의 존재 여부를 확인하도록 수정했습니다.

* `deploy/monitoring/prometheus.aws.yml`
* `deploy/monitoring/grafana/provisioning/dashboards/dashboards.yml`

또한 다음 항목도 함께 검증합니다.

* Grafana 대시보드 디렉터리 존재 여부
* 대시보드 JSON 파일이 1개 이상 존재하는지 여부

필수 파일이 누락된 경우, 누락된 파일 경로를 GitHub Actions 로그에 출력하고 배포를 중단합니다.

### 2. Prometheus·Grafana 컨테이너 강제 재생성

배포 과정에서 `deploy/monitoring` 디렉터리를 삭제하고 새 번들로 교체하지만, 기존 Prometheus와 Grafana 컨테이너가 재사용되면서 이전 bind mount를 계속 유지하는 문제가 있었습니다.

새 monitoring 경로가 컨테이너에 다시 마운트되도록 아래 옵션을 사용해 두 컨테이너를 강제로 재생성하도록 수정했습니다.

```bash
docker compose up \
  -d \
  --force-recreate \
  --no-deps \
  prometheus \
  grafana
```

### 3. Grafana 컨테이너 내부 마운트 검증

호스트에 대시보드 JSON이 존재하는지만 확인하지 않고, Grafana 컨테이너 내부의 아래 경로에서 JSON 파일이 실제로 조회되는지 확인하도록 검증을 추가했습니다.

```text
/var/lib/grafana/dashboards
```

마운트 검증에 실패하면 다음 진단 정보를 로그에 출력합니다.

* Grafana 컨테이너의 mount 정보
* `/var/lib/grafana/dashboards` 내부 파일 목록

---

## 🔍 문제 원인

EC2 호스트에는 Grafana 대시보드 JSON 파일이 정상적으로 존재했지만, Grafana 컨테이너 내부의 대시보드 경로는 비어 있었습니다.

배포 시 호스트의 `deploy/monitoring` 디렉터리는 새로 교체됐으나, 기존 Grafana 컨테이너가 재생성되지 않으면서 삭제된 이전 bind mount를 계속 유지한 것이 원인이었습니다.

---

## ✅ 확인 사항

* [x] monitoring 필수 설정 파일 존재 여부 검증
* [x] Grafana 대시보드 JSON 존재 여부 검증
* [x] Prometheus·Grafana 컨테이너 강제 재생성
* [x] Grafana 컨테이너 내부 대시보드 마운트 검증
* [x] 마운트 실패 시 진단 로그 출력
* [x] 기존 Prometheus 타깃 10개 검증 로직 유지
* [ ] 운영 CD 파이프라인 최종 통과 확인
