### PR TITLE
[Docs] #345 리포트 §6.1 정정 — 좌석 확정 실패는 DLT가 아니라 409 warn으로 사라진다

### DIFF
--- a/load-tests/k6/results/260725-345-chunk-trx/report.md
+++ b/load-tests/k6/results/260725-345-chunk-trx/report.md
@@ -150,9 +150,21 @@ ALTER TABLE seat ADD INDEX idx_seat_status_hold_expired_at (seat_status, hold_ex
 
 **정합성 문제는 아니다** — 트랜잭셔널 Outbox의 at-least-once 설계대로 전부 발행되고, booking-service가 10,000건을 모두 EXPIRED로 전이했다(`bk_expired=10000`, `bk_pending=0`). 다만 **"만료 좌석이 AVAILABLE로 돌아온 시점"과 "예매가 EXPIRED로 보이는 시점"이 최대 8분 이상 벌어진다.** 릴레이 발행 상한 20/s는 #344가 이미 파이프라인의 1차 제약으로 지목한 값이고, 대량 만료는 그 상한을 정면으로 때리는 경로다.
 
-그 지연은 단순한 가시화 지체가 아니다. `PaymentConfirmUseCase:82-85`의 만료 가드가 **이벤트 도착에 의존**하고(`expiredBookingRepository.existsByBookingId`, `BookingExpiredEvent`로 채워진다), 그 이벤트는 릴레이를 **두 홉**(seat→booking, booking→payment) 타야 한다. 창 안에서 결제가 들어오면 가드를 통과해 PG 승인이 실행되고(과금 발생), 이어지는 `SeatConfirmSoldUseCase:28`의 `confirmSoldById`가 이미 AVAILABLE·`booking_number = NULL`인 좌석을 만나 `updated = 0` → `SEAT_NOT_AVAILABLE`(`:45`) → 재시도 → DLT로 간다. **과금은 됐고 `Payment`는 COMPLETED인데 좌석이 확정되지 않는 상태다.** 창 자체는 릴레이 속도와 무관하게 존재하지만(주석이 "best-effort"라 적는 이유다) 릴레이 상한이 그것을 초 단위에서 분 단위로 늘린다.
+그 지연은 단순한 가시화 지체가 아니다. `PaymentConfirmUseCase:82-85`의 만료 가드가 **이벤트 도착에 의존**하고(`expiredBookingRepository.existsByBookingId`, `BookingExpiredEvent`로 채워진다), 그 이벤트는 릴레이를 **두 홉**(seat→booking, booking→payment) 타야 한다. 창 안에서 결제가 들어오면 이렇게 진행된다.
 
-> **후속: #489** (`[공통]` / `fix`). 발행 처리량을 생성률 이상으로 올리는 것이 그 이슈의 범위다. 가드를 이벤트 의존에서 떼는 근본 해법은 payment-service 담당 경계라 별도로 다룬다.
+1. 가드 통과 → PG 승인 실행 → **실제 과금** → `Payment` COMPLETED → `PaymentConfirmedEvent`
+2. **booking-service** `PaymentConfirmedEventListener:81` → `seatRestClient.confirmSold(...)` → seat-service `POST /api/v1/internal/seat/sold`
+3. `SeatConfirmSoldUseCase:28`의 `confirmSoldById`가 이미 `AVAILABLE`·`booking_number = NULL`인 좌석을 만나 `updated = 0` → `:45`에서 `SEAT_NOT_AVAILABLE`
+4. `ErrorStatus.SEAT_NOT_AVAILABLE`은 **409 CONFLICT**(`ErrorStatus.java:112`)
+5. booking 리스너 `:85-92`가 409를 **"이미 확정된 좌석(중복 수신)"으로 해석** → `log.warn` → `ack`
+
+**과금은 됐고 `Payment`는 COMPLETED인데 좌석이 확정되지 않고, 남는 흔적은 "중복 수신" warn 한 줄뿐이다.** DLT도, CRITICAL도, 알림도 없다. 창 자체는 릴레이 속도와 무관하게 존재하지만(주석이 "best-effort"라 적는 이유다) 릴레이 상한이 그것을 초 단위에서 분 단위로 늘린다.
+
+> **정정 (2026-07-26).** 최초 작성 시 이 대목을 "`SEAT_NOT_AVAILABLE` → 재시도 → DLT"라고 적었는데 **틀렸다.** 확인해 보니 (a) seat-service에는 `PaymentConfirmedEvent` 리스너가 없다 — 이 이벤트를 받는 것은 booking-service이고 좌석 확정은 REST 동기 호출이다. (b) booking 리스너는 4xx를 명시적으로 ack하며(`:83-84` "4xx는 재시도해도 결과가 바뀌지 않는 결정적 응답이므로 삼키고 진행"), 그중 409는 정상 중복으로 분류해 `warn`으로 끝낸다. **실제 동작은 DLT보다 조용하다** — 재생할 메시지조차 남지 않는다.
+>
+> 그리고 **409가 두 결과를 뭉갠다**: 좌석이 이미 `SOLD`인 정상 중복(무해)과, 좌석이 만료 해제되어 그 예매의 것이 아닌 경우(치명적)가 같은 상태 코드로 도착한다. 이 구분을 만드는 것이 #489의 두 번째 축이다.
+
+> **후속: #489·#490.** #489(`[공통]`)가 ① 발행 처리량으로 창을 좁히고 ② 409 오분류를 갈라 실패를 관측 가능하게 만든다. #490(`[결제]`)이 결제 확정 전 예매 상태를 동기 확인해 잔여 창까지 막고, 좌석 확정 실패 시 보상 환불을 붙인다(②가 그 선행 신호다).
 
 ## 7. 결론
 
@@ -160,7 +172,7 @@ ALTER TABLE seat ADD INDEX idx_seat_status_hold_expired_at (seat_status, hold_ex
 2. **처리량 대가는 없다** — tick 총 소요가 두 arm에서 겹친다.
 3. **커넥션 풀 고갈 회피는 이 경로의 효과가 아니다** — 단일 스레드 경로라 `pending`이 구조적으로 0이다.
 4. **상한 동작은 설계대로다** — 10,000건이 정확히 5 tick, tick당 2,000건으로 소진됐다(5분 18초).
-5. **관측 공백 두 개를 확정했다** — `seat_held`는 만료 적체를 세지 않는다(PR #487에서 게이지 추가). 만료 이벤트 생성률이 릴레이 상한을 초과해 outbox가 단조 증가하고, 그 지연이 결제 만료 가드를 분 단위로 무력화한다(**#489**).
+5. **관측 공백 세 개를 확정했다** — `seat_held`는 만료 적체를 세지 않는다(PR #487에서 게이지 추가). 만료 이벤트 생성률이 릴레이 상한을 초과해 outbox가 단조 증가하고, 그 지연이 결제 만료 가드를 분 단위로 무력화한다(**#489**·**#490**). 그 실패가 409로 뭉개져 `warn` 한 줄로 사라진다(**#489**).
 
 ## 8. 한계·주의
 


### PR DESCRIPTION
## 🔗 관련 이슈

- #345 (종료됨 — 발행된 리포트의 사실 정정이라 이슈를 다시 열지 않는다)
- 이 정정으로 범위가 바뀐 이슈: #489 (409 오분류 축 추가), #490 (payment 대응 분리, @calla1102)

---

## 📌 주요 변경 사항

- `260725-345-chunk-trx/report.md` §6.1의 **인과 경로 서술 정정** — "좌석 확정 실패 → 재시도 → DLT"는 틀렸다. 실제로는 **409가 "이미 SOLD"로 오분류되어 `warn` 한 줄로 사라진다.**
- §7 결론 5와 후속 이슈 포인터를 #489·#490으로 갱신

**측정 수치와 결론은 영향 없다.** 정정된 것은 릴레이 적체가 만드는 위험을 서술한 문단이다.

---

## 🛠 상세 구현 내용

#490을 작성하며 경로를 코드로 다시 따라가다 발견했다.

### 틀렸던 것

- **"seat-service가 `PaymentConfirmedEvent`를 받는다"** — seat-service에는 그 리스너가 없다. 이벤트를 받는 것은 **booking-service**이고(`PaymentConfirmedEventListener`), 좌석 확정은 REST 동기 호출이다(`:81` → `POST /api/v1/internal/seat/sold`).
- **"재시도 → DLT"** — booking 리스너는 4xx를 명시적으로 ack한다(`:83-84` *"4xx는 재시도해도 결과가 바뀌지 않는 결정적 응답이므로 삼키고 진행"*). **실제 동작은 DLT보다 조용해서 재생할 메시지조차 남지 않는다.**

### 정정하면서 함께 확인된 것

`ErrorStatus.SEAT_NOT_AVAILABLE`은 **409 CONFLICT**(`ErrorStatus.java:112`)이고, 리스너 `:85-92`가 409를 "이미 확정된 좌석(중복 수신)"으로 분류해 `warn`으로 끝낸다. 즉 두 상황이 같은 코드로 도착해 뭉개진다.

| 상황 | 응답 | 실제 의미 |
|---|---|---|
| 좌석이 이미 `SOLD` | 409 | 정상 중복 — 무해 |
| 좌석이 만료 해제되어 그 예매의 것이 아님 | **409** | **과금 후 좌석 없음 — 치명적** |

관측(CRITICAL·알림)도 보상(자동 환불)도 불가능한 상태다. 이 발견으로 **#489의 범위를 넓혔고**(릴레이 처리량으로 창 좁히기 + 409 오분류 분리), **payment 쪽 대응은 #490으로 분리해 할당했다.**

---

## ✅ 테스트

### 테스트 방법

- 문서 변경만이라 실행 테스트는 없다. 정정 근거는 코드 확인이다 — `PaymentConfirmedEventListener`(booking-service), `SeatConfirmSoldUseCase`(seat-service), `ErrorStatus`(common), `SeatInternalController`(seat-service), `BookingInternalController`·`BookingInternalResponse`(booking-service).
- `SeatInternalController`·`BookingInternalController` 확인 결과 **#490의 해법(결제 확정 전 예매 상태 동기 확인)이 payment 단독으로 가능**하다는 것도 함께 확인했다 — booking 내부 API가 이미 `bookingStatus`를 반환하고, payment엔 `TicketRestClient` 호출 패턴이 이미 있다.

### 테스트 결과

- 해당 없음(문서). 리포트의 수치·표·증적 파일은 건드리지 않았다.

### 📸 스크린샷

- 해당 없음

---

## 👀 리뷰 요청 사항

- 정정 방식으로 **문단을 교체하고 그 아래 "정정 (2026-07-26)" 블록으로 무엇이 틀렸는지 남기는** 형태를 택했습니다. 발행된 증적은 조용히 고치면 이력이 사라지므로 #345 본문의 정정 코멘트 관례와 같은 방식을 따랐습니다. 이 방식이 적절한지 확인을 부탁드립니다.
- 409 오분류를 별도 이슈로 쪼개지 않고 **#489에 합쳤습니다**. 같은 사건(대량 만료 창)의 두 축이고 담당·모듈이 겹친다는 판단인데, 이견이 있으시면 지적해 주시기 바랍니다.

---

## ⚠️ 배포 시 주의사항

- 문서 변경만이라 배포 영향이 없다.
