### PR TITLE
[Fix] #509 seat-service 의 비힙을 묶고 컨테이너 메모리를 관측한다

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -265,6 +265,7 @@ jobs:
             redis
             redis-exporter
             node-exporter
+            cadvisor
             kafka
             gateway-service
             auth-service
@@ -553,8 +554,9 @@ jobs:
 
           # 컨테이너가 떴다고 지표가 수집되는 것은 아니다. 타깃 주소가 틀리면 up=0인 채로
           # 배포가 초록불로 끝난다. 실제로 스크랩되는지 확인한다(이슈 #380 완료 조건).
-          # 앱 8 + redis + node + prometheus. node job(#465) 추가로 10→11.
-          EXPECTED_TARGETS=11
+          # 앱 8 + redis + node + cadvisor + prometheus. node job(#465) 추가로 10→11,
+          # cadvisor job(#509) 추가로 11→12.
+          EXPECTED_TARGETS=12
           PROMETHEUS_READY=false
 
           for ATTEMPT in $(seq 1 12); do

--- a/deploy/docker-compose.prod.yml
+++ b/deploy/docker-compose.prod.yml
@@ -145,6 +145,44 @@ services:
     # network_mode: host 는 networks: 와 양립하지 않아 서비스명 DNS 가 없다. 스크랩은 prometheus 의
     # extra_hosts(host.docker.internal)로 간다 — monitoring/prometheus.aws.yml 의 node job.
 
+  # 컨테이너별 메모리 시계열이 없어 seat-service 가 cgroup OOM 으로 죽는 것을 사전에 볼 수단이
+  # 없었다(#509). node-exporter 는 호스트 총량만 재므로 "어느 컨테이너가 한계에 가까운지"를
+  # 답하지 못한다. OOM 직전까지 대시보드에 아무 신호가 없었던 이유다.
+  cadvisor:
+    image: gcr.io/cadvisor/cadvisor:v0.49.1
+    container_name: cadvisor
+    # 이 128m 은 공짜가 아니다. mem_limit 합계가 7,232 → 7,360 MiB 가 되고 호스트 실측
+    # 7.6 GiB(약 7,782 MiB) 대비 여유가 550 → 422 MiB 로 준다(ADR 0006 의 예산 관점).
+    # #509 의 처방으로 seat-service 의 mem_limit 을 올리지 않은 이유이기도 하다 — 올릴 여유를
+    # 관측자가 먼저 가져간다. 관측 없이 상한만 올리면 다음 OOM 도 사후에 dmesg 로 알게 된다.
+    mem_limit: 128m
+    restart: unless-stopped
+    # privileged: true 를 쓰지 않는다. cAdvisor 가 그 권한을 요구하는 것은 커널 OOM 이벤트를
+    # 읽기 위해서인데, /dev/kmsg 하나만 주면 된다. 관측용 컨테이너에 호스트 전권을 주는 것은
+    # ADR 0007 이 관측 스택에 대해 세운 최소 노출 원칙과 어긋난다.
+    devices:
+      - /dev/kmsg
+    volumes:
+      - /:/rootfs:ro
+      - /var/run:/var/run:ro
+      - /sys:/sys:ro
+      - /var/lib/docker/:/var/lib/docker:ro
+    command:
+      # 2 vCPU 를 앱 8개와 나눠 쓰므로 관측자가 측정 대상을 흔들지 않게 줄인다.
+      # docker_only: 컨테이너 밖 cgroup 계층을 훑지 않는다.
+      # enable_metrics: 화이트리스트라 disable 목록을 나열하다 빠뜨리는 실수가 없다.
+      #   memory    — 이 이슈가 필요로 하는 축(container_memory_working_set_bytes)
+      #   cpu       — 메모리와 CPU 가 거의 같은 지점에서 함께 한계에 닿는다(#509)
+      #   oom_event — container_oom_events_total. OOM 을 사후에 dmesg 로 찾지 않아도 된다
+      - "--docker_only=true"
+      - "--housekeeping_interval=15s"
+      - "--enable_metrics=cpu,memory,oom_event"
+    # 관측 포트는 인터넷에 열지 않는다(ADR 0007). Prometheus 가 같은 네트워크에서 서비스명으로
+    # 스크랩한다. cAdvisor 의 기본 포트는 8080 이지만 publish 하지 않으므로 게이트웨이의
+    # 호스트 8080 과 충돌하지 않는다.
+    networks:
+      - ticketrush-network
+
   kafka-volume-init:
     image: apache/kafka:3.7.0
     container_name: ticketrush-kafka-volume-init
