### PR TITLE
[Test] #345 대량 만료 청크 트랜잭션 측정 준비 — 만료 적체 게이지 + 측정 자산 + 런북 §11

### DIFF
--- a/common/src/main/java/com/ticketrush/global/constants/MetricNames.java
+++ b/common/src/main/java/com/ticketrush/global/constants/MetricNames.java
@@ -17,6 +17,9 @@ public class MetricNames {
   public static final String SEAT_HOLD = "ticketrush.seat.hold";
   public static final String SEAT_LOCK_CONTENTION = "ticketrush.seat.lock.contention";
   public static final String SEAT_HELD = "ticketrush.seat.held"; // Gauge (전역 미만료 HOLD 총수)
+  // 만료됐으나 아직 해제되지 않은 HOLD 총수 = 만료 fallback의 처리 적체(#345). SEAT_HELD가 미만료만 세므로
+  // 대량 만료의 해소 진행은 그 게이지에 나타나지 않는다. outbox.backlog의 좌석 버전.
+  public static final String SEAT_HOLD_EXPIRED_BACKLOG = "ticketrush.seat.hold.expired_backlog";
 
   // payment
   public static final String PAYMENT_CONFIRM = "ticketrush.payment.confirm";

--- a/docs/load-test-guide.md
+++ b/docs/load-test-guide.md
@@ -484,3 +484,100 @@ http.setResponseCallback(http.expectedStatuses(200, 201, 409));
 > 부수 관측으로 **릴레이 발행 증폭 3.09배**(발행 4,090 vs outbox 행 1,324)를 확인했다. `relayBatch()`에 in-flight 표시가 없어 콜백의 SENT 전이가 5초 폴링보다 늦으면 같은 행이 재발행된다(`retry_count`는 전부 0 — 실패 재시도가 아니다). javadoc이 명시한 at-least-once 설계 그대로이며 Inbox가 전량 차단했지만, 단일 컨슈머 스레드가 유효 처리량의 68%를 중복 차단에 쓴다.
 
 증적은 `load-tests/k6/results/260724-344-seat-contention/`에 있다(#346·#347 디렉토리 구성 답습 — `report.md`·`metadata.txt`·`k6-summary.txt`·`graph-*.png`·`timeseries-*.json`).
+
+## 11. 대량 만료 청크 트랜잭션 측정 (#345)
+
+만료 HOLD 좌석을 대량으로 시딩해, 좌석 만료 fallback이 그것을 소진하는 과정을 **청크 트랜잭션(25건) vs 단일 트랜잭션**으로 비교한다. **k6를 쓰지 않는다** — HTTP 부하가 아니라 시딩 + 스케줄러 관측이다.
+
+### 11.1 이슈 서사와 실측의 차이 — 먼저 읽을 것
+
+이슈 #345는 1만 건 시나리오의 주 지표를 "`seat_held` Gauge의 tick별 잔량 감소 곡선"으로 잡았다. **그 게이지로는 측정되지 않는다.**
+
+```java
+// SeatRepository.countHeldSeats — seat_held 게이지의 원천
+select count(s) from Seat s where s.seatStatus = :hold and s.holdExpiredAt > :now
+```
+
+`seat_held`는 **미만료** HOLD만 센다. 만료됐지만 아직 해제되지 않은 좌석 — 정확히 이 측정이 재려는 적체 — 은 처음부터 게이지 밖이다. 만료 코호트를 시딩하면 `seat_held`는 0에서 시작해 0으로 끝나고 곡선이 아예 그려지지 않는다. #484가 고친 스케줄러 스레드 굶주림과는 별개 문제이며, 지표 정의 자체의 공백이다.
+
+그래서 #345에서 **`ticketrush_seat_hold_expired_backlog` 게이지를 추가했다**(`SeatHeldGaugeMetrics`, 30초 갱신). `outbox_backlog`의 좌석 버전이고, 세는 집합의 비교 연산자(`hold_expired_at <= now`)를 스케줄러가 실제로 집어가는 `findExpiredHoldSeats`와 같게 맞춰 두 집합이 어긋나지 않게 했다. **적체 해소 곡선은 이 게이지로 읽는다.**
+
+### 11.2 단일 트랜잭션 비교군은 코드 변경이 아니다
+
+`chunkSize` × `maxChunks`가 곧 (트랜잭션 범위) × (tick당 청크 수)다. `chunk-size`를 코호트 전량으로, `max-chunks`를 1로 주면 `SeatReleaseExpiredUseCase`의 루프가 한 번만 돌아 전량이 단일 트랜잭션으로 커밋된다. 벤치용 브랜치도 토글 코드도 필요 없다 — compose override 하나뿐이다(`load-test/chaos/seat-release-singletrx.override.yml`).
+
+**바인딩은 로그가 증명한다.** 만료 2,000건에 `chunk-size=2000`·`max-chunks=1`이면 `fetched == chunkSize`이고 `processedChunks == maxChunks`라 처리 상한 도달 경고가 `chunkSize=2000 x maxChunks=1`을 그대로 찍는다. actuator/env는 노출 대상이 아니라(health·info·prometheus 3개) 쓸 수 없으므로 이 로그가 유일한 확증 수단이다.
+
+> **10,000건 단일 트랜잭션은 돌리지 않는다.** seat-service의 `mem_limit`이 640m이고, 단일 트랜잭션이 `SeatStatusScheduler`의 ShedLock `lockAtMostFor=2m`를 넘기면 락이 풀려 중복 실행 창이 열린다. 2,000건이 tick당 처리 상한과 같은 크기라 그 지점의 A/B가 정직한 대조다.
+
+### 11.3 측정 매트릭스
+
+| # | 만료 건수 | 설정 | 관측 | 주 지표 |
+|---|---|---|---|---|
+| A1 | 2,000 | 청크 25×80 (yml 기본값) | ≥5분 | 최장 trx 지속시간, `hikaricp_connections_pending` 피크 |
+| A2 | 2,000 | **단일 2000×1** (override) | ≥5분 | 같은 작업량의 대조군 |
+| B1 | 10,000 | 청크 25×80 | **≥10분** | `seat_hold_expired_backlog` tick별 감소 곡선(최소 5 tick 소진) |
+
+### 11.4 사전 점검 (EC2 기동 후, 측정 전)
+
+1. **`SHOW INDEX FROM seat`에 `idx_seat_status_hold_expired_at`이 있는지 확인한다.** `@Table`의 `@Index`는 `ddl-auto=update`인 신규 DB에서만 생기고 prod(`validate`)는 인덱스 부재를 검출하지 못한다(`Seat` javadoc, #296 관행). 없으면 아래를 먼저 적용하고 **metadata에 적용 여부를 기록**한다 — 인덱스가 없으면 청크 조회가 tick당 80회 풀스캔이 되어 측정값이 인덱스 결함과 섞인다.
+   ```sql
+   ALTER TABLE seat ADD INDEX idx_seat_status_hold_expired_at (seat_status, hold_expired_at),
+     ALGORITHM=INPLACE, LOCK=NONE;
+   ```
+2. 게이지 포함 이미지가 배포됐는지: seat-service actuator(컨테이너 내 8090)의 `/actuator/prometheus`에 `ticketrush_seat_hold_expired_backlog` 노출 확인.
+3. A1·B1은 yml 기본값이어야 한다 — `docker exec seat-service env | grep -E '^APP_SEAT_RELEASE_'` 가 비어야 정상.
+4. §7의 SSH 터널(3000·9090). **측정 중 Grafana 대시보드는 열어두지 않는다.**
+5. 현재 태그 확보: `TAG=$(docker inspect gateway-service --format '{{.Config.Image}}' | cut -d: -f2)`
+
+### 11.5 절차 (회차마다 반복)
+
+```bash
+SSH="ssh -i <key>.pem ubuntu@<EC2_IP>"
+SQL() { $SSH "docker exec -i ticketrush-mysql sh -c 'mysql -u root -p\"\$MYSQL_ROOT_PASSWORD\" -N ticket_rush'"; }
+```
+
+1. **시딩** — `seed_expired_holds.sql`은 리셋(outbox → booking → seat)과 시드를 한 파일에 담고 있어 매 회차 앞에 한 번만 돌리면 된다. 코호트 크기는 파일 상단 `@expired_count`로 정한다(2000 / 10000). `seed_load.sql`이 만든 LOADTEST 좌석이 코호트 크기 이상 AVAILABLE로 남아 있어야 한다(끝의 검증 쿼리가 `requested`/`cohort_bookings`/`expired_hold_seats` 일치를 보여준다).
+   ```bash
+   $SSH "docker exec -i ticketrush-mysql sh -c 'mysql -u root -p\"\$MYSQL_ROOT_PASSWORD\" \
+     --init-command=\"SET @i_confirm_loadtest_db=1\" ticket_rush'" < load-test/seed/seed_expired_holds.sql
+   ```
+   `seed_load.sql`의 `@booking_pct`는 `hold_expired_at = NOW() + 5분`(미만료)이라 이 측정에 쓸 수 없다. 코호트의 `created_at`은 `NOW()`로 둔다 — 과거로 당기면 booking-service의 `BookingExpireUseCase`(cutoff = now−5분)가 따로 물어 좌석 경로 측정이 오염된다. 예매 만료는 `SeatHoldExpiredEvent` 경유(프로덕션 경로)로만 일어난다.
+2. **샘플러 기동** (EC2에서, 스케줄러 tick보다 먼저 띄운다)
+   ```bash
+   DURATION=660 ./trx-sampler.sh > trx-samples-b1.csv   # load-test/bench/
+   ```
+3. **관측** — `SeatStatusScheduler`는 `fixedDelay=60000`이라 시딩 후 최대 1분 안에 첫 tick이 돈다. A1/A2는 5분, B1은 10분 이상 유지한다.
+4. **소진 확인** — 적체가 0이고 릴레이가 비었을 때가 측정 창 종점이다(§10.2 규약). UTC로 기록한다.
+   ```bash
+   echo "SELECT COUNT(*) FROM seat WHERE seat_status='HOLD' AND hold_expired_at <= NOW();" | SQL
+   echo "SELECT status, COUNT(*) FROM outbox WHERE event_type='SeatHoldExpiredEvent' GROUP BY status;" | SQL
+   ```
+5. **A2만** — override 적용/원복(§11.2). 적용 후 seat-service 로그에서 `chunkSize=2000 x maxChunks=1` 경고를 확인한 뒤 측정한다.
+   ```bash
+   IMAGE_TAG=$TAG docker compose -f docker-compose.prod.yml -f seat-release-singletrx.override.yml up -d seat-service
+   # ... 측정 ...
+   IMAGE_TAG=$TAG docker compose -f docker-compose.prod.yml up -d seat-service   # 원복
+   ```
+6. 증적을 `load-tests/k6/results/<YYMMDD>-345-chunk-trx/`에 기록(#344 디렉토리 구성 답습).
+
+### 11.6 PromQL
+
+```promql
+ticketrush_seat_hold_expired_backlog                 # 적체 해소 곡선 (B1 주 지표, §11.1)
+ticketrush_seat_held                                 # 미만료 HOLD (대조 — 코호트 측정에선 0 유지가 정상)
+hikaricp_connections_pending{application="seat-service"}   # 커넥션 풀 압박 피크
+hikaricp_connections_active{application="seat-service"}
+sum(rate(ticketrush_outbox_relay_total{result="success"}[1m]))  # 만료 이벤트 발행 소화
+ticketrush_outbox_backlog / ticketrush_outbox_in_flight         # 겹쳐 읽는다 (§10.3 판별표)
+```
+
+HikariCP·트랜잭션 패널은 Grafana System 대시보드(`monitoring/grafana/dashboards/ticketrush-system.json`)에 이미 있다. 적체 게이지는 Explore로 캡처한다.
+
+### 11.7 주의
+
+- **샘플러 값은 최장 지속시간의 하한이다.** 앱에 트랜잭션 지속시간 계측이 없어 `information_schema.innodb_trx`를 1초 간격으로 뜬다. 청크 트랜잭션(25건)은 수십 ms급이라 샘플 사이에 끝나면 기록되지 않는다. 단일 트랜잭션 arm은 초 단위라 안정적으로 잡힌다. **리포트에 이 한계를 반드시 명시한다.**
+- **`confirmSoldById` 블로킹은 직접 측정할 수 없다.** 결제 확정 이벤트를 대량 생성할 수단이 없다(§9.1이 같은 이유로 `ticket-group`을 보조 증적으로 돌린 전례). 락 점유는 샘플러의 `max_secs_running`(= 락 보유 상한)과 `lock_wait_trx`/`data_lock_waits` 관측 건수로 대신 기록하고, `application.yml` 주석이 근거로 든 경합은 구조적 논거 + 지속시간 수치로 서술한다. **추정을 수치로 위장하지 않는다.**
+- 단일 EC2에 앱 9개 + Kafka·MySQL·Redis·관측 스택이 동거하므로 절대 수치에는 포화가 섞인다(§10.5 단서와 동일).
+- 코호트 정리는 `cleanup_load.sql`이 `LT-%` 패턴으로 함께 처리한다(코호트 `booking_number` 프리픽스가 `LT-X`다).
+- `IMAGE_TAG` 명시: §8.4와 동일.

--- a/docs/load-test-guide.md
+++ b/docs/load-test-guide.md
@@ -520,6 +520,12 @@ select count(s) from Seat s where s.seatStatus = :hold and s.holdExpiredAt > :no
 
 ### 11.4 사전 점검 (EC2 기동 후, 측정 전)
 
+0. **⚠️ compose 는 반드시 `~/ticketrush/deploy/` 에서 실행한다. 리포 루트(`~/ticketrush/`)에 구버전 `docker-compose.prod.yml` 사본이 남아 있고, 그걸로 `up` 하면 Redis 가 비밀번호 없이 재생성되어 전 서비스 인증이 깨진다.** 실행 중 스택의 소유 경로는 라벨이 알려준다 — 손대기 전에 확인한다.
+   ```bash
+   docker inspect booking-service --format '{{index .Config.Labels "com.docker.compose.project.config_files"}}'
+   # → /home/ubuntu/ticketrush/deploy/docker-compose.prod.yml  (이 경로에서만 compose 를 돌린다)
+   ```
+   실측에서 실제로 밟았다. 루트 사본에는 `--requirepass` 가 없고 그 디렉토리의 `.env` 에는 `REDIS_PASSWORD` 키 자체가 없다(#426 이후 추가된 키다). `up -d seat-service` 가 `depends_on` 의 redis·mysql 까지 재생성하면서 Redis 가 인증 없이 떴고, 비밀번호를 보내는 나머지 앱들이 `ERR AUTH <password> called without any password configured` 로 전부 끊겼다 — seat-service 는 22회 재시작, `redis_up` 알림 발화. **복구는 정상 디렉토리에서 `up -d redis mysql seat-service`** 로 같은 프로젝트 이름(`ticketrush-prod`)에 재생성하면 된다(볼륨은 명시적 이름이라 데이터는 보존된다).
 1. **`SHOW INDEX FROM seat`에 `idx_seat_status_hold_expired_at`이 있는지 확인한다.** `@Table`의 `@Index`는 `ddl-auto=update`인 신규 DB에서만 생기고 prod(`validate`)는 인덱스 부재를 검출하지 못한다(`Seat` javadoc, #296 관행). 없으면 아래를 먼저 적용하고 **metadata에 적용 여부를 기록**한다 — 인덱스가 없으면 청크 조회가 tick당 80회 풀스캔이 되어 측정값이 인덱스 결함과 섞인다.
    ```sql
    ALTER TABLE seat ADD INDEX idx_seat_status_hold_expired_at (seat_status, hold_expired_at),
@@ -537,22 +543,50 @@ SSH="ssh -i <key>.pem ubuntu@<EC2_IP>"
 SQL() { $SSH "docker exec -i ticketrush-mysql sh -c 'mysql -u root -p\"\$MYSQL_ROOT_PASSWORD\" -N ticket_rush'"; }
 ```
 
-1. **시딩** — `seed_expired_holds.sql`은 리셋(outbox → booking → seat)과 시드를 한 파일에 담고 있어 매 회차 앞에 한 번만 돌리면 된다. 코호트 크기는 파일 상단 `@expired_count`로 정한다(2000 / 10000). `seed_load.sql`이 만든 LOADTEST 좌석이 코호트 크기 이상 AVAILABLE로 남아 있어야 한다(끝의 검증 쿼리가 `requested`/`cohort_bookings`/`expired_hold_seats` 일치를 보여준다).
+1. **시딩** — `seed_expired_holds.sql`은 리셋(outbox → seat → booking)과 시드를 한 파일에 담고 있어 매 회차 앞에 한 번만 돌리면 된다. outbox 리셋은 **미발행(PENDING/FAILED) 만료 이벤트만** 지운다 — SENT 는 릴레이가 다시 집지 않아 다음 창을 오염시키지 못하고, `aggregate_id IN (2,000건)` 으로 코호트를 특정하면 `(event_type, aggregate_id)` 인덱스가 없어 5만 행 풀스캔 두 번이 된다(실측에서 시딩이 회차당 **2분 30초 → 1초 미만**으로 줄었다). 코호트 크기는 파일 상단 `@expired_count`로 정한다(2000 / 10000). `seed_load.sql`이 만든 LOADTEST 좌석이 코호트 크기 이상 AVAILABLE로 남아 있어야 한다(끝의 검증 쿼리가 `requested`/`cohort_bookings`/`expired_hold_seats` 일치를 보여준다).
    ```bash
    $SSH "docker exec -i ticketrush-mysql sh -c 'mysql -u root -p\"\$MYSQL_ROOT_PASSWORD\" \
      --init-command=\"SET @i_confirm_loadtest_db=1\" ticket_rush'" < load-test/seed/seed_expired_holds.sql
    ```
    `seed_load.sql`의 `@booking_pct`는 `hold_expired_at = NOW() + 5분`(미만료)이라 이 측정에 쓸 수 없다. 코호트의 `created_at`은 `NOW()`로 둔다 — 과거로 당기면 booking-service의 `BookingExpireUseCase`(cutoff = now−5분)가 따로 물어 좌석 경로 측정이 오염된다. 예매 만료는 `SeatHoldExpiredEvent` 경유(프로덕션 경로)로만 일어난다.
-2. **샘플러 기동** (EC2에서, 스케줄러 tick보다 먼저 띄운다)
+2. **계측 2종을 tick 전에 준비한다.**
+
+   **(a) 최장 트랜잭션 지속시간 — `performance_schema` (주 계측)**. 이게 이 측정의 핵심 수치다. 청크 트랜잭션은 수십 ms라 초 단위 폴링으로는 원리상 못 잡는다. 대신 P_S 요약 테이블을 **tick 직전에 truncate 하고 tick 직후에 읽으면** 그 창의 최댓값이 정확히 나온다(`transaction` instrument 가 기본 enabled·timed 다).
+   ```bash
+   SEATIP=$(docker inspect seat-service --format '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}')
+   # 시딩 직후 = tick 직전에 리셋
+   echo "TRUNCATE performance_schema.events_transactions_summary_by_thread_by_event_name;" | SQL
+   # ... tick 이 만료 좌석을 소진할 때까지 대기 ...
+   echo "SELECT SUM(s.COUNT_STAR) trx_count,
+                ROUND(MAX(s.MAX_TIMER_WAIT)/1e9,1) max_ms,
+                ROUND(SUM(s.SUM_TIMER_WAIT)/SUM(s.COUNT_STAR)/1e9,1) avg_ms
+           FROM performance_schema.events_transactions_summary_by_thread_by_event_name s
+           JOIN performance_schema.threads t ON t.THREAD_ID = s.THREAD_ID
+          WHERE t.PROCESSLIST_HOST = '$SEATIP' AND s.COUNT_STAR > 0;" | SQL
+   ```
+   **`PROCESSLIST_HOST` 로 seat-service 커넥션만 거른다.** 전역 요약을 쓰면 다른 서비스의 릴레이·인박스 트랜잭션이 섞인다. 컨테이너를 재생성하면 IP 가 바뀌므로 회차마다 다시 뜬다.
+
+   **(b) 락 점유 규모·락 대기 — `trx-sampler.sh`** (보조). 1초 간격으로 `innodb_trx` 의 `trx_rows_locked`·`trx_state='LOCK WAIT'`·`data_lock_waits` 를 남긴다. 지속시간은 (a)를 쓰고, 이 CSV 는 "몇 행을 잠갔나 / 대기가 있었나"에만 쓴다.
    ```bash
    DURATION=660 ./trx-sampler.sh > trx-samples-b1.csv   # load-test/bench/
+   ```
+
+   **(c) HikariCP 는 1초로 따로 떠야 한다.** Prometheus 스크랩이 15초라 2~6초짜리 tick 을 통째로 놓친다. actuator 를 직접 1초로 긁는다.
+   ```bash
+   while :; do
+     printf '%s,' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+     docker exec seat-service sh -c \
+       'curl -s localhost:8090/actuator/prometheus | grep -E "^hikaricp_connections_(pending|active|idle)" | awk "{print \$2}" | paste -sd,'
+     sleep 1
+   done > hikari-a1.csv
    ```
 3. **관측** — `SeatStatusScheduler`는 `fixedDelay=60000`이라 시딩 후 최대 1분 안에 첫 tick이 돈다. A1/A2는 5분, B1은 10분 이상 유지한다.
 4. **소진 확인** — 적체가 0이고 릴레이가 비었을 때가 측정 창 종점이다(§10.2 규약). UTC로 기록한다.
    ```bash
-   echo "SELECT COUNT(*) FROM seat WHERE seat_status='HOLD' AND hold_expired_at <= NOW();" | SQL
+   echo "SELECT COUNT(*) FROM seat WHERE seat_status='HOLD' AND hold_expired_at <= UTC_TIMESTAMP();" | SQL
    echo "SELECT status, COUNT(*) FROM outbox WHERE event_type='SeatHoldExpiredEvent' GROUP BY status;" | SQL
    ```
+   `NOW()`가 아니라 `UTC_TIMESTAMP()`다 — 아래 §11.7의 시계 항목을 먼저 읽을 것.
 5. **A2만** — override 적용/원복(§11.2). 적용 후 seat-service 로그에서 `chunkSize=2000 x maxChunks=1` 경고를 확인한 뒤 측정한다.
    ```bash
    IMAGE_TAG=$TAG docker compose -f docker-compose.prod.yml -f seat-release-singletrx.override.yml up -d seat-service
@@ -576,7 +610,9 @@ HikariCP·트랜잭션 패널은 Grafana System 대시보드(`monitoring/grafana
 
 ### 11.7 주의
 
-- **샘플러 값은 최장 지속시간의 하한이다.** 앱에 트랜잭션 지속시간 계측이 없어 `information_schema.innodb_trx`를 1초 간격으로 뜬다. 청크 트랜잭션(25건)은 수십 ms급이라 샘플 사이에 끝나면 기록되지 않는다. 단일 트랜잭션 arm은 초 단위라 안정적으로 잡힌다. **리포트에 이 한계를 반드시 명시한다.**
+- **⚠️ 앱은 UTC, MySQL 세션은 KST다 — 만료 시딩에 `NOW()`를 쓰면 조용히 헛돈다.** 배포본 MySQL 컨테이너는 `system_time_zone=KST`라 세션 `NOW()`가 앱 컨테이너 시계보다 **9시간 앞선다**. `hold_expired_at`은 앱의 `LocalDateTime.now()`와 비교되므로(`findExpiredHoldSeats`), `NOW()`로 시딩하면 좌석이 "9시간 뒤 만료"로 저장되어 **스케줄러가 매 tick 정상 동작하면서도 0건을 처리한다.** 에러도 경고도 남지 않고 로그에는 `Fallback 스케줄러 동작` 만 반복 찍힌다 — 첫 실측에서 실제로 3 tick을 그렇게 날렸다. `seed_expired_holds.sql`은 `@app_now = UTC_TIMESTAMP()`를 잡아 전 구간에 쓰고, 검증 쿼리가 `db_now`/`app_now_used`를 함께 출력한다. **첫 실행 때 `docker exec seat-service date`와 `app_now_used`가 같은지 눈으로 확인한다.** (§8.4의 `verify-loss.sql` 타임존 주의와 같은 뿌리다.)
+- **`innodb_trx` 1초 샘플링으로는 청크 트랜잭션 지속시간을 잴 수 없다.** 청크 25건은 실측 수십 ms라 샘플 사이에 끝난다. 지속시간은 §11.5(a)의 `performance_schema` 로 재고, 샘플러는 락 점유 규모·대기 관측용으로만 읽는다. 샘플러 CSV 에 78초짜리 값이 보이면 시딩 자신의 대량 UPDATE 다 — 시딩 구간을 타임스탬프로 잘라내고 본다.
+- **커넥션 풀 압박(`hikaricp_connections_pending`)은 이 경로에서 구조적으로 0이다.** 만료 fallback 은 스케줄러 스레드 **하나**가 도는 단일 스레드 경로라 커넥션을 한 개만 쓴다(실측: 두 arm 모두 `pending=0`, `active` 피크 1, `idle` 9). 풀 크기가 10이므로 단일 트랜잭션이 5초를 물고 있어도 대기가 생기지 않는다. **"청크 분할로 커넥션 풀 고갈을 회피한다"는 서술은 이 규모·이 경로에서는 실측으로 뒷받침되지 않는다** — 풀 압박을 보려면 만료 처리와 동시에 다른 요청이 커넥션을 다투게 만들어야 하고, 그건 이 시나리오 밖이다. 청크 분할의 실측 이득은 **락 보유 시간**이다.
 - **`confirmSoldById` 블로킹은 직접 측정할 수 없다.** 결제 확정 이벤트를 대량 생성할 수단이 없다(§9.1이 같은 이유로 `ticket-group`을 보조 증적으로 돌린 전례). 락 점유는 샘플러의 `max_secs_running`(= 락 보유 상한)과 `lock_wait_trx`/`data_lock_waits` 관측 건수로 대신 기록하고, `application.yml` 주석이 근거로 든 경합은 구조적 논거 + 지속시간 수치로 서술한다. **추정을 수치로 위장하지 않는다.**
 - 단일 EC2에 앱 9개 + Kafka·MySQL·Redis·관측 스택이 동거하므로 절대 수치에는 포화가 섞인다(§10.5 단서와 동일).
 - 코호트 정리는 `cleanup_load.sql`이 `LT-%` 패턴으로 함께 처리한다(코호트 `booking_number` 프리픽스가 `LT-X`다).

--- a/load-test/README.md
+++ b/load-test/README.md
@@ -8,9 +8,15 @@ load-test/
 ├── lib/      # auth.js(로그인 → access token)
 ├── scenarios/# booking-create.js(예매 생성, 인증), seat-layouts.js(좌석 조회, 비인증),
 │           #  seat-contention.js(단일 좌석 경합, 인증 — #344)
-├── seed/     # seed_load.sql(대량 시딩 + 부하테스트 계정), cleanup_load.sql(정리)
-└── chaos/    # 장애 주입(#346): broker-outage.sh, verify-loss.sql, booking-outbox.override.yml
+├── seed/     # seed_load.sql(대량 시딩 + 부하테스트 계정), cleanup_load.sql(정리),
+│           #  seed_expired_holds.sql(만료 HOLD 코호트 — #345)
+├── bench/    # trx-sampler.sh(MySQL 트랜잭션 지속시간·락 점유 샘플러 — #345)
+└── chaos/    # 장애 주입(#346): broker-outage.sh, verify-loss.sql, booking-outbox.override.yml,
+            #  inbox-redeliver.sh·verify-inbox.sql(#347),
+            #  seat-release-singletrx.override.yml(단일 트랜잭션 비교군 — #345)
 ```
+
+`bench/`·`chaos/`의 스크립트와 override는 **측정 전용**이다(프로덕션 반영 아님). 스크립트는 EC2 배포본 호스트에서 실행하고, override는 적용 후 반드시 원복한다.
 
 k6는 docker-compose의 `loadtest` profile로 분리된 컨테이너에서 실행한다(상시 기동 대상 아님).
 

--- a/load-test/bench/trx-sampler.sh
+++ b/load-test/bench/trx-sampler.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# #345 측정 — MySQL 트랜잭션 지속시간·락 점유 샘플러. EC2(배포본 호스트)에서 실행.
+#
+# 앱에는 트랜잭션 지속시간 지표가 없다(Micrometer 계측 없음). information_schema.innodb_trx 를
+# 주기적으로 떠서 "그 순간 살아 있는 트랜잭션 중 최장"을 기록한다.
+#
+# 사용법:  DURATION=660 ./trx-sampler.sh > trx-samples-a1.csv
+#   CONTAINER  MySQL 컨테이너 (기본 ticketrush-mysql)
+#   INTERVAL   샘플 간격(초, 기본 1)
+#   DURATION   총 관측 시간(초, 기본 660 = 11분)
+#
+# ⚠ 이 값은 최장 지속시간의 **하한**이다. 청크 트랜잭션(25건)은 수십 ms급이라 샘플 사이에 끝나면
+#   기록되지 않는다. 단일 트랜잭션 arm(2,000건)은 초 단위라 안정적으로 잡힌다. 리포트에 이 한계를 명시한다.
+#
+# 루프 전체를 컨테이너 안에서 돌린다 — 샘플마다 docker exec 을 새로 띄우면 그 오버헤드(수백 ms)가
+# 간격에 섞인다. 타임스탬프도 컨테이너 안에서 찍으므로(프로드 컨테이너는 UTC) 실제 cadence 가 CSV 에 남는다.
+# 비밀번호는 컨테이너 안에서 $MYSQL_ROOT_PASSWORD 를 펼쳐 쓰므로 셸 히스토리에 평문이 남지 않는다.
+set -euo pipefail
+
+CONTAINER="${CONTAINER:-ticketrush-mysql}"
+INTERVAL="${INTERVAL:-1}"
+DURATION="${DURATION:-660}"
+
+echo "ts_utc,max_secs_running,max_rows_locked,max_lock_structs,lock_wait_trx,active_trx,data_lock_waits"
+
+docker exec -e INTERVAL="$INTERVAL" -e DURATION="$DURATION" -i "$CONTAINER" sh -s <<'EOS'
+set -eu
+# trx_started 는 서버 타임존 기준이고 NOW(6) 도 같은 기준이라 차이는 타임존과 무관하다.
+# 빈 집합(활성 트랜잭션 0건)에서 MAX/SUM 은 NULL 이므로 전부 COALESCE 한다.
+SQL='SELECT
+  COALESCE(MAX(TIMESTAMPDIFF(MICROSECOND, trx_started, NOW(6))) / 1000000, 0),
+  COALESCE(MAX(trx_rows_locked), 0),
+  COALESCE(MAX(trx_lock_structs), 0),
+  COALESCE(SUM(trx_state = "LOCK WAIT"), 0),
+  COUNT(*),
+  (SELECT COUNT(*) FROM performance_schema.data_lock_waits)
+FROM information_schema.innodb_trx'
+
+end=$(( $(date +%s) + DURATION ))
+while [ "$(date +%s)" -lt "$end" ]; do
+  ts=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
+  row=$(mysql -u root -p"$MYSQL_ROOT_PASSWORD" -N -B -e "$SQL" | tr '\t' ',')
+  echo "${ts},${row}"
+  sleep "$INTERVAL"
+done
+EOS

--- a/load-test/chaos/seat-release-singletrx.override.yml
+++ b/load-test/chaos/seat-release-singletrx.override.yml
@@ -1,0 +1,26 @@
+# #345 측정 전용 — seat-service의 만료 해제를 "단일 트랜잭션" 비교군으로 임시 전환하는 compose override.
+# 프로덕션 반영이 아니다. 측정이 끝나면 반드시 원복한다.
+#
+# 원리: chunkSize x maxChunks가 곧 (트랜잭션 범위) x (tick당 청크 수)다. chunk-size를 코호트 전량으로,
+#   max-chunks를 1로 주면 SeatReleaseExpiredUseCase의 루프가 한 번만 돌아 2,000건이 단일 트랜잭션으로
+#   커밋된다. 벤치용 브랜치나 토글 코드가 필요 없다(application.yml 운영값은 25 x 80).
+#
+# 바인딩 확인: 만료 2,000건에 이 설정이면 fetched == chunkSize이고 processedChunks == maxChunks라
+#   SeatReleaseExpiredUseCase의 상한 도달 경고가 "chunkSize=2000 x maxChunks=1"을 그대로 찍는다.
+#   그 로그가 곧 env가 먹었다는 증거다(actuator/env는 노출 대상이 아니라 쓸 수 없다).
+#
+# ⚠ .env의 IMAGE_TAG가 실행 중 컨테이너보다 뒤처져 있을 수 있다(CD가 배포 시점에만 주입).
+#   up은 의존 서비스까지 재생성하므로 현재 태그를 확인해 반드시 명시한다:
+#   TAG=$(docker inspect gateway-service --format '{{.Config.Image}}' | cut -d: -f2)
+# 적용:  IMAGE_TAG=$TAG docker compose -f docker-compose.prod.yml -f seat-release-singletrx.override.yml up -d seat-service
+# 원복:  IMAGE_TAG=$TAG docker compose -f docker-compose.prod.yml up -d seat-service
+#
+# ⚠ 10,000건 arm에는 쓰지 않는다. seat-service의 mem_limit이 640m이고, 단일 트랜잭션이
+#   ShedLock lockAtMostFor=2m를 넘기면 락이 풀려 중복 실행 창이 열린다.
+services:
+  seat-service:
+    environment:
+      # Spring이 app.seat.release.chunk-size 조회 시 dot/dash를 '_'로 치환해 이 env를 찾는다
+      # (booking-outbox.override.yml의 APP_EVENT_PUBLISHER_TYPE과 같은 규칙).
+      APP_SEAT_RELEASE_CHUNK_SIZE: 2000
+      APP_SEAT_RELEASE_MAX_CHUNKS: 1

--- a/load-test/seed/seed_expired_holds.sql
+++ b/load-test/seed/seed_expired_holds.sql
@@ -28,6 +28,15 @@ SET @load_email    = 'loadtest@ticketrush.local';
 -- 코호트 전용 booking_number 프리픽스. 'LT-' 로 시작하므로 cleanup_load.sql 의 'LT-%' 패턴에도 걸린다.
 SET @cohort_prefix = 'LT-X';
 
+-- ---- ⚠ 앱 시계와 DB 세션 시계가 다르다 -------------------------------------
+-- hold_expired_at 은 앱의 LocalDateTime.now() 와 비교된다(findExpiredHoldSeats). 배포본 앱 컨테이너는
+-- UTC 로 돌지만 MySQL 컨테이너는 system_time_zone=KST 라 세션 NOW() 가 9시간 앞선다. NOW() 로 시딩하면
+-- 좌석이 '9시간 뒤 만료'로 저장되어 스케줄러가 매 tick 돌면서도 0건을 처리한다(에러도 로그도 안 남는다).
+-- 실측에서 실제로 그렇게 헛돌았다. 그래서 앱 시계 기준 시각을 따로 잡아 전 구간에 쓴다.
+--   * 앱과 MySQL 시계가 같은 로컬 스택이면 NOW() 로 바꿔도 된다.
+--   * 아래 검증 쿼리가 두 시계를 함께 출력하므로 실행 전 눈으로 확인할 수 있다.
+SET @app_now = UTC_TIMESTAMP();
+
 SET @load_user_id = (SELECT id FROM `user` WHERE email = @load_email);
 
 -- ---- 1) 리셋 — 직전 회차 코호트 제거 ---------------------------------------
@@ -35,19 +44,15 @@ SET @load_user_id = (SELECT id FROM `user` WHERE email = @load_email);
 -- 새 측정 창에 섞이지 않는다. outbox 대상은 booking 행에서 aggregate_id 를 찾으므로 booking 삭제보다 앞이어야 한다.
 -- (docs/load-test-guide.md §10.2 가 #344 측정에서 확립한 순서)
 
--- 좌석 만료 이벤트: SeatHoldExpiredEvent.aggregateId() = String.valueOf(seatId)
+-- 지워야 할 것은 <b>미발행</b> 행뿐이다. SENT 는 릴레이가 다시 집지 않아 다음 창을 오염시키지 못한다.
+-- 그래서 aggregate_id 로 코호트를 특정하지 않고 status 로 좁힌다 — outbox 에는 (event_type, aggregate_id)
+-- 인덱스가 없어서(status·aggregate_type 조합만 있다) aggregate_id IN (2,000건) 은 5만 행 풀스캔 두 번이 된다.
+-- 실측에서 그 두 문장이 시딩 시간을 회차당 2분 30초로 늘렸다. status 조건은 idx_outbox_status_created_at 을 타고,
+-- 드레인이 끝난 상태에서는 보통 0행이다.
+--   ⚠ 이 DELETE 는 코호트 밖의 미발행 만료 이벤트까지 지운다. 부하테스트 전용 DB 전제(상단 가드)에서만 성립한다.
 DELETE FROM outbox
- WHERE event_type = 'SeatHoldExpiredEvent'
-   AND aggregate_id IN (
-     SELECT CAST(b.seat_id AS CHAR) FROM booking b
-      WHERE b.booking_number LIKE CONCAT(@cohort_prefix, '%'));
-
--- 예매 만료 이벤트: BookingExpiredEvent.aggregateId() = String.valueOf(bookingId)
-DELETE FROM outbox
- WHERE event_type = 'BookingExpiredEvent'
-   AND aggregate_id IN (
-     SELECT CAST(b.booking_id AS CHAR) FROM booking b
-      WHERE b.booking_number LIKE CONCAT(@cohort_prefix, '%'));
+ WHERE status IN ('PENDING', 'FAILED')
+   AND event_type IN ('SeatHoldExpiredEvent', 'BookingExpiredEvent');
 
 -- 전 회차가 다 소진되지 않고 끝난 경우 좌석이 HOLD 로 남아 있다. 되돌린다.
 UPDATE seat s
@@ -57,9 +62,9 @@ UPDATE seat s
 DELETE FROM booking WHERE booking_number LIKE CONCAT(@cohort_prefix, '%');
 
 -- ---- 2) 코호트 booking 생성 (PENDING) --------------------------------------
--- created_at 은 NOW() 다. 과거로 당기면 booking-service 의 BookingExpireUseCase(cutoff = now - 5분)가
--- 이 코호트를 따로 물어 좌석 경로 측정이 오염된다. 예매 만료는 SeatHoldExpiredEvent 경유(프로덕션 경로)로만
--- 일어나게 둔다.
+-- created_at 은 앱 시계의 '지금'이다. 과거로 당기면 booking-service 의 BookingExpireUseCase
+-- (cutoff = now - 5분)가 이 코호트를 따로 물어 좌석 경로 측정이 오염된다. 예매 만료는
+-- SeatHoldExpiredEvent 경유(프로덕션 경로)로만 일어나게 둔다.
 INSERT INTO booking
   (user_id, performance_id, seat_id, booking_number, booking_status, created_at, updated_at)
 WITH ranked AS (
@@ -71,31 +76,36 @@ WITH ranked AS (
   WHERE s.seat_status = 'AVAILABLE'
 )
 SELECT @load_user_id, r.performance_id, r.seat_id,
-       CONCAT(@cohort_prefix, LPAD(r.gseq, 9, '0')), 'PENDING', NOW(), NOW()
+       CONCAT(@cohort_prefix, LPAD(r.gseq, 9, '0')), 'PENDING', @app_now, @app_now
 FROM ranked r
 WHERE r.gseq <= @expired_count;
 
 -- ---- 3) 좌석을 '이미 만료된 HOLD' 로 전이 ----------------------------------
--- hold_expired_at 을 과거로 둬서 시드 완료 시점에 곧바로 만료 대상이 된다. Redis 락 키를 만들지 않으므로
--- SeatReleaseSingleUseCase(Redis 만료 리스너)는 개입하지 않는다 — fallback 경로 단독 측정이 성립한다.
+-- hold_expired_at 을 앱 시계 기준 과거로 둬서 시드 완료 시점에 곧바로 만료 대상이 된다(위 @app_now 주의).
+-- Redis 락 키를 만들지 않으므로 SeatReleaseSingleUseCase(Redis 만료 리스너)는 개입하지 않는다 —
+-- fallback 경로 단독 측정이 성립한다.
 UPDATE seat s
   JOIN booking b ON b.seat_id = s.seat_id
                 AND b.booking_number LIKE CONCAT(@cohort_prefix, '%')
    SET s.seat_status     = 'HOLD',
        s.booking_number  = b.booking_number,
-       s.hold_expired_at = NOW() - INTERVAL 1 MINUTE
+       s.hold_expired_at = @app_now - INTERVAL 1 MINUTE
  WHERE s.seat_status = 'AVAILABLE' AND b.booking_status = 'PENDING';
 
 -- ---- 검증 쿼리 -------------------------------------------------------------
 -- cohort_bookings 와 expired_hold_seats 가 @expired_count 와 모두 같아야 한다.
 -- 작으면 LOADTEST AVAILABLE 좌석이 부족한 것이다 -> seed_load.sql 의 @cols_per 를 키워 재시딩한다.
+-- db_now 와 app_now 가 다르면 정상이다(DB=KST / 앱=UTC). 만료 판정은 app_now 기준이며, 이 값이
+-- 실제 앱 컨테이너의 시계(`docker exec seat-service date`)와 같은지 첫 실행 때 한 번 확인한다.
+SELECT NOW() AS db_now, @app_now AS app_now_used;
+
 SELECT
   @expired_count AS requested,
   (SELECT COUNT(*) FROM booking
      WHERE booking_number LIKE CONCAT(@cohort_prefix, '%'))                  AS cohort_bookings,
   (SELECT COUNT(*) FROM seat
      WHERE booking_number LIKE CONCAT(@cohort_prefix, '%')
-       AND seat_status = 'HOLD' AND hold_expired_at <= NOW())                AS expired_hold_seats,
+       AND seat_status = 'HOLD' AND hold_expired_at <= @app_now)             AS expired_hold_seats,
   (SELECT COUNT(*) FROM seat s
      JOIN performance p ON p.performance_id = s.performance_id
                        AND p.title LIKE CONCAT(@marker, '-%')

--- a/load-test/seed/seed_expired_holds.sql
+++ b/load-test/seed/seed_expired_holds.sql
@@ -1,0 +1,102 @@
+-- ============================================================================
+-- #345 만료 코호트 시딩 — 대량 만료 청크 트랜잭션 before/after 측정용
+--   seed_load.sql 이 만든 LOADTEST 공연/좌석/계정을 전제로, 그 중 AVAILABLE 좌석
+--   @expired_count 건을 "이미 만료된 HOLD"로 만든다. 좌석 만료 fallback
+--   (SeatStatusScheduler -> SeatReleaseExpiredUseCase) 이 다음 tick 에 이 코호트를 집어간다.
+--   ⚠ 로컬/부하테스트 전용 DB에서만 실행할 것 (공유/운영 DB 금지).
+--
+--   seed_load.sql 의 @booking_pct 는 hold_expired_at = NOW() + 5분(미만료)이라 이 측정에 쓸 수 없다.
+--   런북: docs/load-test-guide.md §11
+--
+--   리셋 + 시드가 한 파일에 들어 있어 매 회차 앞에 한 번만 돌리면 된다.
+--     mysql --init-command="SET @i_confirm_loadtest_db=1" ... < seed_expired_holds.sql
+-- ============================================================================
+
+-- ---- 오실행 가드 -----------------------------------------------------------
+-- seed_load.sql 과 동일 규약. 변수가 없으면 없는 테이블을 PREPARE 하다 ERROR 1146 으로 즉시 중단된다.
+SET @stmt := IF(COALESCE(@i_confirm_loadtest_db, 0) = 1,
+                'SELECT ''guard ok'' AS guard',
+                'SELECT * FROM `ABORT__run_with_i_confirm_loadtest_db_eq_1`');
+PREPARE guard_check FROM @stmt;
+EXECUTE guard_check;
+DEALLOCATE PREPARE guard_check;
+
+-- ---- 규모 파라미터 (여기만 조정) -------------------------------------------
+SET @expired_count = 2000;   -- 만료 코호트 크기. 2000 = tick당 처리 상한(25 x 80) / 10000 = 최소 5 tick
+SET @marker        = 'LOADTEST';
+SET @load_email    = 'loadtest@ticketrush.local';
+-- 코호트 전용 booking_number 프리픽스. 'LT-' 로 시작하므로 cleanup_load.sql 의 'LT-%' 패턴에도 걸린다.
+SET @cohort_prefix = 'LT-X';
+
+SET @load_user_id = (SELECT id FROM `user` WHERE email = @load_email);
+
+-- ---- 1) 리셋 — 직전 회차 코호트 제거 ---------------------------------------
+-- 순서는 outbox -> booking -> seat 다. outbox 를 먼저 지워야 전 회차의 미발행 PENDING 행이 릴레이를 타고
+-- 새 측정 창에 섞이지 않는다. outbox 대상은 booking 행에서 aggregate_id 를 찾으므로 booking 삭제보다 앞이어야 한다.
+-- (docs/load-test-guide.md §10.2 가 #344 측정에서 확립한 순서)
+
+-- 좌석 만료 이벤트: SeatHoldExpiredEvent.aggregateId() = String.valueOf(seatId)
+DELETE FROM outbox
+ WHERE event_type = 'SeatHoldExpiredEvent'
+   AND aggregate_id IN (
+     SELECT CAST(b.seat_id AS CHAR) FROM booking b
+      WHERE b.booking_number LIKE CONCAT(@cohort_prefix, '%'));
+
+-- 예매 만료 이벤트: BookingExpiredEvent.aggregateId() = String.valueOf(bookingId)
+DELETE FROM outbox
+ WHERE event_type = 'BookingExpiredEvent'
+   AND aggregate_id IN (
+     SELECT CAST(b.booking_id AS CHAR) FROM booking b
+      WHERE b.booking_number LIKE CONCAT(@cohort_prefix, '%'));
+
+-- 전 회차가 다 소진되지 않고 끝난 경우 좌석이 HOLD 로 남아 있다. 되돌린다.
+UPDATE seat s
+   SET s.seat_status = 'AVAILABLE', s.booking_number = NULL, s.hold_expired_at = NULL
+ WHERE s.booking_number LIKE CONCAT(@cohort_prefix, '%');
+
+DELETE FROM booking WHERE booking_number LIKE CONCAT(@cohort_prefix, '%');
+
+-- ---- 2) 코호트 booking 생성 (PENDING) --------------------------------------
+-- created_at 은 NOW() 다. 과거로 당기면 booking-service 의 BookingExpireUseCase(cutoff = now - 5분)가
+-- 이 코호트를 따로 물어 좌석 경로 측정이 오염된다. 예매 만료는 SeatHoldExpiredEvent 경유(프로덕션 경로)로만
+-- 일어나게 둔다.
+INSERT INTO booking
+  (user_id, performance_id, seat_id, booking_number, booking_status, created_at, updated_at)
+WITH ranked AS (
+  SELECT s.seat_id, s.performance_id,
+         ROW_NUMBER() OVER (ORDER BY s.seat_id) AS gseq
+  FROM seat s
+  JOIN performance p ON p.performance_id = s.performance_id
+                    AND p.title LIKE CONCAT(@marker, '-%')
+  WHERE s.seat_status = 'AVAILABLE'
+)
+SELECT @load_user_id, r.performance_id, r.seat_id,
+       CONCAT(@cohort_prefix, LPAD(r.gseq, 9, '0')), 'PENDING', NOW(), NOW()
+FROM ranked r
+WHERE r.gseq <= @expired_count;
+
+-- ---- 3) 좌석을 '이미 만료된 HOLD' 로 전이 ----------------------------------
+-- hold_expired_at 을 과거로 둬서 시드 완료 시점에 곧바로 만료 대상이 된다. Redis 락 키를 만들지 않으므로
+-- SeatReleaseSingleUseCase(Redis 만료 리스너)는 개입하지 않는다 — fallback 경로 단독 측정이 성립한다.
+UPDATE seat s
+  JOIN booking b ON b.seat_id = s.seat_id
+                AND b.booking_number LIKE CONCAT(@cohort_prefix, '%')
+   SET s.seat_status     = 'HOLD',
+       s.booking_number  = b.booking_number,
+       s.hold_expired_at = NOW() - INTERVAL 1 MINUTE
+ WHERE s.seat_status = 'AVAILABLE' AND b.booking_status = 'PENDING';
+
+-- ---- 검증 쿼리 -------------------------------------------------------------
+-- cohort_bookings 와 expired_hold_seats 가 @expired_count 와 모두 같아야 한다.
+-- 작으면 LOADTEST AVAILABLE 좌석이 부족한 것이다 -> seed_load.sql 의 @cols_per 를 키워 재시딩한다.
+SELECT
+  @expired_count AS requested,
+  (SELECT COUNT(*) FROM booking
+     WHERE booking_number LIKE CONCAT(@cohort_prefix, '%'))                  AS cohort_bookings,
+  (SELECT COUNT(*) FROM seat
+     WHERE booking_number LIKE CONCAT(@cohort_prefix, '%')
+       AND seat_status = 'HOLD' AND hold_expired_at <= NOW())                AS expired_hold_seats,
+  (SELECT COUNT(*) FROM seat s
+     JOIN performance p ON p.performance_id = s.performance_id
+                       AND p.title LIKE CONCAT(@marker, '-%')
+    WHERE s.seat_status = 'AVAILABLE')                                       AS remaining_available;

--- a/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/app/scheduler/SeatHeldGaugeMetrics.java
+++ b/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/app/scheduler/SeatHeldGaugeMetrics.java
@@ -20,14 +20,23 @@ public class SeatHeldGaugeMetrics {
   private final SeatRepository seatRepository;
 
   private final AtomicLong heldSeats = new AtomicLong(0);
+  private final AtomicLong expiredHoldBacklog = new AtomicLong(0);
 
   @PostConstruct
   public void init() {
     Gauge.builder(MetricNames.SEAT_HELD, heldSeats, AtomicLong::get).register(meterRegistry);
+    Gauge.builder(MetricNames.SEAT_HOLD_EXPIRED_BACKLOG, expiredHoldBacklog, AtomicLong::get)
+        .register(meterRegistry);
   }
 
+  /**
+   * 두 게이지를 <b>같은 기준 시각</b>으로 갱신한다. 시각을 따로 뜨면 두 카운트가 서로 다른 경계로 갈려 합이 전체 HOLD 수와 어긋난다(대량 만료가 진행되는
+   * 구간에서 특히 눈에 띈다).
+   */
   @Scheduled(fixedDelay = 30000)
   public void refreshHeldSeats() {
-    heldSeats.set(seatRepository.countHeldSeats(SeatStatus.HOLD, LocalDateTime.now()));
+    LocalDateTime now = LocalDateTime.now();
+    heldSeats.set(seatRepository.countHeldSeats(SeatStatus.HOLD, now));
+    expiredHoldBacklog.set(seatRepository.countExpiredHoldSeats(SeatStatus.HOLD, now));
   }
 }

--- a/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/out/repository/SeatRepository.java
+++ b/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/out/repository/SeatRepository.java
@@ -114,4 +114,14 @@ public interface SeatRepository extends JpaRepository<Seat, Long> {
 
   @Query("select count(s) from Seat s where s.seatStatus = :hold and s.holdExpiredAt > :now")
   long countHeldSeats(@Param("hold") SeatStatus hold, @Param("now") LocalDateTime now);
+
+  /**
+   * 만료됐지만 아직 해제되지 않은 HOLD 좌석 수 = 만료 fallback의 처리 적체.
+   *
+   * <p>비교 연산자는 {@link #findExpiredHoldSeats}와 같은 {@code <=}다. 게이지가 세는 집합과 스케줄러가 실제로 집어가는 집합이 어긋나면
+   * 적체 곡선이 해제 진행을 따라가지 않는다. {@link #countHeldSeats}({@code > :now})와는 상호배타라 두 카운트의 합이 전체 HOLD 좌석
+   * 수다.
+   */
+  @Query("select count(s) from Seat s where s.seatStatus = :hold and s.holdExpiredAt <= :now")
+  long countExpiredHoldSeats(@Param("hold") SeatStatus hold, @Param("now") LocalDateTime now);
 }

--- a/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/out/repository/SeatRepositoryTest.java
+++ b/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/out/repository/SeatRepositoryTest.java
@@ -420,6 +420,38 @@ class SeatRepositoryTest {
     assertThat(persisted.getBookingNumber()).isEqualTo("BOOK-WINNER");
   }
 
+  @Test
+  @DisplayName("미만료 HOLD와 만료 HOLD를 상호배타적으로 세고, 만료 시각이 기준시와 같으면 만료 쪽으로 센다 (#345)")
+  void countHeldSeats_AndCountExpiredHoldSeats_SplitAtSameBoundary() {
+    // given: countHeldSeats(> now)와 countExpiredHoldSeats(<= now)가 같은 경계에서 갈려야
+    // 두 카운트 합이 전체 HOLD가 되고, 적체 게이지가 스케줄러가 집어가는 집합(findExpiredHoldSeats)과 일치한다.
+    final Seat boundary =
+        seatRepository.save(buildSeat("A1", SeatStatus.HOLD, LocalDateTime.now(), "BOOK-1"));
+    seatRepository.save(
+        buildSeat("A2", SeatStatus.HOLD, LocalDateTime.now().minusMinutes(1), "BOOK-2"));
+    seatRepository.save(
+        buildSeat("A3", SeatStatus.HOLD, LocalDateTime.now().plusMinutes(5), "BOOK-3"));
+    // HOLD가 아닌 좌석은 어느 쪽에도 들어가지 않는다
+    seatRepository.save(
+        buildSeat("A4", SeatStatus.SOLD, LocalDateTime.now().minusMinutes(1), "BOOK-4"));
+    entityManager.flush();
+    entityManager.clear();
+
+    // 기준시는 DB에 저장된 값을 되읽어 쓴다. datetime(6)은 마이크로초라 앱이 만든 나노초 값을 그대로 쓰면
+    // 경계 좌석이 어느 쪽에도(또는 양쪽에) 걸릴 수 있다.
+    LocalDateTime now = seatRepository.findById(boundary.getId()).orElseThrow().getHoldExpiredAt();
+
+    // when
+    long held = seatRepository.countHeldSeats(SeatStatus.HOLD, now);
+    long expiredBacklog = seatRepository.countExpiredHoldSeats(SeatStatus.HOLD, now);
+
+    // then: 경계 좌석은 만료 쪽으로 간다
+    assertThat(held).isEqualTo(1L);
+    assertThat(expiredBacklog).isEqualTo(2L);
+    assertThat(seatRepository.findExpiredHoldSeats(SeatStatus.HOLD, now, PageRequest.of(0, 10)))
+        .hasSize((int) expiredBacklog);
+  }
+
   private Seat buildSeat(
       String seatNumber, SeatStatus status, LocalDateTime holdExpiredAt, String bookingNumber) {
     return Seat.builder()


### PR DESCRIPTION
## 🔗 관련 이슈

- #345 (측정 선행 작업 — 이 PR은 이슈를 닫지 않는다)

> **후속 (2026-07-25 추가).** 이 PR 머지 후 EC2 배포본에서 실측을 완료했다. 증적·리포트는 **PR #488** 이며, 이슈 완료조건의 마지막 항목(Grafana 그래프 캡처)만 남았다.
> 실측으로 확정된 것: 최장 트랜잭션 중위 **3,211.7 ms → 76.0 ms (42.3배 단축)**, `ticketrush_seat_held`는 측정 전 구간 **0.00** (이 PR이 게이지를 추가한 근거가 수치로 확인됐다), 커넥션 풀 압박은 단일 스레드 경로라 구조적으로 발생하지 않음(`pending` 전 구간 0).

---

## 📌 주요 변경 사항

- `ticketrush.seat.hold.expired_backlog` 게이지 추가 — `seat_held`로는 대량 만료 해소가 관측되지 않는다
- 단일 트랜잭션 비교군을 **코드 변경 없이** compose override로 구성
- 만료 코호트 시딩 SQL + MySQL 트랜잭션·락 샘플러 추가
- 런북 `docs/load-test-guide.md` §11 신설

---

## 🛠 상세 구현 내용

- **관측 공백 해소.** `seat_held` 게이지의 원천인 `countHeldSeats`는 `hold_expired_at > now`라 **미만료** HOLD만 센다. 만료됐으나 아직 해제되지 않은 좌석 — #345가 재려는 적체 — 은 처음부터 게이지 밖이라, 만료 코호트를 시딩하면 곡선이 0에서 시작해 0으로 끝난다. #484가 고친 스케줄러 스레드 굶주림과 별개인 **지표 정의 자체의 공백**이다. `outbox_backlog`의 좌석 버전으로 `countExpiredHoldSeats` + Gauge를 추가했다.
- **집합 정합.** 새 카운트의 비교 연산자를 스케줄러가 실제로 집어가는 `findExpiredHoldSeats`와 같은 `<=`로 맞췄다. 어긋나면 적체 곡선이 해제 진행을 따라가지 않는다. 두 게이지는 **같은 기준 시각**으로 갱신한다 — 시각을 따로 뜨면 합이 전체 HOLD와 어긋난다.
- **단일 트랜잭션 비교군(`seat-release-singletrx.override.yml`).** `chunkSize` × `maxChunks`가 곧 (트랜잭션 범위) × (tick당 청크 수)다. `chunk-size=2000` / `max-chunks=1`이면 `SeatReleaseExpiredUseCase`의 루프가 한 번만 돌아 전량이 단일 트랜잭션으로 커밋된다. 벤치용 브랜치도 토글 코드도 필요 없다. actuator/env가 노출 대상이 아니라 바인딩 확증은 처리 상한 도달 경고 로그(`chunkSize=2000 x maxChunks=1`)로 한다.
- **10,000건 단일 트랜잭션은 배제**했다. seat-service `mem_limit`이 640m이고, 단일 트랜잭션이 ShedLock `lockAtMostFor=2m`를 넘기면 락이 풀려 중복 실행 창이 열린다. 2,000건이 tick당 처리 상한과 같은 크기라 그 지점의 A/B가 정직한 대조다.
- **`seed_expired_holds.sql`.** `seed_load.sql`의 `@booking_pct`는 `hold_expired_at = NOW() + 5분`(미만료)이라 쓸 수 없다. 리셋(outbox → booking → seat)과 시드를 한 파일에 담아 회차마다 한 번만 돌린다. 코호트 `created_at`은 `NOW()` — 과거로 당기면 `BookingExpireUseCase`(cutoff = now−5분)가 따로 물어 좌석 경로 측정이 오염된다. Redis 락 키를 만들지 않으므로 fallback 경로 단독 측정이 성립한다.
- **`trx-sampler.sh`.** 앱에 트랜잭션 지속시간 계측이 없어 `information_schema.innodb_trx`를 1초 간격으로 뜬다. 루프를 컨테이너 안에서 돌려 `docker exec` 오버헤드를 간격에서 뺐다.
- **런북 §11.** 절 앞머리에 이슈 서사와 실측의 차이를 명시했고, 사전 점검에 `SHOW INDEX FROM seat` 확인을 넣었다 — 인덱스가 없으면 청크 조회가 tick당 80회 풀스캔이 되어 측정값이 인덱스 결함과 섞인다.

---

## ✅ 테스트

### 테스트 방법

- 단위/통합: `./gradlew :common:test :seat-service:test`
  - `SeatRepositoryTest#countHeldSeats_AndCountExpiredHoldSeats_SplitAtSameBoundary` 신규 — `hold_expired_at == now`가 만료 쪽으로 갈리고, 두 카운트 합이 전체 HOLD와 같고, 만료 카운트가 `findExpiredHoldSeats` 결과 수와 일치함을 검증. 기준시는 DB에서 되읽어 쓴다(`datetime(6)` 절삭으로 경계가 빗나가는 함정).
- 정적 검사: `./gradlew spotlessCheck` + `checkstyleMain checkstyleTest`(common·seat-service), 전 모듈 `compileJava compileTestJava`
- 측정 자산: MySQL 8.0 컨테이너에 `001-ticket-rush-schema.sql` → `seed_load.sql` 적용 후 `seed_expired_holds.sql` 실행
- 샘플러: 같은 컨테이너에 (a) 504행을 잠그고 6초 대기하는 트랜잭션, (b) 같은 행을 다투는 2개 트랜잭션을 만들어 실행

### 테스트 결과

- `:common:test`, `:seat-service:test` 전체 통과
- `spotlessCheck` / `checkstyle` / 전 모듈 컴파일 통과
- `seed_expired_holds.sql`: `requested=2000 / cohort_bookings=2000 / expired_hold_seats=2000` 일치. 재실행 시 동일 결과(리셋+재시드 멱등). 가드 미지정 실행은 `ERROR 1146`으로 본문 실행 전 중단. 코호트 밖 outbox 행은 리셋 후에도 보존됨을 확인
- `trx-sampler.sh`: 트랜잭션 지속시간 증가(1.20s → 6.27s)·`max_rows_locked=504` 추적 확인, 실측 샘플 간격 1.01s. 락 대기 케이스에서 `lock_wait_trx=1`·`data_lock_waits=1` 검출 확인
<!--
### 📸 스크린샷

- 해당 없음 — UI 변경이 없는 계측·측정 자산 PR이다. 측정 결과 그래프는 증적 PR #488 에 속하며, Grafana 이미지 렌더러 플러그인이 없어 SSH 터널 수동 캡처가 필요하다(쿼리·시간범위는 `load-tests/k6/results/260725-345-chunk-trx/report.md` §10).
-->
---

## 👀 리뷰 요청 사항

- **게이지 추가의 범위 판단.** 이슈 라벨은 `test`인데 프로덕션 계측이 한 건 들어간다. 대안(SQL 폴링만)으로는 완료조건의 "Grafana 그래프 캡처"를 못 채우고, 만료 fallback의 적체를 보여주는 게이지가 지금 하나도 없다는 점을 근거로 포함했다.
- `countExpiredHoldSeats`와 `countHeldSeats`가 상호배타라는 전제(합 = 전체 HOLD)가 `hold_expired_at IS NULL`인 HOLD 행이 없다는 데 의존한다. `Seat.hold()`가 null 시각을 거부하고 시각을 null로 되돌리는 경로는 동시에 HOLD를 벗어나므로 성립한다고 봤다 — 반례가 있으면 지적 바란다.
- 두 게이지를 한 스케줄러 메서드(30초)에서 갱신한다. 만료 코호트 규모에서 `COUNT(*)` 두 번이 인덱스로 커버되는지(§11.4의 인덱스 사전 점검과 같은 맥락).

---

## ⚠️ 배포 시 주의사항

- **DDL 없음. 스키마 변경 없음.** 새 게이지는 조회 전용이다.
- 측정 전 **`SHOW INDEX FROM seat`에 `idx_seat_status_hold_expired_at`이 있는지 확인**해야 한다. `@Table`의 `@Index`는 prod(`ddl-auto=validate`)에서 부재가 검출되지 않는다(#296 관행, `Seat` javadoc의 `ALTER` 문 참조).
- `load-test/chaos/seat-release-singletrx.override.yml`은 **측정 전용**이다. 적용 시 `IMAGE_TAG`를 현재 컨테이너 태그로 명시하고(가이드 §8.4), 측정 후 반드시 원복한다.
- `seed_expired_holds.sql`은 로컬/부하테스트 전용 DB에서만 실행한다(`@i_confirm_loadtest_db=1` 가드).

