### PR TITLE
[Fix] #457 CD 검증 코드의 버그로 실패한 것을 수정

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -465,7 +465,8 @@ jobs:
 
               if [[ -n "${APPLICATION_SERVICE_SET[$SERVICE]:-}" ]]; then
                 if ! docker logs "${CONTAINER_ID}" 2>&1 \
-                  | grep -Eq 'Started .*Application in .* seconds'; then
+                  | grep -E 'Started .*Application in .* seconds' \
+                  > /dev/null; then
                   echo "${SERVICE}: Spring Boot startup not confirmed"
                   ALL_READY=false
                 fi


### PR DESCRIPTION

## 📌 주요 변경 사항

- Grafana 파일 검증: 통과
Grafana 컨테이너 마운트: 통과
컨테이너 재시작 감지: 발견되지 않음
OOM·unhealthy·exited: 발견되지 않음
실패 지점: Spring Boot 시작 로그 검사
실제 원인: grep -q + pipefail로 인한 false negative
최종 종료: 6회 연속 안정 판정을 만들지 못해 exit 1 
했기 때문에 false negative 수정
-
-

---