@@ -313,8 +351,26 @@ services:
     restart: unless-stopped
     env_file:
       - .env
+    # JVM 옵션은 .env 가 아니라 여기 둔다(#509). environment 가 env_file 보다 우선하므로 EC2 의
+    # .env 에 같은 키가 있어도 이 값이 이긴다. .env 는 저장소에 없어 리뷰도 diff 도 남지 않고,
+    # 파일을 다시 만들면 조용히 사라진다 — 힙 상한이 그렇게 관리될 값이 아니다.
+    #
+    # 비힙 상한을 명시하는 이유: 이 셋은 기본값이 사실상 열려 있어 -Xmx 로 힙을 묶어도 cgroup
+    # 한계를 넘길 수 있다(#509 는 RSS 626 MiB 로 640 MiB 상한에 걸려 커널에 죽었다).
+    #   MaxDirectMemorySize 기본값 = -Xmx = 384 MiB. 힙과 같은 크기가 힙 밖에 또 열려 있었다.
+    #   MaxMetaspaceSize 기본 무제한. 클래스 로딩만큼 계속 자란다.
+    #   ReservedCodeCacheSize 기본 240 MiB 예약.
+    # 합계 384(힙) + 128 + 64 + 64 = 640 이라 상한과 같아 보이지만, 이 값들은 '실사용'이 아니라
+    # '상한'이다. 실사용이 동시에 최대가 되는 일은 없고, 여기 없는 스레드 스택은 위 tomcat
+    # max-threads(50)로 따로 묶었다.
     environment:
       SERVER_PORT: 8086
+      JAVA_TOOL_OPTIONS: >-
+        -Xms128m
+        -Xmx384m
+        -XX:MaxMetaspaceSize=128m
+        -XX:ReservedCodeCacheSize=64m
+        -XX:MaxDirectMemorySize=64m
     depends_on:
       mysql:
         condition: service_healthy

--- a/docs/load-test-guide.md
+++ b/docs/load-test-guide.md
@@ -1371,6 +1371,14 @@ sum(rate(node_disk_read_bytes_total{job="node"}[1m]))
 rate(node_network_transmit_bytes_total{job="node", device="ens5"}[1m])
 rate(node_network_receive_bytes_total{job="node", device="ens5"}[1m])
 
+# ── 컨테이너별 메모리 (cAdvisor, #509) ────────────────────────────────
+# node job 은 호스트 총량이라 "어느 컨테이너가 자기 상한에 가까운지"를 답하지 못한다.
+# seat-service 가 cgroup OOM 으로 죽을 때까지 신호가 없었던 것이 그래서다.
+# 상한 대비 사용률. 1.0 에 가까워지면 커널이 죽인다. 부하 중 상시 띄워 둘 값이다.
+container_memory_working_set_bytes{name!=""} / container_spec_memory_limit_bytes{name!=""}
+# OOM 은 사후에 dmesg 로 찾지 않는다. docker inspect 의 OOMKilled 는 재시작 뒤라 false 다(#509).
+increase(container_oom_events_total{name!=""}[5m])
+
 # ── 게이트웨이 축 (연결 거부는 서버 축에 안 잡힌다 — #496 §2.4) ─────────
 sum(rate(http_server_requests_seconds_count{job="gateway", status=~"5.."}[1m]))
 sum(rate(http_server_requests_seconds_count{job="gateway"}[1m]))

