### PR TITLE
[Fix] #471 booking-service 이벤트 발행 outbox 모드 전환 — AFTER_COMMIT 유실 창 제거

### DIFF
--- a/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/app/usecase/ExpireBookingByNumberUseCase.java
+++ b/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/app/usecase/ExpireBookingByNumberUseCase.java
@@ -8,6 +8,7 @@ import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 /**
  * 좌석 hold 만료 이벤트를 받아 대상 예매를 EXPIRED로 전이한다.
@@ -17,11 +18,13 @@ import org.springframework.stereotype.Service;
  * BookingExpiredEvent}를 재발행해 payment 다운스트림(만료 예매 가드)과의 정합성을 유지한다.
  *
  * <p>멱등성: {@code WHERE bookingStatus = PENDING} 가드로 이미 EXPIRED/CONFIRMED/CANCELED인 예매는 no-op이 된다.
- * 리스너의 {@code InboxService.runIfFirst(...)} 트랜잭션 안에서 호출되므로 별도 {@code @Transactional}은 두지 않는다.
+ * 현재 유일한 호출부인 리스너의 {@code InboxService.runIfFirst(...)} 트랜잭션에 조인(REQUIRED)하며, outbox 발행이 활성 트랜잭션을
+ * 요구하므로 향후 트랜잭션 없는 호출부가 추가될 때를 대비해 방어적으로 {@code @Transactional}을 부착한다(#471).
  */
 @Slf4j
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class ExpireBookingByNumberUseCase {
 
   private final BookingRepository bookingRepository;

--- a/booking-service/src/main/resources/application-test.yml
+++ b/booking-service/src/main/resources/application-test.yml
@@ -1,5 +1,7 @@
 app:
   event-publisher:
+    # outbox 전환(#471)으로 relay·retention 스케줄러가 함께 활성화된다. 별도 비활성 스위치는 없으므로
+    # (seat-service 선례와 동일), 풀컨텍스트 통합 테스트를 추가할 때는 스케줄러가 Kafka/Redis를 요구함에 유의.
     type: outbox
   # 테스트 환경에서는 DLT 모니터/Slack 알림, inbox retention을 명시적으로 비활성화한다.
   dlt:

--- a/booking-service/src/main/resources/application-test.yml
+++ b/booking-service/src/main/resources/application-test.yml
@@ -1,6 +1,6 @@
 app:
   event-publisher:
-    type: kafka
+    type: outbox
   # 테스트 환경에서는 DLT 모니터/Slack 알림, inbox retention을 명시적으로 비활성화한다.
   dlt:
     monitor:

--- a/booking-service/src/main/resources/application.yml
+++ b/booking-service/src/main/resources/application.yml
@@ -60,7 +60,7 @@ app:
     # Kafka 재시도 소진(약 31초)보다 훨씬 길게 잡아 컨슈머 랙·재배포 중 일시 지연의 오탐을 막는다.
     refunding-stuck-threshold-minutes: 30
   event-publisher:
-    type: kafka
+    type: outbox
   outbox:
     aggregate-types:
       - Booking

--- a/docs/kafka-event-guide.md
+++ b/docs/kafka-event-guide.md
@@ -230,7 +230,7 @@ public class OrderEventListener {
 
 > ⚠️ `OutboxEventPublisher.publish()`는 **활성 트랜잭션이 필수**다. 트랜잭션 밖에서 호출하면 `IllegalStateException`을 던진다(*"…비즈니스 변경과 Outbox 저장의 원자성을 보장하려면 호출부를 @Transactional 등으로 감싸세요."*). outbox 모드 서비스는 발행부를 반드시 `@Transactional` 안에서 호출한다.
 
-**현재 배선:** outbox 모드는 **seat-service**만 사용한다. 나머지 서비스(booking·user·performance·payment·ticket·auth)는 `kafka` 모드다. booking-service는 outbox 인프라(relay·retention 스케줄러·`app.outbox` 설정)를 갖추고 있으나 프로파일이 `kafka`라 휴면 상태다.
+**현재 배선:** outbox 모드는 **seat-service·booking-service**가 사용한다(#471에서 booking 전환 — #346 장애 주입 측정으로 유실 0건 검증). 나머지 서비스(user·performance·payment·ticket·auth)는 `kafka` 모드다.
 
 ### 4.2. Outbox 모드 배선
 


### PR DESCRIPTION
## 🔗 관련 이슈

- close #471

---

## 📌 주요 변경 사항

- booking-service 이벤트 발행을 AFTER_COMMIT(`kafka`)에서 트랜잭셔널 Outbox(`outbox`) 모드로 전환
- 테스트 프로파일(`application-test.yml`)도 `outbox`로 맞춰 테스트 배선과 실제 배선을 일치
- `docs/kafka-event-guide.md` §4.1 "현재 배선" 갱신 (outbox: seat-service·booking-service)

---

## 🛠 상세 구현 내용

- `booking-service/src/main/resources/application.yml` — `app.event-publisher.type: kafka → outbox`
  - 휴면 상태였던 `OutboxRelayScheduler`(5s, ShedLock `outboxRelay-booking`)·`OutboxRetentionScheduler`(1h, `outboxRetention-booking`)가 `@ConditionalOnExpression`으로 자동 활성화됨
  - `app.outbox.*`(aggregate-types `[Booking]`·batch-size·max-retries·retention-hours)는 기존 설정 그대로 사용
  - outbox 테이블 DDL(`deploy/mysql/init/001-ticket-rush-schema.sql`)·prod compose는 변경 불필요 (기존 완비, `ddl-auto: validate` 통과)
- `application-test.yml` — seat-service 선례를 따라 test 프로파일도 `outbox`로 전환 (컨텍스트 테스트가 `OutboxEventPublisher`·스케줄러 빈 등록을 실제로 태움)
- 유실 0건 증적: #346 장애 주입 측정(PR #479)이 동일 유효 구성(`APP_EVENT_PUBLISHER_TYPE=outbox` env 오버라이드)으로 AFTER_COMMIT 유실 514건 → outbox 0건을 정량 재현함
- 중복 발행(at-least-once)은 소비 측 Inbox(#347)가 차단하는 전제 유지
- 사전 리뷰 반영 2건: `ExpireBookingByNumberUseCase`에 방어적 `@Transactional` 부착(outbox 발행의 활성 트랜잭션 요구 대비, 기존 트랜잭션 조인이라 의미 동일), test 프로파일에 스케줄러 활성화 유의 주석 추가

---

## ✅ 테스트

### 테스트 방법

- `./gradlew :booking-service:test :common:test` — test 프로파일이 `outbox`로 바뀌어 booking-service 컨텍스트 테스트(`BookingServiceApplicationTests` 등)가 outbox 배선으로 재실행됨

### 테스트 결과

- BUILD SUCCESSFUL (booking-service:test 재실행 통과, 신규 실패 0건)
<!--
### 📸 스크린샷

- (작성 필요)
-->
---

## 👀 리뷰 요청 사항

- 발행 호출부 5곳(이벤트 3종) 전수 확인 결과 모두 활성 트랜잭션 안이며(`OutboxEventPublisher`의 트랜잭션 필수 요건 충족), aggregateType도 전부 `Booking`으로 relay 대상과 일치함 — 혹시 놓친 발행 경로가 있는지 확인 부탁드립니다
- `BookingCreatedEvent` 소비(seat-service 좌석 HOLD)가 즉시 발행 → relay 폴링(최대 ~5초 지연)으로 바뀝니다. 정합성은 SeatHoldFailed 보상 경로로 유지되지만, 피크 시 이중 예매 시도→보상 빈도가 늘 수 있는 창입니다. relay 주기 5s가 티켓팅 SLA에 적정한지 의견 부탁드립니다

---

## ⚠️ 배포 시 주의사항

- 배포 후 Grafana에서 `outbox.backlog` Gauge가 소진(0 수렴)되는지 확인 — relay 스케줄러 정상 동작 검증 (#471 완료 조건)
- `load-test/chaos/booking-outbox.override.yml`은 이번 전환 후 no-op이 되지만 #346 측정 재현 기록으로 유지
