### PR TITLE
[Refactor] #459 Performance 엔티티 stale 덮어쓰기 방어 (@DynamicUpdate 도입)

### DIFF
--- a/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/domain/entity/Performance.java
+++ b/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/domain/entity/Performance.java
@@ -24,10 +24,36 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.DynamicUpdate;
 import org.hibernate.annotations.SQLRestriction;
 
+/*
+ * 동적 UPDATE (#459). Performance를 로드해 더티 체킹으로 쓰는 경로(PATCH·상태 변경·소프트 삭제)는 변경하지 않은
+ * 컬럼까지 포함한 전체 행 UPDATE를 내보낸다. 그러면 로드 이후 다른 트랜잭션이 커밋한 값이 stale 값으로 조용히
+ * 덮어써진다. 특히 예매 오픈 시각 해제(#438)가 커밋된 뒤 PATCH가 커밋되면 해제된 bookingOpenAt이 부활해 공연이
+ * 어드민 모르게 자동 전환 대상으로 복귀하고, bookingOpenAt이 다시 채워지므로 스케줄러의 self-heal조차 불가능하다.
+ *
+ * @Version(낙관적 락)이 아니라 @DynamicUpdate를 쓰는 이유는 stale write의 상대편이 둘 다 벌크 JPQL이기 때문이다.
+ * PerformanceRepository의 clearBookingOpenAt과 bulkTransitionStatusByBookingOpenAtDue는 version을
+ * 증가시키지도 검사하지도 않으므로(seat·booking도 같은 한계 — ADR 0005), @Version을 달아도 PATCH의 버전 검사는
+ * 그대로 통과하고 전체 컬럼 UPDATE가 나간다. 즉 낙관적 락으로는 이 경합이 잡히지 않는다.
+ *
+ * 동적 UPDATE만으로 안전한 이유는 경합하는 경로들이 <b>서로소 컬럼을 쓰기 때문이다.</b> PATCH는 update()가 받은
+ * non-null 필드만, 상태 변경은 performance_status만, 소프트 삭제는 deleted_at만, 두 벌크는 각각
+ * performance_status와 booking_open_at만 건드린다. 변경 컬럼만 SET에 실리면 서로의 쓰기를 덮을 일이 없다.
+ *
+ * 이 불변식이 깨지는 경우는 둘이다. (1) 두 경로가 같은 컬럼을 다투게 되거나, (2) read-modify-write 계산(예: 잔여
+ * 좌석 수 증감)이 엔티티에 추가되면 변경 컬럼만 써도 lost update가 난다. 지금 update()·changeStatus()·
+ * softDelete()는 전부 대입형이라 (2)에 해당하지 않는다. 그때는 @Version 도입을 검토한다.
+ *
+ * 남는 한계로, PATCH가 bookingOpenAt을 명시로 실어 보내면 해제와 같은 컬럼을 다투므로 커밋 순서대로
+ * last-write-wins다. 이건 어드민의 의도적 쓰기라 stale 부활과 구분되며 이번 범위에서 제외했다.
+ *
+ * @DynamicInsert는 도입하지 않는다. INSERT는 생성 경로 하나뿐이라 경합이 없다.
+ */
 @Entity
 @Table(name = "performance")
+@DynamicUpdate
 @SQLRestriction("deleted_at IS NULL")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/domain/entity/Performance.java
+++ b/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/domain/entity/Performance.java
@@ -27,29 +27,42 @@ import lombok.NoArgsConstructor;
 import org.hibernate.annotations.DynamicUpdate;
 import org.hibernate.annotations.SQLRestriction;
 
-/*
- * 동적 UPDATE (#459). Performance를 로드해 더티 체킹으로 쓰는 경로(PATCH·상태 변경·소프트 삭제)는 변경하지 않은
- * 컬럼까지 포함한 전체 행 UPDATE를 내보낸다. 그러면 로드 이후 다른 트랜잭션이 커밋한 값이 stale 값으로 조용히
- * 덮어써진다. 특히 예매 오픈 시각 해제(#438)가 커밋된 뒤 PATCH가 커밋되면 해제된 bookingOpenAt이 부활해 공연이
- * 어드민 모르게 자동 전환 대상으로 복귀하고, bookingOpenAt이 다시 채워지므로 스케줄러의 self-heal조차 불가능하다.
+/**
+ * 공연.
  *
- * @Version(낙관적 락)이 아니라 @DynamicUpdate를 쓰는 이유는 stale write의 상대편이 둘 다 벌크 JPQL이기 때문이다.
- * PerformanceRepository의 clearBookingOpenAt과 bulkTransitionStatusByBookingOpenAtDue는 version을
- * 증가시키지도 검사하지도 않으므로(seat·booking도 같은 한계 — ADR 0005), @Version을 달아도 PATCH의 버전 검사는
- * 그대로 통과하고 전체 컬럼 UPDATE가 나간다. 즉 낙관적 락으로는 이 경합이 잡히지 않는다.
+ * <p><b>동적 UPDATE (#459).</b> 이 엔티티를 로드해 더티 체킹으로 쓰는 경로(PATCH·상태 변경·소프트 삭제)는 변경하지 않은 컬럼까지 포함한 전체 행
+ * UPDATE를 내보낸다. 그러면 로드 이후 다른 트랜잭션이 커밋한 값이 stale 값으로 조용히 덮어써진다. 특히 예매 오픈 시각 해제(#438)가 커밋된 뒤 PATCH가
+ * 커밋되면 해제된 bookingOpenAt이 부활해 공연이 어드민 모르게 자동 전환 대상으로 복귀하고, bookingOpenAt이 다시 채워지므로 스케줄러의
+ * self-heal조차 불가능하다.
  *
- * 동적 UPDATE만으로 안전한 이유는 경합하는 경로들이 <b>서로소 컬럼을 쓰기 때문이다.</b> PATCH는 update()가 받은
- * non-null 필드만, 상태 변경은 performance_status만, 소프트 삭제는 deleted_at만, 두 벌크는 각각
- * performance_status와 booking_open_at만 건드린다. 변경 컬럼만 SET에 실리면 서로의 쓰기를 덮을 일이 없다.
+ * <p>{@code @Version}(낙관적 락)이 아니라 {@code @DynamicUpdate}를 쓰는 이유는 <b>이 경합의 상대편이 둘 다 벌크 JPQL이기
+ * 때문이다.</b> PerformanceRepository의 clearBookingOpenAt과 bulkTransitionStatusByBookingOpenAtDue는
+ * version을 증가시키지도 검사하지도 않으므로(seat·booking도 같은 한계 — ADR 0005), {@code @Version}을 달아도 PATCH의 버전 검사는
+ * 그대로 통과하고 전체 컬럼 UPDATE가 나간다.
  *
- * 이 불변식이 깨지는 경우는 둘이다. (1) 두 경로가 같은 컬럼을 다투게 되거나, (2) read-modify-write 계산(예: 잔여
- * 좌석 수 증감)이 엔티티에 추가되면 변경 컬럼만 써도 lost update가 난다. 지금 update()·changeStatus()·
- * softDelete()는 전부 대입형이라 (2)에 해당하지 않는다. 그때는 @Version 도입을 검토한다.
+ * <p>동적 UPDATE로 충분한 이유는 경합하는 경로들이 <b>서로소 컬럼을 쓰기 때문이다.</b> PATCH는 update()가 받은 non-null 필드만, 상태 변경은
+ * performance_status만, 소프트 삭제는 deleted_at만, 두 벌크는 각각 performance_status와 booking_open_at만 건드린다. 변경
+ * 컬럼만 SET에 실리면 서로의 쓰기를 덮을 일이 없다.
  *
- * 남는 한계로, PATCH가 bookingOpenAt을 명시로 실어 보내면 해제와 같은 컬럼을 다투므로 커밋 순서대로
- * last-write-wins다. 이건 어드민의 의도적 쓰기라 stale 부활과 구분되며 이번 범위에서 제외했다.
+ * <p>이 불변식이 깨지는 경우는 셋이다.
  *
- * @DynamicInsert는 도입하지 않는다. INSERT는 생성 경로 하나뿐이라 경합이 없다.
+ * <ol>
+ *   <li>두 경로가 같은 컬럼을 다투게 되는 경우.
+ *   <li>stale read에 의존하는 가드나 계산이 추가되는 경우. 변경 컬럼만 써도 lost update가 난다.
+ *   <li>{@code @ElementCollection}(imageGalleryUrls·facilities)을 <b>로드된</b> 엔티티에서 바꾸는 경우.
+ *       updateUrls()가 컬렉션 인스턴스를 통째로 교체하므로 Hibernate는 컬렉션 테이블을 전량 DELETE 후 재INSERT하는데, 동적 UPDATE는
+ *       basic 컬럼의 SET 절만 좁힐 뿐 컬렉션 DML에는 관여하지 않는다. 지금은 생성 직후에만 호출돼 문제가 없지만 이미지 수정 기능이 붙으면 달라진다.
+ * </ol>
+ *
+ * <p><b>이미 (2)에 해당하는 경로가 하나 있다 — changeStatus().</b> canTransitionTo()가 로드된(=stale일 수 있는) 상태를 읽어
+ * 전이를 검증하므로, 어드민 둘이 같은 상태를 로드한 뒤 각각 CANCELED와 CLOSED를 커밋하면 늦은 쪽이 종단 상태를 덮는다. 두 경로 모두
+ * performance_status를 쓰는 같은 컬럼 경합이라 동적 UPDATE로는 막을 수 없고, {@code @Version}이었다면 잡혔을 유일한 경합이다. 어드민 동시
+ * 상태 변경이 실제 문제로 드러나면 그때 낙관적 락을 검토한다.
+ *
+ * <p>남는 한계로, PATCH가 bookingOpenAt을 명시로 실어 보내면 해제와 같은 컬럼을 다투므로 커밋 순서대로 last-write-wins다. 이건 어드민의 의도적
+ * 쓰기라 stale 부활과 구분되며 이번 범위에서 제외했다.
+ *
+ * <p>{@code @DynamicInsert}는 도입하지 않는다. INSERT는 생성 경로 하나뿐이라 경합이 없다.
  */
 @Entity
 @Table(name = "performance")