--- a/monitoring/prometheus.aws.yml
+++ b/monitoring/prometheus.aws.yml
@@ -55,6 +55,16 @@ scrape_configs:
         labels:
           stack: observability
 
+  # 컨테이너별 자원 지표(#509). node job 이 호스트 총량을 재는 데 반해 이쪽은 "어느 컨테이너가
+  # 자기 mem_limit 에 가까운지"를 답한다. seat-service 가 cgroup OOM 으로 죽을 때까지 대시보드에
+  # 신호가 없었던 것이 이 job 이 없었기 때문이다. exporter 는 포트를 publish 하지 않는다(ADR 0007).
+  - job_name: 'cadvisor'
+    static_configs:
+      - targets:
+          - 'cadvisor:8080'
+        labels:
+          stack: observability
+
   # 자기 자신. ADR 0007이 "전환 시점"의 기준으로 삼은 '부하 중 Prometheus의 CPU·메모리 점유'를
   # 재려면 prometheus_* 자기 지표가 필요하다. mem_limit(384m) 재평가 근거도 여기서 나온다.
   - job_name: 'prometheus'

--- a/seat-service/src/main/resources/application.yml
+++ b/seat-service/src/main/resources/application.yml
@@ -19,6 +19,19 @@ server:
   tomcat:
     mbeanregistry:
       enabled: true
+    threads:
+      # 기본값 200 을 낮춘다. 스레드 스택은 힙 밖이라 -Xmx 가 막지 못하고 cgroup 만 잡는다.
+      # 200 × 1 MiB 는 mem_limit 640 MiB 짜리 컨테이너에서 감당할 수 없는 몫이고, #509 의
+      # "힙으로 설명되지 않는 242 MiB" 의 유력한 출처다.
+      #
+      # 50 인 근거: 인스턴스가 2 vCPU 다. #348 실측 서버 응답 82ms 에서 60 req/s 면
+      # Little's law 로 동시 5개 — 50 은 그 10배다. 2 vCPU 에 200 스레드는 메모리를 쓰면서
+      # 컨텍스트 스위칭만 늘린다(같은 구간 호스트 CPU 98%).
+      #
+      # ⚠ 트레이드오프: 포화 시 처리량 상한이 스레드 수로 결정될 수 있다. 큐(accept-count 기본
+      # 100)에 쌓여 지연이 늘겠지만, 프로세스가 통째로 죽는 것보다 낫다(fail-slow > fail-dead).
+      # 이 값은 재측정으로 조정한다 — tomcat_threads_busy_threads 가 50 에 붙어 있으면 올린다.
+      max: 50
 
 spring:
   profiles:


### PR DESCRIPTION
## 🔗 관련 이슈

- #509

> ⚠️ **`close` 를 걸지 않았다.** #509 의 완료 조건 4개 중 3개(OOM 재현 안 함·컨테이너 메모리 시계열·`tomcat_threads_*` 조회)가 EC2 배포와 재현 절차 실행을 필요로 해 이 PR 이후에 남는다. `develop` 머지 시점에 이슈가 닫히면 안 된다. #505 가 PR #506(구현) → #507(배포) → #510(측정, 여기서 `close`)로 처리한 것과 같은 순서다.

---

## 📌 주요 변경 사항

- `tomcat max-threads` 200 → 50. 스레드 스택은 힙 밖이라 `-Xmx` 가 막지 못하고 cgroup 만 잡는다
- JVM 옵션을 EC2 의 `.env` 에서 compose 로 옮기고, 열려 있던 비힙 상한 셋을 명시한다
- cAdvisor 를 붙여 컨테이너별 메모리 시계열을 확보한다(`EXPECTED_TARGETS` 11 → 12)

---

## 🛠 상세 구현 내용

