### PR TITLE
[Refactor] #521 좌석 상태 집계 커버링 인덱스 - 단일 컬럼 인덱스는 뺀다

### DIFF
--- a/deploy/mysql/README.md
+++ b/deploy/mysql/README.md
@@ -101,11 +101,14 @@ init SQL은 **빈 DB의 최초 기동에만** 실행된다. 이미 데이터가 
    다만 빠지면 시딩 SQL이 `ERROR 1364`로 깨지고 `validate` CI는 이를 검출하지 못하므로, 여기서 눈으로 확인한다.
 
    ```sh
-   grep -E "idx_seat_performance_id|uk_seat_layout_performance_id" deploy/mysql/init/001-ticket-rush-schema.sql
+   grep -E "idx_seat_performance_id_status_hold_expired_at|uk_seat_layout_performance_id" deploy/mysql/init/001-ticket-rush-schema.sql
    grep -c "NOT NULL DEFAULT '0'" deploy/mysql/init/001-ticket-rush-schema.sql   # @Version 엔티티 수와 일치해야 한다
    grep -E "uk_payment_completed_booking|GENERATED ALWAYS" deploy/mysql/init/001-ticket-rush-schema.sql  # #422 수동 DDL
    grep -E "idx_outbox_aggtype_status_id" deploy/mysql/init/001-ticket-rush-schema.sql  # #483 릴레이 조회
    ```
