### PR TITLE
[Feat] #438 예매 오픈 시각(bookingOpenAt) 해제 API 추가

### DIFF
--- a/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/app/dto/request/PerformancePatchRequest.java
+++ b/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/app/dto/request/PerformancePatchRequest.java
@@ -42,7 +42,9 @@ public record PerformancePatchRequest(
         @Size(max = 255, message = "주소는 255자를 초과할 수 없습니다.")
         String address,
     @Schema(
-            description = "예매 오픈 시각 (yyyy-MM-dd HH:mm:ss, null=수정 안 함 — 한 번 설정하면 해제 불가, 변경만 가능)",
+            description =
+                "예매 오픈 시각 (yyyy-MM-dd HH:mm:ss, null=수정 안 함 — 해제하려면 "
+                    + "DELETE /api/v1/performance/admin/{id}/booking-open-at 사용)",
             example = "2027-08-01 20:00:00")
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
         LocalDateTime bookingOpenAt) {}

--- a/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/app/facade/PerformanceFacade.java
+++ b/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/app/facade/PerformanceFacade.java
@@ -7,6 +7,7 @@ import com.ticketrush.boundedcontext.performance.app.dto.response.PerformanceCre
 import com.ticketrush.boundedcontext.performance.app.dto.response.PerformanceDetailResponse;
 import com.ticketrush.boundedcontext.performance.app.dto.response.PerformanceListResponse;
 import com.ticketrush.boundedcontext.performance.app.usecase.PerformanceChangeStatusUseCase;
+import com.ticketrush.boundedcontext.performance.app.usecase.PerformanceClearBookingOpenAtUseCase;
 import com.ticketrush.boundedcontext.performance.app.usecase.PerformanceCreateUseCase;
 import com.ticketrush.boundedcontext.performance.app.usecase.PerformanceDeleteUseCase;
 import com.ticketrush.boundedcontext.performance.app.usecase.PerformanceGetDetailUseCase;
