### PR TITLE
[Infra] #508 node-exporter 를 host netns 로 옮겨 회선 지표를 호스트 것으로 되돌린다

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
       - name: Prometheus scrape 타깃 검증
         run: |
           python3 - <<'PY'
-          import sys, yaml, pathlib
+          import re, sys, yaml, pathlib
 
           prom = yaml.safe_load(open("monitoring/prometheus.aws.yml", encoding="utf-8"))
           comp = yaml.safe_load(open("deploy/docker-compose.prod.yml", encoding="utf-8"))
@@ -85,13 +85,44 @@ jobs:
           for miss in sorted(expected - scraped):
               errors.append(f"배포되는데 스크랩하지 않는다: {miss}")
 
+          # network_mode: host 인 서비스는 compose 네트워크 DNS 에 이름이 없어 서비스명으로 스크랩할 수
+          # 없다. host.docker.internal 로 잡으므로(#508) 서비스명 대조가 성립하지 않는다. 대신 그 서비스가
+          # --web.listen-address 로 실제 리스닝하는 포트와 대조한다 — 포트 오타는 그대로 잡힌다.
+          host_ports = {
+              m.group(1)
+              for svc in comp["services"].values()
+              if svc.get("network_mode") == "host"
+              for arg in svc.get("command") or []
+              if (m := re.search(r"--web\.listen-address=.*:(\d+)$", str(arg)))
+          }
+
           # 앱이 아닌 타깃(redis-exporter 등)도 스크랩한다. 이 검증의 목적은 up=0 인 타깃을 막는 것이므로,
           # 앱처럼 :8090 을 강제하는 대신 compose 에 그 서비스가 실제로 있는지만 본다.
           # (exporter 는 SERVER_PORT 가 없어 deployed 에 잡히지 않고, 포트도 앱과 다르다.)
           services = set(comp["services"])
           for extra in sorted(scraped - expected):
-              if extra.split(":")[0] not in services:
+              host, _, port = extra.partition(":")
+              if host == "host.docker.internal":
+                  if port not in host_ports:
+                      errors.append(
+                          f"{extra} 를 스크랩하는데 network_mode: host 서비스 중 "
+                          f"--web.listen-address 로 :{port} 를 리스닝하는 것이 없다 (up=0 이 된다)"
+                      )
+              elif host not in services:
                   errors.append(f"스크랩하는데 배포되지 않는다 (up=0 이 된다): {extra}")
+
+          # host.docker.internal 은 도커가 자동으로 만들어 주지 않는다. prometheus 에 host-gateway
+          # 매핑이 없으면 이름 해석에 실패해 up=0 이 된다.
+          if any(t.startswith("host.docker.internal:") for t in scraped):
+              mapped = any(
+                  str(h).startswith("host.docker.internal:")
+                  for h in comp["services"]["prometheus"].get("extra_hosts") or []
+              )
+              if not mapped:
+                  errors.append(
+                      "host.docker.internal 을 스크랩하는데 prometheus 에 "
+                      'extra_hosts: ["host.docker.internal:host-gateway"] 가 없다'
+                  )
 
           # 타깃 포트가 각 서비스의 실제 management.server.port 와 같은가
           for name in sorted(deployed):

--- a/deploy/docker-compose.prod.yml
+++ b/deploy/docker-compose.prod.yml
@@ -110,8 +110,17 @@ services:
     # 컨테이너 안에서 돌지만 재는 대상은 '호스트'다. /proc·/sys를 마운트하고
     # --path.rootfs로 가리켜야 컨테이너 네임스페이스가 아닌 EC2 실제 자원을 읽는다.
     # 이 마운트를 빠뜨리면 지표가 나오긴 하는데 전부 컨테이너 것이라 병목 판단에 못 쓴다.
-    # 적용 확인: node_memory_MemTotal_bytes ≈ 7.6 GiB(ADR 0007 인스턴스 실측치)면 정상.
+    #
+    # 적용 확인은 두 축을 함께 본다 — 메모리만 보면 네트워크 결함을 놓친다(#508).
+    #   node_memory_MemTotal_bytes ≈ 7.6 GiB (ADR 0007 인스턴스 실측치)
+    #   node_network_* 의 device 에 ens5 가 있고 eth0 가 없다
     pid: host