+
+   > `idx_seat_performance_id_status_hold_expired_at`이 빠지면 좌석 상태 집계가 index-only scan을 잃고
+   > 매칭 행을 전부 읽는 계획으로 되돌아간다(#521, `Seat` javadoc). 이것도 실패가 아니라 성능 저하다.
 
    > `idx_outbox_aggtype_status_id`가 빠지면 릴레이 조회의 인덱스 힌트가 무시돼 조회가 배치 크기가 아니라
    > **적체 전체를 읽고 filesort**하는 계획으로 되돌아간다(#483, `OutboxEntity` javadoc). 실패가 아니라

--- a/deploy/mysql/init/001-ticket-rush-schema.sql
+++ b/deploy/mysql/init/001-ticket-rush-schema.sql
@@ -216,7 +216,7 @@ CREATE TABLE `seat` (
   `seat_status` enum('AVAILABLE','HOLD','SOLD') COLLATE utf8mb4_unicode_ci NOT NULL,
   `version` bigint NOT NULL DEFAULT '0',
   PRIMARY KEY (`seat_id`),
-  KEY `idx_seat_performance_id` (`performance_id`),
+  KEY `idx_seat_performance_id_status_hold_expired_at` (`performance_id`,`seat_status`,`hold_expired_at`),
   KEY `idx_seat_status_hold_expired_at` (`seat_status`,`hold_expired_at`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;

--- a/docs/load-test-guide.md
+++ b/docs/load-test-guide.md
@@ -1471,12 +1471,12 @@ ssh -i ~/ticket_rush_ssh.pem ubuntu@<EC2>
 | # | 확인 | 명령 | 기대 |
 |---|---|---|---|
 | G0 | SSE가 인터넷에서 도달 | `timeout 6 curl -sN -H 'Accept: text/event-stream' https://api.ticketrush.store/api/v1/seat/<SSE공연>/seat-status/stream` | `event:connected` 즉시 수신. 무응답이면 §14.1-(f) — nginx 설정이 되돌아간 것이다 |
-| G1 | `performance_id` 인덱스 실존 | `docker exec -i ticketrush-mysql sh -c 'mysql -uroot -p"$MYSQL_ROOT_PASSWORD" ticket_rush -e "SHOW INDEX FROM seat"'` | `idx_seat_performance_id` 존재 |
+| G1 | 집계 커버링 인덱스 실존 | `docker exec -i ticketrush-mysql sh -c 'mysql -uroot -p"$MYSQL_ROOT_PASSWORD" ticket_rush -e "SHOW INDEX FROM seat"'` | `idx_seat_performance_id_status_hold_expired_at` 존재(#521). **인덱스 적용 전후 회차를 비교하는 경우에는 그 회차의 실제 상태를 metadata 에 기록하고 진행한다** |
 | G2 | executor 메트릭 노출 | `docker exec seat-service wget -qO- localhost:8090/actuator/prometheus \| grep executor_` | `executor_queued_tasks{name="seatStatusSseExecutor"}` 존재 |
 | G3 | 배포본 = 저장소 | `docker inspect --format '{{.Config.Image}}' $(docker ps -q)` | 전 서비스 `IMAGE_TAG` 동일 |
 | G4 | seat-service 기준선 | `docker stats --no-stream seat-service` | 400 MiB 내외. 550 MiB면 **재시작 후 시작**(§14.8) |
 
-> **G1이 실패하면 측정 자체가 무의미하다.** 인덱스가 없으면 집계가 풀스캔이 되어 "앱의 특성"이 아니라 "인덱스 부재"를 재게 된다. `@Index`는 `ddl-auto=update`인 로컬/신규 초기화 DB에서만 생성되고 prod(`validate`)는 부재를 검출하지 못한다(`Seat.java:35-51`). 없으면 먼저 수동 DDL을 넣는다.
+> **G1이 실패하면 측정 자체가 무의미하다.** 인덱스가 없으면 집계가 풀스캔이 되어 "앱의 특성"이 아니라 "인덱스 부재"를 재게 된다. `@Index`는 `ddl-auto=update`인 로컬/신규 초기화 DB에서만 생성되고 prod(`validate`)는 부재를 검출하지 못한다(`Seat.java:50-73`). 없으면 먼저 수동 DDL을 넣는다 — 그 런북이 같은 javadoc에 있다.
 
 > **G2가 실패해도 배포하지 않는다.** `SeatStatusSseConfig.java:12`의 `@Bean` 선언 반환 타입이 `Executor`라 Boot의 `TaskExecutorMetricsAutoConfiguration`이 `TaskExecutor` 타입으로 후보를 모으는 단계에서 이 빈을 놓칠 수 있다. 그 경우 큐 적체·거부는 **로그 타임스탬프**로 기록하고(§14.6), 반환 타입을 `ThreadPoolTaskExecutor`로 좁히는 1줄 변경은 **후속 이슈로 분리**한다. 리포트 한계에 "큐 깊이 시계열 부재"를 명시한다.
 

--- a/load-test/scenarios/seat-counts.js
+++ b/load-test/scenarios/seat-counts.js
@@ -2,10 +2,14 @@
 //
 // ── 왜 좌석 수 전제가 측정의 성립 조건인가 ──────────────────────────────────
 // SeatRepository.getStatusCountsByPerformanceIdAndStatuses 의 WHERE 절은
-// `s.performanceId = :performanceId` 하나뿐이다(SeatRepository.java:18-32). idx_seat_performance_id
-// 로 range scan 을 타지만 커버링 인덱스가 아니라 매칭 행을 전부 읽어 CASE 를 평가한다.
-// 즉 응답 시간이 공연당 좌석 수에 정비례한다 — 좌석 수를 고정하지 않은 수치는 해석할 수 없고
-// 다른 환경에서 재현도 불가능하다. 그래서 COUNTS_EXPECTED_SEATS 로 규모를 검증한다.
+// `s.performanceId = :performanceId` 하나뿐이다(SeatRepository.java:18-32). 매칭 행 전부를 훑어
+// CASE 를 평가하므로 응답 시간이 공연당 좌석 수에 정비례한다 — 좌석 수를 고정하지 않은 수치는
+// 해석할 수 없고 다른 환경에서 재현도 불가능하다. 그래서 COUNTS_EXPECTED_SEATS 로 규모를 검증한다.
+//
+// ⚠ #521 이 idx_seat_performance_id_status_hold_expired_at 로 이 스캔을 index-only 로 바꿨다.
+//   스캔 몫은 줄었지만 좌석 수 비례 자체가 사라진 것은 아니다(인덱스 엔트리를 여전히 좌석 수만큼
+//   읽는다). 회차를 비교할 때는 인덱스 적용 여부를 metadata 에 반드시 기록한다 — #403 은 인덱스
+//   없는 상태의 수치다.
 //
 // ── HOLD 비율이 왜 필요한가 ─────────────────────────────────────────────────
 // 집계는 만료 HOLD(holdExpiredAt <= now)를 AVAILABLE 로 선반영한다. 좌석이 전부 AVAILABLE 이면

--- a/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/domain/entity/Seat.java
+++ b/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/domain/entity/Seat.java
@@ -21,8 +21,23 @@ import lombok.NoArgsConstructor;
 /**
  * 좌석. 인덱스 두 개를 두는 근거는 아래와 같다.
  *
- * <p><b>idx_seat_performance_id</b> — {@code SeatRepository.findSeatMapByPerformanceId}가
- * performanceId로만 필터한다. 인덱스가 없으면 공연당 수천 행을 매 요청 풀스캔해 부하 테스트 수치가 앱이 아닌 인덱스 부재를 반영한다.
+ * <p><b>idx_seat_performance_id_status_hold_expired_at</b> — 공연 단위 조회 두 개를 함께 받는다.
+ *
+ * <ul>
+ *   <li><b>상태별 집계</b>({@code getStatusCountsByPerformanceIdAndStatuses})가 읽는 컬럼은 {@code
+ *       performance_id}(WHERE) · {@code seat_status} · {@code hold_expired_at} <b>이 셋이 전부</b>라 이
+ *       인덱스만으로 index-only scan이 끝난다. #403 실측에서 3,000석 집계 비용의 <b>70%</b>가 테이블 접근을 동반한 스캔 몫이었다({@code
+ *       cost ≈ 1.29ms + 0.996µs × 좌석수}). 커버링이 되면 그 몫이 줄어든다 — <b>고정항 1.29ms는 남으며 이 최적화의 상한이
+ *       거기다</b>(#521).
+ *   <li><b>좌석맵 조회</b>({@code findSeatMapByPerformanceId})는 {@code seat_layout_id}·{@code
+ *       seat_number}까지 읽어 커버링은 안 되지만, 선두 컬럼이 {@code performance_id}로 같아 range scan 진입은 동일하다.
+ * </ul>
+ *
+ * <p><b>단일 컬럼 {@code idx_seat_performance_id}는 제거했다(#521).</b> 위 인덱스가 그것의 leftmost prefix 상위집합이라 두
+ * 조회 모두 그대로 받는다. seat 테이블의 나머지 쿼리는 PK나 {@code (seat_status, hold_expired_at)}로 걸리고,
+ * booking-service의 native SQL 두 건({@code JdbcBookingSeatStatusReader} · {@code
+ * JdbcBookingReferenceReader})은 {@code WHERE seat_id = ? AND performance_id = ?}로 <b>PK equality가
+ * 선행</b>이라 무관하다. 중복 인덱스를 남기면 좌석 전이(HOLD/확정/해제) 쓰기 비용만 늘어난다.
  *
  * <p><b>idx_seat_status_hold_expired_at</b> — 만료 HOLD 조회가 주기 스케줄러의 핫패스다(#343). {@code
  * SeatStatusScheduler}(60초)의 {@code findExpiredHoldSeats}와 {@code SeatHeldGaugeMetrics}(30초)의
@@ -42,6 +57,20 @@ import lombok.NoArgsConstructor;
  *     ALGORITHM=INPLACE, LOCK=NONE;
  * </pre>
  *
+ * <p><b>#521의 인덱스 교체도 같은 이유로 수동 DDL이다.</b> 적용 전후로 {@code SHOW INDEX FROM seat} 출력을 증적에 남긴다 —
+ * {@code @Index}가 있다는 것이 prod에 그 인덱스가 있다는 뜻이 아니다(#464에서 booking 2개, #345에서 seat 1개가 미적용인 채로 발견됐다).
+ * 성능 측정 전이면 특히 — 인덱스 부재가 측정하려는 효과를 통째로 덮는다.
+ *
+ * <pre>
+ *   ALTER TABLE seat
+ *     ADD INDEX idx_seat_performance_id_status_hold_expired_at
+ *       (performance_id, seat_status, hold_expired_at),
+ *     ALGORITHM=INPLACE, LOCK=NONE;
+ *   ALTER TABLE seat
+ *     DROP INDEX idx_seat_performance_id,
+ *     ALGORITHM=INPLACE, LOCK=NONE;
+ * </pre>
+ *
  * <p><b>version 컬럼도 기존 가동 DB에 수동 추가해야 한다(#427).</b> 인덱스와 달리 컬럼은 prod의 ddl-auto=validate가 검출하므로, 배포
  * <b>전</b>에 실행하지 않으면 기동이 실패한다. {@code DEFAULT 0}이 기존 행을 백필한다({@code booking.version}과 동일 — ADR 0005
  * 선례).
@@ -54,7 +83,9 @@ import lombok.NoArgsConstructor;
 @Table(
     name = "seat",
     indexes = {
-      @Index(name = "idx_seat_performance_id", columnList = "performance_id"),
+      @Index(
+          name = "idx_seat_performance_id_status_hold_expired_at",
+          columnList = "performance_id, seat_status, hold_expired_at"),
       @Index(name = "idx_seat_status_hold_expired_at", columnList = "seat_status, hold_expired_at")
     })
 @Getter


### PR DESCRIPTION
## 🔗 관련 이슈

- close #521

---

## 📌 주요 변경 사항

- 좌석 상태 집계 쿼리가 **index-only scan** 되도록 `(performance_id, seat_status, hold_expired_at)` 복합 인덱스를 넣었다
- **단일 컬럼 `idx_seat_performance_id`는 제거했다.** 새 인덱스가 그것의 leftmost prefix 상위집합이고, seat 테이블 전체 쿼리를 훑어 대체 가능함을 확인했다(완료조건 3)
- 스키마 스냅샷·스냅샷 확인 grep·런북 G1 게이트·k6 시나리오 주석을 새 인덱스 기준으로 옮겼다
- prod 수동 DDL 런북을 `Seat` javadoc에 추가했다

---

## 🛠 상세 구현 내용

### 왜 커버링인가 — #403이 비용 구조를 확정했다

`cost ≈ 1.29ms + 0.996µs × 좌석수`이고 스캔 몫이 600석에서 32%, **3,000석에서 70%** 다. WHERE 절은 `s.performanceId = :performanceId` 하나뿐인데 `idx_seat_performance_id`가 커버링이 아니라 매칭 행을 전부 읽어 `CASE`를 평가하기 때문이다.

집계가 읽는 컬럼은 `performance_id`(WHERE) · `seat_status` · `hold_expired_at` **이 셋이 전부**라 복합 인덱스만으로 테이블 접근 없이 끝난다. `seat_status`가 DB에서 `enum('AVAILABLE','HOLD','SOLD')` 1바이트라 인덱스 폭도 작다.

> **고정항 1.29ms는 남는다.** 이 최적화의 상한이 거기고, 3,000석에서도 비용의 30%다.

### 기존 인덱스 제거 판단 (완료조건 3)

`performance_id` 선두를 쓰는 쿼리는 정확히 둘이다.

| 쿼리 | 새 인덱스로 되는가 |
|---|---|
| `getStatusCountsByPerformanceIdAndStatuses` | O — index-only scan (이 이슈의 대상) |
| `findSeatMapByPerformanceId` | O — `seat_layout_id`·`seat_number`를 더 읽어 커버링은 아니지만, 선두 컬럼이 같아 range scan 진입은 동일 |

booking-service의 native SQL 두 건(`JdbcBookingSeatStatusReader:19`, `JdbcBookingReferenceReader:26`)은 `WHERE seat_id = ? AND performance_id = ?`로 **PK equality가 선행**이라 무관하다. seat 도메인에 QueryDSL 사용처는 없다. 중복 인덱스를 남기면 좌석 전이(HOLD/확정/해제) 쓰기 비용만 늘어난다.

### 스키마 스냅샷은 KEY 행만 교체했다

`deploy/mysql/README.md`의 재생성 절차는 임시 MySQL + 7개 서비스 순차 기동이라, 인덱스 한 줄 교체에 무관한 drift를 끌어들인다. `validate` CI는 어차피 인덱스 차이를 검출하지 못하므로(README §6 말미) 사람이 눈으로 확인하는 것은 어느 쪽이든 같다 — 그 확인 grep 목록도 함께 갱신했다.

---

## ✅ 테스트

### 테스트 방법

- `./gradlew :seat-service:test :common:test spotlessCheck checkstyleMain checkstyleTest`
- `SeatHoldConcurrencyTest`가 Testcontainers로 실제 MySQL을 띄워 `ddl-auto`로 스키마를 만들므로, **새 `@Index` 선언이 유효한 DDL인지 이 테스트가 함께 검증한다**

### 테스트 결과

- `:seat-service:test`, `:common:test`, `spotlessCheck`, `checkstyleMain`, `checkstyleTest` 전부 **BUILD SUCCESSFUL**

### 📸 스크린샷

- (작성 필요)

---

## 👀 리뷰 요청 사항

- **`idx_seat_performance_id` 제거 판단**을 함께 봐주시기 바랍니다. seat 테이블의 전체 쿼리와 booking-service의 native SQL 2건까지 훑어 대체 가능하다고 판단했으나, 제가 놓친 조회 경로가 있으면 지적해 주시기 바랍니다.
- **스키마 스냅샷을 재생성하지 않고 `KEY` 행만 손으로 고쳤습니다.** README의 절차를 벗어난 선택이라 판단이 필요합니다.
- 인덱스 이름이 `idx_seat_performance_id_status_hold_expired_at`로 45자입니다. 기존 명명 규칙(`idx_{테이블}_{컬럼들}`)을 따른 결과인데, 짧게 줄이는 편이 낫다는 의견이 있으면 알려주시기 바랍니다.

---

## ⚠️ 배포 시 주의사항

- **prod에 수동 DDL이 필요하다.** `@Index`는 `ddl-auto=update`인 신규 DB에서만 생성되고 prod(`validate`)는 인덱스 부재를 검출하지 못한다. #464에서 booking 2개, #345에서 seat 1개가 미적용인 채로 발견된 전례가 있다.

  ```sql
  SHOW INDEX FROM seat;   -- 적용 전 증적
  ALTER TABLE seat
    ADD INDEX idx_seat_performance_id_status_hold_expired_at
      (performance_id, seat_status, hold_expired_at),
    ALGORITHM=INPLACE, LOCK=NONE;
  ALTER TABLE seat DROP INDEX idx_seat_performance_id, ALGORITHM=INPLACE, LOCK=NONE;
  SHOW INDEX FROM seat;   -- 적용 후 증적
  ```

  행수는 #504 회차 기준 36,520이라 INPLACE DDL은 수 초다.

- **DDL 적용 시점이 측정 설계에 걸려 있다.** #512 묶음 배포 직후가 아니라 **before 회차를 돌린 뒤** 적용해야 같은 이미지·같은 호스트에서 before/after가 잡힌다. 이번 배포에 #519·#520 코드가 함께 실리므로 #403 수치를 그대로 before로 쓰면 이미지 차이가 섞인다.
- **이 변경은 성능 변경이다.** #512 묶음 안에 다른 성능 변경이 없어 귀속은 유지된다.