@@ -33,6 +34,7 @@ public class PerformanceFacade {
   private final PerformancePatchUseCase performancePatchUseCase;
   private final PerformanceDeleteUseCase performanceDeleteUseCase;
   private final PerformanceValidateUseCase performanceValidateUseCase;
+  private final PerformanceClearBookingOpenAtUseCase performanceClearBookingOpenAtUseCase;
 
   public PerformanceCreateResponse createPerformance(
       PerformanceCreateRequest request,
@@ -64,6 +66,10 @@ public class PerformanceFacade {
 
   public void patchPerformance(Long performanceId, PerformancePatchRequest request) {
     performancePatchUseCase.execute(performanceId, request);
+  }
+
+  public void clearBookingOpenAt(Long performanceId) {
+    performanceClearBookingOpenAtUseCase.execute(performanceId);
   }
 
   public void deletePerformance(Long performanceId) {

--- a/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/app/usecase/PerformanceClearBookingOpenAtUseCase.java
+++ b/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/app/usecase/PerformanceClearBookingOpenAtUseCase.java
@@ -1,0 +1,33 @@
+package com.ticketrush.boundedcontext.performance.app.usecase;
+
+import com.ticketrush.boundedcontext.performance.out.repository.PerformanceRepository;
+import com.ticketrush.global.constants.CacheConstants;
+import com.ticketrush.global.exception.BusinessException;
+import com.ticketrush.global.status.ErrorStatus;
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class PerformanceClearBookingOpenAtUseCase {
+
+  private final PerformanceRepository performanceRepository;
+
+  /**
+   * 예매 오픈 시각을 해제한다.
+   *
+   * <p>공연 상태는 변경하지 않으므로 이미 ON_SALE로 전환된 공연에 소급 효과는 없다. 이미 해제된 공연에 다시 요청해도 예외 없이 통과한다(멱등).
+   */
+  @CacheEvict(cacheNames = CacheConstants.PERFORMANCE_LIST_CACHE, allEntries = true)
+  @Transactional
+  public void execute(Long performanceId) {
+    int updated = performanceRepository.clearBookingOpenAt(performanceId, LocalDateTime.now());
+
+    if (updated == 0) {
+      throw new BusinessException(ErrorStatus.PERFORMANCE_NOT_FOUND);
+    }
+  }
+}

--- a/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/in/api/v1/PerformanceAdminController.java
+++ b/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/in/api/v1/PerformanceAdminController.java
@@ -107,6 +107,21 @@ public class PerformanceAdminController {
     return ApiResponse.onSuccess(SuccessStatus.OK);
   }
 
+  @Operation(
+      summary = "예매 오픈 시각 해제",
+      description =
+          "공연의 예매 오픈 시각을 해제해 스케줄러 자동 전환 대상에서 제외합니다. "
+              + "이미 해제된 공연에 요청해도 성공합니다. "
+              + "공연 상태는 변경되지 않으므로, 이미 판매 중인 공연을 중단하려면 상태 변경 API를 사용해야 합니다.")
+  @DeleteMapping("/{id}/booking-open-at")
+  public ResponseEntity<ApiResponse<Void>> clearBookingOpenAt(
+      @Parameter(description = "공연 ID") @Positive @PathVariable Long id) {
+
+    performanceFacade.clearBookingOpenAt(id);
+
+    return ApiResponse.onSuccess(SuccessStatus.OK);
+  }
+
   @Operation(summary = "공연 삭제", description = "공연을 논리 삭제합니다. 삭제된 공연은 모든 조회에서 제외됩니다.")
   @DeleteMapping("/{id}")
   public ResponseEntity<ApiResponse<Void>> deletePerformance(

--- a/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/out/repository/PerformanceRepository.java
+++ b/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/out/repository/PerformanceRepository.java
@@ -36,4 +36,28 @@ public interface PerformanceRepository
       @Param("from") PerformanceStatus from,
       @Param("to") PerformanceStatus to,
       @Param("now") LocalDateTime now);
+
+  /**
+   * 예매 오픈 시각만 해제해 스케줄러 자동 전환 대상에서 제외한다.
+   *
+   * <p>엔티티 더티체킹 대신 타깃 UPDATE를 쓰는 이유는 {@code @Version} 부재 때문이다. 엔티티를 로드해 해제하면 전체 컬럼 UPDATE가 나가면서, 로드
+   * 이후 스케줄러가 커밋한 ON_SALE 전환을 stale한 UPCOMING으로 덮어쓴다. 게다가 같은 UPDATE로 bookingOpenAt이 NULL이 되어 벌크 전환
+   * 쿼리의 {@code IS NOT NULL} 조건에서 영구 이탈하므로, 다른 경로와 달리 다음 주기 self-heal조차 불가능해진다.
+   *
+   * <p>벌크 JPQL은 {@code @SQLRestriction}과 Auditing이 적용되지 않으므로 deletedAt 조건과 updatedAt을 명시한다. 영향 행 수가
+   * 0이면 대상 공연이 없거나 이미 소프트 삭제된 경우다.
+   *
+   * <p><b>역방향 경합 창이 남아 있다.</b> 이 쿼리는 stale write를 하지 않지만, 해제 결과가 다른 경로로부터 보호되지는 않는다. 엔티티를 로드하는
+   * PATCH·상태 변경 UseCase는 {@code @Version}/{@code @DynamicUpdate} 부재로 여전히 전체 컬럼 UPDATE를 내보내므로, 그들이
+   * bookingOpenAt을 로드한 뒤 이 해제가 커밋되면 마지막 커밋이 해제된 값을 되살린다. 이 경우 공연이 어드민 모르게 자동 전환 대상으로 복귀하며 판단 근거가
+   * DB에 남지 않아 self-heal도 불가능하다. 근본 해결({@code @DynamicUpdate} 도입)은 엔티티 전역 영향이라 별도 이슈로 분리했다.
+   *
+   * <p>{@code clearAutomatically = true}가 호출 트랜잭션의 영속성 컨텍스트 전체를 비우고 {@code flushAutomatically}는 기본값
+   * false이므로, 같은 트랜잭션에 flush되지 않은 더티 엔티티가 있으면 조용히 유실된다. 엔티티를 함께 다루는 트랜잭션에서 호출하지 말아야 한다.
+   */
+  @Modifying(clearAutomatically = true)
+  @Query(
+      "UPDATE Performance p SET p.bookingOpenAt = null, p.updatedAt = :now "
+          + "WHERE p.id = :id AND p.deletedAt IS NULL")
+  int clearBookingOpenAt(@Param("id") Long id, @Param("now") LocalDateTime now);
 }

--- a/performance-service/src/test/java/com/ticketrush/boundedcontext/performance/in/api/v1/PerformanceAdminControllerTest.java
+++ b/performance-service/src/test/java/com/ticketrush/boundedcontext/performance/in/api/v1/PerformanceAdminControllerTest.java
@@ -80,4 +80,36 @@ class PerformanceAdminControllerTest {
                 .header("X-User-Role", "ADMIN"))
         .andExpect(status().isForbidden());
   }
+
+  @Test
+  @DisplayName("관리자 권한으로 예매 오픈 시각 해제 요청 시 200을 반환한다")
+  void clearBookingOpenAt_admin_success() throws Exception {
+    doNothing().when(performanceFacade).clearBookingOpenAt(1L);
+
+    mockMvc
+        .perform(
+            delete(BASE_URL + "/1/booking-open-at")
+                .header("X-Gateway-Token", INTERNAL_TOKEN)
+                .header("X-User-Id", "1")
+                .header("X-User-Role", "ADMIN"))
+        .andExpect(status().isOk());
+  }
+
+  @Test
+  @DisplayName("일반 사용자 권한으로 예매 오픈 시각 해제 요청 시 403을 반환한다")
+  void clearBookingOpenAt_userRole_forbidden() throws Exception {
+    mockMvc
+        .perform(
+            delete(BASE_URL + "/1/booking-open-at")
+                .header("X-Gateway-Token", INTERNAL_TOKEN)
+                .header("X-User-Id", "1")
+                .header("X-User-Role", "USER"))
+        .andExpect(status().isForbidden());
+  }
+
+  @Test
+  @DisplayName("인증 없이 예매 오픈 시각 해제 요청 시 403을 반환한다")
+  void clearBookingOpenAt_noAuth_forbidden() throws Exception {
+    mockMvc.perform(delete(BASE_URL + "/1/booking-open-at")).andExpect(status().isForbidden());
+  }
 }

--- a/performance-service/src/test/java/com/ticketrush/boundedcontext/performance/in/api/v1/PerformanceClearBookingOpenAtTest.java
+++ b/performance-service/src/test/java/com/ticketrush/boundedcontext/performance/in/api/v1/PerformanceClearBookingOpenAtTest.java
@@ -1,14 +1,17 @@
 package com.ticketrush.boundedcontext.performance.in.api.v1;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.ticketrush.boundedcontext.performance.app.usecase.PerformanceClearBookingOpenAtUseCase;
-import com.ticketrush.boundedcontext.performance.app.usecase.PerformanceOpenBookingUseCase;
 import com.ticketrush.boundedcontext.performance.domain.entity.Performance;
 import com.ticketrush.boundedcontext.performance.domain.types.Genre;
 import com.ticketrush.boundedcontext.performance.domain.types.PerformanceStatus;
 import com.ticketrush.boundedcontext.performance.out.repository.PerformanceRepository;
 import com.ticketrush.global.eventpublisher.EventPublisher;
+import com.ticketrush.global.exception.BusinessException;
+import com.ticketrush.global.status.ErrorStatus;
 import com.ticketrush.global.util.S3UploadUtils;
 import jakarta.persistence.EntityManager;
 import java.time.LocalDate;
@@ -31,12 +34,11 @@ import org.springframework.transaction.annotation.Transactional;
       io.awspring.cloud.autoconfigure.core.AwsAutoConfiguration.class
     })
 @Transactional
