### PR TITLE
[Fix] #509 Metaspace 상한 제거와 cAdvisor 롤백 — 배포 실패 수습

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -265,7 +265,6 @@ jobs:
             redis
             redis-exporter
             node-exporter
-            cadvisor
             kafka
             gateway-service
             auth-service
@@ -554,9 +553,8 @@ jobs:
 
           # 컨테이너가 떴다고 지표가 수집되는 것은 아니다. 타깃 주소가 틀리면 up=0인 채로
           # 배포가 초록불로 끝난다. 실제로 스크랩되는지 확인한다(이슈 #380 완료 조건).
-          # 앱 8 + redis + node + cadvisor + prometheus. node job(#465) 추가로 10→11,
-          # cadvisor job(#509) 추가로 11→12.
-          EXPECTED_TARGETS=12
+          # 앱 8 + redis + node + prometheus. node job(#465) 추가로 10→11.
+          EXPECTED_TARGETS=11
           PROMETHEUS_READY=false
 
           for ATTEMPT in $(seq 1 12); do

--- a/deploy/docker-compose.prod.yml
+++ b/deploy/docker-compose.prod.yml
@@ -355,20 +355,27 @@ services:
     # .env 에 같은 키가 있어도 이 값이 이긴다. .env 는 저장소에 없어 리뷰도 diff 도 남지 않고,
     # 파일을 다시 만들면 조용히 사라진다 — 힙 상한이 그렇게 관리될 값이 아니다.
     #
-    # 비힙 상한을 명시하는 이유: 이 셋은 기본값이 사실상 열려 있어 -Xmx 로 힙을 묶어도 cgroup
-    # 한계를 넘길 수 있다(#509 는 RSS 626 MiB 로 640 MiB 상한에 걸려 커널에 죽었다).
+    # 비힙 상한을 명시하는 이유: 기본값이 사실상 열려 있어 -Xmx 로 힙을 묶어도 cgroup 한계를
+    # 넘길 수 있다(#509 는 RSS 626 MiB 로 640 MiB 상한에 걸려 커널에 죽었다).
     #   MaxDirectMemorySize 기본값 = -Xmx = 384 MiB. 힙과 같은 크기가 힙 밖에 또 열려 있었다.
-    #   MaxMetaspaceSize 기본 무제한. 클래스 로딩만큼 계속 자란다.
-    #   ReservedCodeCacheSize 기본 240 MiB 예약.
-    # 합계 384(힙) + 128 + 64 + 64 = 640 이라 상한과 같아 보이지만, 이 값들은 '실사용'이 아니라
-    # '상한'이다. 실사용이 동시에 최대가 되는 일은 없고, 여기 없는 스레드 스택은 위 tomcat
-    # max-threads(50)로 따로 묶었다.
+    #     실측 최대 1.5 MiB(gateway)라 64m 은 40배 여유다.
+    #   ReservedCodeCacheSize 기본 240 MiB 예약. 실측 최대 33.3 MiB(booking)라 64m 은 2배 여유다.
+    #
+    # ⚠ MaxMetaspaceSize 는 두지 않는다. 처음에 128m 을 줬다가 배포가 실패했다.
+    #   OutOfMemoryError: Metaspace 로 앱이 좀비가 됐고 — 프로세스는 살아 있는데 요청을 처리하지
+    #   못한다 — Prometheus 스크랩이 타임아웃나 CD 의 up 게이트에서 걸렸다. 이유가 둘이다.
+    #     1) "무제한이라 계속 자란다"는 전제가 틀렸다. 상한 없는 7개 서비스 실측이 106-140 MiB 에서
+    #        수렴한다(performance 139.7 / booking 136.1 / user 106.1). 클래스 로딩은 유한하다.
+    #     2) 실패 모드가 나쁘다. 힙 OOM 과 달리 프로세스가 죽지 않아 재시작도 안 되고, 헬스체크가
+    #        아니라 스크랩 타임아웃으로만 드러난다. 조기 경보가 아니라 조용한 마비다.
+    #   예산 관점에서도 무의미하다 — 실측(140)을 덮을 값이면 힙 384 와 합쳐 이미 640 을 넘는다.
+    #
+    # 여기 없는 스레드 스택은 위 tomcat max-threads(50)로 따로 묶었다.
     environment:
       SERVER_PORT: 8086
       JAVA_TOOL_OPTIONS: >-
         -Xms128m
         -Xmx384m
-        -XX:MaxMetaspaceSize=128m
         -XX:ReservedCodeCacheSize=64m
         -XX:MaxDirectMemorySize=64m
     depends_on:

--- a/deploy/docker-compose.prod.yml
+++ b/deploy/docker-compose.prod.yml
@@ -145,44 +145,6 @@ services:
     # network_mode: host 는 networks: 와 양립하지 않아 서비스명 DNS 가 없다. 스크랩은 prometheus 의
     # extra_hosts(host.docker.internal)로 간다 — monitoring/prometheus.aws.yml 의 node job.
 
-  # 컨테이너별 메모리 시계열이 없어 seat-service 가 cgroup OOM 으로 죽는 것을 사전에 볼 수단이
-  # 없었다(#509). node-exporter 는 호스트 총량만 재므로 "어느 컨테이너가 한계에 가까운지"를
-  # 답하지 못한다. OOM 직전까지 대시보드에 아무 신호가 없었던 이유다.
-  cadvisor:
-    image: gcr.io/cadvisor/cadvisor:v0.49.1
-    container_name: cadvisor
-    # 이 128m 은 공짜가 아니다. mem_limit 합계가 7,232 → 7,360 MiB 가 되고 호스트 실측
-    # 7.6 GiB(약 7,782 MiB) 대비 여유가 550 → 422 MiB 로 준다(ADR 0006 의 예산 관점).
-    # #509 의 처방으로 seat-service 의 mem_limit 을 올리지 않은 이유이기도 하다 — 올릴 여유를
-    # 관측자가 먼저 가져간다. 관측 없이 상한만 올리면 다음 OOM 도 사후에 dmesg 로 알게 된다.
-    mem_limit: 128m
-    restart: unless-stopped
-    # privileged: true 를 쓰지 않는다. cAdvisor 가 그 권한을 요구하는 것은 커널 OOM 이벤트를
-    # 읽기 위해서인데, /dev/kmsg 하나만 주면 된다. 관측용 컨테이너에 호스트 전권을 주는 것은
-    # ADR 0007 이 관측 스택에 대해 세운 최소 노출 원칙과 어긋난다.
-    devices:
-      - /dev/kmsg
-    volumes:
-      - /:/rootfs:ro
-      - /var/run:/var/run:ro
-      - /sys:/sys:ro
-      - /var/lib/docker/:/var/lib/docker:ro
-    command:
-      # 2 vCPU 를 앱 8개와 나눠 쓰므로 관측자가 측정 대상을 흔들지 않게 줄인다.
-      # docker_only: 컨테이너 밖 cgroup 계층을 훑지 않는다.
-      # enable_metrics: 화이트리스트라 disable 목록을 나열하다 빠뜨리는 실수가 없다.
-      #   memory    — 이 이슈가 필요로 하는 축(container_memory_working_set_bytes)
-      #   cpu       — 메모리와 CPU 가 거의 같은 지점에서 함께 한계에 닿는다(#509)
-      #   oom_event — container_oom_events_total. OOM 을 사후에 dmesg 로 찾지 않아도 된다
-      - "--docker_only=true"
-      - "--housekeeping_interval=15s"
-      - "--enable_metrics=cpu,memory,oom_event"
-    # 관측 포트는 인터넷에 열지 않는다(ADR 0007). Prometheus 가 같은 네트워크에서 서비스명으로
-    # 스크랩한다. cAdvisor 의 기본 포트는 8080 이지만 publish 하지 않으므로 게이트웨이의
-    # 호스트 8080 과 충돌하지 않는다.
-    networks:
-      - ticketrush-network
-
   kafka-volume-init:
     image: apache/kafka:3.7.0
     container_name: ticketrush-kafka-volume-init

--- a/docs/load-test-guide.md
+++ b/docs/load-test-guide.md
@@ -1371,13 +1371,14 @@ sum(rate(node_disk_read_bytes_total{job="node"}[1m]))
 rate(node_network_transmit_bytes_total{job="node", device="ens5"}[1m])
 rate(node_network_receive_bytes_total{job="node", device="ens5"}[1m])
 
