### PR TITLE
[Test] #546 회차 A 준비 — 폴링 대상 승급 감지 지표 + admit-rate 설정 근거

### DIFF
--- a/docs/load-test-guide.md
+++ b/docs/load-test-guide.md
@@ -1943,6 +1943,8 @@ ticket-service:8090    4,692 → 6,033 ↑ → 4,713 → 6,248 ↑        (Prome
 | G6 | 생성기 EC2 | [ADR 0010](adr/0010-in-aws-load-generator-for-ten-thousand-vu.md) — 같은 리전, spot, 회차 후 **종료** |
 | G7 | **대기열 키 리셋** | `redis-cli --scan --pattern 'queue:*' \| xargs -r redis-cli del` 후 0건 확인. **회차 A·B 양쪽 모두 필수** — 이전 회차의 `queue:opened-at:{pid}`(TTL 6h)가 남아 있으면 `threshold = 경과 × rate` 가 이미 수십만이라 전원이 첫 폴링에서 즉시 승급한다. "유입 제어가 되는가"를 보려던 회차가 그냥 스파이크가 된다 |
 
+> **회차 A는 `QUEUE_ADMIT_RATE` 를 낮춘다(권장 `1`).** 승급 임계치는 `경과 × admit-rate` 라 기본값 20이면 PRELOAD 1만 기준 **8분 20초에 폴링 대상이 승급해 버린다.** 회차가 20분(4계단 × 5분)이라 반드시 걸린다. 승급 후 폴링은 입장 토큰 `SET` 이 붙어 Redis 명령이 2회(`GET`+`ZRANK`)에서 3회로 늘고 `noeviction` Redis 에 쓰기까지 생긴다 — **재려던 "대기 중인 사용자의 폴링" 이 아니라 다른 경로를 재게 되어 `R` 이 과소평가된다.** `1` 이면 1만에 도달하는 데 2.8시간이라 회차 내내 대기 상태가 유지된다. 시나리오의 `queue_status_admitted_leak` 이 이 사고를 감지한다(§16.6).
+>
 > **대기열 개시는 시나리오의 `setup()` 이 한다** — `POST /api/v1/queue/{pid}/open`(ADMIN). 개시 시각을 진입의 부작용으로 두면 오픈 전에 미리 진입해 둔 사람이 임계치를 부풀려 대기열을 무력화할 수 있어서, 운영자만 심도록 되어 있다. **G7 리셋이 이 호출보다 먼저**여야 새 기준점이 잡힌다.
 
 **회차 A (R 실측)**
@@ -1995,6 +1997,7 @@ docker run --rm -v $PWD/load-test:/scripts:ro \
 | `queue_polls_exhausted` | 0 | >0이면 입장 허용량이 유입을 소화하지 못했다 |
 | `queue_booking_forbidden` | 0 | 승급 직후 예매라 0이어야 한다. >0이면 폴링→예매 지연이 입장 토큰 TTL(5m)을 넘었다 |
 | `queue_admitted` | 해석 대상 | 0과 1 사이여야 한다. 정확히 1.000이면 지표가 아니라 스크립트를 의심한다 |
+| **`queue_status_admitted_leak`** (회차 A) | **0** | >0이면 폴링 대상이 회차 도중 승급해 측정 경로가 2회에서 3회로 바뀌었다. `R` 을 재지 못한 회차이므로 **폐기하고 `QUEUE_ADMIT_RATE` 를 낮춰 다시 돈다** |
 | 생성기 종료 | 필수 | CD가 건드리지 않아 "떠 있는 줄 몰랐다"가 가능하다(ADR 0010) |
 
 **§6.1 재현성 규칙이 여기서 한 겹 더 걸린다.** [ADR 0010](adr/0010-in-aws-load-generator-for-ten-thousand-vu.md)이 생성기를 로컬에서 AWS로 옮겼으므로 **이 회차 수치를 ADR 0004 토폴로지 회차(#348·#403·#529 등)와 절대값으로 직접 잇지 않는다.** 비교가 필요하면 그 사실을 리포트 한계에 적는다.

--- a/load-test/scenarios/waiting-room.js
+++ b/load-test/scenarios/waiting-room.js
@@ -110,6 +110,12 @@ const bookingForbidden = new Rate('queue_booking_forbidden');
 const statusUnavailable = new Rate('queue_status_unavailable');
 // 안전 상한에 걸려 끝난 VU. > 0 이면 입장 허용량이 유입을 소화하지 못한 것이다.
 const pollsExhausted = new Counter('queue_polls_exhausted');
+// status 회차 전용 무효 판정. 폴링 대상이 회차 도중 승급하면 그 이후 폴링은 입장 토큰 SET 이 붙어
+// Redis 명령이 2회(GET+ZRANK) 에서 3회로 늘고 noeviction Redis 에 쓰기까지 생긴다. 재려던 것은
+// '대기 중인 사용자의 폴링' 인데 다른 경로를 재게 되므로 R 이 과소평가된다.
+//   threshold = 경과 x admit-rate 라 PRELOAD 1만 - admit-rate 20 이면 8분 20초에 승급한다.
+//   회차가 20분(4계단 x 5분)이므로 반드시 걸린다 → status 회차는 QUEUE_ADMIT_RATE 를 낮춘다(런북 §16.4).
+const statusAdmittedLeak = new Rate('queue_status_admitted_leak');
 
 function signAccessToken(userId, role) {
   const header = encoding.b64encode(JSON.stringify({ alg: 'HS256', typ: 'JWT' }), 'rawurl');
@@ -210,7 +216,9 @@ export function setup() {
 
 /** status 회차 — 상태 확인 경로만 두드려 R 을 잰다. 사용자 행동이 아니라 경로 용량 측정이라 sleep 이 없다. */
 export function pollOnly(data) {
-  pollStatus(data.waitingToken);
+  const res = pollStatus(data.waitingToken);
+  // > 0 이면 폴링 대상이 승급해 측정 경로가 바뀌었다 = 이 회차는 R 을 재지 못했다.
+  statusAdmittedLeak.add(Boolean(jsonField(res, 'result.entry_token')));
 }
 
 /** flood 회차 — 진입 → 서버 지시 폴링 → 입장 → 예매의 전 여정. */


### PR DESCRIPTION
## 🔗 관련 이슈

- close #546 의 준비 몫 (회차 실행·리포트는 이 PR 뒤에)
- ref #472 · #512 묶음 D

---

## 📌 주요 변경 사항

배포 전에 로컬(게이트웨이 + Redis)에서 k6 두 프로파일을 모두 돌렸다. **EC2 과금 시간에 시나리오 버그를 만나지 않으려는 목적**이었는데, 회차 설계에 걸리는 문제가 하나 나왔다.

- `queue_status_admitted_leak` 지표 신설 (`load-test/scenarios/waiting-room.js`)
- 런북 §16.4 에 `QUEUE_ADMIT_RATE` 설정 근거, §16.6 에 무효 판정 항목 추가

---

## 🛠 상세 구현 내용

### 기본 admit-rate 20 이면 회차가 다른 것을 잰다

승급 임계치는 `경과 × admit-rate` 다. PRELOAD 1만 기준 **8분 20초**면 폴링 대상의 순번을 넘어서는데, 회차는 20분(4계단 × 5분)이라 반드시 걸린다.

승급 후 폴링은 입장 토큰 `SET` 이 붙어 Redis 명령이 **2회(`GET`+`ZRANK`) → 3회**가 되고 `noeviction` Redis 에 쓰기까지 생긴다. 재려던 "대기 중인 사용자의 폴링"이 아니라 다른 경로를 재게 되므로 **`R` 이 과소평가된다.**

`QUEUE_ADMIT_RATE=1` 이면 1만에 도달하는 데 2.8시간이라 회차 내내 대기 상태가 유지된다.

### 실측으로 확증했다

| 조건 | `queue_status_admitted_leak` | entry-token |
|---|---|---|
| `admit-rate=20`(기본) | **77.48%** (1394/1799) | 1개 |
| `admit-rate=1` | **0.00%** (0/1799) | 0개 |

지표가 없으면 이 사고는 **리포트에 흔적을 남기지 않는다** — 수치는 그럴듯하게 나오고 `R` 만 낮게 잡힌다. 그래서 무효 판정 축으로 넣었다.

---

## ✅ 테스트

### 테스트 방법

로컬 게이트웨이(`bootRun`) + Redis(`docker compose up redis`)에 k6 컨테이너로 두 프로파일 실행. `k6 inspect` 로 문법 확인.

### 테스트 결과

같은 스모크에서 함께 확인한 것 — **전부 정상**:

| 확인 | 결과 |
|---|---|
| `status` 프로파일 | 폴링 1,200회 실패 0, `queue_status_unavailable` 0% |
| `flood` 프로파일 | `queue_admitted` 87.79%(1331/1516) ↔ `queue_polls_exhausted` 185 가 정확히 상보 |
| Redis 키 TTL | 4종 전부 약 6시간(21,53x초) |
| 키 증식 | 사용자 300명 → `waiting-token` 300 + `user-token` 300 (1:1) |

**`flood` 결과가 PR #544 의 버그 수정을 증명한다.** `jsonField` 가 경로 없을 때 `undefined` 를 주는데 `!== null` 로 판정하던 코드였다면 `queue_admitted` 가 100% 로 나왔을 자리다.

---

## 👀 리뷰 요청 사항

- `QUEUE_ADMIT_RATE=1` 을 런북 권장값으로만 두고 시나리오에 강제하지 않았습니다. 회차 B(flood)는 반대로 현실적인 허용량이 필요해서 프로파일마다 다른 값이 맞다고 봤는데, 아예 `status` 프로파일에서 강제하는 편이 나을지 의견 주세요.