### PR TITLE
[Fix] #509 develop → main 재배포 — Metaspace 상한 제거와 cAdvisor 롤백

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -265,7 +265,6 @@ jobs:
             redis
             redis-exporter
             node-exporter
-            cadvisor
             kafka
             gateway-service
             auth-service
@@ -554,9 +553,8 @@ jobs:
 
           # 컨테이너가 떴다고 지표가 수집되는 것은 아니다. 타깃 주소가 틀리면 up=0인 채로
           # 배포가 초록불로 끝난다. 실제로 스크랩되는지 확인한다(이슈 #380 완료 조건).
-          # 앱 8 + redis + node + cadvisor + prometheus. node job(#465) 추가로 10→11,
-          # cadvisor job(#509) 추가로 11→12.
-          EXPECTED_TARGETS=12
+          # 앱 8 + redis + node + prometheus. node job(#465) 추가로 10→11.
+          EXPECTED_TARGETS=11
           PROMETHEUS_READY=false
 
           for ATTEMPT in $(seq 1 12); do

--- a/deploy/docker-compose.prod.yml
+++ b/deploy/docker-compose.prod.yml
@@ -355,20 +355,27 @@ services:
     # .env 에 같은 키가 있어도 이 값이 이긴다. .env 는 저장소에 없어 리뷰도 diff 도 남지 않고,
     # 파일을 다시 만들면 조용히 사라진다 — 힙 상한이 그렇게 관리될 값이 아니다.
     #
-    # 비힙 상한을 명시하는 이유: 이 셋은 기본값이 사실상 열려 있어 -Xmx 로 힙을 묶어도 cgroup
-    # 한계를 넘길 수 있다(#509 는 RSS 626 MiB 로 640 MiB 상한에 걸려 커널에 죽었다).
+    # 비힙 상한을 명시하는 이유: 기본값이 사실상 열려 있어 -Xmx 로 힙을 묶어도 cgroup 한계를
+    # 넘길 수 있다(#509 는 RSS 626 MiB 로 640 MiB 상한에 걸려 커널에 죽었다).
     #   MaxDirectMemorySize 기본값 = -Xmx = 384 MiB. 힙과 같은 크기가 힙 밖에 또 열려 있었다.
-    #   MaxMetaspaceSize 기본 무제한. 클래스 로딩만큼 계속 자란다.
-    #   ReservedCodeCacheSize 기본 240 MiB 예약.
-    # 합계 384(힙) + 128 + 64 + 64 = 640 이라 상한과 같아 보이지만, 이 값들은 '실사용'이 아니라
-    # '상한'이다. 실사용이 동시에 최대가 되는 일은 없고, 여기 없는 스레드 스택은 위 tomcat
-    # max-threads(50)로 따로 묶었다.
+    #     실측 최대 1.5 MiB(gateway)라 64m 은 40배 여유다.
+    #   ReservedCodeCacheSize 기본 240 MiB 예약. 실측 최대 33.3 MiB(booking)라 64m 은 2배 여유다.
+    #
+    # ⚠ MaxMetaspaceSize 는 두지 않는다. 처음에 128m 을 줬다가 배포가 실패했다.
+    #   OutOfMemoryError: Metaspace 로 앱이 좀비가 됐고 — 프로세스는 살아 있는데 요청을 처리하지
+    #   못한다 — Prometheus 스크랩이 타임아웃나 CD 의 up 게이트에서 걸렸다. 이유가 둘이다.
+    #     1) "무제한이라 계속 자란다"는 전제가 틀렸다. 상한 없는 7개 서비스 실측이 106-140 MiB 에서
+    #        수렴한다(performance 139.7 / booking 136.1 / user 106.1). 클래스 로딩은 유한하다.
+    #     2) 실패 모드가 나쁘다. 힙 OOM 과 달리 프로세스가 죽지 않아 재시작도 안 되고, 헬스체크가
+    #        아니라 스크랩 타임아웃으로만 드러난다. 조기 경보가 아니라 조용한 마비다.
+    #   예산 관점에서도 무의미하다 — 실측(140)을 덮을 값이면 힙 384 와 합쳐 이미 640 을 넘는다.
+    #
+    # 여기 없는 스레드 스택은 위 tomcat max-threads(50)로 따로 묶었다.
     environment:
       SERVER_PORT: 8086
       JAVA_TOOL_OPTIONS: >-
         -Xms128m
         -Xmx384m