+    # netns까지 호스트여야 하는 이유: /proc/net 은 일반 파일이 아니라 network namespace 에 묶인
+    # 경로다. 커널이 /proc/net/dev 내용을 '읽는 프로세스의 netns' 기준으로 만들기 때문에, 위
+    # /proc 마운트와 --path.procfs 로는 넘어오지 않는다. 브리지 컨테이너로 두면 호스트 ens5 가
+    # 아니라 자기 veth(eth0)만 나온다 — #348 이 지목한 회선 축을 재는 수단이 통째로 막혔었다(#508).
+    # CPU·메모리는 같은 마운트로 정상이라 이 결함은 조용했다. pid: host 는 PID namespace 라 별개다.
+    network_mode: host
     volumes:
       - /proc:/host/proc:ro
       - /sys:/host/sys:ro
@@ -120,9 +129,21 @@ services:
       - "--path.procfs=/host/proc"
       - "--path.sysfs=/host/sys"
       - "--path.rootfs=/rootfs"
-    # 관측 포트는 인터넷에 열지 않는다(ADR 0007). Prometheus가 같은 네트워크에서 서비스명으로 스크랩한다.
-    networks:
-      - ticketrush-network
+      # 관측 포트는 인터넷에 열지 않는다(ADR 0007). host netns 라 기본값 0.0.0.0 이면 공인 IP가
+      # 붙은 ens5 에도 열려, 방어선이 수동 관리하는 보안그룹 규칙 하나가 된다 — ADR 0007 이 9090 에
+      # 대해 기각한 바로 그 구조다. docker0 게이트웨이에만 묶으면 소켓이 ens5 에 아예 없다.
+      # 127.0.0.1 은 쓸 수 없다. Prometheus 는 브리지 컨테이너라 호스트 루프백에 닿지 못한다.
+      - "--web.listen-address=172.17.0.1:9100"
+      # host netns 라 veth(컨테이너 수만큼)·compose 브리지가 전부 딸려 온다. 회선 판정에 쓰는 건
+      # ens5 하나이고, 나머지는 컨테이너가 늘 때마다 불어나는 시리즈다.
+      #
+      # 두 벌인 이유: device 라벨을 붙이는 collector 가 둘이고 필터 플래그가 서로 다르다.
+      # netdev  = 트래픽 카운터(node_network_*_bytes_total) — 회선 병목을 재는 축
+      # netclass = 인터페이스 메타데이터(node_network_up·mtu·speed) — 한쪽만 걸면 veth 가 남는다
+      - "--collector.netdev.device-exclude=^(veth.*|br-.*|docker0)$"
+      - "--collector.netclass.ignored-devices=^(veth.*|br-.*|docker0)$"
+    # network_mode: host 는 networks: 와 양립하지 않아 서비스명 DNS 가 없다. 스크랩은 prometheus 의
+    # extra_hosts(host.docker.internal)로 간다 — monitoring/prometheus.aws.yml 의 node job.
 
   kafka-volume-init:
     image: apache/kafka:3.7.0
@@ -385,6 +406,10 @@ services:
     #   ssh -L 9090:localhost:9090 <user>@<EIP>
     ports:
       - "127.0.0.1:9090:9090"
+    # node-exporter 는 host netns 라(#508) compose 네트워크의 DNS 에 이름이 없다. docker0
+    # 게이트웨이로 나가 거기 리스닝 중인 exporter 를 긁는다. 주소는 도커가 컨테이너별로 채워 넣는다.
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     volumes:
       # 배포본은 앱이 같은 네트워크의 컨테이너이므로 서비스명 기반 scrape 설정을 쓴다.
       - ./monitoring/prometheus.aws.yml:/etc/prometheus/prometheus.yml:ro

--- a/docs/adr/0007-observability-stack-colocation.md
+++ b/docs/adr/0007-observability-stack-colocation.md
@@ -54,6 +54,7 @@ Prometheus 자기 자신(`localhost:9090`)도 스크랩한다. 아래 "전환 �
 | 3000 | Grafana | `127.0.0.1` | **SSH 터널** |
 | 8090 | gateway actuator | `127.0.0.1` | CD 헬스체크(EC2 호스트 내부) |
 | 8090 | 나머지 7개 actuator | publish 안 함 | 컨테이너 네트워크 전용 |
