### PR TITLE
[Refactor] #505 seat-service 응답 gzip 압축 활성화 — 221KB 가 회선을 먼저 채운다

### DIFF
--- a/docs/load-test-guide.md
+++ b/docs/load-test-guide.md
@@ -1080,10 +1080,16 @@ Nginx는 부하 경로에 있으면서(443 → `127.0.0.1:8080`) 자체 지표�
 |---|---|
 | 좌석맵 응답(공연당 2,080석) | **221KB** (좌석당 107.6 bytes) |
 | 조회 여정 1회 중 좌석맵 비중 | **99.05%** (목록 1,775B + 상세 367B + 좌석맵 223,720B) |
-| gzip | **미적용** — `Accept-Encoding: gzip` 을 보내도 크기 동일, `Content-Encoding` 없음 |
+| gzip | 측정 당시 **미적용** — `Accept-Encoding: gzip` 을 보내도 크기 동일, `Content-Encoding` 없음 |
 | gzip level 6 적용 시 | **9,709B (95.66% 절감)** |
 
-원인은 두 겹이다. Spring Boot 의 `server.compression.enabled` 기본값이 false 이고 어느 서비스 yml 에도 설정이 없으며, 호스트 Nginx 에도 gzip 지시어가 없다(`docs/production-domain-https.md` §7).
+원인은 두 겹이었다. Spring Boot 의 `server.compression.enabled` 기본값이 false 이고 어느 서비스 yml 에도 설정이 없으며, 호스트 Nginx 에도 gzip 지시어가 없다(`docs/production-domain-https.md` §7).
+
+> **✅ 해소됨 — `#505`.** seat-service 의 `application.yml` 에 `server.compression.enabled: true` 를 켰다(앱 origin 압축, 선택 근거는 `load-tests/k6/results/260727-348-openrun-e2e/report.md` §3.4). 로컬 실측으로 `Content-Encoding: gzip` 과 11.8배 축소를 확인했다(9,771B → 830B).
+>
+> **`min-response-size`(기본 2KB)가 걸러 줄 것이라는 예상은 틀렸다.** Tomcat 의 `CompressionConfig` 는 `contentLength != -1 && contentLength < min` 일 때만 제외하는데, MVC 컨트롤러 응답은 `Transfer-Encoding: chunked` 라 길이가 -1 이라서 크기 판정을 건너뛴다. 결과적으로 **seat-service 의 작은 JSON 응답도 함께 압축된다**(실측: `seat-counts` 199B → 185B). 길이를 알리는 actuator 응답(49B)은 예상대로 제외됐다. 압축 CPU 를 측정할 때 "좌석맵 하나만 압축된다"고 가정하지 말 것.
+>
+> **아래 캘리브레이션 값(조회 ≤ 10 iter/s)은 221KB 응답 기준이라 압축 적용 후에는 무의미하다** — 스모크로 새 무릎을 다시 잡아야 한다.
 
 **측정 관점에서 이것이 뜻하는 바:**
 