-        -XX:MaxMetaspaceSize=128m
         -XX:ReservedCodeCacheSize=64m
         -XX:MaxDirectMemorySize=64m
     depends_on:

--- a/deploy/docker-compose.prod.yml
+++ b/deploy/docker-compose.prod.yml
@@ -145,44 +145,6 @@ services:
     # network_mode: host 는 networks: 와 양립하지 않아 서비스명 DNS 가 없다. 스크랩은 prometheus 의
     # extra_hosts(host.docker.internal)로 간다 — monitoring/prometheus.aws.yml 의 node job.
 
-  # 컨테이너별 메모리 시계열이 없어 seat-service 가 cgroup OOM 으로 죽는 것을 사전에 볼 수단이
-  # 없었다(#509). node-exporter 는 호스트 총량만 재므로 "어느 컨테이너가 한계에 가까운지"를
-  # 답하지 못한다. OOM 직전까지 대시보드에 아무 신호가 없었던 이유다.
-  cadvisor:
-    image: gcr.io/cadvisor/cadvisor:v0.49.1
-    container_name: cadvisor
-    # 이 128m 은 공짜가 아니다. mem_limit 합계가 7,232 → 7,360 MiB 가 되고 호스트 실측
-    # 7.6 GiB(약 7,782 MiB) 대비 여유가 550 → 422 MiB 로 준다(ADR 0006 의 예산 관점).
-    # #509 의 처방으로 seat-service 의 mem_limit 을 올리지 않은 이유이기도 하다 — 올릴 여유를
-    # 관측자가 먼저 가져간다. 관측 없이 상한만 올리면 다음 OOM 도 사후에 dmesg 로 알게 된다.
-    mem_limit: 128m
-    restart: unless-stopped
-    # privileged: true 를 쓰지 않는다. cAdvisor 가 그 권한을 요구하는 것은 커널 OOM 이벤트를
-    # 읽기 위해서인데, /dev/kmsg 하나만 주면 된다. 관측용 컨테이너에 호스트 전권을 주는 것은
-    # ADR 0007 이 관측 스택에 대해 세운 최소 노출 원칙과 어긋난다.
-    devices:
-      - /dev/kmsg
-    volumes:
-      - /:/rootfs:ro
-      - /var/run:/var/run:ro
-      - /sys:/sys:ro
-      - /var/lib/docker/:/var/lib/docker:ro
-    command:
-      # 2 vCPU 를 앱 8개와 나눠 쓰므로 관측자가 측정 대상을 흔들지 않게 줄인다.
-      # docker_only: 컨테이너 밖 cgroup 계층을 훑지 않는다.
-      # enable_metrics: 화이트리스트라 disable 목록을 나열하다 빠뜨리는 실수가 없다.
-      #   memory    — 이 이슈가 필요로 하는 축(container_memory_working_set_bytes)
-      #   cpu       — 메모리와 CPU 가 거의 같은 지점에서 함께 한계에 닿는다(#509)
-      #   oom_event — container_oom_events_total. OOM 을 사후에 dmesg 로 찾지 않아도 된다
-      - "--docker_only=true"
-      - "--housekeeping_interval=15s"
-      - "--enable_metrics=cpu,memory,oom_event"
-    # 관측 포트는 인터넷에 열지 않는다(ADR 0007). Prometheus 가 같은 네트워크에서 서비스명으로
-    # 스크랩한다. cAdvisor 의 기본 포트는 8080 이지만 publish 하지 않으므로 게이트웨이의
-    # 호스트 8080 과 충돌하지 않는다.
-    networks:
-      - ticketrush-network
-
   kafka-volume-init:
     image: apache/kafka:3.7.0
     container_name: ticketrush-kafka-volume-init

--- a/docs/load-test-guide.md
+++ b/docs/load-test-guide.md
@@ -1371,13 +1371,14 @@ sum(rate(node_disk_read_bytes_total{job="node"}[1m]))
 rate(node_network_transmit_bytes_total{job="node", device="ens5"}[1m])
 rate(node_network_receive_bytes_total{job="node", device="ens5"}[1m])
 