+| 9100 | node-exporter | `172.17.0.1` (docker0) | Prometheus 컨테이너 전용. netdev를 호스트 것으로 읽으려 host netns로 뜨므로(#508) publish가 아니라 리스닝 주소로 노출면을 좁힌다 |
 
 ```bash
 ssh -i <key>.pem -L 3000:localhost:3000 -L 9090:localhost:9090 <user>@<EIP>

--- a/docs/load-test-guide.md
+++ b/docs/load-test-guide.md
@@ -1366,6 +1366,10 @@ sum by (instance) (rate(jvm_gc_pause_seconds_sum{job="ticketrush-services"}[5m])
 100 * avg(rate(node_cpu_seconds_total{job="node", mode="iowait"}[1m]))
 node_memory_MemTotal_bytes{job="node"} - node_memory_MemAvailable_bytes{job="node"}
 sum(rate(node_disk_read_bytes_total{job="node"}[1m]))
+# 회선 축. device 를 ens5(호스트 NIC)로 고정한다 — #508 이전에는 여기가 컨테이너 veth 라
+# 실제의 1/6500 인 값이 나왔고, 대시보드는 "회선 한가함"으로 읽혔다.
+rate(node_network_transmit_bytes_total{job="node", device="ens5"}[1m])
+rate(node_network_receive_bytes_total{job="node", device="ens5"}[1m])
 
 # ── 게이트웨이 축 (연결 거부는 서버 축에 안 잡힌다 — #496 §2.4) ─────────
 sum(rate(http_server_requests_seconds_count{job="gateway", status=~"5.."}[1m]))

--- a/monitoring/prometheus.aws.yml
+++ b/monitoring/prometheus.aws.yml
@@ -42,12 +42,16 @@ scrape_configs:
         labels:
           stack: observability
 
-  # EC2 호스트 자원(CPU·메모리·디스크) 지표(#465). 부하 테스트(#348)에서 "호스트가 포화라 느린지,
-  # 앱이 느린지"를 가르는 판정 근거다. exporter는 포트를 publish 하지 않는다(ADR 0007).
+  # EC2 호스트 자원(CPU·메모리·디스크·네트워크) 지표(#465). 부하 테스트(#348)에서 "호스트가 포화라
+  # 느린지, 앱이 느린지"를 가르는 판정 근거다.
+  #
+  # 서비스명이 아니라 host.docker.internal 인 이유: node-exporter 는 netdev 를 호스트 것으로 읽으려고
+  # network_mode: host 로 뜬다(#508). 그래서 compose 네트워크의 DNS 에 이름이 없다. exporter 는
+  # docker0 게이트웨이에만 리스닝하므로 여전히 인터넷에서는 닿지 않는다(ADR 0007).
   - job_name: 'node'
     static_configs:
       - targets:
-          - 'node-exporter:9100'
+          - 'host.docker.internal:9100'
         labels:
           stack: observability
 


### PR DESCRIPTION
## 🔗 관련 이슈

- close #508

---

## 📌 주요 변경 사항

- `node-exporter` 를 `network_mode: host` 로 전환해 `node_network_*` 가 컨테이너 veth 가 아닌 호스트 NIC(`ens5`)를 보고하게 한다
- 리스닝 주소를 docker0 게이트웨이(`172.17.0.1`)로 좁혀, host netns 전환에도 관측 포트가 인터넷에 열리지 않게 한다(ADR 0007 유지)
- netdev·netclass 양쪽에 veth·`br-*`·docker0 제외 필터를 걸어 회선 축만 남긴다
- CI 의 scrape 타깃 검증이 host netns 를 모르던 것을 고친다(검출력은 유지)

---

## 🛠 상세 구현 내용

**원인.** `/proc/net` 은 일반 파일이 아니라 network namespace 에 묶인 경로다. 커널이 `/proc/net/dev` 내용을 '읽는 프로세스의 netns' 기준으로 만들기 때문에, 호스트 `/proc` 을 바인드 마운트하고 `--path.procfs` 를 줘도 netdev 만은 넘어오지 않는다. 부하 중 Prometheus 는 `eth0` 881 B/s 를 냈고 호스트 실제 NIC 는 약 5.8 MB/s 였다 — 6,500배 차이다.

같은 마운트로 CPU·메모리는 정상이라 **이 결함은 조용했다.** 지표가 없는 게 아니라 그럴듯한 작은 값이 나와 "회선은 한가하다"로 읽혔고, #348 회차에서 회선 포화를 k6 클라이언트 수치로 역추정해야 했던 원인이 이것이다.

**스크랩 경로.** host netns 는 `networks:` 와 양립하지 않아 서비스명 DNS 가 사라진다. `prometheus` 에 `extra_hosts: ["host.docker.internal:host-gateway"]` 를 주고 node job 타깃을 `host.docker.internal:9100` 으로 옮겼다.

**리스닝 주소.** 이슈가 후보로 적은 `127.0.0.1:9100` 은 쓸 수 없다 — Prometheus 는 여전히 브리지 컨테이너라 호스트 루프백에 닿지 못한다. docker0 게이트웨이에 묶으면 `host-gateway` 로 Prometheus 만 닿고, 공인 IP 가 붙은 `ens5` 에는 소켓이 아예 열리지 않는다. 기본값 `0.0.0.0` 이었다면 방어선이 수동 관리하는 보안그룹 규칙 하나가 되는데, 이는 ADR 0007 이 9090 에 대해 기각한 바로 그 구조다.

**필터가 두 벌인 이유.** `device` 라벨을 붙이는 collector 가 둘이고 플래그가 서로 다르다. netdev(`node_network_*_bytes_total`)는 `--collector.netdev.device-exclude`, netclass(`node_network_up`·`mtu`·`speed`)는 `--collector.netclass.ignored-devices` 다. 한쪽만 걸면 나머지에 veth 18개가 그대로 남는다.

**CI 검증.** 첫 커밋이 CI 의 "Prometheus scrape 타깃 검증"(#380)을 깼다 — 이 검증은 "타깃 호스트 = compose 서비스명"을 전제하는데 host netns 서비스는 그 전제 밖이다. 전제를 넓히되 검출력은 유지했다. 서비스명 대신 그 서비스가 `--web.listen-address` 로 실제 리스닝하는 포트와 대조하므로 **포트 오타는 그대로 잡힌다.** 더해서 `host.docker.internal` 은 도커가 자동으로 만들어 주지 않으므로, `prometheus` 에 host-gateway 매핑이 없으면 잡도록 검사를 하나 추가했다(그 경우 이름 해석 실패로 `up=0` 이 되는데, 이 검증의 목적이 정확히 그것이다).

**문서.** compose 주석의 적용 확인 기준이 메모리(7.6 GiB)만 보고 있어 네트워크에 대해서는 통과해도 거짓이었다 — 두 축을 함께 보도록 고쳤다. 회선 축 PromQL 을 `load-test-guide` §13.6 에, 9100 리스닝 주소를 ADR 0007 §3 노출 표에 추가했다. "인터넷에 여는 것은 8080 하나뿐"이라는 결정 자체는 그대로다.

---

## ✅ 테스트

### 테스트 방법

자동화 테스트(Gradle)는 없다 — Java 코드 변경이 없는 compose·설정 변경이다. 대신 배포 전 로컬에서 확인 가능한 범위를 실제로 실행해 확인했다.

- CD 와 동일한 검증: `cp deploy/.env.prod.example deploy/.env` 후 `docker compose --env-file deploy/.env -f deploy/docker-compose.prod.yml config -q`
- exporter 플래그 존재: `docker run --rm prom/node-exporter:v1.8.2 --help`
- 필터 정규식 실동작: 실제 컨테이너를 띄워 `--collector.netdev.device-exclude` / `--collector.netclass.ignored-devices` 에 `^(veth.*|br-.*|docker0|eth0)$` 를 주고 `/metrics` 에서 `eth0` 소거를 확인
- compose 의 단독 `$` 처리: 최소 compose 로 컨테이너를 만들어 `docker inspect .Config.Cmd` 비교
- CI 검증 스크립트: `ci.yml` 의 heredoc 파이썬을 그대로 추출해 로컬에서 실행. 통과만이 아니라 **반례 3종**(타깃 포트 오타 `9100→9101`, `extra_hosts` 누락, 없는 서비스 `ghost-exporter` 스크랩)을 각각 임시 트리에 만들어 실제로 잡히는지 확인

### 테스트 결과

- `config -q` exit 0 (`network_mode: host` + `networks:` 동시 지정이 있으면 여기서 실패한다)
- 두 필터 플래그 모두 v1.8.2 에 존재
- 필터 적용 후 `node_network_transmit_bytes_total`·`node_network_up` 양쪽에서 `eth0` 소거 확인. **한쪽만 걸었을 때는 netclass 지표에 `eth0` 가 남는 것도 함께 확인**했다(그래서 두 벌이다)
- 단독 `$` 는 리터럴 그대로 컨테이너에 전달됨(`config` 출력의 `$$` 는 round-trip 이스케이프일 뿐)
- CI 검증: 현재 설정 exit 0, 반례 3종 모두 exit 1 로 검출(기존 검사 회귀 없음)

**아직 확인하지 못한 것 — 완료 조건은 배포 후에만 닫힌다.** 배포 시점에 EC2 에서 확인한다.

| 확인 | 방법 | 기대 |
|---|---|---|
| 호스트 인터페이스 보고 | `count by (device) (node_network_transmit_bytes_total)` | `ens5` 있음, `eth0`·veth 없음 |
| 자릿수 일치 | 부하 중 `rate(...{device="ens5"}[1m])` vs `/proc/net/dev` 델타 | 같은 자릿수 |
| 인터넷 비노출 | `ss -lntp \| grep 9100` | `172.17.0.1:9100` 만 |
| 스크랩 유지 | `up{job="node"}` | `1` |
| 회귀 없음 | `node_memory_MemTotal_bytes` | ≈ 7.6 GiB |

### 📸 스크린샷

- (작성 필요)

---

## 👀 리뷰 요청 사항

- **`172.17.0.1` 하드코딩을 수용할지 판단을 부탁드립니다.** 데몬 `bip` 설정을 바꾸면 스크랩이 끊깁니다. 대안인 compose 서브넷 고정은 기존 `ticketrush-network` 재생성을 강제해 CD 의 `up -d` 가 실패하므로 택하지 않았습니다. 배포 시 `ip -4 addr show docker0` 로 실측해 다르면 그 값으로 교체할 예정입니다.
- **ADR 0007 §3 노출 표에 9100 행을 추가한 것**이 적절한지 확인이 필요합니다. 결정 자체는 그대로 두고 표만 현실에 맞춘 것이나, ADR 사후 수정이라 이견이 있으면 지적해 주시기 바랍니다.

---

## ⚠️ 배포 시 주의사항

- **배포 전 EC2 에서 세 가지를 확인해야 한다.** 이번 작업 중에는 SSH 가 타임아웃(포트 22 도달 불가)이라 확인하지 못했다.
  - `ip -4 addr show docker0` → 게이트웨이가 정말 `172.17.0.1` 인가
  - `docker version` → `host-gateway` 는 Docker 20.10+
  - `ss -lntp | grep 9100` → 호스트에서 9100 을 쓰는 것이 없는가
- **`prometheus` 도 재생성된다**(`extra_hosts` 추가). CD 가 이미 `up -d --force-recreate --no-deps prometheus grafana` 를 돌리므로 자동 처리된다.
- exporter 교체 수초간 node 지표에 공백이 생긴다. 부하 측정 중이 아니면 무해하다.
- `cd.yml` 은 손대지 않았다 — `EXPECTED_SERVICES` 에 `node-exporter` 가 그대로 있고 타깃 수(`EXPECTED_TARGETS=11`)도 변하지 않는다.
- **주소가 틀리면 배포가 자동으로 실패한다.** `cd.yml` 은 `UP_COUNT == EXPECTED_TARGETS && DOWN_COUNT == 0` 을 강제한다. `172.17.0.1` 이 그 호스트의 docker0 이 아니면 node 타깃이 down 으로 남아 배포가 exit 1 로 끝난다 — 눈먼 채 배포되지 않는다.