-class PerformanceOpenBookingTest {
+class PerformanceClearBookingOpenAtTest {
 
   @MockitoBean private S3UploadUtils s3UploadUtils;
   @MockitoBean private EventPublisher eventPublisher;
 
-  @Autowired private PerformanceOpenBookingUseCase performanceOpenBookingUseCase;
   @Autowired private PerformanceClearBookingOpenAtUseCase performanceClearBookingOpenAtUseCase;
   @Autowired private PerformanceRepository performanceRepository;
   @Autowired private EntityManager em;
@@ -65,79 +67,64 @@ class PerformanceOpenBookingTest {
   }
 
   @Test
-  @DisplayName("오픈 시각이 도래한 UPCOMING 공연은 ON_SALE로 전환된다")
-  void openBooking_dueUpcoming_transitionsToOnSale() {
-    Performance performance = savePerformance(LocalDateTime.now().minusMinutes(1));
+  @DisplayName("설정된 예매 오픈 시각을 해제하면 null이 된다")
+  void clearBookingOpenAt_success() {
+    Performance performance = savePerformance(LocalDateTime.now().plusDays(1));
 
-    int openedCount = performanceOpenBookingUseCase.execute();
+    performanceClearBookingOpenAtUseCase.execute(performance.getId());
 
-    assertThat(openedCount).isEqualTo(1);
-    assertThat(refetch(performance.getId()).getPerformanceStatus())
-        .isEqualTo(PerformanceStatus.ON_SALE);
+    assertThat(refetch(performance.getId()).getBookingOpenAt()).isNull();
   }
 
+  /**
+   * 이 테스트는 H2에서 돌아 affected rows 의미론까지 검증하지는 못한다. 프로덕션(MySQL)에서 멱등성이 성립하는 근거는 updatedAt이 항상 갱신되는 것과
+   * Connector/J가 기본적으로 matched rows를 반환하는 것 두 가지다. updatedAt 갱신을 빼는 리팩토링은 H2에서 초록불인 채 MySQL에서만 깨질 수
+   * 있다.
+   */
   @Test
-  @DisplayName("오픈 시각이 아직 도래하지 않은 공연은 전환되지 않는다")
-  void openBooking_futureOpenAt_notTransitioned() {
-    Performance performance = savePerformance(LocalDateTime.now().plusHours(1));
-
-    int openedCount = performanceOpenBookingUseCase.execute();
-
-    assertThat(openedCount).isZero();
-    assertThat(refetch(performance.getId()).getPerformanceStatus())
-        .isEqualTo(PerformanceStatus.UPCOMING);
-  }
-
-  @Test
-  @DisplayName("오픈 시각이 설정되지 않은 공연은 전환 대상이 아니다")
-  void openBooking_nullOpenAt_notTransitioned() {
+  @DisplayName("이미 해제된 공연에 다시 해제를 요청해도 예외 없이 통과한다")
+  void clearBookingOpenAt_alreadyNull_idempotent() {
     Performance performance = savePerformance(null);
+    Long id = performance.getId();
 
-    int openedCount = performanceOpenBookingUseCase.execute();
+    assertThatCode(() -> performanceClearBookingOpenAtUseCase.execute(id))
+        .doesNotThrowAnyException();
 
-    assertThat(openedCount).isZero();
-    assertThat(refetch(performance.getId()).getPerformanceStatus())
-        .isEqualTo(PerformanceStatus.UPCOMING);
+    assertThat(refetch(id).getBookingOpenAt()).isNull();
   }
 
   @Test
-  @DisplayName("해제 API로 오픈 시각을 지운 공연은 시각이 도래했더라도 전환되지 않는다")
-  void openBooking_clearedOpenAt_notTransitioned() {
+  @DisplayName("이미 판매 중인 공연을 해제해도 상태는 ON_SALE로 유지된다")
+  void clearBookingOpenAt_onSale_statusNotRolledBack() {
     Performance performance = savePerformance(LocalDateTime.now().minusMinutes(1));
+    performance.changeStatus(PerformanceStatus.ON_SALE);
     em.flush();
 
     performanceClearBookingOpenAtUseCase.execute(performance.getId());
 
-    int openedCount = performanceOpenBookingUseCase.execute();
-
-    assertThat(openedCount).isZero();
-    assertThat(refetch(performance.getId()).getPerformanceStatus())
-        .isEqualTo(PerformanceStatus.UPCOMING);
+    Performance cleared = refetch(performance.getId());
+    assertThat(cleared.getBookingOpenAt()).isNull();
+    assertThat(cleared.getPerformanceStatus()).isEqualTo(PerformanceStatus.ON_SALE);
   }
 
   @Test
-  @DisplayName("어드민이 취소한(CANCELED) 공연은 오픈 시각이 도래해도 전환되지 않는다")
-  void openBooking_canceled_notTransitioned() {
-    Performance performance = savePerformance(LocalDateTime.now().minusMinutes(1));
-    performance.changeStatus(PerformanceStatus.CANCELED);
-    em.flush();
-
-    int openedCount = performanceOpenBookingUseCase.execute();
-
-    assertThat(openedCount).isZero();
-    assertThat(refetch(performance.getId()).getPerformanceStatus())
-        .isEqualTo(PerformanceStatus.CANCELED);
+  @DisplayName("존재하지 않는 공연 ID로 해제 요청 시 예외 발생")
+  void clearBookingOpenAt_notFound() {
+    assertThatThrownBy(() -> performanceClearBookingOpenAtUseCase.execute(Long.MAX_VALUE))
+        .isInstanceOf(BusinessException.class)
+        .hasMessage(ErrorStatus.PERFORMANCE_NOT_FOUND.getMessage());
   }
 
   @Test
-  @DisplayName("소프트 삭제된 공연은 오픈 시각이 도래해도 전환되지 않는다")
-  void openBooking_softDeleted_notTransitioned() {
-    Performance performance = savePerformance(LocalDateTime.now().minusMinutes(1));
+  @DisplayName("소프트 삭제된 공연에 해제 요청 시 예외 발생")
+  void clearBookingOpenAt_softDeleted_notFound() {
+    Performance performance = savePerformance(LocalDateTime.now().plusDays(1));
+    Long id = performance.getId();
     performance.softDelete();
     em.flush();
 
-    int openedCount = performanceOpenBookingUseCase.execute();
-
-    assertThat(openedCount).isZero();
+    assertThatThrownBy(() -> performanceClearBookingOpenAtUseCase.execute(id))
+        .isInstanceOf(BusinessException.class)
+        .hasMessage(ErrorStatus.PERFORMANCE_NOT_FOUND.getMessage());
   }
 }


### PR DESCRIPTION
## 🔗 관련 이슈

- close #438

---

## 📌 주요 변경 사항

- 예매 오픈 시각 해제 API 추가 (`DELETE /api/v1/performance/admin/{id}/booking-open-at`)
- 해제된 공연은 스케줄러 자동 전환 대상에서 제외되어 어드민 수동 전환만 가능
- 공연 수정 API의 `bookingOpenAt` Swagger 설명을 전용 해제 API 안내로 갱신

---

## 🛠 상세 구현 내용

- **전용 엔드포인트 방식 채택** — PATCH 바디에서 "필드 미지정"과 "명시적 null"을 구분하려면 `JsonNullable`이 필요한데, 저장소에 선례가 없는 신규 의존성 + `common`의 `JacksonConfig` 변경(전 서비스 직렬화 영향) + springdoc 렌더링 미검증이 겹쳐 배제했습니다. 기존 PATCH의 null 규약은 그대로 보존됩니다.

- **해제는 엔티티 더티체킹이 아닌 타깃 UPDATE로 처리** — `Performance`에는 `@Version`도 `@DynamicUpdate`도 없어, 엔티티를 로드해 해제하면 전체 컬럼 UPDATE가 나갑니다. 그러면 로드 이후 스케줄러가 커밋한 `ON_SALE` 전환을 stale한 `UPCOMING`으로 덮어쓰고, **동시에 `bookingOpenAt`이 NULL이 되어 벌크 전환 쿼리의 `IS NOT NULL` 조건에서 이탈**하므로 리포지토리 Javadoc이 근거로 삼던 "다음 주기 self-heal"조차 불가능해집니다. 결과는 공연이 UPCOMING으로 영구 고착되는 것이라 `@Modifying` 타깃 UPDATE로 해당 컬럼만 갱신합니다.

- **멱등 처리** — 이미 해제된 공연에 재요청해도 200. 영향 행 수가 0일 때만 404이며, 소프트 삭제된 공연은 벌크 JPQL에 `@SQLRestriction`이 안 걸리므로 `deletedAt IS NULL`을 명시해 404로 처리합니다.

- **공연 상태는 변경하지 않음** — `PerformanceStatus.canTransitionTo`가 `ON_SALE → UPCOMING`을 막고 있고, 전이 규칙 변경은 상태 머신 전반 재검토로 번져 이 이슈 범위를 벗어납니다. 이미 판매 중인 공연을 중단하려면 기존 상태 변경 API를 쓰도록 Swagger에 안내했습니다.

---

## ✅ 테스트

### 테스트 방법

- `./gradlew :performance-service:test`

### 테스트 결과

- **76 tests, 0 failures** (신규 9건: 해제 UseCase 5 + 스케줄러 연계 1 + 컨트롤러 인가 3)
  - 설정된 오픈 시각 해제 → null
  - 이미 해제된 공연 재요청 → 멱등 통과
  - **ON_SALE 공연 해제 → 시각만 null, 상태는 ON_SALE 유지**
  - 미존재 / 소프트 삭제 공연 → `PERFORMANCE_NOT_FOUND`
  - **해제 API 경유 후 오픈 시각이 도래해도 자동 전환되지 않음** (완료조건 ② e2e)
  - ADMIN 200 / USER 403 / 무인증 403

### 📸 스크린샷

---

## 👀 리뷰 요청 사항

- **역방향 경합 창을 이 PR에서 닫지 않은 판단**을 봐주세요. 해제 경로 자체는 타깃 UPDATE로 stale write를 제거했지만, 엔티티를 로드하는 PATCH·상태 변경 UseCase가 여전히 전체 컬럼 UPDATE를 내보내므로 그들이 커밋하며 해제된 값을 되살릴 수 있습니다. 근본 해결(`@DynamicUpdate`)은 엔티티 전역 영향이라 **#459로 분리**하고, 이 PR에서는 `clearBookingOpenAt` Javadoc에 창의 존재를 명시만 했습니다.

- 캐시 evict는 엄밀히는 불필요합니다(`bookingOpenAt`이 `PerformanceListResponse`에 없고 상세 조회는 `@Cacheable`이 아님). 상태 변경 UseCase 5개가 전부 evict 중이라 일관성 목적으로 넣었는데, 빼는 게 낫다고 보시면 말씀해 주세요.

---

## ⚠️ 배포 시 주의사항

- **이 PR 자체는 스키마 변경이 없습니다.** `booking_open_at`은 이미 nullable이고 엔티티 필드·컬럼 정의를 건드리지 않아 스냅샷도 무변경 → 수동 DDL 불필요.
- 다만 **#298의 `booking_open_at ADD COLUMN`이 prod에 아직 미반영**(#441 체크리스트 ①)이라, prod는 `validate` 모드이므로 그 DDL이 선행되어야 이 기능도 동작합니다.
- Breaking change 아님 — 순수 신규 엔드포인트라 프론트 공지 불필요.
- Gateway는 `/api/v1/performance/**` 프리픽스 라우팅이라 별도 설정 변경 없이 노출됩니다.