-# ── 컨테이너별 메모리 (cAdvisor, #509) ────────────────────────────────
-# node job 은 호스트 총량이라 "어느 컨테이너가 자기 상한에 가까운지"를 답하지 못한다.
-# seat-service 가 cgroup OOM 으로 죽을 때까지 신호가 없었던 것이 그래서다.
-# 상한 대비 사용률. 1.0 에 가까워지면 커널이 죽인다. 부하 중 상시 띄워 둘 값이다.
-container_memory_working_set_bytes{name!=""} / container_spec_memory_limit_bytes{name!=""}
-# OOM 은 사후에 dmesg 로 찾지 않는다. docker inspect 의 OOMKilled 는 재시작 뒤라 false 다(#509).
-increase(container_oom_events_total{name!=""}[5m])
+# ── 컨테이너별 메모리 — 아직 수단이 없다(#515) ────────────────────────
+# 위 node_* 는 호스트 총량이라 "어느 컨테이너가 자기 mem_limit 에 가까운지"를 답하지 못한다.
+# #509 에서 seat-service 가 cgroup OOM 으로 죽을 때까지 신호가 없었던 것이 그래서다.
+# cAdvisor 로 메우려 했으나 Docker 29 + cgroup v2 + systemd 조합에서 컨테이너를 열거하지
+# 못해 되돌렸다(#515 에 실측 기록). 그때까지 컨테이너 메모리는 이 두 가지로만 본다.
+#   부하 중:   ssh <EC2> 'docker stats --no-stream seat-service'
+#   OOM 판정:  ssh <EC2> 'sudo dmesg -T | grep CONSTRAINT_MEMCG'
+#              ⚠ docker inspect 의 OOMKilled 는 재시작 뒤라 false 로 나온다 — 믿지 말 것
 
 # ── 게이트웨이 축 (연결 거부는 서버 축에 안 잡힌다 — #496 §2.4) ─────────
 sum(rate(http_server_requests_seconds_count{job="gateway", status=~"5.."}[1m]))

--- a/monitoring/prometheus.aws.yml
+++ b/monitoring/prometheus.aws.yml
@@ -55,16 +55,6 @@ scrape_configs:
         labels:
           stack: observability
 
-  # 컨테이너별 자원 지표(#509). node job 이 호스트 총량을 재는 데 반해 이쪽은 "어느 컨테이너가
-  # 자기 mem_limit 에 가까운지"를 답한다. seat-service 가 cgroup OOM 으로 죽을 때까지 대시보드에
-  # 신호가 없었던 것이 이 job 이 없었기 때문이다. exporter 는 포트를 publish 하지 않는다(ADR 0007).
-  - job_name: 'cadvisor'
-    static_configs:
-      - targets:
-          - 'cadvisor:8080'
-        labels:
-          stack: observability
-
   # 자기 자신. ADR 0007이 "전환 시점"의 기준으로 삼은 '부하 중 Prometheus의 CPU·메모리 점유'를
   # 재려면 prometheus_* 자기 지표가 필요하다. mem_limit(384m) 재평가 근거도 여기서 나온다.
   - job_name: 'prometheus'


### PR DESCRIPTION
## 🔗 관련 이슈

- #509

> ⚠️ `close` 를 걸지 않는다. 배포 후 재현 절차(80 iter/s)가 남아 있다.

---

## 📌 주요 변경 사항

PR #513 이 배포에서 실패해 그 두 부분을 되돌린다. **tomcat max-threads(50)와 JVM 옵션의 compose 이전은 유지한다** — 그 둘은 정상 동작했다.