-# ── 컨테이너별 메모리 (cAdvisor, #509) ────────────────────────────────
-# node job 은 호스트 총량이라 "어느 컨테이너가 자기 상한에 가까운지"를 답하지 못한다.
-# seat-service 가 cgroup OOM 으로 죽을 때까지 신호가 없었던 것이 그래서다.
-# 상한 대비 사용률. 1.0 에 가까워지면 커널이 죽인다. 부하 중 상시 띄워 둘 값이다.
-container_memory_working_set_bytes{name!=""} / container_spec_memory_limit_bytes{name!=""}
-# OOM 은 사후에 dmesg 로 찾지 않는다. docker inspect 의 OOMKilled 는 재시작 뒤라 false 다(#509).
-increase(container_oom_events_total{name!=""}[5m])
+# ── 컨테이너별 메모리 — 아직 수단이 없다(#515) ────────────────────────
+# 위 node_* 는 호스트 총량이라 "어느 컨테이너가 자기 mem_limit 에 가까운지"를 답하지 못한다.
+# #509 에서 seat-service 가 cgroup OOM 으로 죽을 때까지 신호가 없었던 것이 그래서다.
+# cAdvisor 로 메우려 했으나 Docker 29 + cgroup v2 + systemd 조합에서 컨테이너를 열거하지
+# 못해 되돌렸다(#515 에 실측 기록). 그때까지 컨테이너 메모리는 이 두 가지로만 본다.
+#   부하 중:   ssh <EC2> 'docker stats --no-stream seat-service'
+#   OOM 판정:  ssh <EC2> 'sudo dmesg -T | grep CONSTRAINT_MEMCG'
+#              ⚠ docker inspect 의 OOMKilled 는 재시작 뒤라 false 로 나온다 — 믿지 말 것
 
 # ── 게이트웨이 축 (연결 거부는 서버 축에 안 잡힌다 — #496 §2.4) ─────────
 sum(rate(http_server_requests_seconds_count{job="gateway", status=~"5.."}[1m]))

--- a/monitoring/prometheus.aws.yml
+++ b/monitoring/prometheus.aws.yml
@@ -55,16 +55,6 @@ scrape_configs:
         labels:
           stack: observability
 
-  # 컨테이너별 자원 지표(#509). node job 이 호스트 총량을 재는 데 반해 이쪽은 "어느 컨테이너가
-  # 자기 mem_limit 에 가까운지"를 답한다. seat-service 가 cgroup OOM 으로 죽을 때까지 대시보드에
-  # 신호가 없었던 것이 이 job 이 없었기 때문이다. exporter 는 포트를 publish 하지 않는다(ADR 0007).
-  - job_name: 'cadvisor'
-    static_configs:
-      - targets:
-          - 'cadvisor:8080'
-        labels:
-          stack: observability
-
   # 자기 자신. ADR 0007이 "전환 시점"의 기준으로 삼은 '부하 중 Prometheus의 CPU·메모리 점유'를
   # 재려면 prometheus_* 자기 지표가 필요하다. mem_limit(384m) 재평가 근거도 여기서 나온다.
   - job_name: 'prometheus'


### PR DESCRIPTION
## 🔗 관련 이슈

- #508 (닫지 않는다 — 배포 후 실측이 남아 있다)
- #509 (닫지 않는다 — 재현 절차 실행이 남아 있다)
- 배포 묶음 트래킹: #512 의 **묶음 A 재배포**

---

## 📌 주요 변경 사항

`develop` → `main` **재배포.** PR #514 의 배포가 CD 게이트에서 실패해 그 원인을 제거한 것이 전부다.

- **[Fix] #509** — `-XX:MaxMetaspaceSize=128m` 제거, cAdvisor 롤백 (PR #516)

앱 코드 변경은 없다. `seat-service/application.yml` 의 `max-threads: 50` 과 compose 의 나머지 JVM 옵션은 **PR #514 에서 이미 나갔고 정상 동작 중**이다.

---

## 🛠 상세 구현 내용

### 왜 첫 배포가 실패했나

