### PR TITLE
[Refactor] #464 내 예매 목록 조회 전수 스캔 제거 — (user_id, booking_status) 인덱스 추가 및 엔티티 인덱스 drift 보정

### DIFF
--- a/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/domain/entity/Booking.java
+++ b/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/domain/entity/Booking.java
@@ -42,8 +42,9 @@ import lombok.NoArgsConstructor;
  *     ALGORITHM=INPLACE, LOCK=NONE;
  * </pre>
  *
- * <p>idx_booking_status_updated_at은 ADR 0005에서 이미 적용된 전제라 위 DDL에 포함하지 않는다(중복 실행 시 Duplicate key
- * name).
+ * <p>실행 전 {@code SHOW INDEX FROM booking}으로 두 인덱스의 실존 여부를 먼저 확인한다. idx_booking_status_updated_at은
+ * ADR 0005에서 이미 적용된 전제라 위 DDL에 포함하지 않았지만(중복 실행 시 Duplicate key name), 이 전제 역시 검증된 적 없는 가정이므로 — 이
+ * 클래스가 보정한 drift가 그랬듯 — 확인 결과 없으면 그때 같은 방식으로 함께 추가한다.
  */
 @Entity
 @Table(

--- a/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/domain/entity/Booking.java
+++ b/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/domain/entity/Booking.java
@@ -9,6 +9,7 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.Index;
 import jakarta.persistence.Table;
 import jakarta.persistence.Version;
 import java.time.LocalDateTime;
@@ -17,8 +18,40 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+/**
+ * 예매. 인덱스 두 개를 두는 근거는 아래와 같다.
+ *
+ * <p><b>idx_booking_user_id_status</b> — 내 예매 목록 조회(#464). {@code BookingGetMyBookingsUseCase}가
+ * 호출하는 {@code findByUserIdAndBookingStatus}는 이 인덱스가 없으면 옵티마이저가 idx_booking_status_updated_at의 선두
+ * 컬럼(booking_status)만 써서 <b>CONFIRMED 전체를 훑은 뒤 user_id로 필터한다</b>. 반환이 {@code Page}라 count 쿼리까지 같은
+ * 스캔을 반복한다(18,000행/CONFIRMED 12,600행 기준 요청당 15.6ms → 0.2ms, count는 커버링 인덱스가 되어 원본 테이블 접근이 사라짐). 컬럼
+ * 순서는 둘 다 equality지만 선택도가 높은 {@code user_id}가 선두다. {@code created_at}을 붙인 3컬럼은 측정으로 기각했다 —
+ * CONFIRMED 경로의 정렬 키가 {@code confirmed_at DESC, created_at DESC}라 filesort가 그대로 남고, 후보가 이미 사용자당 수십
+ * 행으로 줄어든 뒤의 정렬이라 실익이 없다. 대가로 예매 쓰기마다 인덱스 유지 비용이 늘어난다 — 전수 스캔 2회를 없애는 값으로 수용한다.
+ *
+ * <p><b>idx_booking_status_updated_at</b> — 환불 복구 폴링용(ADR 0005). 스키마 스냅샷과 ADR에는 있는데 엔티티 선언이 누락돼
+ * 로컬(ddl-auto=update)·H2 테스트 DB에는 생성되지 않던 drift를 #464에서 보정했다.
+ *
+ * <p><b>기존 가동 DB에는 수동 DDL이 필요하다.</b> {@code @Table}의 {@code @Index}는 ddl-auto=update인 로컬/신규 초기화
+ * DB(init SQL)에서만 생성되고, prod(validate)는 인덱스 부재를 검출하지 못한다(#296 수동 DDL 관행과 동일). 아래는 인덱스가 없는 기존 DB에만
+ * 실행한다(신규 초기화 DB는 init SQL이 이미 만들어 Duplicate key name 실패):
+ *
+ * <pre>
+ *   ALTER TABLE booking
+ *     ADD INDEX idx_booking_user_id_status (user_id, booking_status),
+ *     ALGORITHM=INPLACE, LOCK=NONE;
+ * </pre>
+ *
+ * <p>idx_booking_status_updated_at은 ADR 0005에서 이미 적용된 전제라 위 DDL에 포함하지 않는다(중복 실행 시 Duplicate key
+ * name).
+ */
 @Entity
-@Table(name = "booking")
+@Table(
+    name = "booking",
+    indexes = {
+      @Index(name = "idx_booking_user_id_status", columnList = "user_id, booking_status"),
+      @Index(name = "idx_booking_status_updated_at", columnList = "booking_status, updated_at")
+    })
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AttributeOverride(name = "id", column = @Column(name = "booking_id"))

--- a/deploy/mysql/init/001-ticket-rush-schema.sql
+++ b/deploy/mysql/init/001-ticket-rush-schema.sql
@@ -19,13 +19,14 @@ CREATE TABLE `booking` (
   `booking_number` varchar(50) COLLATE utf8mb4_unicode_ci NOT NULL,
   `booking_status` enum('CANCELED','CONFIRMED','EXPIRED','PENDING','REFUNDED','REFUNDING') COLLATE utf8mb4_unicode_ci NOT NULL,
   `confirmed_at` datetime(6) DEFAULT NULL,
-  `refund_failed_at` datetime(6) DEFAULT NULL,
   `performance_id` bigint NOT NULL,
+  `refund_failed_at` datetime(6) DEFAULT NULL,
   `seat_id` bigint NOT NULL,
   `user_id` bigint NOT NULL,
   `version` bigint NOT NULL DEFAULT '0',
   PRIMARY KEY (`booking_id`),
   UNIQUE KEY `UK6j74n7w8mp19sixr5272028mk` (`booking_number`),
+  KEY `idx_booking_user_id_status` (`user_id`,`booking_status`),
   KEY `idx_booking_status_updated_at` (`booking_status`,`updated_at`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
@@ -255,10 +256,10 @@ CREATE TABLE `ticket` (
   `created_at` datetime(6) DEFAULT NULL,
   `updated_at` datetime(6) DEFAULT NULL,
   `booking_id` bigint NOT NULL,
-  `user_id` bigint DEFAULT NULL,
   `ticket_status` enum('CANCELED','UNUSED','USED') COLLATE utf8mb4_unicode_ci NOT NULL,
   `ticket_token_hash` varchar(64) COLLATE utf8mb4_unicode_ci NOT NULL,
   `used_at` datetime(6) DEFAULT NULL,
+  `user_id` bigint DEFAULT NULL,
   PRIMARY KEY (`ticket_id`),
   UNIQUE KEY `UKgco27k8cbs8j67db3oadbna6o` (`booking_id`),
   UNIQUE KEY `UKgbou3cclxytcn7k5xlag9s0n8` (`ticket_token_hash`)


### PR DESCRIPTION
## 🔗 관련 이슈

- close #464

---

## 📌 주요 변경 사항

- `Booking` 엔티티 `@Table`에 인덱스 2개 선언: `idx_booking_user_id_status`(신규) / `idx_booking_status_updated_at`(기존 drift 보정)
- 인덱스 근거·컬럼 순서 이유·3컬럼 기각 사유·기존 가동 DB용 수동 DDL 런북을 클래스 javadoc에 기록 (Seat 관례)
- (리뷰 반영) 런북에 `SHOW INDEX FROM booking` 사전 확인 단계 추가 — 배포 전 두 인덱스 실존 여부를 검증
- `deploy/mysql/init/001-ticket-rush-schema.sql` 재생성 (README 절차 그대로)

---

## 🛠 상세 구현 내용

- `idx_booking_user_id_status (user_id, booking_status)`: 내 예매 목록 조회(`findByUserIdAndBookingStatus` + Page count)가 CONFIRMED 전체를 두 번 훑던 전수 스캔 제거. 이슈 측정 기준 요청당 15.6ms → 0.2ms, count는 커버링 인덱스로 원본 테이블 접근 소멸(438배). 컬럼 순서는 둘 다 equality지만 선택도 높은 `user_id` 선두. `created_at` 3컬럼은 filesort 미제거·실익 없음으로 측정 기각(이슈 본문)
- `idx_booking_status_updated_at (booking_status, updated_at)`: 스냅샷·ADR 0005에는 있으나 엔티티 `@Index` 선언이 없어 로컬(ddl-auto=update)·H2 테스트 DB에 생성되지 않던 drift 보정
- 스냅샷 재생성: 빈 MySQL 8.0(utf8mb4_unicode_ci)에 7개 서비스 순차 기동 → payment 수동 DDL 재적용 → 덤프. grep 검증 완료:
  - booking에 두 `KEY` 존재 ✅
  - `uk_payment_completed_booking` / `GENERATED ALWAYS` 유실 없음 (#422 재발 방지) ✅
  - `NOT NULL DEFAULT '0'` 2건 (booking·seat version) ✅
- (리뷰 반영) 런북의 "idx_booking_status_updated_at은 ADR 0005에서 이미 적용된 전제" 자체가 검증 안 된 가정(이번 drift와 동일 유형)이라, 수동 DDL 실행 전 `SHOW INDEX`로 실존 확인 후 없으면 함께 추가하도록 javadoc 보강
- 재생성 부산물로 `booking.refund_failed_at`, `ticket.user_id` 컬럼 정의 위치가 Hibernate 신규 생성 순서(알파벳)로 이동 — 스키마 의미·validate·앱 동작 영향 없음

---

## ✅ 테스트

### 테스트 방법

- `./gradlew :booking-service:test` 전체 실행 (H2 기반 `BookingVersionDefaultTest`·`BookingRepositoryTest` 포함 — `@Index` 선언이 H2 DDL 생성에 반영된 상태로 통과 확인)
- `schema-validate` CI로 스냅샷·엔티티 정합 검증

### 테스트 결과

- BUILD SUCCESSFUL — booking-service 테스트 전체 통과
<!--
### 📸 스크린샷
-->
---

## 👀 리뷰 요청 사항

- ~~스냅샷 재생성 diff에서 booking `KEY` 추가 외 컬럼 위치 이동 2건이 의도된 재생성 부산물인지 한 번 봐주세요~~
  → **확인 완료(리뷰 반영)**: 두 건(`booking.refund_failed_at`, `ticket.user_id`) 모두 Hibernate 6 알파벳 순 컬럼 생성 순서에 수렴한 재생성 부산물이 맞음. 기존 위치가 오히려 과거 수동 ALTER의 흔적이었고, MySQL 컬럼 물리 순서는 스키마 의미·`ddl-auto=validate`·앱 동작에 영향 없음

---

## ⚠️ 배포 시 주의사항

- ✅ **prod 수동 DDL 실행 완료 (2026-07-23)**: 사전 `SHOW INDEX` 확인 결과 **`idx_booking_status_updated_at`도 prod에 부재**했음(ADR 0005는 DDL을 지시만 했을 뿐 적용을 주장한 적 없음 — "이미 적용됐을 것"이라는 이 PR의 가정이 거짓이었던 것. 볼륨이 인덱스 포함 스냅샷 이전에 초기화되고 수동 ALTER가 실행되지 않았던 것으로 추정). 두 인덱스를 한 ALTER로 함께 추가하고 `SHOW INDEX`로 검증 완료. 사전 확인 단계가 실전에서 바로 유효했음
- ~~**이미 가동 중인 DB에는 수동 DDL 필요**~~ (`Booking` javadoc 런북): `ALTER TABLE booking ADD INDEX idx_booking_user_id_status (user_id, booking_status), ALGORITHM=INPLACE, LOCK=NONE;` — 실행 전 `SHOW INDEX FROM booking`으로 두 인덱스 실존 여부를 먼저 확인하고, `idx_booking_status_updated_at`이 없으면(ADR 0005 미적용 DB) 그때 함께 추가 (리뷰 반영)
- #463(payment 인덱스)은 이 PR이 머지된 develop 기준으로 스냅샷을 재생성해야 함 (이슈 #464 코멘트의 직렬화 결정)