- `-XX:MaxMetaspaceSize=128m` 제거 — 이것이 배포를 깨뜨렸다
- cAdvisor 제거 — 이 호스트에서 컨테이너를 열거하지 못한다 (→ #515)

---

## 🛠 상세 구현 내용

### 1. MaxMetaspaceSize 가 배포를 깨뜨렸다

seat-service 가 `OutOfMemoryError: Metaspace` 를 반복하며 좀비가 됐다 — **프로세스는 살아 있는데 요청을 처리하지 못한다.** Prometheus 스크랩이 타임아웃나 CD 의 `UP_COUNT == 12` 게이트에서 걸렸다. **게이트는 의도대로 작동해 깨진 채로 넘어가지 않았다.**

두 가지가 틀렸다.

**(a) 근거로 삼은 전제가 사실이 아니었다.** compose 주석에 *"MaxMetaspaceSize 기본 무제한, 클래스 로딩만큼 계속 자란다"* 고 적었는데, 상한 없는 7개 서비스의 실측이 **106-140 MiB 에서 수렴**한다.

| 서비스 | Metaspace |
|---|---|
| performance | 139.7 MiB |
| booking | 136.1 MiB |
| ticket | 120.3 MiB |
| payment | 118.1 MiB |
| auth | 112.0 MiB |
| user | 106.1 MiB |
| gateway | 56.3 MiB |

내가 준 128m 은 이 분포의 한복판이라 부족했다.

**(b) 실패 모드가 나쁘다.** 힙 OOM 과 달리 프로세스가 죽지 않아 재시작도 안 되고, 헬스체크가 아니라 스크랩 타임아웃으로만 드러난다. "폭주를 조기에 잡는다"는 명분이었는데 실제로는 조용한 마비다. 예산으로도 무의미하다 — 실측(140)을 덮을 값이면 힙 384 와 합쳐 이미 640 을 넘는다.

**나머지 두 상한은 유지한다.** 실측 대비 여유가 크다.

| | 지정 | 실측 최대 | 여유 |
|---|---|---|---|
| `ReservedCodeCacheSize` | 64m | 33.3 MiB (booking) | 2배 |
| `MaxDirectMemorySize` | 64m | 1.5 MiB (gateway) | 40배 |

### 2. cAdvisor 가 컨테이너를 열거하지 못한다

배포 후 실측에서 `container_*` 시리즈에 컨테이너가 하나도 없었다.

| 시도 | 결과 |
|---|---|
| v0.49.1 | `docker container factory failed: client version 1.41 is too old, minimum 1.44` (호스트 Docker 29.1.3) |
| v0.52.1 | 등록 성공. **그래도 컨테이너 0건** |
| `--cap-add SYSLOG` | `/dev/kmsg: operation not permitted` 해소. 컨테이너 여전히 0건 |
| `--privileged` + cgroup 마운트 + `--docker_only` 해제 | 48개로 늘었으나 전부 cgroup 계층. `docker-<id>.scope` **0건** |

cgroup 에는 `/sys/fs/cgroup/system.slice/docker-<id>.scope` 가 실재한다 — cAdvisor 가 그걸 컨테이너로 매핑하지 못하는 것이다. 128 MiB 를 먹으면서 데이터를 못 주므로 되돌린다. 수단은 #515 에서 다시 고른다.

**내 검증이 부실했다.** 호스트 Docker 버전은 확인했으면서 cAdvisor 와의 API 호환은 보지 않았고, `/dev/kmsg` 는 파일 존재만 확인하고 읽기 권한을 확인하지 않았다. 로컬에서 `id="/"` 만 나온 것도 "Docker Desktop 의 WSL 경로 문제"로 결론지었는데, 실제로는 같은 API 버전 문제였을 가능성이 크다 — 환경 탓으로 넘긴 신호였다.

---

## ✅ 테스트

### 테스트 방법

- `docker compose config -q`
- CI scrape 타깃 검증 스크립트 로컬 실행
- EC2 에 임시 적용 후 seat-service 재생성 → 실제 복구 확인
- cAdvisor 는 EC2 에서 버전·권한 조합을 바꿔가며 4회 실측

### 테스트 결과

- `compose config -q` exit 0 / CI scrape 검증 exit 0
- `mem_limit` 합계 7,360 → **7,232 MiB**(컨테이너 15개), 여유 422 → **550 MiB** 로 원복
- **EC2 현재 상태 — 타깃 12/12 up** (임시 적용분 기준. 이 PR 배포 후 11/11 이 된다)

| 확인 | 결과 |
|---|---|
| `OutOfMemoryError` 재발 | **0건** |
| seat-service `RestartCount` | **0** |
| 기준선 RSS | **412.9 MiB / 640 (64.5%)** — 이전 439 MiB |
| `tomcat_threads_config_max_threads` | **50** — max-threads 적용 확인 |
| JVM 실인식값 | 힙 384 / CodeCache 64 / Direct 64 / **Metaspace 무제한 복귀** |
| #508 device 목록 | `ens5`, `lo` 만 — veth·br 전부 제외 |
| #508 리스닝 | `172.17.0.1:9100` 만 |

### 📸 스크린샷

- (작성 필요)

---

## 👀 리뷰 요청 사항

- **기준선 RSS 가 439 → 412.9 MiB 로 26 MiB 밖에 안 줄었습니다.** 제가 PR #513 에서 "기준선이 내려갈 것"이라 예상한 것은 부정확했습니다 — `max-threads` 는 **상한**이지 실제 생성 수가 아니라, 무부하에서는 어차피 스레드가 적습니다(`min-spare-threads` 10). **이 처방의 효과는 부하 중에만 드러납니다.** 판정을 부하 회차로 미루는 데 이견이 있으면 말씀해 주시기 바랍니다.
- **EC2 에 임시 수정을 손으로 적용한 상태입니다.** 이 PR 이 배포되면 번들이 덮어써 정합이 맞습니다. 그전까지는 저장소와 배포본이 어긋나 있다는 점을 공유합니다.

---

## ⚠️ 배포 시 주의사항

- **`EXPECTED_TARGETS` 가 11 로 돌아간다.** cAdvisor 가 빠지므로 12 로 두면 배포가 실패한다.
- 이 PR 은 #508 과 함께 **묶음 A**(#512)의 재배포다.
