### PR TITLE
[Feat] #556 응답 파싱 중 MismatchedInputException 발생

### DIFF
--- a/auth-service/src/main/java/com/ticketrush/boundedcontext/auth/out/apiclient/UserServiceClient.java
+++ b/auth-service/src/main/java/com/ticketrush/boundedcontext/auth/out/apiclient/UserServiceClient.java
@@ -42,38 +42,73 @@ public class UserServiceClient {
   public UserServiceSocialLoginResponse socialLogin(UserServiceSocialLoginRequest request) {
 
     log.info("🔥 user-service로 보내는 request = {}", request);
+
     try {
       log.info("🔥 JSON = {}", new ObjectMapper().writeValueAsString(request));
     } catch (JsonProcessingException e) {
       log.error("JSON 변환 실패", e);
     }
 
-    UserServiceSocialLoginResponse response =
-        restClient
-            .post()
-            .uri(userServiceBaseUrl + SOCIAL_LOGIN_PATH)
-            .contentType(MediaType.APPLICATION_JSON)
-            .body(request)
-            .retrieve()
-            .onStatus(
-                HttpStatusCode::is4xxClientError,
-                (req, res) -> {
-                  log.error("user-service 4xx 에러 발생: status={}", res.getStatusCode());
-                  throw new BusinessException(ErrorStatus.AUTH_USER_BAD_REQUEST);
-                })
-            .onStatus(
-                HttpStatusCode::is5xxServerError,
-                (req, res) -> {
-                  log.error("user-service 5xx 에러 발생: status={}", res.getStatusCode());
-                  throw new BusinessException(ErrorStatus.AUTH_USER_SERVER_ERROR);
-                })
-            .body(UserServiceSocialLoginResponse.class);
+    try {
+      /*
+       * user-service 응답은 아래와 같은 ApiResponse 래퍼 구조입니다.
+       *
+       * {
+       *   "is_success": true,
+       *   "code": "COMMON_200",
+       *   "message": "성공입니다.",
+       *   "result": {
+       *     "user_id": 1,
+       *     "name": "사용자 이름",
+       *     "is_new_user": true
+       *   }
+       * }
+       *
+       * 따라서 UserServiceSocialLoginResponse로 바로 역직렬화하지 않고,
+       * UserServiceApiResponse<UserServiceSocialLoginResponse>로 받은 뒤
+       * result를 꺼내야 합니다.
+       */
+      UserServiceApiResponse<UserServiceSocialLoginResponse> response =
+          restClient
+              .post()
+              .uri(userServiceBaseUrl + SOCIAL_LOGIN_PATH)
+              .contentType(MediaType.APPLICATION_JSON)
+              .body(request)
+              .retrieve()
+              .onStatus(
+                  HttpStatusCode::is4xxClientError,
+                  (req, res) -> {
+                    log.error("user-service 소셜 로그인 4xx 에러 발생: status={}", res.getStatusCode());
 
-    if (response == null) {
+                    throw new BusinessException(ErrorStatus.AUTH_USER_BAD_REQUEST);
+                  })
+              .onStatus(
+                  HttpStatusCode::is5xxServerError,
+                  (req, res) -> {
+                    log.error("user-service 소셜 로그인 5xx 에러 발생: status={}", res.getStatusCode());
+
+                    throw new BusinessException(ErrorStatus.AUTH_USER_SERVER_ERROR);
+                  })
+              .body(
+                  new ParameterizedTypeReference<
+                      UserServiceApiResponse<UserServiceSocialLoginResponse>>() {});
+
+      if (response == null || response.result() == null) {
+        log.error("user-service 소셜 로그인 응답이 비어 있습니다. response={}", response);
+
+        throw new BusinessException(ErrorStatus.AUTH_USER_COMMUNICATION_FAILED);
+      }
+
+      return response.result();
+
+    } catch (BusinessException e) {
+      throw e;
+
+    } catch (Exception e) {
+      log.error("user-service 소셜 로그인 통신 또는 응답 파싱 실패 request={}", request, e);
+
       throw new BusinessException(ErrorStatus.AUTH_USER_COMMUNICATION_FAILED);
     }
-
-    return response;
   }
 
   // 존재하는 이메일 검증
@@ -92,12 +127,14 @@ public class UserServiceClient {
                   HttpStatusCode::is4xxClientError,
                   (req, res) -> {
                     log.error("user-service 이메일 중복 확인 4xx 에러 발생: status={}", res.getStatusCode());
+
                     throw new BusinessException(ErrorStatus.AUTH_EMAIL_EXISTS_CHECK_BAD_REQUEST);
                   })
               .onStatus(
                   HttpStatusCode::is5xxServerError,
                   (req, res) -> {
                     log.error("user-service 이메일 중복 확인 5xx 에러 발생: status={}", res.getStatusCode());
+
                     throw new BusinessException(ErrorStatus.AUTH_EMAIL_EXISTS_CHECK_SERVER_ERROR);
                   })
               .body(
@@ -105,6 +142,7 @@ public class UserServiceClient {
                       UserServiceApiResponse<UserServiceEmailExistsResponse>>() {});
 
       if (response == null || response.result() == null || response.result().exists() == null) {
+
         throw new BusinessException(ErrorStatus.AUTH_EMAIL_EXISTS_CHECK_COMMUNICATION_FAILED);
       }
 
@@ -112,8 +150,10 @@ public class UserServiceClient {
 
     } catch (BusinessException e) {
       throw e;
+
     } catch (Exception e) {
       log.error("user-service 이메일 중복 확인 통신 실패 email={}", email, e);
+
       throw new BusinessException(ErrorStatus.AUTH_EMAIL_EXISTS_CHECK_COMMUNICATION_FAILED);
     }
   }
@@ -140,6 +180,7 @@ public class UserServiceClient {
                   (req, res) -> {
                     log.error(
                         "user-service 로그인용 회원 정보 조회 4xx 에러 발생: status={}", res.getStatusCode());
+
                     throw new BusinessException(ErrorStatus.AUTH_LOGIN_FAILED);
                   })
               .onStatus(
@@ -147,6 +188,7 @@ public class UserServiceClient {
                   (req, res) -> {
                     log.error(
                         "user-service 로그인용 회원 정보 조회 5xx 에러 발생: status={}", res.getStatusCode());
+
                     throw new BusinessException(ErrorStatus.AUTH_USER_SERVER_ERROR);
                   })
               .body(
@@ -161,8 +203,10 @@ public class UserServiceClient {
 
     } catch (BusinessException e) {
       throw e;
+
     } catch (Exception e) {
       log.error("user-service 로그인용 회원 정보 조회 통신 실패 email={}", email, e);
+
       throw new BusinessException(ErrorStatus.AUTH_USER_COMMUNICATION_FAILED);
     }
   }
@@ -185,6 +229,7 @@ public class UserServiceClient {
                   (req, res) -> {
                     log.error(
                         "user-service 테스트 토큰용 회원 정보 조회 4xx 에러 발생: status={}", res.getStatusCode());
+
                     throw new BusinessException(ErrorStatus.AUTH_LOGIN_FAILED);
                   })
               .onStatus(
@@ -192,6 +237,7 @@ public class UserServiceClient {
                   (req, res) -> {
                     log.error(
                         "user-service 테스트 토큰용 회원 정보 조회 5xx 에러 발생: status={}", res.getStatusCode());
+
                     throw new BusinessException(ErrorStatus.AUTH_USER_SERVER_ERROR);
                   })
               .body(
@@ -206,8 +252,10 @@ public class UserServiceClient {
 
     } catch (BusinessException e) {
       throw e;
+
     } catch (Exception e) {
       log.error("user-service 테스트 토큰용 회원 정보 조회 통신 실패 userId={}", userId, e);
+
       throw new BusinessException(ErrorStatus.AUTH_USER_COMMUNICATION_FAILED);
     }
   }

--- a/user-service/src/main/java/com/ticketrush/boundedcontext/user/app/dto/response/SocialLoginResponse.java
+++ b/user-service/src/main/java/com/ticketrush/boundedcontext/user/app/dto/response/SocialLoginResponse.java
@@ -1,4 +1,8 @@
 package com.ticketrush.boundedcontext.user.app.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 public record SocialLoginResponse(
-    Long userId, String name, boolean isNewUser) {} // true = 회원가입 직후, false = 기존 유저
+    @JsonProperty("user_id") Long userId,
+    String name,
+    @JsonProperty("is_new_user") boolean isNewUser) {} // true = 회원가입 직후, false = 기존 유저


### PR DESCRIPTION
## 🔗 관련 이슈

- close #556 

---

## 📌 주요 변경 사항

- 소셜 로그인 과정에서 발생하던 `MismatchedInputException` 오류 수정
- `auth-service`가 `user-service`의 공통 응답 래퍼를 정상적으로 파싱하도록 변경
- 소셜 로그인 응답 및 통신 실패에 대한 예외 처리와 로그 추가

---

## 🛠 상세 구현 내용

- `UserServiceClient.socialLogin()`의 응답 타입을 `UserServiceSocialLoginResponse`에서 `UserServiceApiResponse<UserServiceSocialLoginResponse>`로 변경
- `ParameterizedTypeReference`를 사용하여 제네릭 응답 타입을 역직렬화하도록 수정
- `user-service` 응답의 `result()`를 추출하여 실제 소셜 로그인 결과를 반환하도록 변경
- 응답 또는 `result`가 비어 있는 경우 `AUTH_USER_COMMUNICATION_FAILED` 예외가 발생하도록 처리
- 소셜 로그인 요청 중 통신 또는 응답 파싱 실패 시 관련 로그가 남도록 처리

---

## ✅ 테스트

### 테스트 방법

- 카카오 및 구글 인가 코드를 발급받아 `POST /api/v1/auth/social/login` 호출
- 수정 전 `UserServiceClient.socialLogin()`에서 발생하던 응답 파싱 오류 재현
- 수정 후 소셜 로그인 응답이 정상적으로 파싱되는지 확인
- 아래 명령어로 관련 서비스 검증 수행

```bash
./gradlew :auth-service:check :user-service:check