**진단.** `mem_limit` 640 MiB 에 `-Xmx384m` 인데 OOM 시점 `anon-rss` 가 626 MiB 였다. 실측으로 압축(#505)은 원인이 아님이 갈렸다(gzip/identity 의 ΔRSS 7% 이내, 도착률을 4배 올렸을 때 요청당 비용은 오히려 9.59 → 5.92 KB/req 로 감소 — 누수가 아니라 워킹셋이다). 남은 것은 **부하 전 기준선이 이미 439 MiB / 640 MiB (69%)** 라는 여유 부족이다.

**(1) `max-threads` 200 → 50.** 2 vCPU 인 인스턴스에서 200 스레드는 메모리를 쓰면서 컨텍스트 스위칭만 늘린다(같은 구간 호스트 CPU 98%). #348 실측 서버 응답 82ms 에서 60 req/s 면 Little's law 로 동시 5개라 50 은 그 10배다.

트레이드오프를 명시한다 — 포화 시 처리량 상한이 스레드 수로 결정될 수 있다. 큐(`accept-count` 기본 100)에 쌓여 지연이 늘겠지만 **프로세스가 통째로 죽는 것보다 낫다**(fail-slow > fail-dead). `tomcat_threads_busy_threads` 가 50 에 붙어 있으면 올린다.

**SSE 는 영향받지 않는다.** `SseEmitter` 는 MVC async 라 요청 스레드를 즉시 반환하고, 브로드캐스트는 `seatStatusSseExecutor`(core 4 / max 16)가 처리한다. SSE 구독 수는 `maxConnections`(기본 8192)에 묶이지 `max-threads` 에 묶이지 않는다. #403(SSE 대량 구독 측정)의 상한이 이 값으로 바뀌지 않는다는 뜻이다.

**(2) JVM 옵션을 compose 로.** 기존 `-Xms128m -Xmx384m` 은 저장소 어디에도 없었다 — Dockerfile 은 `java -jar app.jar` 뿐이고 `.env.prod.example` 에도 없다. EC2 의 `.env` 에만 있어 **리뷰도 diff 도 남지 않고, 파일을 다시 만들면 조용히 사라진다.** `environment` 가 `env_file` 보다 우선하므로 이 값이 이긴다.

비힙 상한 셋은 기본값이 사실상 열려 있었다.

| | 기본값 | 지정 |
|---|---|---|
| `MaxDirectMemorySize` | **`-Xmx` 와 동일 = 384 MiB** | 64m |
| `MaxMetaspaceSize` | 무제한 | 128m |
| `ReservedCodeCacheSize` | 240 MiB 예약 | 64m |

**(3) cAdvisor.** `privileged: true` 를 쓰지 않는다 — cAdvisor 가 그 권한을 요구하는 것은 커널 OOM 이벤트를 읽기 위해서인데 `/dev/kmsg` 하나면 된다. 2 vCPU 를 앱 8개와 나눠 쓰므로 `--enable_metrics` 화이트리스트로 `cpu,memory,oom_event` 만 남겼다(`disable_metrics` 를 나열하다 빠뜨리는 실수가 없다). `container_oom_events_total` 덕에 다음 OOM 은 `dmesg` 로 찾지 않아도 된다.

---

## ✅ 테스트

### 테스트 방법

- `./gradlew :seat-service:test` — `application.yml` 변경 영향
- `./gradlew spotlessCheck`
- CD 와 동일한 검증: `docker compose --env-file deploy/.env -f deploy/docker-compose.prod.yml config -q`
- CI 의 scrape 타깃 검증 스크립트를 `ci.yml` 에서 추출해 로컬 실행(cadvisor job 추가분)
- cAdvisor 실제 기동: 컨테이너를 띄워 `--enable_metrics` 화이트리스트 동작과 지표 존재 확인
- SSE 영향 검토: `SeatController`·`SeatStatusSseConfig`·`SeatStatusSseEventSender` 를 읽어 요청 스레드 점유 여부 확인

### 테스트 결과

- `:seat-service:test` BUILD SUCCESSFUL
- `spotlessCheck` BUILD SUCCESSFUL
- `compose config -q` exit 0. `JAVA_TOOL_OPTIONS` 가 한 줄로 정상 렌더됨
- CI scrape 검증 exit 0 (`cadvisor:8080` 이 compose 서비스라 통과)
- cAdvisor: `container_memory_working_set_bytes`·`container_oom_events_total`·`container_spec_memory_limit_bytes`(가이드에 넣은 사용률 쿼리의 분모) 존재 확인, 제외 대상인 `container_network_*` 는 0건, 전체 75 시리즈로 축소됨
  - ⚠️ **`name` 라벨까지는 로컬에서 확인하지 못했다.** Docker Desktop 이 WSL 경로 구조 때문에 컨테이너를 인식하지 못해(`failed to identify the read-write layer ID`) root cgroup(`id="/"`)만 나온다. 가이드 쿼리의 `{name!=""}` 필터가 의도대로 컨테이너만 남기는지는 **실제 Linux 배포 후 확인해야 한다.** 안 되면 `id=~"/docker/.*"` 로 바꾼다
- 예산 재계산: 합계 7,232 → **7,360 MiB** / 호스트 7,782 MiB → 여유 550 → **422 MiB**

**배포 후에만 닫히는 완료 조건이 남아 있다.** 재현 절차(80 iter/s)를 그대로 돌려야 한다.

| 완료 조건 | 검증 방법 |
|---|---|
| OOM 으로 죽지 않는다 | `docker inspect seat-service` 의 `RestartCount` 증가 0 |
| 컨테이너 메모리 시계열 | `container_memory_working_set_bytes{name="seat-service"}` |
| `tomcat_threads_*` 조회 | `tomcat_threads_config_max{instance="seat-service:8090"}` 가 50 |
| 예산 안에서 성립 | 호스트 `free -m` available |

### 📸 스크린샷

- (작성 필요)

---

## 👀 리뷰 요청 사항

- **`max-threads: 50` 이 적절한지 판단을 부탁드립니다.** 200 → 50 은 4배 축소라 공격적일 수 있습니다. 근거는 위 Little's law 계산이지만, 포화 구간에서 응답이 길어지면 필요한 동시 스레드도 늘어납니다. 100 이 안전하다고 보시면 그렇게 조정하겠습니다.
- **이 처방이 가설에 기반한다는 점을 공유합니다.** 스레드 스택이 242 MiB 의 주된 몫이라는 직접 증거는 없습니다(NMT 미사용, 과거 `tomcat_threads_current_threads` 조회 불가). 배포 후 기준선 RSS 가 유의하게 내려가지 않으면 가설이 틀린 것이고, 그때는 NMT 로 비힙 내역을 직접 떠야 합니다. 이 순서에 이견이 있으면 지적해 주시기 바랍니다.
- **나머지 7개 서비스의 JVM 옵션은 `.env` 에 그대로 둡니다.** 같은 문제를 갖고 있을 것으로 보이나 이 이슈 범위 밖이라 손대지 않았습니다. 별도 이슈로 뺄지 의견 부탁드립니다.

---

## ⚠️ 배포 시 주의사항

- **`EXPECTED_TARGETS` 를 12 로 올렸다.** cAdvisor 가 뜨지 않거나 스크랩되지 않으면 CD 가 `UP_COUNT == 12` 를 만족하지 못해 배포가 실패한다 — 조용히 넘어가지 않는다.
- **cAdvisor 는 `/var/lib/docker` 와 `/dev/kmsg` 를 요구한다.** Ubuntu 기본 경로 기준이며, 도커 data-root 를 옮겼다면 마운트 경로를 함께 고쳐야 한다.
- **EC2 `.env` 에 `JAVA_TOOL_OPTIONS` 가 남아 있어도 무해하다**(compose 가 이긴다). 다만 혼란을 줄이려면 배포 후 그 줄을 지우는 편이 낫다.
- **관측자가 측정 대상을 흔든다.** cAdvisor 자체가 2 vCPU 중 일부와 128 MiB 를 쓴다. 이번 변경 이후 회차의 리포트에는 이 사실을 한계로 명시해야 한다.
- 이 PR 은 #508 과 함께 **묶음 A**(트래킹 이슈 #512)로 배포한다.
