### PR TITLE
[Feat] #520 좌석 상태 이벤트에 발행 경로 태그 추가

### DIFF
--- a/common/src/main/java/com/ticketrush/global/constants/MetricNames.java
+++ b/common/src/main/java/com/ticketrush/global/constants/MetricNames.java
@@ -24,6 +24,11 @@ public class MetricNames {
   // 이벤트가 안 왔다는 사실조차 모르므로, 이 카운터가 유일한 관측 축이다. #403 실측에서 회차 하나에
   // 2,009건(시도의 10.3%)이 사라졌는데 그걸 로그 파싱으로만 셀 수 있었다.
   public static final String SEAT_SSE_EVENT_REJECTED = "ticketrush.seat.sse.event.rejected";
+  // SSE 전송 큐에 들어간 이벤트를 발행 경로별로 센다(#520). REJECTED가 "얼마나 잃었나"를 말한다면 이쪽은
+  // "그 큐를 누가 채웠나"를 말한다. #403은 큐 깊이가 평균 50·최대 307까지 튀는 것을 봤지만 도착 불균일의
+  // 출처를 가르지 못했다(리포트 §10) — executor_queued_tasks와 겹쳐 읽으라고 있는 축이다.
+  // 태그 값은 SeatEventSource 열거형이라 유한 집합이 컴파일 시점에 보장된다.
+  public static final String SEAT_SSE_EVENT_PUBLISHED = "ticketrush.seat.sse.event.published";
 
   // payment
   public static final String PAYMENT_CONFIRM = "ticketrush.payment.confirm";
@@ -56,6 +61,8 @@ public class MetricNames {
   public static final String TAG_CONSUMER_GROUP = "consumer_group";
   public static final String TAG_AGGREGATE_TYPE = "aggregate_type";
   public static final String TAG_PROVIDER = "provider";
+  // 이벤트를 만든 발행 경로(#520). 값은 seat-service의 SeatEventSource 열거형이 SSOT다.
+  public static final String TAG_SOURCE = "source";
 
   // ===== Tag values =====
   public static final String RESULT_SUCCESS = "success";

--- a/docs/load-test-guide.md
+++ b/docs/load-test-guide.md
@@ -1478,7 +1478,9 @@ ssh -i ~/ticket_rush_ssh.pem ubuntu@<EC2>
 
 > **G1이 실패하면 측정 자체가 무의미하다.** 인덱스가 없으면 집계가 풀스캔이 되어 "앱의 특성"이 아니라 "인덱스 부재"를 재게 된다. `@Index`는 `ddl-auto=update`인 로컬/신규 초기화 DB에서만 생성되고 prod(`validate`)는 부재를 검출하지 못한다(`Seat.java:35-51`). 없으면 먼저 수동 DDL을 넣는다.
 
-> **G2가 실패해도 배포하지 않는다.** `SeatStatusSseConfig.java:12`의 `@Bean` 선언 반환 타입이 `Executor`라 Boot의 `TaskExecutorMetricsAutoConfiguration`이 `TaskExecutor` 타입으로 후보를 모으는 단계에서 이 빈을 놓칠 수 있다. 그 경우 큐 적체·거부는 **로그 타임스탬프**로 기록하고(§14.6), 반환 타입을 `ThreadPoolTaskExecutor`로 좁히는 1줄 변경은 **후속 이슈로 분리**한다. 리포트 한계에 "큐 깊이 시계열 부재"를 명시한다.
+> **G2는 #403에서 실패했고 그 원인은 PR #519가 고쳤다.** `SeatStatusSseConfig`의 `@Bean` 반환 타입이 `Executor`라 Boot의 `TaskExecutorMetricsAutoConfiguration`이 `TaskExecutor` 타입으로 후보를 모으는 단계에서 이 빈을 놓쳤다. 반환 타입을 `ThreadPoolTaskExecutor`로 좁혀 해결했으므로 **그 변경이 배포된 이미지에서는 G2가 통과해야 한다.** 그래도 실패하면 배포본이 그 커밋을 담고 있는지(G3)부터 본다. 큐 깊이 시계열 없이 회차를 돌리면 §14.6의 판정이 로그 파싱으로 되돌아간다.
+
+> **G5 — 발행 경로 태그(#520).** `docker exec seat-service wget -qO- localhost:8090/actuator/prometheus | grep ticketrush_seat_sse_event_published` 가 **source 라벨 5종을 전부** 내야 한다(`booking_hold`·`expire_single`·`scheduler_fallback`·`confirm_sold`·`refund_release`). 카운터를 기동 시 미리 등록하므로 발행이 0건인 경로도 나온다 — **라벨이 빠져 있으면 배포본에 #520이 없는 것이지 그 경로가 조용한 것이 아니다.**
 
 ### 14.3 시딩
 
@@ -1624,6 +1626,14 @@ sum(rate(http_server_requests_seconds_sum{instance="seat-service:8090"}[1m])) by
 executor_queued_tasks{name="seatStatusSseExecutor"}        # 1000 이 상한
 executor_active_threads{name="seatStatusSseExecutor"}
 executor_pool_size_threads{name="seatStatusSseExecutor"}   # 4 -> 16 은 큐 포화 뒤에만
+
+# 발행 경로별 도착률(#520). 위 큐 깊이와 겹쳐 읽는 것이 이 축의 용도다 — #403 은 큐가 평균 50 ·
+# 최대 307 까지 튀는 것을 봤지만 그 불균일이 어느 경로에서 왔는지 가르지 못했다(§10).
+# source 값 5종: booking_hold / expire_single / scheduler_fallback / confirm_sold / refund_release
+sum by (source) (rate(ticketrush_seat_sse_event_published_total[1m]))
+# 스케줄러 fallback 만 떼어 본다. tick 당 최대 2,000 건(chunk 25 x max-chunks 80)이 한 번에 들어가는데
+# 큐 용량이 1000 이라, 버스트가 여기서 온다면 이 선이 60초 주기의 톱니로 보인다.
+rate(ticketrush_seat_sse_event_published_total{source="scheduler_fallback"}[1m])
 
 # 거부 = 이벤트 유실(#403 이후 추가). 위 큐 깊이가 '왜' 를 말하고 이 카운터가 '얼마나' 를 말한다.
 rate(ticketrush_seat_sse_event_rejected_total[1m])

--- a/load-test/bench/dump-timeseries.py
+++ b/load-test/bench/dump-timeseries.py
@@ -122,6 +122,9 @@ QUERIES = [
     ("sse-executor-active", 'executor_active_threads{name="seatStatusSseExecutor"}'),
     ("sse-executor-pool-size", 'executor_pool_size_threads{name="seatStatusSseExecutor"}'),
     ("sse-executor-completed-rate", 'rate(executor_completed_tasks_total{name="seatStatusSseExecutor"}[1m])'),
+    # 발행 경로별 도착률(#520). 위 큐 깊이와 같은 창에 떠야 겹쳐 읽을 수 있다 — #403 은 큐가 평균 50 ·
+    # 최대 307 까지 튀는 것을 봤지만 그 불균일의 출처를 가르지 못했다(§10). source 5종.
+    ("sse-published-by-source", 'sum by (source) (rate(ticketrush_seat_sse_event_published_total[1m]))'),
     ("k6-sse-propagation-p95", 'k6_sse_propagation_ms_p95'),
     ("k6-sse-propagation-p99", 'k6_sse_propagation_ms_p99'),
     ("k6-sse-probe-booking-p95", 'k6_sse_probe_booking_duration_p95'),

--- a/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/app/support/SeatEventSource.java
+++ b/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/app/support/SeatEventSource.java
@@ -1,0 +1,53 @@
+package com.ticketrush.boundedcontext.seat.app.support;
+
+/**
+ * 좌석 상태 이벤트를 만든 발행 경로(#520). {@code MetricNames.TAG_SOURCE} 태그 값이 된다.
+ *
+ * <p><b>왜 필요한가.</b> #403 실측에서 구독자 600명 구간의 전파 지연 p95가 2.77s인데 자기 이벤트의 팬아웃 몫은 약 170ms뿐이었다. 나머지는 앞에
+ * 쌓인 큐를 기다린 시간이고 그게 지연의 지배항이다. 그런데 평균 이용률이 38%로 여유로운데도 큐 깊이가 평균 50, 최대 307까지 튄다 — 도착이 고르지 않다는 뜻인데
+ * <b>그 불균일이 어느 경로에서 오는지 가를 수단이 없었다</b>(리포트 §10). 경로별 발행률을 {@code executor_queued_tasks}와 겹쳐 읽는 것이 그
+ * 답이다.
+ *
+ * <p><b>왜 열거형인가.</b> 발행 경로는 호출자만 안다 — 좌석 상태로 유도할 수 없다. {@link #EXPIRE_SINGLE}과 {@link
+ * #SCHEDULER_FALLBACK}은 결과 상태가 똑같이 {@code AVAILABLE}이다. 그리고 태그 값은 유한 집합이어야 하는데( {@code MetricNames}
+ * 규약), 문자열 상수는 오타를 컴파일 시점에 못 잡는다.
+ *
+ * <p><b>새 발행 경로를 추가하면 여기에도 값을 더한다.</b> 빠뜨리면 그 도착이 다른 경로에 섞여 §10의 질문에 다시 답하지 못하게 된다.
+ */
+public enum SeatEventSource {
+
+  /** 예매 유입 — Kafka {@code BookingCreatedEvent} → HOLD 진입 ({@code SeatHoldUseCase}). */
+  BOOKING_HOLD("booking_hold"),
+
+  /**
+   * 해제 주 경로 — Redis 키 만료 이벤트로 1건씩 즉시 해제({@code SeatReleaseSingleUseCase}). 좌석 락 TTL이 5분이라 예매 5분 뒤 이
+   * 경로가 두 번째 이벤트를 낸다. 고르게 퍼진다.
+   */
+  EXPIRE_SINGLE("expire_single"),
+
+  /**
+   * 해제 fallback — {@code SeatStatusScheduler}(60초)가 놓친 것을 쓸어 담는다({@code
+   * SeatReleaseExpiredChunkProcessor}). tick당 최대 2,000건(chunk 25 × max-chunks 80)이 한 번에 executor로
+   * 들어가는데 <b>큐 용량이 1000</b>이라, 버스트의 유력한 용의자다.
+   */
+  SCHEDULER_FALLBACK("scheduler_fallback"),
+
+  /** 판매 확정 — 내부 API {@code SeatInternalController} → {@code SeatConfirmSoldUseCase}. */
+  CONFIRM_SOLD("confirm_sold"),
+
+  /**
+   * 환불 반환 — Kafka {@code PaymentCanceledEvent} → SOLD를 AVAILABLE로({@code
+   * SeatReleaseSoldSeatUseCase}).
+   */
+  REFUND_RELEASE("refund_release");
+
+  private final String tagValue;
+
+  SeatEventSource(String tagValue) {
+    this.tagValue = tagValue;
+  }
+
+  public String tagValue() {
+    return tagValue;
+  }
+}

--- a/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/app/support/SeatStatusEventPublisher.java
+++ b/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/app/support/SeatStatusEventPublisher.java
@@ -3,22 +3,64 @@ package com.ticketrush.boundedcontext.seat.app.support;
 import com.ticketrush.boundedcontext.seat.app.dto.response.SeatStatusChangedResponse;
 import com.ticketrush.boundedcontext.seat.app.mapper.SeatMapper;
 import com.ticketrush.boundedcontext.seat.domain.entity.Seat;
-import lombok.RequiredArgsConstructor;
+import com.ticketrush.global.constants.MetricNames;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import java.util.EnumMap;
+import java.util.Map;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.support.TransactionSynchronization;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 @Component
-@RequiredArgsConstructor
 public class SeatStatusEventPublisher {
 
   private final SeatStatusEventSender seatStatusEventSender;
   private final SeatMapper seatMapper;
 
-  public void publishAfterCommit(Seat seat) {
+  /**
+   * 경로별 Counter를 기동 시 전부 만들어 둔다(#520).
+   *
+   * <p>핫패스에서 {@code Counter.builder(...).register(...)}를 부르지 않으려는 것이다 — {@code
+   * SeatStatusSseEventSender}가 거부 카운터에 대해 남긴 근거와 같다. 여기는 그쪽보다 조건이 나쁘다. {@link
+   * SeatEventSource#SCHEDULER_FALLBACK}이 tick당 최대 2,000건을 한 번에 밀어 넣는데, 그 구간이 정확히 이 지표를 읽으려는 구간이라 계측
+   * 비용이 관측 대상에 섞이면 안 된다.
+   *
+   * <p>미리 만들어 두면 <b>아직 한 번도 발행되지 않은 경로도 0으로 노출된다</b>는 이점이 따라온다. 지연 생성이면 "그 경로가 조용했다"와 "그 경로를 계측하지
+   * 못하고 있다"가 그래프에서 구분되지 않는다.
+   */
+  private final Map<SeatEventSource, Counter> publishedCounters =
+      new EnumMap<>(SeatEventSource.class);
+
+  public SeatStatusEventPublisher(
+      SeatStatusEventSender seatStatusEventSender,
+      SeatMapper seatMapper,
+      MeterRegistry meterRegistry) {
+    this.seatStatusEventSender = seatStatusEventSender;
+    this.seatMapper = seatMapper;
+
+    for (SeatEventSource source : SeatEventSource.values()) {
+      publishedCounters.put(
+          source,
+          Counter.builder(MetricNames.SEAT_SSE_EVENT_PUBLISHED)
+              .tag(MetricNames.TAG_SOURCE, source.tagValue())
+              .register(meterRegistry));
+    }
+  }
+
+  /**
+   * 좌석 상태 변경 이벤트를 커밋 이후에 발행한다.
+   *
+   * <p>{@code source}는 호출자만 아는 정보다 — 좌석 상태로 유도할 수 없다({@link SeatEventSource} 참고). 카운터는 <b>실제 send
+   * 시점에</b> 올린다. 롤백된 트랜잭션의 발행을 세면 큐 도착과 어긋나 이 지표를 넣은 이유 자체가 무너진다({@code
+   * SeatHoldUseCase.incrementSuccessAfterCommit}과 같은 선).
+   */
+  public void publishAfterCommit(Seat seat, SeatEventSource source) {
     SeatStatusChangedResponse event = seatMapper.toChangedResponse(seat);
+    Counter published = publishedCounters.get(source);
 
     if (!TransactionSynchronizationManager.isSynchronizationActive()) {
+      published.increment();
       seatStatusEventSender.send(event);
       return;
     }
@@ -27,6 +69,7 @@ public class SeatStatusEventPublisher {
         new TransactionSynchronization() {
           @Override
           public void afterCommit() {
+            published.increment();
             seatStatusEventSender.send(event);
           }
         });

--- a/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/app/usecase/SeatConfirmSoldUseCase.java
+++ b/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/app/usecase/SeatConfirmSoldUseCase.java
@@ -1,5 +1,6 @@
 package com.ticketrush.boundedcontext.seat.app.usecase;
 
+import com.ticketrush.boundedcontext.seat.app.support.SeatEventSource;
 import com.ticketrush.boundedcontext.seat.app.support.SeatStatusEventPublisher;
 import com.ticketrush.boundedcontext.seat.domain.entity.Seat;
 import com.ticketrush.boundedcontext.seat.out.repository.SeatRepository;
@@ -38,7 +39,7 @@ public class SeatConfirmSoldUseCase {
             .orElseThrow(() -> new BusinessException(ErrorStatus.SEAT_NOT_FOUND));
 
     if (updatedCount == 1) {
-      seatStatusEventPublisher.publishAfterCommit(seat);
+      seatStatusEventPublisher.publishAfterCommit(seat, SeatEventSource.CONFIRM_SOLD);
       forceReleaseAfterCommit(seatId);
       log.info("좌석 판매 확정 완료. bookingNumber: {}, seatId: {}", bookingNumber, seatId);
       return;

--- a/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/app/usecase/SeatHoldUseCase.java
+++ b/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/app/usecase/SeatHoldUseCase.java
@@ -1,5 +1,6 @@
 package com.ticketrush.boundedcontext.seat.app.usecase;
 
+import com.ticketrush.boundedcontext.seat.app.support.SeatEventSource;
 import com.ticketrush.boundedcontext.seat.app.support.SeatStatusEventPublisher;
 import com.ticketrush.boundedcontext.seat.domain.entity.Seat;
 import com.ticketrush.boundedcontext.seat.out.repository.SeatRepository;
@@ -54,7 +55,7 @@ public class SeatHoldUseCase {
     }
 
     seat.hold(holdExpiredAt, bookingNumber);
-    seatStatusEventPublisher.publishAfterCommit(seat);
+    seatStatusEventPublisher.publishAfterCommit(seat, SeatEventSource.BOOKING_HOLD);
     incrementSuccessAfterCommit();
     return true;
   }

--- a/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/app/usecase/SeatReleaseExpiredChunkProcessor.java
+++ b/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/app/usecase/SeatReleaseExpiredChunkProcessor.java
@@ -1,5 +1,6 @@
 package com.ticketrush.boundedcontext.seat.app.usecase;
 
+import com.ticketrush.boundedcontext.seat.app.support.SeatEventSource;
 import com.ticketrush.boundedcontext.seat.app.support.SeatHoldExpiredPublisher;
 import com.ticketrush.boundedcontext.seat.app.support.SeatStatusEventPublisher;
 import com.ticketrush.boundedcontext.seat.domain.entity.Seat;
@@ -72,7 +73,7 @@ public class SeatReleaseExpiredChunkProcessor {
        * UPDATE ... WHERE seat_id = ? 더티 체킹 쓰기가 되살아난다. 즉 위 가드가 무력화된다. */
       seatHoldExpiredPublisher.publish(seat);
       seat.releaseHold();
-      seatStatusEventPublisher.publishAfterCommit(seat);
+      seatStatusEventPublisher.publishAfterCommit(seat, SeatEventSource.SCHEDULER_FALLBACK);
       released++;
     }
 

--- a/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/app/usecase/SeatReleaseSingleUseCase.java
+++ b/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/app/usecase/SeatReleaseSingleUseCase.java
@@ -1,5 +1,6 @@
 package com.ticketrush.boundedcontext.seat.app.usecase;
 
+import com.ticketrush.boundedcontext.seat.app.support.SeatEventSource;
 import com.ticketrush.boundedcontext.seat.app.support.SeatHoldExpiredPublisher;
 import com.ticketrush.boundedcontext.seat.app.support.SeatStatusEventPublisher;
 import com.ticketrush.boundedcontext.seat.out.repository.SeatRepository;
@@ -49,7 +50,7 @@ public class SeatReleaseSingleUseCase {
               // 조정이고, 위 조건부 UPDATE가 이미 DB를 바꿨다. 가드가 통과했으므로 스냅샷은 최신이다.
               seatHoldExpiredPublisher.publish(seat);
               seat.releaseHold();
-              seatStatusEventPublisher.publishAfterCommit(seat);
+              seatStatusEventPublisher.publishAfterCommit(seat, SeatEventSource.EXPIRE_SINGLE);
               log.info("Redis 만료 이벤트 수신: 좌석 {} 상태를 AVAILABLE로 즉시 롤백했습니다.", seatId);
             },
             () ->

--- a/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/app/usecase/SeatReleaseSoldSeatUseCase.java
+++ b/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/app/usecase/SeatReleaseSoldSeatUseCase.java
@@ -1,5 +1,6 @@
 package com.ticketrush.boundedcontext.seat.app.usecase;
 
+import com.ticketrush.boundedcontext.seat.app.support.SeatEventSource;
 import com.ticketrush.boundedcontext.seat.app.support.SeatStatusEventPublisher;
 import com.ticketrush.boundedcontext.seat.out.repository.SeatRepository;
 import com.ticketrush.global.types.SeatStatus;
@@ -54,7 +55,7 @@ public class SeatReleaseSoldSeatUseCase {
     }
 
     seat.releaseBooking(); // SOLD → AVAILABLE
-    seatStatusEventPublisher.publishAfterCommit(seat);
+    seatStatusEventPublisher.publishAfterCommit(seat, SeatEventSource.REFUND_RELEASE);
     log.info("환불 좌석 반환 완료. seatId: {}", seatId);
   }
 }

--- a/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/app/facade/SeatHoldConcurrencyTest.java
+++ b/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/app/facade/SeatHoldConcurrencyTest.java
@@ -133,7 +133,8 @@ class SeatHoldConcurrencyTest {
         new SeatHoldUseCase(
             seatRepository,
             // SSE 전송은 이 테스트의 관심사가 아니다. SeatStatusEventSender가 인터페이스라 람다로 끝난다.
-            new SeatStatusEventPublisher(event -> {}, Mappers.getMapper(SeatMapper.class)),
+            new SeatStatusEventPublisher(
+                event -> {}, Mappers.getMapper(SeatMapper.class), meterRegistry),
             meterRegistry);
 
     // ponytail: SeatFacade의 생성자 11개 중 홀드 경로가 쓰는 4개만 채우고 나머지 7개는 null로 둔다.

--- a/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/app/support/SeatStatusEventPublisherTest.java
+++ b/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/app/support/SeatStatusEventPublisherTest.java
@@ -1,46 +1,55 @@
 package com.ticketrush.boundedcontext.seat.app.support;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 
 import com.ticketrush.boundedcontext.seat.app.mapper.SeatMapper;
 import com.ticketrush.boundedcontext.seat.domain.entity.Seat;
+import com.ticketrush.global.constants.MetricNames;
 import com.ticketrush.global.types.SeatStatus;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.time.LocalDateTime;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.mapstruct.factory.Mappers;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
-import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 @ExtendWith(MockitoExtension.class)
 class SeatStatusEventPublisherTest {
 
-  @InjectMocks private SeatStatusEventPublisher seatStatusEventPublisher;
+  private SeatStatusEventPublisher seatStatusEventPublisher;
+  private SimpleMeterRegistry meterRegistry;
 
   @Mock private SeatStatusEventSender seatStatusEventSender;
 
-  @Spy private SeatMapper seatMapper = Mappers.getMapper(SeatMapper.class);
+  private final SeatMapper seatMapper = Mappers.getMapper(SeatMapper.class);
+
+  @BeforeEach
+  void setUp() {
+    // @InjectMocks 대신 손으로 조립한다 — 카운터를 생성자에서 등록하므로 실제 레지스트리가 필요하다
+    // (SeatHoldUseCaseTest와 같은 패턴).
+    meterRegistry = new SimpleMeterRegistry();
+    seatStatusEventPublisher =
+        new SeatStatusEventPublisher(seatStatusEventSender, seatMapper, meterRegistry);
+  }
 
   @Test
   @DisplayName("트랜잭션이 없으면 좌석 상태 변경 이벤트를 즉시 발행한다")
   void publishAfterCommitPublishesImmediatelyWithoutTransaction() {
     // given
     LocalDateTime holdExpiredAt = LocalDateTime.now().plusMinutes(5);
-    Seat seat =
-        Seat.builder()
-            .seatLayoutId(10L)
-            .performanceId(1L)
-            .seatNumber("A-1")
-            .seatStatus(SeatStatus.HOLD)
-            .holdExpiredAt(holdExpiredAt)
-            .build();
+    Seat seat = seat(holdExpiredAt);
 
     // when
-    seatStatusEventPublisher.publishAfterCommit(seat);
+    seatStatusEventPublisher.publishAfterCommit(seat, SeatEventSource.BOOKING_HOLD);
 
     // then
     verify(seatStatusEventSender)
@@ -52,5 +61,74 @@ class SeatStatusEventPublisherTest {
                         && event.seatNumber().equals("A-1")
                         && event.seatStatus() == SeatStatus.HOLD
                         && event.holdExpiredAt().equals(holdExpiredAt)));
+  }
+
+  @ParameterizedTest
+  @EnumSource(SeatEventSource.class)
+  @DisplayName("발행 경로마다 자기 source 태그로만 계측된다")
+  void publishAfterCommitCountsPerSource(SeatEventSource source) {
+    // when
+    seatStatusEventPublisher.publishAfterCommit(seat(null), source);
+
+    // then — 자기 태그만 1이고 나머지 경로는 0으로 남는다. 한 경로의 증가가 다른 경로에 새면
+    // #403 §10이 남긴 질문(도착 불균일의 출처)에 다시 답하지 못하게 된다.
+    for (SeatEventSource other : SeatEventSource.values()) {
+      assertThat(publishedCount(other)).isEqualTo(other == source ? 1.0 : 0.0);
+    }
+  }
+
+  @Test
+  @DisplayName("카운터는 기동 시 전부 등록되어, 발행이 없는 경로도 0으로 노출된다")
+  void countersAreRegisteredEagerlyForEverySource() {
+    // then — 지연 생성이면 '조용한 경로'와 '계측되지 않는 경로'가 그래프에서 구분되지 않는다.
+    for (SeatEventSource source : SeatEventSource.values()) {
+      assertThat(
+              meterRegistry
+                  .find(MetricNames.SEAT_SSE_EVENT_PUBLISHED)
+                  .tag(MetricNames.TAG_SOURCE, source.tagValue())
+                  .counter())
+          .as("경로 %s 의 카운터가 등록되어 있어야 한다", source)
+          .isNotNull();
+    }
+  }
+
+  @Test
+  @DisplayName("트랜잭션이 있으면 커밋 전에는 발행도 계측도 하지 않는다")
+  void publishAfterCommitDefersUntilCommit() {
+    TransactionSynchronizationManager.initSynchronization();
+    try {
+      // when
+      seatStatusEventPublisher.publishAfterCommit(seat(null), SeatEventSource.SCHEDULER_FALLBACK);
+
+      // then — 롤백된 트랜잭션의 발행을 세면 큐 도착과 어긋난다. 아직 커밋 전이므로 둘 다 일어나지 않아야 한다.
+      verifyNoInteractions(seatStatusEventSender);
+      assertThat(publishedCount(SeatEventSource.SCHEDULER_FALLBACK)).isZero();
+      assertThat(TransactionSynchronizationManager.getSynchronizations()).hasSize(1);
+
+      // when — 커밋 훅이 돌면 그때 발행되고 그때 세어진다
+      TransactionSynchronizationManager.getSynchronizations().forEach(s -> s.afterCommit());
+
+      // then
+      verify(seatStatusEventSender).send(argThat(event -> event.performanceId().equals(1L)));
+      assertThat(publishedCount(SeatEventSource.SCHEDULER_FALLBACK)).isEqualTo(1.0);
+    } finally {
+      TransactionSynchronizationManager.clearSynchronization();
+    }
+  }
+
+  private double publishedCount(SeatEventSource source) {
+    return meterRegistry
+        .counter(MetricNames.SEAT_SSE_EVENT_PUBLISHED, MetricNames.TAG_SOURCE, source.tagValue())
+        .count();
+  }
+
+  private Seat seat(LocalDateTime holdExpiredAt) {
+    return Seat.builder()
+        .seatLayoutId(10L)
+        .performanceId(1L)
+        .seatNumber("A-1")
+        .seatStatus(SeatStatus.HOLD)
+        .holdExpiredAt(holdExpiredAt)
+        .build();
   }
 }

--- a/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/app/usecase/SeatConfirmSoldUseCaseTest.java
+++ b/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/app/usecase/SeatConfirmSoldUseCaseTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
+import com.ticketrush.boundedcontext.seat.app.support.SeatEventSource;
 import com.ticketrush.boundedcontext.seat.app.support.SeatStatusEventPublisher;
 import com.ticketrush.boundedcontext.seat.domain.entity.Seat;
 import com.ticketrush.boundedcontext.seat.out.repository.SeatRepository;
@@ -49,7 +50,7 @@ class SeatConfirmSoldUseCaseTest {
     // then
     verify(seatRepository).confirmSoldById(seatId, bookingNumber, SeatStatus.HOLD, SeatStatus.SOLD);
     verify(seatRepository).findById(seatId);
-    verify(seatStatusEventPublisher).publishAfterCommit(seat);
+    verify(seatStatusEventPublisher).publishAfterCommit(seat, SeatEventSource.CONFIRM_SOLD);
     verify(seatUnlockUseCase).forceRelease(seatId);
   }
 

--- a/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/app/usecase/SeatHoldUseCaseTest.java
+++ b/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/app/usecase/SeatHoldUseCaseTest.java
@@ -6,6 +6,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 
+import com.ticketrush.boundedcontext.seat.app.support.SeatEventSource;
 import com.ticketrush.boundedcontext.seat.app.support.SeatStatusEventPublisher;
 import com.ticketrush.boundedcontext.seat.domain.entity.Seat;
 import com.ticketrush.boundedcontext.seat.out.repository.SeatRepository;
@@ -67,7 +68,7 @@ class SeatHoldUseCaseTest {
     assertThat(seat.getSeatStatus()).isEqualTo(SeatStatus.HOLD);
     assertThat(seat.getHoldExpiredAt()).isEqualTo(expiredAt);
     assertThat(seat.getBookingNumber()).isEqualTo(bookingNumber);
-    verify(seatStatusEventPublisher).publishAfterCommit(seat);
+    verify(seatStatusEventPublisher).publishAfterCommit(seat, SeatEventSource.BOOKING_HOLD);
     assertThat(
             meterRegistry
                 .counter(MetricNames.SEAT_HOLD, MetricNames.TAG_RESULT, MetricNames.RESULT_SUCCESS)

--- a/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/app/usecase/SeatReleaseExpiredChunkProcessorTest.java
+++ b/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/app/usecase/SeatReleaseExpiredChunkProcessorTest.java
@@ -8,6 +8,7 @@ import static org.mockito.BDDMockito.willAnswer;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
+import com.ticketrush.boundedcontext.seat.app.support.SeatEventSource;
 import com.ticketrush.boundedcontext.seat.app.support.SeatHoldExpiredPublisher;
 import com.ticketrush.boundedcontext.seat.app.support.SeatStatusEventPublisher;
 import com.ticketrush.boundedcontext.seat.domain.entity.Seat;
@@ -61,8 +62,10 @@ class SeatReleaseExpiredChunkProcessorTest {
     assertThat(expiredSeat1.getSeatStatus()).isEqualTo(SeatStatus.AVAILABLE);
     assertThat(expiredSeat2.getSeatStatus()).isEqualTo(SeatStatus.AVAILABLE);
     verify(seatRepository).findExpiredHoldSeats(SeatStatus.HOLD, now, PageRequest.of(0, chunkSize));
-    verify(seatStatusEventPublisher).publishAfterCommit(expiredSeat1);
-    verify(seatStatusEventPublisher).publishAfterCommit(expiredSeat2);
+    verify(seatStatusEventPublisher)
+        .publishAfterCommit(expiredSeat1, SeatEventSource.SCHEDULER_FALLBACK);
+    verify(seatStatusEventPublisher)
+        .publishAfterCommit(expiredSeat2, SeatEventSource.SCHEDULER_FALLBACK);
     verify(seatHoldExpiredPublisher).publish(expiredSeat1);
     verify(seatHoldExpiredPublisher).publish(expiredSeat2);
   }
@@ -129,7 +132,8 @@ class SeatReleaseExpiredChunkProcessorTest {
     // then: 팔린 좌석이 풀려 재판매되면 안 된다
     assertThat(seat.getSeatStatus()).isEqualTo(SeatStatus.HOLD);
     verify(seatHoldExpiredPublisher, never()).publish(any(Seat.class));
-    verify(seatStatusEventPublisher, never()).publishAfterCommit(any(Seat.class));
+    verify(seatStatusEventPublisher, never())
+        .publishAfterCommit(any(Seat.class), any(SeatEventSource.class));
     // 조회 건수는 그대로 세되(오케스트레이터의 다음 청크 판단용), 해제 건수에선 빠져야 로그가 부풀지 않는다
     assertThat(result.fetched()).isEqualTo(1);
     assertThat(result.released()).isZero();

--- a/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/app/usecase/SeatReleaseSingleUseCaseTest.java
+++ b/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/app/usecase/SeatReleaseSingleUseCaseTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 
+import com.ticketrush.boundedcontext.seat.app.support.SeatEventSource;
 import com.ticketrush.boundedcontext.seat.app.support.SeatHoldExpiredPublisher;
 import com.ticketrush.boundedcontext.seat.app.support.SeatStatusEventPublisher;
 import com.ticketrush.boundedcontext.seat.domain.entity.Seat;
@@ -73,7 +74,7 @@ class SeatReleaseSingleUseCaseTest {
     // then
     verify(seatRepository).findById(seatId);
     verify(seatHoldExpiredPublisher).publish(seat);
-    verify(seatStatusEventPublisher).publishAfterCommit(seat);
+    verify(seatStatusEventPublisher).publishAfterCommit(seat, SeatEventSource.EXPIRE_SINGLE);
     assertThat(bookingNumberAtPublish.get()).isEqualTo("BK-1"); // releaseHold 전 캡처 보장
   }
 

--- a/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/app/usecase/SeatReleaseSoldSeatUseCaseTest.java
+++ b/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/app/usecase/SeatReleaseSoldSeatUseCaseTest.java
@@ -5,6 +5,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 
+import com.ticketrush.boundedcontext.seat.app.support.SeatEventSource;
 import com.ticketrush.boundedcontext.seat.app.support.SeatStatusEventPublisher;
 import com.ticketrush.boundedcontext.seat.domain.entity.Seat;
 import com.ticketrush.boundedcontext.seat.out.repository.SeatRepository;
@@ -49,7 +50,7 @@ class SeatReleaseSoldSeatUseCaseTest {
 
     // then
     assertThat(seat.getSeatStatus()).isEqualTo(SeatStatus.AVAILABLE);
-    verify(seatStatusEventPublisher).publishAfterCommit(seat);
+    verify(seatStatusEventPublisher).publishAfterCommit(seat, SeatEventSource.REFUND_RELEASE);
   }
 
   @Test
@@ -64,7 +65,7 @@ class SeatReleaseSoldSeatUseCaseTest {
 
     // then
     assertThat(seat.getSeatStatus()).isEqualTo(SeatStatus.AVAILABLE);
-    verify(seatStatusEventPublisher).publishAfterCommit(seat);
+    verify(seatStatusEventPublisher).publishAfterCommit(seat, SeatEventSource.REFUND_RELEASE);
   }
 
   @Test


### PR DESCRIPTION
## 🔗 관련 이슈

- close #520

---

## 📌 주요 변경 사항

- `SeatEventSource` 열거형을 만들고 `publishAfterCommit(Seat)` → `publishAfterCommit(Seat, source)`로 바꿨다
- 경로별 발행 건수를 `ticketrush.seat.sse.event.published{source}`로 노출한다
- **이슈 본문의 전제와 달리 발행 경로는 3개가 아니라 5개였다.** 아래 상세 참고
- `SeatStatusChangedResponse`는 손대지 않았다 — 외부 계약 불변(완료조건 3)
- 런북 §14.7 PromQL·§14.2 게이트, `dump-timeseries.py` 회차 덤프에 이 축을 넣었다

---

## 🛠 상세 구현 내용

### 왜 필요한가 — #403이 답하지 못한 것

구독자 600명 구간의 전파 지연 p95가 2.77s인데 자기 이벤트의 팬아웃 몫은 약 170ms뿐이다. 나머지는 **앞에 쌓인 큐를 기다린 시간**이고 그게 지연의 지배항이다. 그런데 평균 이용률이 `9 태스크/s × 0.167s / 4 스레드 ≈ 38%`로 여유로운데도 큐 깊이가 평균 50, **최대 307**까지 튄다.

도착이 고르지 않다는 뜻인데, 그 불균일이 Redis 만료 쪽인지 스케줄러 fallback 쪽인지 **가를 수단이 없었다**(리포트 §10). 경로별 발행률을 `executor_queued_tasks`와 겹쳐 읽는 것이 그 답이다.

### ⚠️ 발행 경로는 5개다 (이슈는 3개로 적었다)

이슈가 지목한 셋 중 `publishAfterCommit`을 **직접 호출하는 것은 `SeatReleaseSingleUseCase` 하나뿐**이다. 나머지 둘은 트리거일 뿐 호출은 하위 빈에서 일어나고, 이슈에 없던 호출처가 둘 더 있었다.

| 태그 값 | 실제 호출 지점 | 트리거 |
|---|---|---|
| `booking_hold` | `SeatHoldUseCase:57` | Kafka `BookingCreatedEvent` → `BookingCreatedEventListener:48` |
| `expire_single` | `SeatReleaseSingleUseCase:52` | Redis 키 만료 → `SeatLockExpirationListener:39` |
| `scheduler_fallback` | `SeatReleaseExpiredChunkProcessor:75` | `SeatStatusScheduler:26`(60초)의 청크 루프 |
| `confirm_sold` | `SeatConfirmSoldUseCase:41` | 내부 API `SeatInternalController:31` (**이슈 누락**) |
| `refund_release` | `SeatReleaseSoldSeatUseCase:57` | Kafka `PaymentCanceledEvent` (**이슈 누락**) |

**뒤 둘을 빼면 같은 큐를 채우는 도착이 "미분류"로 남아 §10의 질문에 여전히 답하지 못한다.** 완료조건이 "최소 3종"이므로 5종은 조건을 넘어서지 축소하지 않는다.

### 왜 파라미터를 더하는가

발행 경로는 **호출자만 안다.** `expire_single`과 `scheduler_fallback`은 결과 상태가 똑같이 `AVAILABLE`이라 좌석에서 유도할 수 없다. 문자열 상수 대신 열거형인 것은 태그 값이 유한 집합이어야 한다는 `MetricNames` 규약을 컴파일 시점에 강제하기 위해서다.

### 카운터는 기동 시 전부 등록한다

핫패스에서 `Counter.builder(...).register(...)`를 부르지 않으려는 것으로, `SeatStatusSseEventSender`가 거부 카운터에 남긴 근거와 같다. **여기는 조건이 더 나쁘다** — `scheduler_fallback`이 tick당 최대 2,000건(chunk 25 × max-chunks 80)을 한 번에 밀어 넣는데, 그 구간이 정확히 이 지표를 읽으려는 구간이라 계측 비용이 관측 대상에 섞이면 안 된다.

부수 효과로 **발행이 0건인 경로도 0으로 노출된다.** 지연 생성이면 "그 경로가 조용했다"와 "그 경로를 계측하지 못하고 있다"가 그래프에서 구분되지 않는다.

### 증가 시점은 실제 send 시점이다

롤백된 트랜잭션의 발행을 세면 큐 도착과 어긋나 이 지표를 넣은 이유 자체가 무너진다. `SeatHoldUseCase.incrementSuccessAfterCommit`이 #427에서 잡은 것과 같은 종류의 버그다.

---

## ✅ 테스트

### 테스트 방법

- `SeatStatusEventPublisherTest`를 `@InjectMocks`에서 **`SimpleMeterRegistry` 수동 조립**으로 바꾸고 케이스 4개로 확장했다(`SeatHoldUseCaseTest:34-39`와 같은 패턴).
  - `@ParameterizedTest @EnumSource` — 경로 5종이 **자기 태그만** 1이고 나머지는 0인지(태그 격리)
  - 카운터가 기동 시 5종 전부 등록되는지
  - 트랜잭션 활성 시 **커밋 전에는 발행도 계측도 하지 않고**, `afterCommit` 훅이 돌면 그때 둘 다 일어나는지
  - 기존 페이로드 단언(외부 계약 불변)
- `./gradlew :seat-service:test :common:test spotlessCheck checkstyleMain checkstyleTest`

### 테스트 결과

- 전부 **BUILD SUCCESSFUL**

### 📸 스크린샷

- (작성 필요)

---

## 👀 리뷰 요청 사항

- **이슈에 없던 두 경로(`confirm_sold`·`refund_release`)를 포함했습니다.** 완료조건은 "최소 3종"이라 범위를 넘지는 않으나, 스코프 판단이 맞는지 확인을 부탁드립니다. 빼면 그 도착이 미분류로 남습니다.
- 태그 값을 `MetricNames` 문자열 상수가 아니라 **열거형**에 둔 것이 규약에서 벗어나 보일 수 있습니다. 메트릭 이름과 태그 키는 `MetricNames`에 두고 값만 열거형으로 옮겼는데, 이견이 있으면 지적해 주시기 바랍니다.
- 시그니처 변경이 프로덕션 5파일 + 테스트 6파일에 파급됩니다. 기계적 인자 추가지만 누락이 없는지 봐주시면 좋겠습니다.

---

## ⚠️ 배포 시 주의사항

- **배포되어야 효과가 난다.** 현재 EC2는 `1f2ed5d2...`로 이 변경이 없다. 후속 재측정은 배포 이후에 돌린다.
- 이 변경은 **측정 수단**이므로 #512 배포 묶음에서 성능 변경과 함께 올려도 귀속이 깨지지 않는다.
- 배포 후 런북 §14.2의 **G5 게이트**로 확인한다 — `source` 라벨 5종이 전부 나와야 한다. 라벨이 빠져 있으면 **그 경로가 조용한 것이 아니라 배포본에 이 변경이 없는 것**이다.
