### PR TITLE
[Fix] #484 스케줄러 스레드 풀 크기 명시 + Kafka max.block.ms로 스케줄러 상호 블로킹 제거

### DIFF
--- a/booking-service/src/main/resources/application.yml
+++ b/booking-service/src/main/resources/application.yml
@@ -9,6 +9,13 @@ spring:
     name: booking-service
   jpa:
     open-in-view: false
+  task:
+    scheduling:
+      pool:
+        # @Scheduled 5개(relay·booking 만료·outbox/inbox/dlt retention)가 스레드 하나를 공유하면
+        # 하나가 블로킹될 때 나머지가 함께 밀린다. 특히 relay의 producer.send()가 브로커 메타데이터
+        # 대기로 잡히면(KafkaConfig max.block.ms) 만료 fallback까지 멈춘다. 스케줄러 수만큼 준다.
+        size: 5
 
 service:
   seat:

--- a/common/src/main/java/com/ticketrush/global/config/KafkaConfig.java
+++ b/common/src/main/java/com/ticketrush/global/config/KafkaConfig.java
@@ -59,6 +59,11 @@ public class KafkaConfig {
   private static final int FETCH_MAX_WAIT_MS = 500;
   private static final int MAX_POLL_INTERVAL_MS = 300_000;
   private static final int DELIVERY_TIMEOUT_MS = 120_000;
+  // send()가 브로커 메타데이터·버퍼 대기로 동기 블로킹되는 최대 시간. 기본 60초는 outbox relay가
+  // @Scheduled 스레드에서 send()를 호출하므로 브로커가 불가할 때 그 스레드를 60초씩 문다. 5초로 잘라
+  // relay가 스레드를 오래 붙잡지 않게 한다. relay 주기(5s)와 정합하며, 짧은 메타데이터 갱신·리더 선출은
+  // 견딘다. 장기 브로커 장애 시에는 어차피 발행이 불가하고, DEAD 전이(max-retries)와 DLT/알림이 받는다.
+  private static final int MAX_BLOCK_MS = 5_000;
   private static final long BACKOFF_INITIAL_INTERVAL_MS = 1_000L;
   private static final long BACKOFF_MAX_INTERVAL_MS = 60_000L;
 
@@ -80,6 +85,7 @@ public class KafkaConfig {
     configProps.put(ProducerConfig.ACKS_CONFIG, ACKS_ALL);
     configProps.put(ProducerConfig.RETRIES_CONFIG, PRODUCER_RETRIES);
     configProps.put(ProducerConfig.DELIVERY_TIMEOUT_MS_CONFIG, DELIVERY_TIMEOUT_MS);
+    configProps.put(ProducerConfig.MAX_BLOCK_MS_CONFIG, MAX_BLOCK_MS);
     configProps.put(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, ENABLE_IDEMPOTENCE);
     configProps.put(ProducerConfig.MAX_IN_FLIGHT_REQUESTS_PER_CONNECTION, MAX_IN_FLIGHT_REQUESTS);
     configProps.put(ProducerConfig.LINGER_MS_CONFIG, LINGER_MS);

--- a/seat-service/src/main/resources/application.yml
+++ b/seat-service/src/main/resources/application.yml
@@ -9,6 +9,13 @@ spring:
     name: seat-service
   jpa:
     open-in-view: false
+  task:
+    scheduling:
+      pool:
+        # @Scheduled 4개(relay·좌석 만료 fallback·outbox retention·held 게이지)가 스레드 하나를
+        # 공유하면 하나가 블로킹될 때 나머지가 함께 밀린다. 특히 relay의 producer.send()가 브로커
+        # 메타데이터 대기로 잡히면(KafkaConfig max.block.ms) 만료 fallback까지 멈춘다. 스케줄러 수만큼 준다.
+        size: 4
   data:
     redis:
       # Lettuce 기본 커맨드 타임아웃(60s)은 hang형 Redis 장애 시 좌석 락 경로를 60초 물린다.


### PR DESCRIPTION
## 🔗 관련 이슈

- close #484

---

## 📌 주요 변경 사항

- booking·seat 서비스의 `@Scheduled` 스케줄러들이 스레드 하나(Spring 기본 `pool.size=1`)를 공유해, 하나가 블로킹되면 같은 서비스의 다른 스케줄러까지 함께 밀리는 문제를 제거한다.
- Kafka producer `max.block.ms`를 명시(기본 60초 → 5초)해 `producer.send()`가 스케줄러 스레드를 잡는 최대 시간을 통제한다.

---

## 🛠 상세 구현 내용

- **`spring.task.scheduling.pool.size` 명시** — booking=5, seat=4 (서비스별 `@Scheduled` 개수 기준). 이제 relay·만료 fallback·retention 스케줄러가 서로 다른 스레드에서 돌아 한쪽 블로킹이 다른 쪽을 멈추지 않는다.
- **`KafkaConfig` producer `max.block.ms=5000`** — outbox relay가 `@Scheduled` 스레드에서 `producer.send()`를 호출하는데, 브로커 메타데이터를 못 얻으면 기본 60초까지 그 스레드가 동기 블로킹된다. 상한을 relay 주기(5초)와 정합하는 5초로 잘라 스레드 점유를 통제한다. 장기 브로커 장애 시엔 어차피 발행이 불가하며 DEAD 전이(`max-retries`)·DLT/알림이 받는다.
- **범위 제외** — performance는 `@Scheduled`가 1개라 상호 블로킹이 불가해 제외. ticket 등 나머지 서비스는 스케줄러가 없다. 다중 인스턴스 대응(ShedLock `lockAtMostFor` 재산정)은 단일 인스턴스 배포(ADR 0006~0008) 전제로 성립하지 않아 이슈에서 제외했다.

---

## ✅ 테스트

### 테스트 방법

- `./gradlew :common:test :booking-service:test :seat-service:test spotlessCheck`

### 테스트 결과

- `common`·`booking-service`·`seat-service` 테스트 통과. (`seat-service`의 `SeatHoldConcurrencyTest`는 Docker/Testcontainers 필요 테스트로, Docker 미가동 환경에서 `initializationError`로 스킵 — 본 변경과 무관)
- `spotlessCheck` BUILD SUCCESSFUL
<!--
### 📸 스크린샷

- 
-->
---

## 👀 리뷰 요청 사항

- `max.block.ms=5000` 값 적정성 — 단기 메타데이터 갱신·리더 선출은 견디되 스케줄러 스레드 점유를 5초로 상한. 트레이드오프(장기 장애 시 outbox row가 더 빨리 FAILED→DEAD)를 수용할 만한지 확인 부탁.

---

## ⚠️ 배포 시 주의사항

- 공용 `KafkaConfig`(common) 변경이라 outbox/kafka 발행을 쓰는 전 서비스의 producer에 `max.block.ms=5000`이 적용된다.