--- a/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/domain/entity/Performance.java
+++ b/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/domain/entity/Performance.java
@@ -30,19 +30,22 @@ import org.hibernate.annotations.SQLRestriction;
 /**
  * 공연.
  *
- * <p><b>동적 UPDATE (#459).</b> 이 엔티티를 로드해 더티 체킹으로 쓰는 경로(PATCH·상태 변경·소프트 삭제)는 변경하지 않은 컬럼까지 포함한 전체 행
- * UPDATE를 내보낸다. 그러면 로드 이후 다른 트랜잭션이 커밋한 값이 stale 값으로 조용히 덮어써진다. 특히 예매 오픈 시각 해제(#438)가 커밋된 뒤 PATCH가
- * 커밋되면 해제된 bookingOpenAt이 부활해 공연이 어드민 모르게 자동 전환 대상으로 복귀하고, bookingOpenAt이 다시 채워지므로 스케줄러의
- * self-heal조차 불가능하다.
+ * <p><b>동적 UPDATE (#459).</b> 이 어노테이션이 붙기 전에는 엔티티를 로드해 더티 체킹으로 쓰는 경로(PATCH·상태 변경·소프트 삭제)가 변경하지 않은
+ * 컬럼까지 포함한 전체 행 UPDATE를 내보냈고, 그래서 로드 이후 다른 트랜잭션이 커밋한 값이 stale 값으로 조용히 덮어써졌다. 특히 예매 오픈 시각 해제(#438)가
+ * 커밋된 뒤 PATCH가 커밋되면 해제된 bookingOpenAt이 부활해 공연이 어드민 모르게 자동 전환 대상으로 복귀했고, bookingOpenAt이 다시 채워지므로
+ * 스케줄러의 self-heal조차 불가능했다.
  *
- * <p>{@code @Version}(낙관적 락)이 아니라 {@code @DynamicUpdate}를 쓰는 이유는 <b>이 경합의 상대편이 둘 다 벌크 JPQL이기
+ * <p>{@code @Version}(낙관적 락)이 아니라 {@code @DynamicUpdate}를 택한 이유는 <b>이 경합의 상대편이 둘 다 벌크 JPQL이기
  * 때문이다.</b> PerformanceRepository의 clearBookingOpenAt과 bulkTransitionStatusByBookingOpenAtDue는
- * version을 증가시키지도 검사하지도 않으므로(seat·booking도 같은 한계 — ADR 0005), {@code @Version}을 달아도 PATCH의 버전 검사는
- * 그대로 통과하고 전체 컬럼 UPDATE가 나간다.
+ * version을 증가시키지도 검사하지도 않으므로(seat·booking도 같은 한계 — ADR 0005), {@code @Version}만 달아서는 PATCH의 버전 검사가
+ * 그대로 통과한다. JPQL {@code UPDATE VERSIONED}로 벌크까지 version을 올리면 낙관적 락도 성립하지만(ADR 0005가 booking에 대해 같은
+ * 선택지를 남겨 뒀다), 스케줄러가 10초마다 도는 탓에 어드민 PATCH가 산발적으로 409를 맞게 된다. 여기서 원한 것은 충돌을 알리는 게 아니라 서로 무관한 수정이
+ * 조용히 둘 다 성립하는 것이라 동적 UPDATE를 골랐다.
  *
  * <p>동적 UPDATE로 충분한 이유는 경합하는 경로들이 <b>서로소 컬럼을 쓰기 때문이다.</b> PATCH는 update()가 받은 non-null 필드만, 상태 변경은
  * performance_status만, 소프트 삭제는 deleted_at만, 두 벌크는 각각 performance_status와 booking_open_at만 건드린다. 변경
- * 컬럼만 SET에 실리면 서로의 쓰기를 덮을 일이 없다.
+ * 컬럼만 SET에 실리면 서로의 쓰기를 덮을 일이 없다. 다섯 경로가 공유하는 컬럼은 updated_at 하나뿐인데, Auditing 리스너와 벌크 JPQL이 언제나 현재
+ * 시각을 넣으므로 stale 값이 실릴 수 없어 무해하다.
  *
  * <p>이 불변식이 깨지는 경우는 셋이다.
  *
@@ -54,15 +57,16 @@ import org.hibernate.annotations.SQLRestriction;
  *       basic 컬럼의 SET 절만 좁힐 뿐 컬렉션 DML에는 관여하지 않는다. 지금은 생성 직후에만 호출돼 문제가 없지만 이미지 수정 기능이 붙으면 달라진다.
  * </ol>
  *
- * <p><b>이미 (2)에 해당하는 경로가 하나 있다 — changeStatus().</b> canTransitionTo()가 로드된(=stale일 수 있는) 상태를 읽어
- * 전이를 검증하므로, 어드민 둘이 같은 상태를 로드한 뒤 각각 CANCELED와 CLOSED를 커밋하면 늦은 쪽이 종단 상태를 덮는다. 두 경로 모두
- * performance_status를 쓰는 같은 컬럼 경합이라 동적 UPDATE로는 막을 수 없고, {@code @Version}이었다면 잡혔을 유일한 경합이다. 어드민 동시
- * 상태 변경이 실제 문제로 드러나면 그때 낙관적 락을 검토한다.
+ * <p><b>(1)에 해당하는 경로는 이미 있다.</b> 어드민 둘이 같은 필드를 PATCH하거나 동시에 상태를 바꾸면 같은 컬럼을 다투므로 동적 UPDATE로 갈리지 않고
+ * 나중 커밋이 이긴다. 그중 changeStatus()는 canTransitionTo()가 로드된(=stale일 수 있는) 상태를 읽어 전이를 검증하는 (2) 유형이기도 해서,
+ * 어드민 둘이 각각 CANCELED와 CLOSED를 커밋하면 종단 상태가 덮인다. 소프트 삭제와 겹칠 때도 PATCH 내용이 이미 보이지 않는 행에 적용되고 사라진다. 이런
+ * 경합을 조용히 넘기지 않고 사용자에게 드러내야 한다면, 그때 낙관적 락({@code @Version} + 벌크의 {@code UPDATE VERSIONED})을 검토한다.
  *
  * <p>남는 한계로, PATCH가 bookingOpenAt을 명시로 실어 보내면 해제와 같은 컬럼을 다투므로 커밋 순서대로 last-write-wins다. 이건 어드민의 의도적
  * 쓰기라 stale 부활과 구분되며 이번 범위에서 제외했다.
  *
- * <p>{@code @DynamicInsert}는 도입하지 않는다. INSERT는 생성 경로 하나뿐이라 경합이 없다.
+ * <p>{@code @DynamicInsert}는 이번 범위 밖이다. null 컬럼을 INSERT문에서 빼 DB default가 먹게 하는 기능이라 이 이슈가 다루는 동시
+ * 쓰기와는 무관하다.
  */
 @Entity
 @Table(name = "performance")