`Deploy on EC2` 가 `UP_COUNT == 12` 를 만족하지 못해 exit 1 로 끝났다. **seat-service 하나만 down** 이었고 나머지 11개는 전부 up 이었다.

```
http://seat-service:8090/actuator/prometheus health=down
  error=Get "...": context deadline exceeded
```

`-XX:MaxMetaspaceSize=128m` 이 부족해 `OutOfMemoryError: Metaspace` 가 반복됐다. **프로세스는 살아 있는데 요청을 처리하지 못하는 좀비**라 재시작도 안 되고 스크랩 타임아웃으로만 드러났다. 상한 없는 7개 서비스 실측이 106-140 MiB 에서 수렴하므로(performance 139.7 / booking 136.1 / user 106.1) 128m 이 애초에 부족했다.

cAdvisor 는 별개 이유다 — 이 호스트(Docker 29.1.3 + cgroup v2 + systemd)에서 컨테이너를 하나도 열거하지 못했다. 128 MiB 를 먹으면서 데이터를 못 주므로 뺐고, 수단은 **#515** 에서 다시 고른다.

### 이번 배포로 정합이 맞는다

**현재 EC2 는 저장소와 어긋나 있다.** 장애 복구를 위해 compose 를 손으로 고쳐 seat-service 를 재생성했다(`MaxMetaspaceSize` 줄 삭제). 이 PR 이 배포되면 번들이 그 파일을 덮어써 저장소가 다시 SSOT 가 된다. cAdvisor 컨테이너도 `--remove-orphans` 로 정리된다.

---

## ✅ 테스트

### 테스트 방법

PR #516 에서 검증을 마쳤다. 이 PR 에서는 **EC2 현재 상태**를 다시 확인했다.

### 테스트 결과

**임시 적용분 기준 현재 EC2 상태** — 이 PR 이 배포되면 타깃이 12 → 11 이 된다.

| 확인 | 결과 |
|---|---|
| `OutOfMemoryError` 재발 | **0건** |
| seat-service `RestartCount` | **0** |
| 스크랩 타깃 | 12/12 up |
| 기준선 RSS | **412.9 MiB / 640 (64.5%)** — 이전 439 MiB |
| `tomcat_threads_config_max_threads` | **50** |
| JVM 실인식값 | 힙 384 / CodeCache 64 / Direct 64 / Metaspace 무제한 |
| #508 device 목록 | `ens5`, `lo` 만 — veth 15개·br 3개 전부 제외 |
| #508 리스닝 | `172.17.0.1:9100` 만 |

**저장소 검증**: `compose config -q` exit 0, CI scrape 타깃 검증 exit 0, `mem_limit` 합계 7,232 MiB(15개)로 원복.

### 📸 스크린샷

- (작성 필요)

---

## 👀 리뷰 요청 사항

- **첫 배포 실패는 제 판단 착오였습니다.** "MaxMetaspaceSize 는 무제한이라 계속 자란다"는 전제를 실측 없이 썼고, 그 값이 실측 분포 한복판이라 부족했습니다. 같은 종류의 실수를 막으려면 **비힙 관련 값은 실측을 먼저 붙이는 것**을 규칙으로 삼는 편이 낫다고 봅니다 — 의견 부탁드립니다.
- **CD 게이트가 제 역할을 했습니다.** 깨진 채로 배포가 끝나지 않았고 `lastError` 로 원인이 즉시 갈렸습니다. `EXPECTED_TARGETS` 를 유지·관리하는 비용이 이번에 값을 했다고 봅니다.

---

## ⚠️ 배포 시 주의사항

- **`EXPECTED_TARGETS` 가 11 로 돌아간다.** cAdvisor 가 빠지므로 12 로 두면 배포가 실패한다.
- **cAdvisor 컨테이너가 정리되어야 한다.** CD 의 `up -d --remove-orphans` 가 처리한다 — 배포 후 `docker ps` 에서 사라졌는지 확인한다.
- 배포 후 두 이슈의 완료 조건 검증(부하 회차 포함)이 남는다. 결과는 `[Test] #508, 509` 측정 PR 로 올리고 **거기서 두 이슈를 닫는다**.
