### PR TITLE
[Test] #549 커넥션 프로브 저장소 편입 — ADR 0010 기각 근거의 재현 수단

### DIFF
--- a/load-test/scenarios/connection-probe.js
+++ b/load-test/scenarios/connection-probe.js
@@ -1,0 +1,76 @@
+// (j) 동시 커넥션 상한 프로브 — 부하 생성기가 목표 VU 를 실제로 만들 수 있는지만 본다 (#549).
+//
+// ── 이 프로브가 답하는 질문 ────────────────────────────────────────────────
+// "생성기를 AWS 안으로 옮겨야 하는가." 부하 회차를 돌리기 전에 **생성기 쪽 한계를 먼저 재는**
+// 도구다. 앱은 거의 건드리지 않는다 — VU 는 목표까지 올리되 요청은 30초에 한 번뿐이라, 1만 VU
+// 에서도 RPS 는 333 이고 커넥션만 1만 개가 유지된다.
+//
+// 이 구분이 핵심이다. 회차가 무너졌을 때 '앱이 못 버틴 것' 과 '생성기가 못 만든 것' 은 그래프가
+// 비슷하게 생겼는데 결론이 정반대다. 회차 전에 이걸 떼어 재 두면 그 혼동이 없다.
+//
+// ── 실제로 무엇을 뒤집었나 ─────────────────────────────────────────────────
+// ADR 0010 은 "1만 VU 는 로컬에서 불가능하다" 며 생성기를 AWS 임시 EC2 로 옮기기로 결정했고,
+// 근거로 ① 가정용 업로드 대역 ② Docker NAT·포트 고갈 ③ 가정 공유기 세션 테이블을 들었다.
+// 이 프로브가 셋 다 반증했다(2026-08-01, 6분 30초, 비용 0):
+//   probe_connect_failed 0.00% (0/99,944) / 서버측 established 정확히 10,000 을 3분 이상 유지
+//   data_sent 30 MB = 74 kB/s (0.6 Mbps) — 대역은 근처에도 못 갔다
+//   ephemeral 포트 28,231 개 · 컨테이너 nofile 1,048,576 — 고갈 여유
+// 그래서 회차 B 를 로컬 k6 로 마쳤고 ADR 0010 은 '기각됨' 이 됐다.
+// 증적: load-tests/k6/results/260801-549-queue-flood/ (metadata.txt 의 PROBE 절)
+//
+// ⚠ **이 프로브가 통과했다고 회차가 통과하는 것은 아니다.** 커넥션 1만과 목표 RPS 를 동시에
+//   요구하는 것은 이 프로브가 재지 않는다(여기서는 333 RPS 뿐이다). 회차 B 가 실제로 그 조합에서
+//   무너졌다 — 다만 무너진 쪽은 생성기가 아니라 대상이었고, 그 구분이 이 프로브 덕에 가능했다.
+//
+// ── 실행 ───────────────────────────────────────────────────────────────────
+//   docker run --rm -v $PWD/load-test:/scripts:ro --ulimit nofile=1048576:1048576 \
+//     grafana/k6:latest run -e BASE_URL=https://api.ticketrush.store \
+//     -e PROBE_VUS=10000 /scripts/scenarios/connection-probe.js
+//
+// 서버측에서 함께 센다(커넥션이 실제로 도달했는지는 대상에서 봐야 한다):
+//   ss -tn state established '( sport = :443 )' | tail -n +2 | wc -l
+// 프록시 요청 1건이 클라이언트+업스트림 2슬롯을 먹으므로, 진행 중 요청이 있으면 이 값은 VU 수를
+// 넘는다(회차 B-1 에서 VU 1만에 established 16,701 이 나온 이유다).
+import http from 'k6/http';
+import { sleep } from 'k6';
+import { Rate, Trend } from 'k6/metrics';
+import { BASE_URL } from '../config/env.js';
+
+const TARGET = Number(__ENV.PROBE_VUS || 10000);
+// nginx keepalive_timeout 기본값(75초)보다 짧아야 한다 — 길면 커넥션이 폴링 사이에 끊겨
+// '유지되는 커넥션 수' 가 아니라 '재접속 빈도' 를 재게 된다.
+const IDLE = Number(__ENV.PROBE_IDLE_SECONDS || 30);
+// 앱 부하를 최소로 두려면 DB·Redis 를 타지 않는 경로여야 한다.
+const PATH = __ENV.PROBE_PATH || '/actuator/health';
+
+export const options = {
+  scenarios: {
+    hold: {
+      executor: 'ramping-vus',
+      startVUs: 0,
+      stages: [
+        { target: TARGET, duration: __ENV.PROBE_RAMP || '3m' },
+        { target: TARGET, duration: __ENV.PROBE_HOLD || '3m' },
+        { target: 0, duration: '30s' },
+      ],
+      gracefulRampDown: '10s',
+    },
+  },
+  // 임계값을 두지 않는다 — 깨지는 지점을 보는 것이 목적이라 조기 중단시키면 안 된다.
+  thresholds: {},
+};
+
+// 이 프로브의 유일한 판정축. status 0 은 HTTP 응답이 아니라 **커넥션이 안 맺어진 것**이다
+// (포트 고갈·공유기 세션 테이블·dial timeout). 4xx/5xx 는 앱 이야기라 여기서 구분해 둔다.
+const connectFailed = new Rate('probe_connect_failed');
+const connecting = new Trend('probe_connecting_ms', true);
+
+export default function () {
+  const res = http.get(`${BASE_URL}${PATH}`, {
+    headers: { 'Accept-Encoding': 'gzip' },
+    tags: { name: 'probe' },
+  });
+  connectFailed.add(res.status === 0);
+  connecting.add(res.timings.connecting);
+  sleep(IDLE);
+}

