### PR TITLE
[Refactor] #462 좌석 배치 조회의 불필요한 SeatLayout 조인 제거 및 미사용 count 메서드 삭제

### DIFF
--- a/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/app/dto/response/SeatMapItemResponse.java
+++ b/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/app/dto/response/SeatMapItemResponse.java
@@ -3,7 +3,8 @@ package com.ticketrush.boundedcontext.seat.app.dto.response;
 import com.ticketrush.global.types.SeatStatus;
 import java.time.LocalDateTime;
 
-public record SeatLayoutResponse(
+/** 공연 좌석 배치도(seat map)를 구성하는 좌석 1건. {@code SeatLayout} 엔티티의 프로젝션이 아니다. */
+public record SeatMapItemResponse(
     Long seatId,
     Long seatLayoutId,
     String seatNumber,

--- a/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/app/facade/SeatFacade.java
+++ b/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/app/facade/SeatFacade.java
@@ -1,13 +1,13 @@
 package com.ticketrush.boundedcontext.seat.app.facade;
 
-import com.ticketrush.boundedcontext.seat.app.dto.response.SeatLayoutResponse;
+import com.ticketrush.boundedcontext.seat.app.dto.response.SeatMapItemResponse;
 import com.ticketrush.boundedcontext.seat.app.dto.response.SeatNumberResponse;
 import com.ticketrush.boundedcontext.seat.app.dto.response.SeatStatusCountsResponse;
 import com.ticketrush.boundedcontext.seat.app.support.SeatStatusStreamSubscriber;
 import com.ticketrush.boundedcontext.seat.app.usecase.SeatConfirmSoldUseCase;
 import com.ticketrush.boundedcontext.seat.app.usecase.SeatCreateDefaultLayoutUseCase;
 import com.ticketrush.boundedcontext.seat.app.usecase.SeatGetNumbersUseCase;
-import com.ticketrush.boundedcontext.seat.app.usecase.SeatGetSeatLayoutsUseCase;
+import com.ticketrush.boundedcontext.seat.app.usecase.SeatGetSeatMapUseCase;
 import com.ticketrush.boundedcontext.seat.app.usecase.SeatGetStatusCountsUseCase;
 import com.ticketrush.boundedcontext.seat.app.usecase.SeatHoldUseCase;
 import com.ticketrush.boundedcontext.seat.app.usecase.SeatLockUseCase;
@@ -30,7 +30,7 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 public class SeatFacade {
 
   private final SeatGetStatusCountsUseCase seatGetStatusCountsUseCase;
-  private final SeatGetSeatLayoutsUseCase seatGetSeatLayoutsUseCase;
+  private final SeatGetSeatMapUseCase seatGetSeatMapUseCase;
   private final SeatGetNumbersUseCase seatGetNumbersUseCase;
   private final SeatCreateDefaultLayoutUseCase seatCreateDefaultLayoutUseCase;
   private final SeatConfirmSoldUseCase seatConfirmSoldUseCase;
@@ -41,8 +41,8 @@ public class SeatFacade {
   private final SeatLayoutRepository seatLayoutRepository;
   private final EventPublisher eventPublisher;
 
-  public List<SeatLayoutResponse> getPerformanceSeatLayouts(Long performanceId) {
-    return seatGetSeatLayoutsUseCase.execute(performanceId);
+  public List<SeatMapItemResponse> getPerformanceSeatMap(Long performanceId) {
+    return seatGetSeatMapUseCase.execute(performanceId);
   }
 
   public List<SeatNumberResponse> getSeatNumbers(List<Long> seatIds) {

--- a/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/app/usecase/SeatGetSeatMapUseCase.java
+++ b/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/app/usecase/SeatGetSeatMapUseCase.java
@@ -1,6 +1,6 @@
 package com.ticketrush.boundedcontext.seat.app.usecase;
 
-import com.ticketrush.boundedcontext.seat.app.dto.response.SeatLayoutResponse;
+import com.ticketrush.boundedcontext.seat.app.dto.response.SeatMapItemResponse;
 import com.ticketrush.boundedcontext.seat.out.repository.SeatRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -10,12 +10,12 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
-public class SeatGetSeatLayoutsUseCase {
+public class SeatGetSeatMapUseCase {
 
   private final SeatRepository seatRepository;
 
-  public List<SeatLayoutResponse> execute(Long performanceId) {
+  public List<SeatMapItemResponse> execute(Long performanceId) {
     // 공연 ID에 해당하는 정적 좌석 맵 리스트 반환
-    return seatRepository.findSeatLayoutsByPerformanceId(performanceId);
+    return seatRepository.findSeatMapByPerformanceId(performanceId);
   }
 }

--- a/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/domain/entity/Seat.java
+++ b/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/domain/entity/Seat.java
@@ -21,7 +21,7 @@ import lombok.NoArgsConstructor;
 /**
  * 좌석. 인덱스 두 개를 두는 근거는 아래와 같다.
  *
- * <p><b>idx_seat_performance_id</b> — {@code SeatRepository.findSeatLayoutsByPerformanceId}가
+ * <p><b>idx_seat_performance_id</b> — {@code SeatRepository.findSeatMapByPerformanceId}가
  * performanceId로만 필터한다. 인덱스가 없으면 공연당 수천 행을 매 요청 풀스캔해 부하 테스트 수치가 앱이 아닌 인덱스 부재를 반영한다.
  *
  * <p><b>idx_seat_status_hold_expired_at</b> — 만료 HOLD 조회가 주기 스케줄러의 핫패스다(#343). {@code

--- a/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/in/api/v1/SeatController.java
+++ b/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/in/api/v1/SeatController.java
@@ -1,6 +1,6 @@
 package com.ticketrush.boundedcontext.seat.in.api.v1;
 
-import com.ticketrush.boundedcontext.seat.app.dto.response.SeatLayoutResponse;
+import com.ticketrush.boundedcontext.seat.app.dto.response.SeatMapItemResponse;
 import com.ticketrush.boundedcontext.seat.app.dto.response.SeatNumberResponse;
 import com.ticketrush.boundedcontext.seat.app.dto.response.SeatStatusCountsResponse;
 import com.ticketrush.boundedcontext.seat.app.facade.SeatFacade;
@@ -31,9 +31,9 @@ public class SeatController {
 
   @GetMapping("/{performanceId}/seat-layouts")
   @Operation(summary = "공연별 좌석 배치 조회", description = "공연 ID에 해당하는 좌석 ID, 좌석 배치 ID, 좌석 번호를 조회합니다.")
-  public ResponseEntity<ApiResponse<List<SeatLayoutResponse>>> getSeatLayouts(
+  public ResponseEntity<ApiResponse<List<SeatMapItemResponse>>> getSeatMap(
       @PathVariable Long performanceId) {
-    List<SeatLayoutResponse> response = seatFacade.getPerformanceSeatLayouts(performanceId);
+    List<SeatMapItemResponse> response = seatFacade.getPerformanceSeatMap(performanceId);
     return ApiResponse.onSuccess(SuccessStatus.OK, response);
   }
 

--- a/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/out/repository/SeatRepository.java
+++ b/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/out/repository/SeatRepository.java
@@ -15,10 +15,6 @@ import org.springframework.data.repository.query.Param;
 
 public interface SeatRepository extends JpaRepository<Seat, Long> {
 
-  Long countByPerformanceId(Long performanceId);
-
-  Long countByPerformanceIdAndSeatStatus(Long performanceId, SeatStatus seatStatus);
-
   @Query(
       "SELECT new com.ticketrush.boundedcontext.seat.app.dto.response.SeatStatusCountsResponse("
           + "COUNT(s), "
@@ -43,9 +39,8 @@ public interface SeatRepository extends JpaRepository<Seat, Long> {
 
   @Query(
       "SELECT new com.ticketrush.boundedcontext.seat.app.dto.response.SeatLayoutResponse("
-          + "s.id, sl.id, s.seatNumber, s.seatStatus, s.holdExpiredAt) "
+          + "s.id, s.seatLayoutId, s.seatNumber, s.seatStatus, s.holdExpiredAt) "
           + "FROM Seat s "
-          + "JOIN SeatLayout sl ON s.seatLayoutId = sl.id "
           + "WHERE s.performanceId = :performanceId")
   List<SeatLayoutResponse> findSeatLayoutsByPerformanceId(
       @Param("performanceId") Long performanceId);

--- a/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/out/repository/SeatRepository.java
+++ b/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/out/repository/SeatRepository.java
@@ -1,6 +1,6 @@
 package com.ticketrush.boundedcontext.seat.out.repository;
 
-import com.ticketrush.boundedcontext.seat.app.dto.response.SeatLayoutResponse;
+import com.ticketrush.boundedcontext.seat.app.dto.response.SeatMapItemResponse;
 import com.ticketrush.boundedcontext.seat.app.dto.response.SeatNumberResponse;
 import com.ticketrush.boundedcontext.seat.app.dto.response.SeatStatusCountsResponse;
 import com.ticketrush.boundedcontext.seat.domain.entity.Seat;
@@ -38,12 +38,11 @@ public interface SeatRepository extends JpaRepository<Seat, Long> {
   }
 
   @Query(
-      "SELECT new com.ticketrush.boundedcontext.seat.app.dto.response.SeatLayoutResponse("
+      "SELECT new com.ticketrush.boundedcontext.seat.app.dto.response.SeatMapItemResponse("
           + "s.id, s.seatLayoutId, s.seatNumber, s.seatStatus, s.holdExpiredAt) "
           + "FROM Seat s "
           + "WHERE s.performanceId = :performanceId")
-  List<SeatLayoutResponse> findSeatLayoutsByPerformanceId(
-      @Param("performanceId") Long performanceId);
+  List<SeatMapItemResponse> findSeatMapByPerformanceId(@Param("performanceId") Long performanceId);
 
   @Query(
       "SELECT new com.ticketrush.boundedcontext.seat.app.dto.response.SeatNumberResponse("

--- a/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/app/usecase/SeatCreateDefaultLayoutUseCaseTest.java
+++ b/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/app/usecase/SeatCreateDefaultLayoutUseCaseTest.java
@@ -3,7 +3,7 @@ package com.ticketrush.boundedcontext.seat.app.usecase;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import com.ticketrush.boundedcontext.seat.app.dto.response.SeatLayoutResponse;
+import com.ticketrush.boundedcontext.seat.app.dto.response.SeatMapItemResponse;
 import com.ticketrush.boundedcontext.seat.domain.entity.SeatLayout;
 import com.ticketrush.boundedcontext.seat.out.repository.SeatLayoutRepository;
 import com.ticketrush.boundedcontext.seat.out.repository.SeatRepository;
@@ -42,10 +42,12 @@ class SeatCreateDefaultLayoutUseCaseTest {
     assertThat(layouts.getFirst().getTotalRows()).isEqualTo(10);
     assertThat(layouts.getFirst().getMaxCols()).isEqualTo(12);
 
-    List<SeatLayoutResponse> seats = seatRepository.findSeatLayoutsByPerformanceId(performanceId);
+    List<SeatMapItemResponse> seats = seatRepository.findSeatMapByPerformanceId(performanceId);
     assertThat(seats).hasSize(120);
-    assertThat(seats).extracting(SeatLayoutResponse::seatStatus).containsOnly(SeatStatus.AVAILABLE);
-    assertThat(seats).extracting(SeatLayoutResponse::seatNumber).contains("A-1", "J-12");
+    assertThat(seats)
+        .extracting(SeatMapItemResponse::seatStatus)
+        .containsOnly(SeatStatus.AVAILABLE);
+    assertThat(seats).extracting(SeatMapItemResponse::seatNumber).contains("A-1", "J-12");
   }
 
   @Test
@@ -60,7 +62,7 @@ class SeatCreateDefaultLayoutUseCaseTest {
 
     // then
     assertThat(seatLayoutRepository.findAll()).hasSize(1);
-    assertThat(seatRepository.findSeatLayoutsByPerformanceId(performanceId)).hasSize(120);
+    assertThat(seatRepository.findSeatMapByPerformanceId(performanceId)).hasSize(120);
   }
 
   @Test

--- a/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/app/usecase/SeatCreateDefaultLayoutUseCaseTest.java
+++ b/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/app/usecase/SeatCreateDefaultLayoutUseCaseTest.java
@@ -42,13 +42,9 @@ class SeatCreateDefaultLayoutUseCaseTest {
     assertThat(layouts.getFirst().getTotalRows()).isEqualTo(10);
     assertThat(layouts.getFirst().getMaxCols()).isEqualTo(12);
 
-    assertThat(seatRepository.countByPerformanceId(performanceId)).isEqualTo(120L);
-    assertThat(
-            seatRepository.countByPerformanceIdAndSeatStatus(performanceId, SeatStatus.AVAILABLE))
-        .isEqualTo(120L);
-
     List<SeatLayoutResponse> seats = seatRepository.findSeatLayoutsByPerformanceId(performanceId);
     assertThat(seats).hasSize(120);
+    assertThat(seats).extracting(SeatLayoutResponse::seatStatus).containsOnly(SeatStatus.AVAILABLE);
     assertThat(seats).extracting(SeatLayoutResponse::seatNumber).contains("A-1", "J-12");
   }
 
@@ -64,7 +60,7 @@ class SeatCreateDefaultLayoutUseCaseTest {
 
     // then
     assertThat(seatLayoutRepository.findAll()).hasSize(1);
-    assertThat(seatRepository.countByPerformanceId(performanceId)).isEqualTo(120L);
+    assertThat(seatRepository.findSeatLayoutsByPerformanceId(performanceId)).hasSize(120);
   }
 
   @Test

--- a/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/app/usecase/SeatGetSeatMapUseCaseTest.java
+++ b/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/app/usecase/SeatGetSeatMapUseCaseTest.java
@@ -30,8 +30,7 @@ class SeatGetSeatMapUseCaseTest {
         List.of(
             new SeatMapItemResponse(1L, 101L, "A-1", SeatStatus.AVAILABLE, null),
             new SeatMapItemResponse(2L, 101L, "A-2", SeatStatus.HOLD, null));
-    given(seatRepository.findSeatMapByPerformanceId(performanceId))
-        .willReturn(expectedResponses);
+    given(seatRepository.findSeatMapByPerformanceId(performanceId)).willReturn(expectedResponses);
 
     // when
     List<SeatMapItemResponse> actualResponses = useCase.execute(performanceId);

--- a/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/app/usecase/SeatGetSeatMapUseCaseTest.java
+++ b/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/app/usecase/SeatGetSeatMapUseCaseTest.java
@@ -3,7 +3,7 @@ package com.ticketrush.boundedcontext.seat.app.usecase;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 
-import com.ticketrush.boundedcontext.seat.app.dto.response.SeatLayoutResponse;
+import com.ticketrush.boundedcontext.seat.app.dto.response.SeatMapItemResponse;
 import com.ticketrush.boundedcontext.seat.out.repository.SeatRepository;
 import com.ticketrush.global.types.SeatStatus;
 import java.util.List;
@@ -15,9 +15,9 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
-class SeatGetSeatLayoutsUseCaseTest {
+class SeatGetSeatMapUseCaseTest {
 
-  @InjectMocks private SeatGetSeatLayoutsUseCase useCase;
+  @InjectMocks private SeatGetSeatMapUseCase useCase;
 
   @Mock private SeatRepository seatRepository;
 
@@ -26,15 +26,15 @@ class SeatGetSeatLayoutsUseCaseTest {
   void executeReturnsSeatLayouts() {
     // given
     Long performanceId = 1L;
-    List<SeatLayoutResponse> expectedResponses =
+    List<SeatMapItemResponse> expectedResponses =
         List.of(
-            new SeatLayoutResponse(1L, 101L, "A-1", SeatStatus.AVAILABLE, null),
-            new SeatLayoutResponse(2L, 101L, "A-2", SeatStatus.HOLD, null));
-    given(seatRepository.findSeatLayoutsByPerformanceId(performanceId))
+            new SeatMapItemResponse(1L, 101L, "A-1", SeatStatus.AVAILABLE, null),
+            new SeatMapItemResponse(2L, 101L, "A-2", SeatStatus.HOLD, null));
+    given(seatRepository.findSeatMapByPerformanceId(performanceId))
         .willReturn(expectedResponses);
 
     // when
-    List<SeatLayoutResponse> actualResponses = useCase.execute(performanceId);
+    List<SeatMapItemResponse> actualResponses = useCase.execute(performanceId);
 
     // then
     assertThat(actualResponses).hasSize(2);

--- a/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/in/api/v1/SeatControllerTest.java
+++ b/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/in/api/v1/SeatControllerTest.java
@@ -6,7 +6,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.ticketrush.boundedcontext.seat.app.dto.response.SeatLayoutResponse;
+import com.ticketrush.boundedcontext.seat.app.dto.response.SeatMapItemResponse;
 import com.ticketrush.boundedcontext.seat.app.dto.response.SeatNumberResponse;
 import com.ticketrush.boundedcontext.seat.app.dto.response.SeatStatusCountsResponse;
 import com.ticketrush.boundedcontext.seat.app.facade.SeatFacade;
@@ -35,14 +35,14 @@ class SeatControllerTest {
   @Test
   @WithMockUser
   @DisplayName("공연 ID로 전체 좌석 맵 조회를 성공하고 200 OK를 반환한다")
-  void getSeatLayouts() throws Exception {
+  void getSeatMap() throws Exception {
     // given
     Long performanceId = 1L;
-    List<SeatLayoutResponse> mockResponse =
+    List<SeatMapItemResponse> mockResponse =
         List.of(
-            new SeatLayoutResponse(1L, 101L, "A-1", SeatStatus.AVAILABLE, null),
-            new SeatLayoutResponse(2L, 101L, "A-2", SeatStatus.HOLD, null));
-    given(seatFacade.getPerformanceSeatLayouts(performanceId)).willReturn(mockResponse);
+            new SeatMapItemResponse(1L, 101L, "A-1", SeatStatus.AVAILABLE, null),
+            new SeatMapItemResponse(2L, 101L, "A-2", SeatStatus.HOLD, null));
+    given(seatFacade.getPerformanceSeatMap(performanceId)).willReturn(mockResponse);
 
     // when & then
     mockMvc

--- a/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/out/repository/SeatRepositoryTest.java
+++ b/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/out/repository/SeatRepositoryTest.java
@@ -4,7 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.tuple;
 
-import com.ticketrush.boundedcontext.seat.app.dto.response.SeatLayoutResponse;
+import com.ticketrush.boundedcontext.seat.app.dto.response.SeatMapItemResponse;
 import com.ticketrush.boundedcontext.seat.domain.entity.Seat;
 import com.ticketrush.boundedcontext.seat.domain.entity.SeatLayout;
 import com.ticketrush.global.types.SeatStatus;
@@ -27,7 +27,7 @@ class SeatRepositoryTest {
 
   @Test
   @DisplayName("공연 ID로 해당 공연의 좌석 정보(DTO)만 조회한다")
-  void findSeatLayoutsByPerformanceId() {
+  void findSeatMapByPerformanceId() {
     // given
     Long targetPerformanceId = 1L;
     Long otherPerformanceId = 99L;
@@ -73,17 +73,17 @@ class SeatRepositoryTest {
     entityManager.clear();
 
     // when
-    List<SeatLayoutResponse> result =
-        seatRepository.findSeatLayoutsByPerformanceId(targetPerformanceId);
+    List<SeatMapItemResponse> result =
+        seatRepository.findSeatMapByPerformanceId(targetPerformanceId);
 
     // then
     assertThat(result)
         .hasSize(2)
         .extracting(
-            SeatLayoutResponse::seatId,
-            SeatLayoutResponse::seatLayoutId,
-            SeatLayoutResponse::seatNumber,
-            SeatLayoutResponse::seatStatus)
+            SeatMapItemResponse::seatId,
+            SeatMapItemResponse::seatLayoutId,
+            SeatMapItemResponse::seatNumber,
+            SeatMapItemResponse::seatStatus)
         .containsExactlyInAnyOrder(
             tuple(seat1.getId(), targetLayout.getId(), "A-1", SeatStatus.AVAILABLE),
             tuple(seat2.getId(), targetLayout.getId(), "A-2", SeatStatus.AVAILABLE));

--- a/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/out/repository/SeatRepositoryTest.java
+++ b/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/out/repository/SeatRepositoryTest.java
@@ -26,7 +26,7 @@ class SeatRepositoryTest {
   @Autowired private TestEntityManager entityManager;
 
   @Test
-  @DisplayName("Seat과 마스터 SeatLayout을 조인하여 해당하는 공연의 좌석 정보(DTO)만 조회한다")
+  @DisplayName("공연 ID로 해당 공연의 좌석 정보(DTO)만 조회한다")
   void findSeatLayoutsByPerformanceId() {
     // given
     Long targetPerformanceId = 1L;


### PR DESCRIPTION
## 🔗 관련 이슈

- close #462

---

## 📌 주요 변경 사항

- `SeatRepository.findSeatLayoutsByPerformanceId`에서 결과에 기여하지 않는 `JOIN SeatLayout` 제거
- 호출처가 없는 `countByPerformanceId` / `countByPerformanceIdAndSeatStatus` 삭제
- 삭제된 count 메서드를 사용하던 테스트 단언을 좌석 배치 조회 쿼리 기반으로 대체
- 좌석 배치 조회 체인을 SeatMap 네이밍으로 통일 (`SeatLayoutResponse` → `SeatMapItemResponse` 등, URL·JSON 필드명 유지)

---

## 🛠 상세 구현 내용

- 조인 조건이 `s.seatLayoutId = sl.id`이므로 select의 `sl.id`는 항상 `s.seatLayoutId`와 동일 → 조인 줄을 삭제하고 `sl.id`를 `s.seatLayoutId`로 교체 (이슈 측정 기준 cost 420→210, 1.28ms→0.433ms, 반환 행 동일)
- `SeatCreateDefaultLayoutUseCaseTest`: count 단언 2개를 `findSeatLayoutsByPerformanceId` 결과로 대체 — `hasSize(120)` + `extracting(seatStatus).containsOnly(AVAILABLE)`로 기존 검증 의도(총 120석·전부 AVAILABLE) 유지
- `SeatRepositoryTest`: `@DisplayName`의 조인 언급 제거. `seatLayoutId == targetLayout.getId()` 단언은 그대로 유지되어 조인 제거 후 값 동일성을 직접 검증
- 인덱스·스키마(`deploy/mysql/init/001-ticket-rush-schema.sql`)·엔티티 `@Index`는 변경 없음
- **SeatMap 리네이밍** (2번째 커밋): 조인 제거 후 `SeatLayoutResponse`가 `SeatLayout` 엔티티(배치판 메타데이터)의 프로젝션처럼 읽히는 이름 충돌을 해소. 컨트롤러→파사드→유스케이스→리포지토리 수직 체인을 `getSeatMap` / `getPerformanceSeatMap` / `SeatGetSeatMapUseCase` / `findSeatMapByPerformanceId` / `SeatMapItemResponse`로 일관 변경. 공개 계약(URL `/seat-layouts`, JSON 필드명)은 유지해 API 영향 없음

---

## ✅ 테스트

### 테스트 방법

- `./gradlew :seat-service:test` 전체 실행
- 기존 `SeatRepositoryTest.findSeatMapByPerformanceId`가 조인 제거 후에도 `seatLayoutId` 값·타 공연 좌석 제외를 검증
- `SeatCreateDefaultLayoutUseCaseTest`의 대체 단언(120석 + 전부 AVAILABLE)으로 삭제된 count 검증 의도 유지

### 테스트 결과

- BUILD SUCCESSFUL — seat-service 테스트 전체 통과
<!--
### 📸 스크린샷
-->
---

## 👀 리뷰 요청 사항

- 조인 제거로 이름이 실제 반환물과 어긋나는 문제는 논의 후 이 PR에서 SeatMap 체계로 리네이밍해 해소했습니다. 새 네이밍(`SeatMapItemResponse` 등)에 이견 있으시면 의견 부탁드립니다.

---

## ⚠️ 배포 시 주의사항

- 없음 — 쿼리 반환 결과 동일, 스키마·인덱스 무변경