--- a/docs/production-domain-https.md
+++ b/docs/production-domain-https.md
@@ -215,6 +215,8 @@ server {
 }
 ```
 
+> **gzip 지시어가 없는 것은 의도적이다(`#505`).** 응답 압축은 nginx 가 아니라 **각 앱 origin** 에서 건다(현재 seat-service). 앱 8개와 관측 스택이 2 vCPU 한 대에 동거하는 구성이라(ADR 0007) 압축 CPU 를 nginx 한 곳에 몰면 그 자체가 새 병목이 되고, origin 압축은 내부 홉(서비스→게이트웨이) 전송량까지 함께 줄인다. 비교표는 `load-tests/k6/results/260727-348-openrun-e2e/report.md` §3.4 참고. 위 설정은 클라이언트의 `Accept-Encoding` 을 지우지 않으므로(`proxy_set_header Accept-Encoding ""` 없음) 헤더가 상류로 그대로 전달되고, 앱이 붙인 `Content-Encoding: gzip` 도 그대로 내려온다.
+
 설정 활성화:
 
 ```bash

--- a/seat-service/src/main/resources/application.yml
+++ b/seat-service/src/main/resources/application.yml
@@ -1,6 +1,19 @@
 server:
   port: 8086
   forward-headers-strategy: framework
+  # 좌석맵 응답이 221KB(2,080석)라 회선이 먼저 찼다 — 서버 82ms 인데 클라이언트 p95 35초였다(#348).
+  # gzip level 6 으로 9,709B(95.66% 절감)가 된다. 게이트웨이(WebFlux 프록시)나 nginx 가 아니라
+  # origin 에서 거는 이유는 load-tests/k6/results/260727-348-openrun-e2e/report.md §3.4 참고(#505).
+  # mime-types 기본값에 application/json 이 있어 별도 지정하지 않는다. SSE(text/event-stream)는
+  # 기본 mime-types 에 없어 압축되지 않는다.
+  #
+  # ⚠ min-response-size(기본 2KB)는 이 서비스에서 사실상 동작하지 않는다. Tomcat 의
+  # CompressionConfig 가 `contentLength != -1 && contentLength < min` 일 때만 걸러내는데,
+  # MVC 컨트롤러 응답은 Transfer-Encoding: chunked 라 길이가 -1 이다. 그래서 작은 응답도
+  # 함께 압축된다(실측: seat-counts 199B → 185B). Content-Length 를 알리려면 응답 전체를
+  # 버퍼링해야 해서 그 비용이 아끼려는 압축 비용보다 크다 — 그대로 둔다.
+  compression:
+    enabled: true
   # Boot 2.2 부터 기본값이 false 라 톰캣 ThreadPool MBean 이 등록되지 않고, Micrometer 의
   # tomcat.threads.* 바인딩이 통째로 빈다(#500). 스레드 포화를 수치로 볼 수단이라 켠다.
   tomcat:


### PR DESCRIPTION
## 🔗 관련 이슈

- #505

> ⚠️ **`close`를 걸지 않았다.** #505 의 완료 조건 5개 중 3개(prod 실측·호스트 CPU 전후 비교·#348 재측정)가 EC2 기동을 필요로 해 이 PR 이후에 남는다. `develop` 머지 시점에 이슈가 닫히면 안 된다.

---

## 📌 주요 변경 사항

- seat-service 에 `server.compression.enabled: true` 를 켜 좌석맵 응답을 gzip 압축한다 (#348 이 식별한 1차 병목)
- 압축 지점으로 (A) 앱 origin 을 채택한 근거를 yml 주석과 `docs/production-domain-https.md` §7 에 남긴다
- `min-response-size` 2KB 가 작은 응답을 걸러 준다는 이슈의 전제가 **틀렸음**을 실측으로 확인하고 문서에 반영한다

---

## 🛠 상세 구현 내용

### 왜 필요한가

#348 측정에서 좌석맵 조회 `GET /api/v1/seat/{id}/seat-layouts` 의 **서버 처리는 81.96ms 인데 클라이언트 p95 는 34.97초**였다. 같은 구간 호스트 CPU 58.86%, gateway 5xx 0건. 앱이 느린 게 아니라 **221KB 응답을 전달하는 데 걸린 시간**이고, 조회 여정 1회 수신량의 99.05% 가 좌석맵 하나다.

### 어디에 켰나 — (A) 앱 origin, seat-service 한 곳

| | (A) 앱 origin | (B) Nginx |
|---|---|---|
| CPU 부담 | 앱 컨테이너에 분산 | 호스트 nginx 한 곳에 집중 |
| 내부 홉(서비스→게이트웨이) | 압축됨 | 비압축 그대로 |

앱 8개와 관측 스택이 2 vCPU 한 대에 동거하는 구성이라([ADR 0007](https://github.com/TicketRush/TicketRush-backend/blob/develop/docs/adr/0007-observability-stack-colocation.md)) nginx 한 곳에 압축 CPU 를 몰면 그 자체가 새 병목이 될 수 있다. 비교표 전문은 `load-tests/k6/results/260727-348-openrun-e2e/report.md` §3.4.

그중 **seat-service 에만** 켰다. 2KB 를 넘는 응답이 좌석맵(223,720B)뿐이고 공연 목록(1,775B)·상세(367B)는 그렇지 않아, 나머지 6개 MVC 서비스에 같은 설정을 복제해도 오늘 압축되는 응답이 하나도 없다.

### ⚠ 이슈의 전제 하나가 실측에서 뒤집혔다

이슈 본문은 "`min-response-size` 기본 2KB 라 좌석맵만 걸리고 작은 응답은 자연히 제외된다"고 적었다. **그렇지 않다.**

Tomcat 의 `CompressionConfig` 는 `contentLength != -1 && contentLength < min` 일 때만 제외하는데, **MVC 컨트롤러 응답은 `Transfer-Encoding: chunked` 라 길이가 -1** 이라 크기 판정 자체를 건너뛴다.

| 응답 | 크기 | 압축 여부 |
|---|---|---|
| `seat-counts` | 199 B | **압축됨** (→ 185 B) — chunked |
| `actuator/health` | 49 B | 제외됨 — actuator 가 `Content-Length` 를 세팅 |

`Content-Length` 를 알리려면 응답 전체를 버퍼링해야 해서 그 비용이 아끼려는 압축 비용보다 크다. 그대로 두되 함정을 yml 주석과 `docs/load-test-guide.md` §13.1-(f) 에 남겼다. **재측정에서 압축 CPU 를 읽을 때 "좌석맵 하나만 압축된다"고 가정하면 안 된다.**

### 문서

- `docs/load-test-guide.md` §13.1-(f) — "gzip 미적용" 단정을 정정. 측정 당시 수치는 기록물이라 보존하고 해소 사실·실측값·위 함정을 덧붙였다. 캘리브레이션 값(조회 ≤ 10 iter/s)이 221KB 기준이라 압축 후 무의미하다는 경고도 같은 절에 붙였다 — 그 값이 바로 아래 문단에 그대로 남아 있어 오해하기 쉬운 자리다.
- `docs/production-domain-https.md` §7 — 사이트 설정에 gzip 지시어가 없는 것이 누락이 아니라 선택임을 명시. 나중에 (B)안이 중복 적용되지 않게 근거와 비교표 위치를 남겼다.

---

## ✅ 테스트

### 테스트 방법

**자동화 테스트** — 새로 작성한 테스트는 없다(설정 한 줄 변경). 기존 스위트를 회귀 확인용으로 실행했다.

```
./gradlew :seat-service:spotlessCheck :seat-service:test
```

**로컬 실측** — `docker compose up -d redis kafka` + 호스트 MySQL 로 local 프로파일 기동 후(`SeatDataInit` 이 `performanceId=1` 시딩), seat-service 직접(8086)과 게이트웨이 경유(8080) 양쪽에서 확인했다.

```bash
curl -D - -H 'Accept-Encoding: gzip'     -o /dev/null -w '%{size_download}\n' http://localhost:8086/api/v1/seat/1/seat-layouts
curl -D - -H 'Accept-Encoding: identity' -o /dev/null -w '%{size_download}\n' http://localhost:8086/api/v1/seat/1/seat-layouts
```

### 테스트 결과

**자동화 테스트: BUILD SUCCESSFUL** — `spotlessCheck` 통과, `:seat-service:test` 100건 전부 통과(Testcontainers 기반 `SeatHoldConcurrencyTest` 포함).

**로컬 실측:**

| 경로 | identity | gzip | 헤더 |
|---|---|---|---|
| seat-service 직접 (8086) | 9,771 B | **830 B** (11.8배) | `Content-Encoding: gzip`, `vary: accept-encoding` |
| **게이트웨이 경유 (8080)** | 9,771 B | **828 B** | 유지됨 — 라우트 필터가 `RewritePath` 뿐이라 본문 미가공 |
| SSE `/seat-status/stream` | — | — | `text/event-stream` 이라 **압축 안 됨** (기본 mime-types 에 없음) |

- 압축 해제 결과는 원본과 동일하다(요청마다 달라지는 `trace_id` 외 차이 없음)
- `mime-types` 기본값에 `application/json` 이 포함되는 것은 Boot 4.0 `org.springframework.boot.web.server.Compression` 에서 직접 확인했다 — 별도 지정 불필요

> 로컬 좌석 수가 prod(2,080석)보다 적어 절대값은 다르다. prod 실측(221KB → 10KB)은 배포 후 별도 확인한다.

### 📸 스크린샷

- 

---

## 👀 리뷰 요청 사항

- **적용 범위를 seat-service 한 곳으로 좁힌 판단**을 봐 주시기 바랍니다. 이슈 본문은 "(A) 각 MVC 서비스"로 적었는데, 현재 2KB 를 넘는 응답이 좌석맵뿐이라 나머지 6개에 복제해도 압축되는 응답이 없다고 보고 seat-service 에만 켰습니다. 일관성을 위해 전 서비스에 거는 편이 낫다는 의견이 있으면 말씀해 주십시오.
- **`min-response-size` 가 무력화된다는 사실을 그대로 두는 판단**에 이견이 있는지 확인이 필요합니다. 작은 응답까지 압축되지만(199B → 185B), 막으려면 응답 전체를 버퍼링해 `Content-Length` 를 세팅해야 해서 배보다 배꼽이 큽니다.
- 게이트웨이 통과는 로컬에서 확인했으나 **nginx 를 거치는 prod 경로는 아직 검증 전**입니다. 배포 후 확인 항목으로 남겨 두었습니다.

---

## ⚠️ 배포 시 주의사항

- **배포 직후 아래를 가장 먼저 확인한다.** 이게 안 되면 그 아래 측정은 전부 의미가 없다.

  ```bash
  curl -D - -H 'Accept-Encoding: gzip' -o /dev/null -w '%{size_download} bytes\n' \
       https://api.ticketrush.store/api/v1/seat/4/seat-layouts
  ```
  - `Content-Encoding: gzip` 헤더가 **있어야** 한다
  - `size_download` 가 **10KB 수준**이어야 한다 (현재 220,990)

- **압축은 CPU 를 쓴다.** 호스트 CPU 가 이미 피크에서 100% 에 닿은 구성이므로(#348 §4.3) 적용 후 CPU 변화를 반드시 함께 본다. 위 함정 때문에 작은 응답까지 압축되므로 **부하가 좌석맵에만 걸린다고 가정하면 안 된다.**
- **#348 의 캘리브레이션 값(browse 10 iter/s 상한)은 이 변경 후 무의미해진다.** 221KB 응답 기준으로 회선(4.5 MB/s)을 넘지 않게 잡은 값이라, 스모크로 새 무릎을 다시 잡아야 한다.
- prod 배포는 `develop` → `main` 머지 PR 로 CD 가 트리거된다. 이 PR 은 `develop` 까지다.