--- a/load-tests/k6/results/260801-549-queue-flood/metadata.txt
+++ b/load-tests/k6/results/260801-549-queue-flood/metadata.txt
@@ -24,8 +24,12 @@ GENERATOR_DECISION=로컬 k6. ADR 0010 의 "AWS 임시 EC2" 를 기각한다.
 #   ③ 가정 공유기 세션 테이블("통상 수천") — 서버측 established :443 이 정확히 10,000 으로
 #      3분 이상 유지됐고 probe_connect_failed 0.00%(0/99,944).
 #   회차 후 ADR 0010 의 상태를 이 실측으로 정정한다.
-PROBE=1만 VU 커넥션 프로브(scratchpad/connection-probe.js, 6분 30초).
-#   probe_connect_failed 0.00% / http_req_failed 0.00% / connecting p95 7.53ms / vus_max 10,000.
+PROBE=1만 VU 커넥션 프로브(load-test/scenarios/connection-probe.js, 6분 30초).
+#   probe_connect_failed 0.00%(0/99,944) / http_req_failed 0.00% / connecting p95 7.53ms / vus_max 10,000
+#   / data_sent 30 MB = 74 kB/s(0.6 Mbps) / 서버측 established 정확히 10,000 을 3분 이상 유지.
+#   재현: docker run --rm -v $PWD/load-test:/scripts:ro --ulimit nofile=1048576:1048576 \
+#         grafana/k6:latest run -e BASE_URL=https://api.ticketrush.store -e PROBE_VUS=10000 \
+#         /scripts/scenarios/connection-probe.js
 
 # ── 사전 게이트 (런북 §16.4) ────────────────────────────────────────────────
 G0_EC2=기동. ⚠ .env 의 IMAGE_TAG 가 6b7301a0(ECR·CD기록·저장소 어디에도 없는 값)을 가리켜


### PR DESCRIPTION
## 🔗 관련 이슈

- #549 (이미 `CLOSED` — **닫지 않는다.** 그 회차 산출물의 결함을 메우는 PR이다)

---

## 📌 주요 변경 사항

**근거는 인용해 놓고 재현 수단을 안 남겼다.** `load-tests/k6/results/260801-549-queue-flood/metadata.txt`가 [ADR 0010](../blob/develop/docs/adr/0010-in-aws-load-generator-for-ten-thousand-vu.md) 기각의 근거로 `scratchpad/connection-probe.js`를 가리키고 있었는데, 그 스크립트는 임시 디렉터리에만 있어 세션이 끝나면 사라진다. "정말 되나"를 다시 물으면 처음부터 만들어야 한다.

- `load-test/scenarios/connection-probe.js` **신규**
- `metadata.txt`의 `PROBE` 절 — 경로 정정 + 재현 명령 + 실측값 보강

---

## 🛠 상세 구현 내용

### 이 프로브의 쓸모 — 두 실패를 회차 전에 갈라 둔다

**"앱이 못 버틴 것"과 "생성기가 못 만든 것"은 그래프가 비슷하게 생겼는데 결론이 정반대다.** 이 프로브는 앱을 거의 건드리지 않고 생성기 쪽 한계만 잰다 — VU는 목표까지 올리되 요청은 30초에 한 번뿐이라 **1만 VU에서도 RPS는 333이고 커넥션만 1만 개가 유지된다.**