--- a/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/out/repository/PerformanceRepository.java
+++ b/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/out/repository/PerformanceRepository.java
@@ -24,6 +24,10 @@ public interface PerformanceRepository
    * — 은 {@code Performance}의 {@code @DynamicUpdate}(#459)가 막는다. PATCH가 바꾸지 않은 performanceStatus는
    * SET 절에 실리지 않으므로 stale 값이 전환을 덮지 않는다. 그전에는 다음 주기 self-heal에 기대고 있었다.
    *
+   * <p>어드민 상태 변경은 이 벌크와 같은 performanceStatus를 쓰므로 동적 UPDATE로 갈리지 않는 같은 컬럼 경합이다. 그럼에도 전환이 되돌려지지 않는
+   * 이유는 {@code PerformanceStatus.canTransitionTo}상 <b>UPCOMING을 목적지로 갖는 전이가 없어</b> 생성 외에는 UPCOMING을
+   * 쓸 경로가 없기 때문이다. 전이표에 →UPCOMING이 추가되면 이 전제가 깨진다.
+   *
    * <p>{@code clearAutomatically = true}가 호출 트랜잭션의 영속성 컨텍스트 전체를 비우므로, 엔티티를 로드하는 다른 트랜잭션에서 재사용하지 말고
    * 스케줄러 전용으로만 호출해야 한다.
    */
@@ -43,8 +47,9 @@ public interface PerformanceRepository
    *
    * <p>엔티티 더티체킹 대신 타깃 UPDATE를 쓴다. 도입 당시 이유는 전체 컬럼 UPDATE였다 — 엔티티를 로드해 해제하면 로드 이후 스케줄러가 커밋한 ON_SALE
    * 전환을 stale한 UPCOMING으로 덮어쓰고, 같은 UPDATE로 bookingOpenAt이 NULL이 되어 벌크 전환 쿼리의 {@code IS NOT NULL}
-   * 조건에서 영구 이탈하므로 다음 주기 self-heal조차 불가능해졌다. {@code @DynamicUpdate}(#459) 이후로는 더티체킹으로도 안전해졌지만,
-   * {@code Performance.update()}가 null을 "수정 안 함"으로 해석해 해제를 표현할 수 없으므로 타깃 UPDATE를 유지한다.
+   * 조건에서 영구 이탈하므로 다음 주기 self-heal조차 불가능해졌다. {@code @DynamicUpdate}(#459) 이후로는 더티체킹으로도 안전하지만 그대로
+   * 유지한다 — SELECT 없이 deletedAt 가드까지 한 문장으로 처리하고, 영향 행 수 0을 그대로 PERFORMANCE_NOT_FOUND 판정에 쓰기
+   * 때문이다({@code PerformanceClearBookingOpenAtUseCase}).
    *
    * <p>벌크 JPQL은 {@code @SQLRestriction}과 Auditing이 적용되지 않으므로 deletedAt 조건과 updatedAt을 명시한다. 영향 행 수가
    * 0이면 대상 공연이 없거나 이미 소프트 삭제된 경우다.

--- a/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/out/repository/PerformanceRepository.java
+++ b/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/out/repository/PerformanceRepository.java
@@ -20,8 +20,9 @@ public interface PerformanceRepository
    * 예매 오픈 시각이 도래한 공연을 벌크 전환한다.
    *
    * <p>벌크 JPQL은 {@code @SQLRestriction}이 적용되지 않으므로 deletedAt 조건을 명시한다. WHERE의 from 상태 가드는 어드민 수동
-   * 전환이 먼저 커밋된 경우(예: CANCELED)의 lost update를 막는다. 단 역방향 — 어드민 PATCH가 UPCOMING으로 로드한 사이 벌크가 ON_SALE
-   * 커밋 — 은 {@code @Version} 부재로 stale 값이 덮어쓸 수 있으나, 스케줄러가 10초 주기로 재실행되며 다음 주기에 self-heal 된다.
+   * 전환이 먼저 커밋된 경우(예: CANCELED)의 lost update를 막는다. 역방향 — 어드민 PATCH가 UPCOMING으로 로드한 사이 벌크가 ON_SALE 커밋
+   * — 은 {@code Performance}의 {@code @DynamicUpdate}(#459)가 막는다. PATCH가 바꾸지 않은 performanceStatus는
+   * SET 절에 실리지 않으므로 stale 값이 전환을 덮지 않는다. 그전에는 다음 주기 self-heal에 기대고 있었다.
    *
    * <p>{@code clearAutomatically = true}가 호출 트랜잭션의 영속성 컨텍스트 전체를 비우므로, 엔티티를 로드하는 다른 트랜잭션에서 재사용하지 말고
    * 스케줄러 전용으로만 호출해야 한다.
@@ -40,17 +41,20 @@ public interface PerformanceRepository
   /**
    * 예매 오픈 시각만 해제해 스케줄러 자동 전환 대상에서 제외한다.
    *
-   * <p>엔티티 더티체킹 대신 타깃 UPDATE를 쓰는 이유는 {@code @Version} 부재 때문이다. 엔티티를 로드해 해제하면 전체 컬럼 UPDATE가 나가면서, 로드
-   * 이후 스케줄러가 커밋한 ON_SALE 전환을 stale한 UPCOMING으로 덮어쓴다. 게다가 같은 UPDATE로 bookingOpenAt이 NULL이 되어 벌크 전환
-   * 쿼리의 {@code IS NOT NULL} 조건에서 영구 이탈하므로, 다른 경로와 달리 다음 주기 self-heal조차 불가능해진다.
+   * <p>엔티티 더티체킹 대신 타깃 UPDATE를 쓴다. 도입 당시 이유는 전체 컬럼 UPDATE였다 — 엔티티를 로드해 해제하면 로드 이후 스케줄러가 커밋한 ON_SALE
+   * 전환을 stale한 UPCOMING으로 덮어쓰고, 같은 UPDATE로 bookingOpenAt이 NULL이 되어 벌크 전환 쿼리의 {@code IS NOT NULL}
+   * 조건에서 영구 이탈하므로 다음 주기 self-heal조차 불가능해졌다. {@code @DynamicUpdate}(#459) 이후로는 더티체킹으로도 안전해졌지만,
+   * {@code Performance.update()}가 null을 "수정 안 함"으로 해석해 해제를 표현할 수 없으므로 타깃 UPDATE를 유지한다.
    *
    * <p>벌크 JPQL은 {@code @SQLRestriction}과 Auditing이 적용되지 않으므로 deletedAt 조건과 updatedAt을 명시한다. 영향 행 수가
    * 0이면 대상 공연이 없거나 이미 소프트 삭제된 경우다.
    *
-   * <p><b>역방향 경합 창이 남아 있다.</b> 이 쿼리는 stale write를 하지 않지만, 해제 결과가 다른 경로로부터 보호되지는 않는다. 엔티티를 로드하는
-   * PATCH·상태 변경 UseCase는 {@code @Version}/{@code @DynamicUpdate} 부재로 여전히 전체 컬럼 UPDATE를 내보내므로, 그들이
-   * bookingOpenAt을 로드한 뒤 이 해제가 커밋되면 마지막 커밋이 해제된 값을 되살린다. 이 경우 공연이 어드민 모르게 자동 전환 대상으로 복귀하며 판단 근거가
-   * DB에 남지 않아 self-heal도 불가능하다. 근본 해결({@code @DynamicUpdate} 도입)은 엔티티 전역 영향이라 별도 이슈로 분리했다.
+   * <p><b>역방향 경합 창은 해소됐다(#459).</b> 예전에는 엔티티를 로드하는 PATCH·상태 변경 UseCase가 전체 컬럼 UPDATE를 내보내, 그들이
+   * bookingOpenAt을 로드한 뒤 이 해제가 커밋되면 마지막 커밋이 해제된 값을 되살렸다. 지금은 {@code Performance}의
+   * {@code @DynamicUpdate}가 bookingOpenAt을 SET 절에서 빼므로 부활하지 않는다.
+   *
+   * <p>단 PATCH가 bookingOpenAt을 <b>명시로 실어 보내면</b> 해제와 같은 컬럼을 다투므로 커밋 순서대로 last-write-wins다. 이건 stale
+   * 부활이 아니라 어드민의 의도적 쓰기라 방어 대상에서 제외했다.
    *
    * <p>{@code clearAutomatically = true}가 호출 트랜잭션의 영속성 컨텍스트 전체를 비우고 {@code flushAutomatically}는 기본값
    * false이므로, 같은 트랜잭션에 flush되지 않은 더티 엔티티가 있으면 조용히 유실된다. 엔티티를 함께 다루는 트랜잭션에서 호출하지 말아야 한다.

--- a/performance-service/src/test/java/com/ticketrush/boundedcontext/performance/in/api/v1/PerformanceConcurrentWriteTest.java
+++ b/performance-service/src/test/java/com/ticketrush/boundedcontext/performance/in/api/v1/PerformanceConcurrentWriteTest.java
@@ -1,0 +1,194 @@
+package com.ticketrush.boundedcontext.performance.in.api.v1;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.ticketrush.boundedcontext.performance.app.usecase.PerformanceClearBookingOpenAtUseCase;
+import com.ticketrush.boundedcontext.performance.app.usecase.PerformanceOpenBookingUseCase;
+import com.ticketrush.boundedcontext.performance.domain.entity.Performance;
+import com.ticketrush.boundedcontext.performance.domain.types.Genre;
+import com.ticketrush.boundedcontext.performance.domain.types.PerformanceStatus;
+import com.ticketrush.boundedcontext.performance.out.repository.PerformanceRepository;
+import com.ticketrush.global.eventpublisher.EventPublisher;
+import com.ticketrush.global.util.S3UploadUtils;
+import java.sql.Timestamp;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.support.TransactionTemplate;
+
+/**
+ * 서로소 컬럼을 쓰는 두 경로가 겹칠 때 stale 값이 서로를 덮지 않는지 검증한다(#459).
+ *
+ * <p>클래스 레벨 {@code @Transactional}을 쓰지 않는다. 이 시나리오는 "T1이 로드한 뒤 T2가 커밋하고 그 다음 T1이 커밋한다"는 순서 자체가 재현
+ * 대상이라, 테스트 트랜잭션 하나로 감싸 롤백하는 기존 방식으로는 커밋 경계를 만들 수 없다. 대신 {@code TransactionTemplate} 두 개로 T2를
+ * {@code REQUIRES_NEW}로 끼워 넣어 순서를 결정론적으로 고정한다 — 실제 경합은 스레드 타이밍이 아니라 커밋 순서에서 나오므로 스레드를 띄우지 않아도 동일한
+ * 상황이며, 그 덕에 flaky하지 않다.
+ *
+ * <p>검증은 "UPDATE의 SET 절에 어떤 컬럼이 실렸는가"를 직접 보지 않고 <b>다른 트랜잭션이 커밋한 값이 살아남는가</b>로 한다. 레포에 SQL 문장을 단언할
+ * 인프라가 없기도 하지만, SQL 문자열 비교는 취약한 반면 이 단언은 회귀가 실제로 사용자에게 드러나는 형태 그대로다. {@code Performance}에서
+ * {@code @DynamicUpdate}를 떼면 아래 세 건이 모두 깨진다.
+ *
+ * <p>커밋이 실제로 남으므로 {@code @AfterEach}에서 물리 삭제한다. H2가 {@code DB_CLOSE_DELAY=-1}이라 컨텍스트를 공유하는 다른 테스트를
+ * 오염시키고, {@code @SQLRestriction} 때문에 소프트 삭제된 행은 JPA로는 지울 수 없다.
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+@EnableAutoConfiguration(
+    exclude = {
+      io.awspring.cloud.autoconfigure.s3.S3AutoConfiguration.class,
+      io.awspring.cloud.autoconfigure.core.AwsAutoConfiguration.class
+    })
+class PerformanceConcurrentWriteTest {
+
+  private static final String PATCHED_TITLE = "수정된 공연명";
+
+  @MockitoBean private S3UploadUtils s3UploadUtils;
+  @MockitoBean private EventPublisher eventPublisher;
+
+  @Autowired private PerformanceRepository performanceRepository;
+  @Autowired private PerformanceClearBookingOpenAtUseCase performanceClearBookingOpenAtUseCase;
+  @Autowired private PerformanceOpenBookingUseCase performanceOpenBookingUseCase;
+  @Autowired private PlatformTransactionManager transactionManager;
+  @Autowired private JdbcTemplate jdbcTemplate;
+
+  private TransactionTemplate outerTx;
+  private TransactionTemplate separateTx;
+
+  @BeforeEach
+  void setUp() {
+    outerTx = new TransactionTemplate(transactionManager);
+    separateTx = new TransactionTemplate(transactionManager);
+    separateTx.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
+  }
+
+  @AfterEach
+  void tearDown() {
+    jdbcTemplate.update("DELETE FROM performance_images");
+    jdbcTemplate.update("DELETE FROM performance_facilities");
+    jdbcTemplate.update("DELETE FROM performance");
+  }
+
+  private Long saveCommitted(LocalDateTime bookingOpenAt) {
+    return separateTx.execute(
+        status ->
+            performanceRepository
+                .save(
+                    Performance.builder()
+                        .title("공연명")
+                        .performer("출연진")
+                        .genre(Genre.CONCERT)
+                        .description("설명")
+                        .showDate(LocalDate.now().plusDays(30))
+                        .showTime(LocalTime.of(19, 0))
+                        .durationMinutes(120)
+                        .price(50000L)
+                        .totalSeats(100)
+                        .address("서울")
+                        .bookingOpenAt(bookingOpenAt)
+                        .build())
+                .getId());
+  }
+
+  private Performance findCommitted(Long performanceId) {
+    return separateTx.execute(
+        status -> performanceRepository.findById(performanceId).orElseThrow());
+  }
+
+  /** PATCH가 공연명만 바꾸는 상황. bookingOpenAt은 전송되지 않았으므로(null) 엔티티에서 건드리지 않는다. */
+  private void patchTitleOnly(Performance performance) {
+    performance.update(PATCHED_TITLE, null, null, null, null, null, null, null, null, null, null);
+  }
+
+  @Test
+  @DisplayName("PATCH가 로드한 뒤 예매 오픈 시각이 해제되면, PATCH 커밋이 해제를 되살리지 않는다")
+  void patchDoesNotResurrectClearedBookingOpenAt() {
+    Long performanceId = saveCommitted(LocalDateTime.now().plusDays(1));
+
+    outerTx.executeWithoutResult(
+        status -> {
+          Performance loaded = performanceRepository.findById(performanceId).orElseThrow();
+          patchTitleOnly(loaded);
+
+          separateTx.executeWithoutResult(
+              inner -> performanceClearBookingOpenAtUseCase.execute(performanceId));
+        });
+
+    Performance result = findCommitted(performanceId);
+    assertThat(result.getBookingOpenAt()).isNull();
+    assertThat(result.getTitle()).isEqualTo(PATCHED_TITLE);
+  }
+
+  @Test
+  @DisplayName("상태 변경이 로드한 뒤 예매 오픈 시각이 해제되면, 상태 변경 커밋이 해제를 되살리지 않는다")
+  void changeStatusDoesNotResurrectClearedBookingOpenAt() {
+    Long performanceId = saveCommitted(LocalDateTime.now().plusDays(1));
+
+    outerTx.executeWithoutResult(
+        status -> {
+          Performance loaded = performanceRepository.findById(performanceId).orElseThrow();
+          loaded.changeStatus(PerformanceStatus.ON_SALE);
+
+          separateTx.executeWithoutResult(
+              inner -> performanceClearBookingOpenAtUseCase.execute(performanceId));
+        });
+
+    Performance result = findCommitted(performanceId);
+    assertThat(result.getBookingOpenAt()).isNull();
+    assertThat(result.getPerformanceStatus()).isEqualTo(PerformanceStatus.ON_SALE);
+  }
+
+  /**
+   * 역방향 경합. 이전에는 스케줄러가 10초 주기로 재실행되며 다음 주기에 self-heal 되는 것에 기대고 있었다(PerformanceRepository Javadoc).
+   * 이제는 PATCH가 status를 SET에 싣지 않으므로 되돌아가는 일 자체가 없다.
+   */
+  @Test
+  @DisplayName("PATCH가 로드한 뒤 스케줄러가 예매를 오픈하면, PATCH 커밋이 상태를 되돌리지 않는다")
+  void patchDoesNotRevertScheduledStatusTransition() {
+    Long performanceId = saveCommitted(LocalDateTime.now().minusMinutes(1));
+
+    outerTx.executeWithoutResult(
+        status -> {
+          Performance loaded = performanceRepository.findById(performanceId).orElseThrow();
+          patchTitleOnly(loaded);
+
+          separateTx.executeWithoutResult(inner -> performanceOpenBookingUseCase.execute());
+        });
+
+    Performance result = findCommitted(performanceId);
+    assertThat(result.getPerformanceStatus()).isEqualTo(PerformanceStatus.ON_SALE);
+    assertThat(result.getTitle()).isEqualTo(PATCHED_TITLE);
+  }
+
+  /**
+   * {@code @DynamicUpdate}는 변경된 필드만 SET에 싣는데, updatedAt은 도메인 코드가 아니라 Auditing 리스너가
+   * {@code @PreUpdate} 시점에 채운다. 그 값이 dirty 판정에 잡히지 않으면 updated_at이 갱신되지 않는 조용한 회귀가 된다. 비교 기준을 과거로
+   * 직접 심어 시간 해상도에 의존하지 않고 판정한다.
+   */
+  @Test
+  @DisplayName("동적 UPDATE에서도 updatedAt은 갱신된다")
+  void updatedAtIsStillRefreshed() {
+    Long performanceId = saveCommitted(null);
+    LocalDateTime past = LocalDateTime.now().minusDays(1);
+    jdbcTemplate.update(
+        "UPDATE performance SET updated_at = ? WHERE performance_id = ?",
+        Timestamp.valueOf(past),
+        performanceId);
+
+    outerTx.executeWithoutResult(
+        status -> patchTitleOnly(performanceRepository.findById(performanceId).orElseThrow()));
+
+    assertThat(findCommitted(performanceId).getUpdatedAt()).isAfter(past);
+  }
+}

--- a/performance-service/src/test/java/com/ticketrush/boundedcontext/performance/in/api/v1/PerformanceConcurrentWriteTest.java
+++ b/performance-service/src/test/java/com/ticketrush/boundedcontext/performance/in/api/v1/PerformanceConcurrentWriteTest.java
@@ -20,6 +20,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.temporal.ChronoUnit;
+import java.util.Map;
 import java.util.Optional;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -48,9 +49,10 @@ import org.springframework.transaction.support.TransactionTemplate;
  * {@code @DynamicUpdate}를 떼면 stale 방지 4건이 모두 깨진다.
  *
  * <p>커밋이 실제로 남으므로 {@code @AfterEach}에서 물리 삭제한다. {@code @SQLRestriction} 때문에 소프트 삭제된 행은 JPA로는 지울 수
- * 없어 네이티브로 지운다. 조건 없이 전량 삭제해도 되는 이유는 이 testdb를 공유하는 다른 클래스가 전부 클래스 레벨 {@code @Transactional}로 롤백되어
- * 커밋된 행을 남기지 않기 때문이다(비트랜잭셔널한 PerformanceListCacheTest는 {@code @DynamicPropertySource}로 DB 자체가 분리돼
- * 있다). 컨텍스트 캐시를 재사용하려고 일부러 DB를 분리하지 않았으므로, 앞으로 커밋을 남기는 클래스가 testdb에 추가되면 이 정리를 자기 id 기준으로 좁혀야 한다.
+ * 없어 네이티브로 지운다. 조건 없이 전량 삭제해도 되는 이유는 이 testdb에 <b>커밋을 남기는 클래스가 현재 이 클래스뿐</b>이기 때문이다(다른 통합 테스트는 클래스
+ * 레벨 {@code @Transactional}로 롤백되고, 비트랜잭셔널한 PerformanceListCacheTest는
+ * {@code @DynamicPropertySource}로 DB 자체가 분리돼 있다). 컨텍스트 캐시를 재사용하려고 일부러 DB를 분리하지 않았으므로, 앞으로 커밋을 남기는
+ * 클래스가 testdb에 추가되면 이 정리를 자기 id 기준으로 좁혀야 한다.
  */
 @SpringBootTest
 @ActiveProfiles("test")
@@ -195,6 +197,9 @@ class PerformanceConcurrentWriteTest {
    * 소프트 삭제 부활. 회귀 시 <b>삭제한 공연이 목록에 다시 나타나므로</b> 이 클래스가 막는 것 중 사용자에게 가장 먼저 드러나는 사고다.
    * {@code @SQLRestriction} 때문에 PATCH는 언제나 deleted_at이 NULL인 상태로 로드하고, 전체 컬럼 UPDATE는 그 NULL을 그대로 다시
    * 쓴다.
+   *
+   * <p>삭제 유지만 단언하면 PATCH가 아무것도 하지 않아도 통과하므로, 삭제된 행을 네이티브로 읽어 <b>제목 갱신이 실제로 커밋됐는지</b>까지 함께 본다. 다른
+   * 케이스가 title·status 생존으로 경합 성립을 자기검증하는 것과 같은 이유다.
    */
   @Test
   @DisplayName("PATCH가 로드한 뒤 공연이 삭제되면, PATCH 커밋이 삭제를 되살리지 않는다")
@@ -209,6 +214,12 @@ class PerformanceConcurrentWriteTest {
         });
 
     assertThat(findCommitted(performanceId)).isEmpty();
+
+    Map<String, Object> deletedRow =
+        jdbcTemplate.queryForMap(
+            "SELECT deleted_at, title FROM performance WHERE performance_id = ?", performanceId);
+    assertThat(deletedRow.get("deleted_at")).isNotNull();
+    assertThat(deletedRow.get("title")).isEqualTo(PATCHED_TITLE);
   }
 
   /**
@@ -220,7 +231,8 @@ class PerformanceConcurrentWriteTest {
   @DisplayName("PATCH가 예매 오픈 시각을 명시 전송하면 나중에 커밋한 PATCH가 해제를 이긴다")
   void explicitBookingOpenAtInPatchOverwritesClear() {
     Long performanceId = saveCommitted(LocalDateTime.now().plusDays(1));
-    LocalDateTime rescheduled = LocalDateTime.now().plusDays(7).truncatedTo(ChronoUnit.MILLIS);
+    // API는 @JsonFormat("yyyy-MM-dd HH:mm:ss")로 초 단위까지만 바인딩되므로 계약에 맞춰 자른다.
+    LocalDateTime rescheduled = LocalDateTime.now().plusDays(7).truncatedTo(ChronoUnit.SECONDS);
 
     outerTx.executeWithoutResult(
         status -> {

--- a/performance-service/src/test/java/com/ticketrush/boundedcontext/performance/in/api/v1/PerformanceConcurrentWriteTest.java
+++ b/performance-service/src/test/java/com/ticketrush/boundedcontext/performance/in/api/v1/PerformanceConcurrentWriteTest.java
@@ -2,8 +2,13 @@ package com.ticketrush.boundedcontext.performance.in.api.v1;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.ticketrush.boundedcontext.performance.app.dto.request.PerformanceChangeStatusRequest;
+import com.ticketrush.boundedcontext.performance.app.dto.request.PerformancePatchRequest;
+import com.ticketrush.boundedcontext.performance.app.usecase.PerformanceChangeStatusUseCase;
 import com.ticketrush.boundedcontext.performance.app.usecase.PerformanceClearBookingOpenAtUseCase;
+import com.ticketrush.boundedcontext.performance.app.usecase.PerformanceDeleteUseCase;
 import com.ticketrush.boundedcontext.performance.app.usecase.PerformanceOpenBookingUseCase;
+import com.ticketrush.boundedcontext.performance.app.usecase.PerformancePatchUseCase;
 import com.ticketrush.boundedcontext.performance.domain.entity.Performance;
 import com.ticketrush.boundedcontext.performance.domain.types.Genre;
 import com.ticketrush.boundedcontext.performance.domain.types.PerformanceStatus;
@@ -14,6 +19,8 @@ import java.sql.Timestamp;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.temporal.ChronoUnit;
+import java.util.Optional;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -38,10 +45,12 @@ import org.springframework.transaction.support.TransactionTemplate;
  *
  * <p>검증은 "UPDATE의 SET 절에 어떤 컬럼이 실렸는가"를 직접 보지 않고 <b>다른 트랜잭션이 커밋한 값이 살아남는가</b>로 한다. 레포에 SQL 문장을 단언할
  * 인프라가 없기도 하지만, SQL 문자열 비교는 취약한 반면 이 단언은 회귀가 실제로 사용자에게 드러나는 형태 그대로다. {@code Performance}에서
- * {@code @DynamicUpdate}를 떼면 아래 세 건이 모두 깨진다.
+ * {@code @DynamicUpdate}를 떼면 stale 방지 4건이 모두 깨진다.
  *
- * <p>커밋이 실제로 남으므로 {@code @AfterEach}에서 물리 삭제한다. H2가 {@code DB_CLOSE_DELAY=-1}이라 컨텍스트를 공유하는 다른 테스트를
- * 오염시키고, {@code @SQLRestriction} 때문에 소프트 삭제된 행은 JPA로는 지울 수 없다.
+ * <p>커밋이 실제로 남으므로 {@code @AfterEach}에서 물리 삭제한다. {@code @SQLRestriction} 때문에 소프트 삭제된 행은 JPA로는 지울 수
+ * 없어 네이티브로 지운다. 조건 없이 전량 삭제해도 되는 이유는 이 testdb를 공유하는 다른 클래스가 전부 클래스 레벨 {@code @Transactional}로 롤백되어
+ * 커밋된 행을 남기지 않기 때문이다(비트랜잭셔널한 PerformanceListCacheTest는 {@code @DynamicPropertySource}로 DB 자체가 분리돼
+ * 있다). 컨텍스트 캐시를 재사용하려고 일부러 DB를 분리하지 않았으므로, 앞으로 커밋을 남기는 클래스가 testdb에 추가되면 이 정리를 자기 id 기준으로 좁혀야 한다.
  */
 @SpringBootTest
 @ActiveProfiles("test")
@@ -58,8 +67,11 @@ class PerformanceConcurrentWriteTest {
   @MockitoBean private EventPublisher eventPublisher;
 
   @Autowired private PerformanceRepository performanceRepository;
+  @Autowired private PerformancePatchUseCase performancePatchUseCase;
+  @Autowired private PerformanceChangeStatusUseCase performanceChangeStatusUseCase;
   @Autowired private PerformanceClearBookingOpenAtUseCase performanceClearBookingOpenAtUseCase;
   @Autowired private PerformanceOpenBookingUseCase performanceOpenBookingUseCase;
+  @Autowired private PerformanceDeleteUseCase performanceDeleteUseCase;
   @Autowired private PlatformTransactionManager transactionManager;
   @Autowired private JdbcTemplate jdbcTemplate;
 
@@ -101,14 +113,24 @@ class PerformanceConcurrentWriteTest {
                 .getId());
   }
 
-  private Performance findCommitted(Long performanceId) {
-    return separateTx.execute(
-        status -> performanceRepository.findById(performanceId).orElseThrow());
+  private Optional<Performance> findCommitted(Long performanceId) {
+    return separateTx.execute(status -> performanceRepository.findById(performanceId));
   }
 
-  /** PATCH가 공연명만 바꾸는 상황. bookingOpenAt은 전송되지 않았으므로(null) 엔티티에서 건드리지 않는다. */
-  private void patchTitleOnly(Performance performance) {
-    performance.update(PATCHED_TITLE, null, null, null, null, null, null, null, null, null, null);
+  private PerformancePatchRequest patchRequest(String title, LocalDateTime bookingOpenAt) {
+    return new PerformancePatchRequest(
+        title, null, null, null, null, null, null, null, null, null, bookingOpenAt);
+  }
+
+  /**
+   * 공연명만 바꾸는 PATCH. bookingOpenAt은 전송되지 않았으므로(null) {@code Performance.update()}가 건드리지 않는다.
+   *
+   * <p>엔티티 메서드를 직접 부르지 않고 UseCase를 태우는 이유는 경합의 반대편(해제·스케줄러)도 UseCase로 돌리기 때문이다. 실제 진입점이 로드하는 방식이
+   * 바뀌면 이 테스트도 함께 깨져야 한다. {@code PerformancePatchUseCase}는 {@code @Transactional}(REQUIRED)이라
+   * outerTx에 참여하므로 커밋 순서 시나리오는 그대로 유지된다.
+   */
+  private void patchTitleOnly(Long performanceId) {
+    performancePatchUseCase.execute(performanceId, patchRequest(PATCHED_TITLE, null));
   }
 
   @Test
@@ -118,14 +140,13 @@ class PerformanceConcurrentWriteTest {
 
     outerTx.executeWithoutResult(
         status -> {
-          Performance loaded = performanceRepository.findById(performanceId).orElseThrow();
-          patchTitleOnly(loaded);
+          patchTitleOnly(performanceId);
 
           separateTx.executeWithoutResult(
               inner -> performanceClearBookingOpenAtUseCase.execute(performanceId));
         });
 
-    Performance result = findCommitted(performanceId);
+    Performance result = findCommitted(performanceId).orElseThrow();
     assertThat(result.getBookingOpenAt()).isNull();
     assertThat(result.getTitle()).isEqualTo(PATCHED_TITLE);
   }
@@ -137,14 +158,14 @@ class PerformanceConcurrentWriteTest {
 
     outerTx.executeWithoutResult(
         status -> {
-          Performance loaded = performanceRepository.findById(performanceId).orElseThrow();
-          loaded.changeStatus(PerformanceStatus.ON_SALE);
+          performanceChangeStatusUseCase.execute(
+              performanceId, new PerformanceChangeStatusRequest(PerformanceStatus.ON_SALE));
 
           separateTx.executeWithoutResult(
               inner -> performanceClearBookingOpenAtUseCase.execute(performanceId));
         });
 
-    Performance result = findCommitted(performanceId);
+    Performance result = findCommitted(performanceId).orElseThrow();
     assertThat(result.getBookingOpenAt()).isNull();
     assertThat(result.getPerformanceStatus()).isEqualTo(PerformanceStatus.ON_SALE);
   }
@@ -160,15 +181,57 @@ class PerformanceConcurrentWriteTest {
 
     outerTx.executeWithoutResult(
         status -> {
-          Performance loaded = performanceRepository.findById(performanceId).orElseThrow();
-          patchTitleOnly(loaded);
+          patchTitleOnly(performanceId);
 
           separateTx.executeWithoutResult(inner -> performanceOpenBookingUseCase.execute());
         });
 
-    Performance result = findCommitted(performanceId);
+    Performance result = findCommitted(performanceId).orElseThrow();
     assertThat(result.getPerformanceStatus()).isEqualTo(PerformanceStatus.ON_SALE);
     assertThat(result.getTitle()).isEqualTo(PATCHED_TITLE);
+  }
+
+  /**
+   * 소프트 삭제 부활. 회귀 시 <b>삭제한 공연이 목록에 다시 나타나므로</b> 이 클래스가 막는 것 중 사용자에게 가장 먼저 드러나는 사고다.
+   * {@code @SQLRestriction} 때문에 PATCH는 언제나 deleted_at이 NULL인 상태로 로드하고, 전체 컬럼 UPDATE는 그 NULL을 그대로 다시
+   * 쓴다.
+   */
+  @Test
+  @DisplayName("PATCH가 로드한 뒤 공연이 삭제되면, PATCH 커밋이 삭제를 되살리지 않는다")
+  void patchDoesNotResurrectSoftDeletedPerformance() {
+    Long performanceId = saveCommitted(null);
+
+    outerTx.executeWithoutResult(
+        status -> {
+          patchTitleOnly(performanceId);
+
+          separateTx.executeWithoutResult(inner -> performanceDeleteUseCase.execute(performanceId));
+        });
+
+    assertThat(findCommitted(performanceId)).isEmpty();
+  }
+
+  /**
+   * 이건 방어 대상이 아니라 <b>이번에 결정한 의미론</b>을 고정하는 특성화 테스트다(#459). PATCH가 bookingOpenAt을 명시로 실어 보내면 해제와 같은
+   * 컬럼을 다투므로 동적 UPDATE로 갈리지 않고 나중에 커밋한 쪽이 이긴다. 어드민의 의도적 쓰기라 stale 부활과 구분해 방어하지 않기로 했다. 나중에 누가 이걸
+   * 버그로 보고 되돌리려 할 때 이 테스트가 판단 근거가 된다.
+   */
+  @Test
+  @DisplayName("PATCH가 예매 오픈 시각을 명시 전송하면 나중에 커밋한 PATCH가 해제를 이긴다")
+  void explicitBookingOpenAtInPatchOverwritesClear() {
+    Long performanceId = saveCommitted(LocalDateTime.now().plusDays(1));
+    LocalDateTime rescheduled = LocalDateTime.now().plusDays(7).truncatedTo(ChronoUnit.MILLIS);
+
+    outerTx.executeWithoutResult(
+        status -> {
+          performancePatchUseCase.execute(performanceId, patchRequest(null, rescheduled));
+
+          separateTx.executeWithoutResult(
+              inner -> performanceClearBookingOpenAtUseCase.execute(performanceId));
+        });
+
+    assertThat(findCommitted(performanceId).orElseThrow().getBookingOpenAt())
+        .isEqualTo(rescheduled);
   }
 
   /**
@@ -186,9 +249,8 @@ class PerformanceConcurrentWriteTest {
         Timestamp.valueOf(past),
         performanceId);
 
-    outerTx.executeWithoutResult(
-        status -> patchTitleOnly(performanceRepository.findById(performanceId).orElseThrow()));
+    outerTx.executeWithoutResult(status -> patchTitleOnly(performanceId));
 
-    assertThat(findCommitted(performanceId).getUpdatedAt()).isAfter(past);
+    assertThat(findCommitted(performanceId).orElseThrow().getUpdatedAt()).isAfter(past);
   }
 }


### PR DESCRIPTION
## 🔗 관련 이슈

- close #459

---

## 📌 주요 변경 사항

- `Performance` 엔티티에 `@DynamicUpdate` 도입 — 더티체킹 경로가 변경한 컬럼만 UPDATE하도록 좁힘 (실측: **18컬럼 → 2컬럼**)
- 해제된 `bookingOpenAt`·스케줄러 전환·소프트 삭제가 동시 PATCH에 덮어써지던 stale write 차단
- 커밋 경계를 재현하는 동시성 테스트 6건 신설
- `PerformanceRepository` Javadoc의 "역방향 경합 창" 서술을 해소 결과에 맞게 갱신
- **스키마 변경 없음**

---

## 🛠 상세 구현 내용

- **`@Version`이 아니라 `@DynamicUpdate`를 택한 이유**: 이 경합의 상대편(`clearBookingOpenAt`, `bulkTransitionStatusByBookingOpenAtDue`)이 둘 다 `@Modifying` 벌크 JPQL이라 version을 증가·검사하지 않습니다(`Booking.java`·`Seat.java`에 동일 한계 기록, ADR 0005). `@Version`만 달아서는 PATCH의 버전 검사가 그대로 통과합니다. `UPDATE VERSIONED`로 벌크까지 version을 올리면 낙관적 락도 성립하지만, 스케줄러가 10초마다 도는 탓에 어드민 PATCH가 산발적으로 409를 맞습니다. 여기서 원한 것은 충돌을 알리는 게 아니라 **서로 무관한 수정이 조용히 둘 다 성립하는 것**이라 동적 UPDATE를 골랐습니다. 경합 경로들이 서로소 컬럼(11필드 / status / deleted_at / booking_open_at)을 쓰므로 이것만으로 충돌이 사라집니다
- **잔여 위험을 엔티티 Javadoc에 명시**: 같은 컬럼을 다투는 경합은 여전히 last-write-wins입니다. 특히 `changeStatus()`는 `canTransitionTo()`가 stale 상태를 읽는 check-then-act라, 어드민 둘이 각각 CANCELED/CLOSED를 커밋하면 종단 상태가 덮입니다. 이런 경합을 사용자에게 드러내야 한다면 그때 낙관적 락(+`UPDATE VERSIONED`)을 검토하도록 근거를 남겼습니다
- **범위 밖으로 둔 것**: PATCH가 `bookingOpenAt`을 명시 전송하는 경합은 어드민의 의도적 쓰기라 last-write-wins를 유지하고, 이를 특성화 테스트로 고정했습니다
- `@DynamicInsert`는 이번 범위 밖입니다 (null 컬럼을 INSERT에서 빼 DB default를 먹이는 기능이라 동시 쓰기와 무관)

---

## ✅ 테스트

### 테스트 방법

- `PerformanceConcurrentWriteTest` 신설 — `TransactionTemplate` 2개(REQUIRED + REQUIRES_NEW)로 "T1 로드 → T2 커밋 → T1 커밋"을 결정론적으로 재현. 스레드를 쓰지 않아 flaky하지 않습니다
- 6개 시나리오 전부 **실제 UseCase 진입점** 경유(PATCH·상태변경·해제·스케줄러·삭제)
- SQL 문장을 단언하는 대신 "다른 트랜잭션이 커밋한 값이 살아남는가"로 검증하고, 각 케이스가 title·status 생존을 함께 단언해 경합이 실제로 성립했음을 자기검증합니다

### 테스트 결과

- performance-service **82/82 통과** (`--rerun-tasks`, Docker 기동 상태)
- **`@DynamicUpdate`를 제거하면 정확히 4건이 red**가 되는 것을 실행해 확인했습니다: bookingOpenAt 부활 2종 / 스케줄러 역방향 / 소프트 삭제 부활. 특성화 테스트와 `updatedAt` 테스트는 양쪽 모두 green이 정상입니다
- `updated_at` 회귀 없음을 SQL 로그로 실측했습니다 — `update performance set performance_status=?, updated_at=? where performance_id=?`

---

## 👀 리뷰 요청 사항

- `@DynamicUpdate` 채택 근거(특히 `@Version`만으로는 이 경합에 무력하다는 판단)에 이견이 있는지
- `changeStatus()` check-then-act 잔여 위험을 후속 이슈로 올릴지, 주석 기록으로 충분한지
- 컨벤션 SSOT·ADR 반영은 이번 PR에서 뺐습니다 (엔티티 주석에 근거를 남기는 `Seat`/`Booking` 관행을 따름). 레포 최초 `@DynamicUpdate` 도입이라 ADR 0005에 상호참조를 남길지는 별도 판단이 필요해 보입니다

---

## ⚠️ 배포 시 주의사항

- **스키마 변경 없음** — prod 수동 DDL 불필요, CI schema drift 영향 없음, 시딩 SQL 영향 없음
- **API 스펙 변경 없음** — 프론트 공지 불필요
- 롤백은 어노테이션 한 줄 제거로 충분하며 DB 롤백이 필요 없습니다