판정축은 `probe_connect_failed`, 즉 **`status === 0`**(HTTP 응답이 아니라 커넥션 자체가 안 맺어진 것 — 포트 고갈·공유기 세션 테이블·dial timeout)이다. 4xx/5xx는 앱 이야기라 섞지 않는다.

### 실제로 무엇을 뒤집었나

ADR 0010은 "1만 VU는 로컬에서 불가능하다"며 생성기를 AWS 임시 EC2로 옮기기로 하고 벽 세 가지를 들었다. 이 프로브가 **6분 30초, 비용 0**으로 셋 다 반증했다.

| ADR 0010의 주장 | 실측 |
|---|---|
| 가정용 업로드 대역이 상한 | `data_sent` 30 MB = 74 kB/s (**0.6 Mbps**) |
| Docker NAT · 포트 고갈이 앱보다 먼저 | ephemeral 포트 **28,231** · 컨테이너 `nofile` **1,048,576** |
| 가정 공유기 세션 테이블 "통상 수천" | 서버측 established **정확히 10,000**을 3분 이상 유지, `probe_connect_failed` **0.00%**(0/99,944) |

그래서 회차 B를 로컬 k6로 마쳤고 ADR 0010은 **기각됨**이 됐다.

### 한계도 헤더에 적었다

**이 프로브가 통과했다고 회차가 통과하는 것은 아니다.** 커넥션 1만과 목표 RPS를 **동시에** 요구하는 조건은 여기서 재지 않는다(333 RPS뿐이다). 회차 B-1이 실제로 그 조합에서 무너졌다 — 다만 **무너진 쪽이 생성기가 아니라 대상**이라는 판별이 이 프로브 덕에 가능했다.

### 서버측 카운트도 절차에 적었다

커넥션이 실제로 도달했는지는 대상에서 봐야 한다.

```bash
ss -tn state established '( sport = :443 )' | tail -n +2 | wc -l
```

프록시 요청 1건이 클라이언트+업스트림 **2슬롯**을 먹으므로, 진행 중 요청이 있으면 이 값은 VU 수를 넘는다 — 회차 B-1에서 VU 1만에 established **16,701**이 나온 이유다.

---

## ✅ 테스트

### 테스트 방법

1. `k6 inspect --execution-requirements` — 파싱·시나리오 구성 확인
2. **로컬 nginx 대상 스모크** — 실제 실행까지 확인(대상 EC2가 정지 상태라 prod로는 못 돌렸다)
3. `./gradlew spotlessCheck`

### 테스트 결과

**1. 파싱** — `totalDuration 6m40s` / `maxVUs 10000`.

**2. 스모크** — `nginx:alpine` 임시 컨테이너 대상, 20 VU / 램프 5s / 유지 5s:

```
probe_connect_failed ...: 0.00%  0 out of 240
probe_connecting_ms ....: avg=119.26µs  p(95)=1.37ms
http_req_failed ........: 0.00%  0 out of 240
iterations .............: 240
vus_max ................: 20
```

커스텀 지표 2종이 정상 집계되고 이터레이션이 도는 것을 확인했다. **파싱만 보고 넘기지 않았다** — 임시 컨테이너는 정리했다.

**3.** `spotlessCheck` exit 0.

<!--
### 📸 스크린샷
그래프가 없는 스크립트 추가라 해당 없음.
-->

---

## 👀 리뷰 요청 사항

- **이미 닫힌 이슈(#549) 번호를 제목에 썼습니다.** 새 이슈를 만들 만한 규모가 아니고 그 회차의 산출물을 보수하는 것이라 이렇게 했는데, 별도 이슈가 낫다고 보시면 지적해 주시기 바랍니다.
- **`PROBE_PATH` 기본값을 `/actuator/health`로 둔 판단**을 봐주시기 바랍니다. DB·Redis를 타지 않아 앱 부하가 최소인 경로를 골랐는데, 이 경로가 나중에 인증 뒤로 옮겨지면 프로브가 조용히 401을 재게 됩니다(그때는 `status`가 0이 아니라 401이라 `probe_connect_failed`는 여전히 0으로 나옵니다).

---

## ⚠️ 배포 시 주의사항

**배포 대상이 아니다.** 프로덕션 코드는 바뀌지 않는다 — k6 시나리오 1개와 증적 문서 1줄뿐이다.

실행 시에는 **생성기 쪽 커널 한계를 먼저 올려야 한다**(`--ulimit nofile=1048576:1048576`, ephemeral 포트 범위). 안 그러면 1만 커넥션에서 **생성기가 대상보다 먼저 고갈돼** 프로브가 자기 자신을 재게 된다. 재현 명령은 `metadata.txt`의 `PROBE` 절에 그대로 적혀 있다.
