### PR TITLE
[Feat] #560 예매 단건 조회 API와 목록 응답 보강

### DIFF
--- a/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/app/dto/response/BookingDetailResponse.java
+++ b/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/app/dto/response/BookingDetailResponse.java
@@ -1,0 +1,57 @@
+package com.ticketrush.boundedcontext.booking.app.dto.response;
+
+import com.ticketrush.boundedcontext.booking.domain.entity.Booking;
+import com.ticketrush.boundedcontext.booking.domain.types.BookingStatus;
+import com.ticketrush.boundedcontext.booking.out.apiclient.dto.PerformanceInfoResponse;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+/**
+ * 예매 단건 상세 응답 (#560). 공연·좌석 필드는 각 서비스 조회 실패 시 null(응답에서 생략)일 수 있다 — 그때 프론트는 {@code
+ * performanceId}/{@code seatId}로 재조회한다.
+ */
+@Schema(description = "예매 단건 상세 응답 DTO")
+public record BookingDetailResponse(
+    @Schema(
+            description = "예매 ID. 입장권 QR 조회(GET /api/v1/ticket/bookings/{bookingId}/qr)의 키다.",
+            example = "1")
+        Long bookingId,
+    @Schema(description = "클라이언트에게 노출되는 주문/예약 번호", example = "X7B29-KLPW1") String bookingNumber,
+    @Schema(description = "예매 상태", example = "CONFIRMED") BookingStatus bookingStatus,
+    @Schema(description = "공연 ID. 공연 필드가 비어 있을 때 재조회 키다.", example = "10") Long performanceId,
+    @Schema(description = "공연 이름. performance-service 장애 시 null.", example = "오페라의 유령")
+        String performanceTitle,
+    @Schema(description = "공연 날짜. performance-service 장애 시 null.", example = "2026-05-22")
+        LocalDate performanceDate,
+    @Schema(description = "공연 시간. performance-service 장애 시 null.", example = "19:30:00")
+        LocalTime performanceTime,
+    @Schema(description = "공연 장소. performance-service 장애 시 null.", example = "서울 예술의전당 오페라극장")
+        String performanceAddress,
+    @Schema(description = "좌석 ID. 좌석 번호가 비어 있을 때 재조회 키다.", example = "100") Long seatId,
+    @Schema(description = "좌석 번호. seat-service 장애 시 null.", example = "A-1") String seatNumber,
+    @Schema(description = "예매 확정일", example = "2026-05-22 10:30:00") LocalDateTime confirmedAt,
+    @Schema(
+            description = "결제 금액. 공연당 단일가·1인 1매라 공연 가격과 같다. performance-service 장애 시 null.",
+            example = "150000")
+        Long paymentAmount) {
+
+  /** {@code performance}와 {@code seatNumber}는 조회 실패 시 null이 허용된다(부분 응답). */
+  public static BookingDetailResponse of(
+      Booking booking, PerformanceInfoResponse performance, String seatNumber) {
+    return new BookingDetailResponse(
+        booking.getId(),
+        booking.getBookingNumber(),
+        booking.getBookingStatus(),
+        booking.getPerformanceId(),
+        (performance == null) ? null : performance.title(),
+        (performance == null) ? null : performance.showDate(),
+        (performance == null) ? null : performance.showTime(),
+        (performance == null) ? null : performance.address(),
+        booking.getSeatId(),
+        seatNumber,
+        booking.getConfirmedAt(),
+        (performance == null) ? null : performance.price());
+  }
+}

--- a/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/app/dto/response/BookingDetailResponse.java
+++ b/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/app/dto/response/BookingDetailResponse.java
@@ -33,7 +33,16 @@ public record BookingDetailResponse(
     @Schema(description = "좌석 번호. seat-service 장애 시 null.", example = "A-1") String seatNumber,
     @Schema(description = "예매 확정일", example = "2026-05-22 10:30:00") LocalDateTime confirmedAt,
     @Schema(
-            description = "결제 금액. 공연당 단일가·1인 1매라 공연 가격과 같다. performance-service 장애 시 null.",
+            description =
+                "PENDING 예매의 결제 마감 시각. PENDING이 아니면 null이다. 예매번호만 든 화면(딥링크·새로고침)에서도 "
+                    + "이 값으로 카운트다운을 복원할 수 있다 (#559).",
+            example = "2026-05-22 10:35:00")
+        LocalDateTime expiresAt,
+    @Schema(
+            description =
+                "결제 금액. 공연당 단일가·1인 1매라 공연 가격과 같다. performance-service 장애 시 null. "
+                    + "출처가 현재 공연 가격이므로, 예매 후 관리자가 가격을 바꾸면 이 값도 함께 바뀐다 — "
+                    + "실제 결제액의 SSOT는 payment-service다.",
             example = "150000")
         Long paymentAmount) {
 
@@ -52,6 +61,7 @@ public record BookingDetailResponse(
         booking.getSeatId(),
         seatNumber,
         booking.getConfirmedAt(),
+        booking.paymentExpiresAt(),
         (performance == null) ? null : performance.price());
   }
 }

--- a/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/app/dto/response/BookingMySummaryResponse.java
+++ b/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/app/dto/response/BookingMySummaryResponse.java
@@ -1,0 +1,71 @@
+package com.ticketrush.boundedcontext.booking.app.dto.response;
+
+import com.ticketrush.boundedcontext.booking.domain.types.BookingStatus;
+import com.ticketrush.boundedcontext.booking.out.apiclient.dto.PerformanceInfoResponse;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+/**
+ * 회원 예매 목록 응답 (#560). {@link BookingSummaryResponse}(admin 목록과 공유)에 회원 예매 조회 화면이 요구하는 공연·좌석·금액 필드를
+ * 보강한 전용 DTO다 — 공유 DTO를 직접 보강하면 enrichment 없는 admin 응답까지 바뀐다.
+ *
+ * <p>보강 필드는 각 서비스 조회 실패 시 null(응답에서 생략)일 수 있다 — 프론트는 {@code performanceId}/{@code seatId}로 재조회한다.
+ */
+@Schema(description = "회원 예매 목록 응답 DTO")
+public record BookingMySummaryResponse(
+    @Schema(description = "예매 ID. 입장권 QR 조회의 키다.", example = "1") Long bookingId,
+    @Schema(description = "클라이언트에게 노출되는 주문/예약 번호", example = "X7B29-KLPW1") String bookingNumber,
+    @Schema(description = "회원 ID", example = "5") Long userId,
+    @Schema(description = "공연 ID. 공연 필드가 비어 있을 때 재조회 키다.", example = "10") Long performanceId,
+    @Schema(description = "좌석 ID. 좌석 번호가 비어 있을 때 재조회 키다.", example = "100") Long seatId,
+    @Schema(description = "예매 상태", example = "CONFIRMED") BookingStatus bookingStatus,
+    @Schema(description = "예매 확정일", example = "2026-05-22 10:30:00") LocalDateTime confirmedAt,
+    @Schema(
+            description = "마지막 환불 실패 시각. null이 아니면 취소를 요청했으나 환불에 실패해 예매가 유지된 것이다.",
+            example = "2026-05-23 11:00:00")
+        LocalDateTime refundFailedAt,
+    @Schema(
+            description = "마지막 변경 시각. REFUNDING이면 환불 요청이 시작된 시각이다 (#397).",
+            example = "2026-05-23 11:00:00")
+        LocalDateTime updatedAt,
+    @Schema(
+            description =
+                "PENDING 예매의 결제 마감 시각. PENDING이 아니면 null이다. 새로고침 후에도 이 값으로 카운트다운을 복원할 수 있다 (#559).",
+            example = "2026-05-22 10:35:00")
+        LocalDateTime expiresAt,
+    @Schema(description = "공연 이름. performance-service 장애 시 null.", example = "오페라의 유령")
+        String performanceTitle,
+    @Schema(
+            description = "공연 날짜. 예정/지난 공연 탭 분기 기준이다. performance-service 장애 시 null.",
+            example = "2026-05-22")
+        LocalDate performanceDate,
+    @Schema(description = "공연 장소. performance-service 장애 시 null.", example = "서울 예술의전당 오페라극장")
+        String performanceAddress,
+    @Schema(description = "좌석 번호. seat-service 장애 시 null.", example = "A-1") String seatNumber,
+    @Schema(
+            description = "결제 금액. 공연당 단일가·1인 1매라 공연 가격과 같다. performance-service 장애 시 null.",
+            example = "150000")
+        Long paymentAmount) {
+
+  /** {@code performance}와 {@code seatNumber}는 조회 실패 시 null이 허용된다(부분 응답). */
+  public static BookingMySummaryResponse from(
+      BookingSummaryResponse core, PerformanceInfoResponse performance, String seatNumber) {
+    return new BookingMySummaryResponse(
+        core.bookingId(),
+        core.bookingNumber(),
+        core.userId(),
+        core.performanceId(),
+        core.seatId(),
+        core.bookingStatus(),
+        core.confirmedAt(),
+        core.refundFailedAt(),
+        core.updatedAt(),
+        core.expiresAt(),
+        (performance == null) ? null : performance.title(),
+        (performance == null) ? null : performance.showDate(),
+        (performance == null) ? null : performance.address(),
+        seatNumber,
+        (performance == null) ? null : performance.price());
+  }
+}

--- a/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/app/dto/response/BookingMySummaryResponse.java
+++ b/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/app/dto/response/BookingMySummaryResponse.java
@@ -44,7 +44,10 @@ public record BookingMySummaryResponse(
         String performanceAddress,
     @Schema(description = "좌석 번호. seat-service 장애 시 null.", example = "A-1") String seatNumber,
     @Schema(
-            description = "결제 금액. 공연당 단일가·1인 1매라 공연 가격과 같다. performance-service 장애 시 null.",
+            description =
+                "결제 금액. 공연당 단일가·1인 1매라 공연 가격과 같다. performance-service 장애 시 null. "
+                    + "출처가 현재 공연 가격이므로, 예매 후 관리자가 가격을 바꾸면 이 값도 함께 바뀐다 — "
+                    + "실제 결제액의 SSOT는 payment-service다.",
             example = "150000")
         Long paymentAmount) {
 

--- a/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/app/facade/BookingFacade.java
+++ b/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/app/facade/BookingFacade.java
@@ -10,7 +10,7 @@ import com.ticketrush.boundedcontext.booking.app.usecase.BookingAdminRetryRefund
 import com.ticketrush.boundedcontext.booking.app.usecase.BookingCancelMyBookingUseCase;
 import com.ticketrush.boundedcontext.booking.app.usecase.BookingCountUseCase;
 import com.ticketrush.boundedcontext.booking.app.usecase.BookingCreateUseCase;
-import com.ticketrush.boundedcontext.booking.app.usecase.BookingGetMyBookingUseCase;
+import com.ticketrush.boundedcontext.booking.app.usecase.BookingGetMyBookingDetailUseCase;
 import com.ticketrush.boundedcontext.booking.app.usecase.BookingGetMyBookingsUseCase;
 import com.ticketrush.boundedcontext.booking.app.usecase.BookingGetRefundFailedBookingsUseCase;
 import com.ticketrush.boundedcontext.booking.app.usecase.BookingGetRefundingStuckBookingsUseCase;
@@ -24,6 +24,7 @@ import com.ticketrush.boundedcontext.booking.out.apiclient.PerformanceRestClient
 import com.ticketrush.boundedcontext.booking.out.apiclient.SeatRestClient;
 import com.ticketrush.boundedcontext.booking.out.apiclient.dto.PerformanceInfoResponse;
 import com.ticketrush.global.dto.request.OffsetPageRequest;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -39,7 +40,7 @@ public class BookingFacade {
 
   private final BookingIssueNumberUseCase bookingIssueNumberUseCase;
   private final BookingCreateUseCase bookingCreateUseCase;
-  private final BookingGetMyBookingUseCase bookingGetMyBookingUseCase;
+  private final BookingGetMyBookingDetailUseCase bookingGetMyBookingDetailUseCase;
   private final BookingGetMyBookingsUseCase bookingGetMyBookingsUseCase;
   private final PerformanceRestClient performanceRestClient;
   private final BookingCountUseCase bookingCountUseCase;
@@ -76,7 +77,7 @@ public class BookingFacade {
    * <p>보강 실패는 각 클라이언트가 빈 값으로 흡수하므로(부분 응답) 여기에는 catch가 없다. 한 도메인의 실패가 다른 도메인 필드에 닿는 경로도 없다.
    */
   public BookingDetailResponse getMyBooking(Long userId, String bookingNumber) {
-    Booking booking = bookingGetMyBookingUseCase.execute(userId, bookingNumber);
+    Booking booking = bookingGetMyBookingDetailUseCase.execute(userId, bookingNumber);
 
     PerformanceInfoResponse performance =
         performanceRestClient.getPerformance(booking.getPerformanceId()).orElse(null);
@@ -96,11 +97,13 @@ public class BookingFacade {
         bookingGetMyBookingsUseCase.execute(userId, bookingStatus, pageRequest);
     List<BookingSummaryResponse> content = page.getContent();
 
+    // 순서를 페이지 순서로 고정한다(LinkedHashSet). 보강이 예산·장애로 중간에 끊길 때 HashSet이면 어느 행이
+    // 채워질지가 매 요청 달라져, 새로고침마다 다른 행의 공연 정보가 나타났다 사라진다.
     Map<Long, PerformanceInfoResponse> performances =
         performanceRestClient.getPerformances(
             content.stream()
                 .map(BookingSummaryResponse::performanceId)
-                .collect(Collectors.toSet()));
+                .collect(Collectors.toCollection(LinkedHashSet::new)));
     Map<Long, String> seatNumbers =
         seatRestClient.getSeatNumbers(
             content.stream().map(BookingSummaryResponse::seatId).distinct().toList());

--- a/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/app/facade/BookingFacade.java
+++ b/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/app/facade/BookingFacade.java
@@ -2,12 +2,14 @@ package com.ticketrush.boundedcontext.booking.app.facade;
 
 import com.ticketrush.boundedcontext.booking.app.dto.request.BookingCreateRequest;
 import com.ticketrush.boundedcontext.booking.app.dto.response.BookingCountResponse;
+import com.ticketrush.boundedcontext.booking.app.dto.response.BookingDetailResponse;
 import com.ticketrush.boundedcontext.booking.app.dto.response.BookingPendingResponse;
 import com.ticketrush.boundedcontext.booking.app.dto.response.BookingSummaryResponse;
 import com.ticketrush.boundedcontext.booking.app.usecase.BookingAdminRetryRefundUseCase;
 import com.ticketrush.boundedcontext.booking.app.usecase.BookingCancelMyBookingUseCase;
 import com.ticketrush.boundedcontext.booking.app.usecase.BookingCountUseCase;
 import com.ticketrush.boundedcontext.booking.app.usecase.BookingCreateUseCase;
+import com.ticketrush.boundedcontext.booking.app.usecase.BookingGetMyBookingUseCase;
 import com.ticketrush.boundedcontext.booking.app.usecase.BookingGetMyBookingsUseCase;
 import com.ticketrush.boundedcontext.booking.app.usecase.BookingGetRefundFailedBookingsUseCase;
 import com.ticketrush.boundedcontext.booking.app.usecase.BookingGetRefundingStuckBookingsUseCase;
@@ -17,8 +19,11 @@ import com.ticketrush.boundedcontext.booking.app.usecase.BookingValidateSeatAvai
 import com.ticketrush.boundedcontext.booking.app.usecase.BookingValidateTicketNotUsedUseCase;
 import com.ticketrush.boundedcontext.booking.domain.entity.Booking;
 import com.ticketrush.boundedcontext.booking.domain.types.BookingStatus;
+import com.ticketrush.boundedcontext.booking.out.apiclient.PerformanceRestClient;
 import com.ticketrush.boundedcontext.booking.out.apiclient.SeatRestClient;
+import com.ticketrush.boundedcontext.booking.out.apiclient.dto.PerformanceInfoResponse;
 import com.ticketrush.global.dto.request.OffsetPageRequest;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -31,7 +36,9 @@ public class BookingFacade {
 
   private final BookingIssueNumberUseCase bookingIssueNumberUseCase;
   private final BookingCreateUseCase bookingCreateUseCase;
+  private final BookingGetMyBookingUseCase bookingGetMyBookingUseCase;
   private final BookingGetMyBookingsUseCase bookingGetMyBookingsUseCase;
+  private final PerformanceRestClient performanceRestClient;
   private final BookingCountUseCase bookingCountUseCase;
   private final BookingCancelMyBookingUseCase bookingCancelMyBookingUseCase;
   private final SeatRestClient seatRestClient;
@@ -57,6 +64,23 @@ public class BookingFacade {
     Booking booking = bookingCreateUseCase.execute(request);
 
     return BookingPendingResponse.from(booking);
+  }
+
+  /**
+   * 본인 예매 단건 조회 (#560). DB 조회(트랜잭션 안)와 타 도메인 보강(트랜잭션 밖)을 여기서 잇는다 — UseCase에서 원격 호출을 하면 DB 커넥션을 쥔 채
+   * 타임아웃을 대기하게 된다.
+   *
+   * <p>보강 실패는 각 클라이언트가 빈 값으로 흡수하므로(부분 응답) 여기에는 catch가 없다. 한 도메인의 실패가 다른 도메인 필드에 닿는 경로도 없다.
+   */
+  public BookingDetailResponse getMyBooking(Long userId, String bookingNumber) {
+    Booking booking = bookingGetMyBookingUseCase.execute(userId, bookingNumber);
+
+    PerformanceInfoResponse performance =
+        performanceRestClient.getPerformance(booking.getPerformanceId()).orElse(null);
+    String seatNumber =
+        seatRestClient.getSeatNumbers(List.of(booking.getSeatId())).get(booking.getSeatId());
+
+    return BookingDetailResponse.of(booking, performance, seatNumber);
   }
 
   public Page<BookingSummaryResponse> getMyBookings(

--- a/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/app/facade/BookingFacade.java
+++ b/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/app/facade/BookingFacade.java
@@ -3,6 +3,7 @@ package com.ticketrush.boundedcontext.booking.app.facade;
 import com.ticketrush.boundedcontext.booking.app.dto.request.BookingCreateRequest;
 import com.ticketrush.boundedcontext.booking.app.dto.response.BookingCountResponse;
 import com.ticketrush.boundedcontext.booking.app.dto.response.BookingDetailResponse;
+import com.ticketrush.boundedcontext.booking.app.dto.response.BookingMySummaryResponse;
 import com.ticketrush.boundedcontext.booking.app.dto.response.BookingPendingResponse;
 import com.ticketrush.boundedcontext.booking.app.dto.response.BookingSummaryResponse;
 import com.ticketrush.boundedcontext.booking.app.usecase.BookingAdminRetryRefundUseCase;
@@ -24,6 +25,8 @@ import com.ticketrush.boundedcontext.booking.out.apiclient.SeatRestClient;
 import com.ticketrush.boundedcontext.booking.out.apiclient.dto.PerformanceInfoResponse;
 import com.ticketrush.global.dto.request.OffsetPageRequest;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -83,9 +86,31 @@ public class BookingFacade {
     return BookingDetailResponse.of(booking, performance, seatNumber);
   }
 
-  public Page<BookingSummaryResponse> getMyBookings(
+  /**
+   * 내 예매 목록 조회 (#560). 단건 조회와 같은 축으로 공연·좌석을 보강한다 — distinct 공연 묶음 조회 + 좌석 벌크 1회. 보강 실패는 각 클라이언트가
+   * 흡수해 해당 도메인 필드만 null이다(부분 응답).
+   */
+  public Page<BookingMySummaryResponse> getMyBookings(
       Long userId, BookingStatus bookingStatus, OffsetPageRequest pageRequest) {
-    return bookingGetMyBookingsUseCase.execute(userId, bookingStatus, pageRequest);
+    Page<BookingSummaryResponse> page =
+        bookingGetMyBookingsUseCase.execute(userId, bookingStatus, pageRequest);
+    List<BookingSummaryResponse> content = page.getContent();
+
+    Map<Long, PerformanceInfoResponse> performances =
+        performanceRestClient.getPerformances(
+            content.stream()
+                .map(BookingSummaryResponse::performanceId)
+                .collect(Collectors.toSet()));
+    Map<Long, String> seatNumbers =
+        seatRestClient.getSeatNumbers(
+            content.stream().map(BookingSummaryResponse::seatId).distinct().toList());
+
+    return page.map(
+        summary ->
+            BookingMySummaryResponse.from(
+                summary,
+                performances.get(summary.performanceId()),
+                seatNumbers.get(summary.seatId())));
   }
 
   public BookingCountResponse countMyBookings(Long userId, BookingStatus bookingStatus) {

--- a/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/app/usecase/BookingGetMyBookingDetailUseCase.java
+++ b/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/app/usecase/BookingGetMyBookingDetailUseCase.java
@@ -16,11 +16,11 @@ import org.springframework.transaction.annotation.Transactional;
  */
 @Service
 @RequiredArgsConstructor
-public class BookingGetMyBookingUseCase {
+@Transactional(readOnly = true)
+public class BookingGetMyBookingDetailUseCase {
 
   private final BookingRepository bookingRepository;
 
-  @Transactional(readOnly = true)
   public Booking execute(Long userId, String bookingNumber) {
     return bookingRepository
         .findByBookingNumberAndUserId(bookingNumber, userId)

--- a/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/app/usecase/BookingGetMyBookingUseCase.java
+++ b/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/app/usecase/BookingGetMyBookingUseCase.java
@@ -1,0 +1,29 @@
+package com.ticketrush.boundedcontext.booking.app.usecase;
+
+import com.ticketrush.boundedcontext.booking.domain.entity.Booking;
+import com.ticketrush.boundedcontext.booking.out.repository.BookingRepository;
+import com.ticketrush.global.exception.BusinessException;
+import com.ticketrush.global.status.ErrorStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 본인 예매 단건 조회 (#560). DB 조회만 담당한다 — 타 도메인 보강은 트랜잭션 밖(Facade)에서 한다.
+ *
+ * <p>조회 자체를 소유자 조건으로 걸어({@code findByBookingNumberAndUserId}) 타인 예매와 미존재를 같은 404로 수렴시킨다 — 응답 코드로 타인
+ * 예매의 존재 여부가 새지 않게 한다.
+ */
+@Service
+@RequiredArgsConstructor
+public class BookingGetMyBookingUseCase {
+
+  private final BookingRepository bookingRepository;
+
+  @Transactional(readOnly = true)
+  public Booking execute(Long userId, String bookingNumber) {
+    return bookingRepository
+        .findByBookingNumberAndUserId(bookingNumber, userId)
+        .orElseThrow(() -> new BusinessException(ErrorStatus.BOOKING_NOT_FOUND));
+  }
+}

--- a/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/in/api/v1/BookingController.java
+++ b/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/in/api/v1/BookingController.java
@@ -3,8 +3,8 @@ package com.ticketrush.boundedcontext.booking.in.api.v1;
 import com.ticketrush.boundedcontext.booking.app.dto.request.BookingPendingRequest;
 import com.ticketrush.boundedcontext.booking.app.dto.response.BookingCountResponse;
 import com.ticketrush.boundedcontext.booking.app.dto.response.BookingDetailResponse;
+import com.ticketrush.boundedcontext.booking.app.dto.response.BookingMySummaryResponse;
 import com.ticketrush.boundedcontext.booking.app.dto.response.BookingPendingResponse;
-import com.ticketrush.boundedcontext.booking.app.dto.response.BookingSummaryResponse;
 import com.ticketrush.boundedcontext.booking.app.facade.BookingFacade;
 import com.ticketrush.boundedcontext.booking.domain.types.BookingStatus;
 import com.ticketrush.global.dto.request.OffsetPageRequest;
@@ -55,13 +55,18 @@ public class BookingController {
 
   @Operation(
       summary = "내 예매 내역 조회",
-      description = "로그인한 사용자의 예매 내역을 조회합니다. 좌석 번호와 공연 상세 정보는 각 모듈 API에서 조회합니다.")
+      description =
+          """
+          로그인한 사용자의 예매 내역을 조회합니다. 공연 이름·날짜·장소, 좌석 번호, 결제 금액을 함께
+          내려줍니다(#560). 해당 필드는 각 서비스 장애 시 응답에서 빠질 수 있으며(부분 응답), 그때는
+          `performance_id`/`seat_id`로 재조회하십시오.
+          """)
   @GetMapping("/me")
-  public ResponseEntity<ApiResponse<List<BookingSummaryResponse>>> getMyBookings(
+  public ResponseEntity<ApiResponse<List<BookingMySummaryResponse>>> getMyBookings(
       @AuthenticationPrincipal CustomUserDetails user,
       @RequestParam(defaultValue = "CONFIRMED") BookingStatus status,
       @ModelAttribute OffsetPageRequest pageRequest) {
-    Page<BookingSummaryResponse> response =
+    Page<BookingMySummaryResponse> response =
         bookingFacade.getMyBookings(user.getUserId(), status, pageRequest);
 
     return ApiResponse.onSuccess(SuccessStatus.OK, response);

--- a/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/in/api/v1/BookingController.java
+++ b/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/in/api/v1/BookingController.java
@@ -2,6 +2,7 @@ package com.ticketrush.boundedcontext.booking.in.api.v1;
 
 import com.ticketrush.boundedcontext.booking.app.dto.request.BookingPendingRequest;
 import com.ticketrush.boundedcontext.booking.app.dto.response.BookingCountResponse;
+import com.ticketrush.boundedcontext.booking.app.dto.response.BookingDetailResponse;
 import com.ticketrush.boundedcontext.booking.app.dto.response.BookingPendingResponse;
 import com.ticketrush.boundedcontext.booking.app.dto.response.BookingSummaryResponse;
 import com.ticketrush.boundedcontext.booking.app.facade.BookingFacade;
@@ -11,6 +12,7 @@ import com.ticketrush.global.dto.response.ApiResponse;
 import com.ticketrush.global.security.CustomUserDetails;
 import com.ticketrush.global.status.SuccessStatus;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import java.util.List;
@@ -61,6 +63,32 @@ public class BookingController {
       @ModelAttribute OffsetPageRequest pageRequest) {
     Page<BookingSummaryResponse> response =
         bookingFacade.getMyBookings(user.getUserId(), status, pageRequest);
+
+    return ApiResponse.onSuccess(SuccessStatus.OK, response);
+  }
+
+  @Operation(
+      summary = "내 예매 단건 조회",
+      description =
+          """
+          로그인한 사용자 본인의 예매를 예매번호로 조회합니다. 예매번호는 `X7B29-KLPW1`처럼
+          영문 대문자·숫자 10자리를 5자리씩 하이픈으로 연결한 형식입니다.
+
+          `booking_id`는 입장권 QR 조회(`GET /api/v1/ticket/bookings/{bookingId}/qr`)의 키입니다 —
+          예매번호만 든 화면(딥링크·새로고침)에서 이 API로 되찾을 수 있습니다.
+
+          공연·좌석 필드는 해당 서비스 장애 시 응답에서 빠질 수 있습니다(부분 응답). 그때는
+          `performance_id`/`seat_id`로 각 서비스에 재조회하십시오. 예매자 이름·이메일은 본인 조회이므로
+          `GET /api/v1/user/me`로 조합합니다.
+
+          타인 예매와 존재하지 않는 예매는 동일하게 404(`BOOKING_404_001`)입니다 — 응답 코드로
+          타인 예매의 존재 여부를 노출하지 않습니다.
+          """)
+  @GetMapping("/{bookingNumber}")
+  public ResponseEntity<ApiResponse<BookingDetailResponse>> getMyBooking(
+      @AuthenticationPrincipal CustomUserDetails user,
+      @Parameter(description = "예매 번호") @PathVariable String bookingNumber) {
+    BookingDetailResponse response = bookingFacade.getMyBooking(user.getUserId(), bookingNumber);
 
     return ApiResponse.onSuccess(SuccessStatus.OK, response);
   }

--- a/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/out/apiclient/PerformanceRestClient.java
+++ b/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/out/apiclient/PerformanceRestClient.java
@@ -1,0 +1,81 @@
+package com.ticketrush.boundedcontext.booking.out.apiclient;
+
+import com.ticketrush.boundedcontext.booking.out.apiclient.dto.PerformanceApiResponse;
+import com.ticketrush.boundedcontext.booking.out.apiclient.dto.PerformanceInfoResponse;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
+
+/**
+ * 예매 조회 응답 보강용 공연 상세 조회 클라이언트. performance-service의 <b>공개</b> API를 호출하므로 내부 토큰이 없다.
+ *
+ * <p><b>실패해도 예외를 밖으로 내지 않는다(#560 부분 응답 정책).</b> 여기서 던지면 performance-service 장애가 예매 조회 전체를 죽인다.
+ * booking 코어 필드는 이미 DB에서 확정됐으므로, 공연 필드만 비운 채 응답하고 프론트가 performanceId로 재조회하게 한다.
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PerformanceRestClient {
+
+  private final RestClient performanceServiceRestClient;
+
+  /** 단건 조회. 4xx·5xx·타임아웃·본문 결손 등 모든 실패는 {@code Optional.empty()}로 수렴한다. */
+  public Optional<PerformanceInfoResponse> getPerformance(Long performanceId) {
+    try {
+      return Optional.ofNullable(fetch(performanceId));
+    } catch (RestClientException e) {
+      log.warn(
+          "[PerformanceRestClient] 공연 조회 실패, 공연 필드는 null로 응답합니다. performanceId={}",
+          performanceId,
+          e);
+      return Optional.empty();
+    }
+  }
+
+  /**
+   * 벌크 조회. 공개 API에 벌크 엔드포인트가 없어 순차 호출한다(호출 측이 distinct 보장, 페이지 기본 10건).
+   *
+   * <p>4xx(삭제된 공연 등)는 해당 건만 비우고 계속 가지만, 그 외 실패(5xx·타임아웃)는 서비스 장애로 보고 잔여 호출을 중단한다 — 장애 중 남은 건들이
+   * 타임아웃을 반복하며 톰캣 스레드를 n×2초씩 붙잡는 것을 막는다. 실패한 공연은 맵에서 빠진다.
+   */
+  public Map<Long, PerformanceInfoResponse> getPerformances(Collection<Long> performanceIds) {
+    Map<Long, PerformanceInfoResponse> result = new HashMap<>();
+    for (Long performanceId : performanceIds) {
+      try {
+        PerformanceInfoResponse info = fetch(performanceId);
+        if (info != null) {
+          result.put(performanceId, info);
+        }
+      } catch (HttpClientErrorException e) {
+        log.warn(
+            "[PerformanceRestClient] 공연 조회 실패({}), 해당 건만 비우고 계속합니다. performanceId={}",
+            e.getStatusCode(),
+            performanceId);
+      } catch (RestClientException e) {
+        log.warn(
+            "[PerformanceRestClient] performance-service 통신 실패, 잔여 공연 조회를 중단합니다. performanceId={}",
+            performanceId,
+            e);
+        break;
+      }
+    }
+    return result;
+  }
+
+  private PerformanceInfoResponse fetch(Long performanceId) {
+    PerformanceApiResponse response =
+        performanceServiceRestClient
+            .get()
+            .uri("/api/v1/performance/{id}", performanceId)
+            .retrieve()
+            .body(PerformanceApiResponse.class);
+    return (response == null) ? null : response.result();
+  }
+}

--- a/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/out/apiclient/PerformanceRestClient.java
+++ b/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/out/apiclient/PerformanceRestClient.java
@@ -6,8 +6,9 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
-import lombok.RequiredArgsConstructor;
+import java.util.concurrent.TimeUnit;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestClient;
@@ -21,10 +22,17 @@ import org.springframework.web.client.RestClientException;
  */
 @Slf4j
 @Component
-@RequiredArgsConstructor
 public class PerformanceRestClient {
 
   private final RestClient performanceServiceRestClient;
+  private final long bulkBudgetMs;
+
+  public PerformanceRestClient(
+      RestClient performanceServiceRestClient,
+      @Value("${service.performance.bulk-budget-ms:3000}") long bulkBudgetMs) {
+    this.performanceServiceRestClient = performanceServiceRestClient;
+    this.bulkBudgetMs = bulkBudgetMs;
+  }
 
   /** 단건 조회. 4xx·5xx·타임아웃·본문 결손 등 모든 실패는 {@code Optional.empty()}로 수렴한다. */
   public Optional<PerformanceInfoResponse> getPerformance(Long performanceId) {
@@ -40,14 +48,31 @@ public class PerformanceRestClient {
   }
 
   /**
-   * 벌크 조회. 공개 API에 벌크 엔드포인트가 없어 순차 호출한다(호출 측이 distinct 보장, 페이지 기본 10건).
+   * 벌크 조회. 공개 API에 벌크 엔드포인트가 없어 순차 호출한다(호출 측이 distinct 보장).
    *
-   * <p>4xx(삭제된 공연 등)는 해당 건만 비우고 계속 가지만, 그 외 실패(5xx·타임아웃)는 서비스 장애로 보고 잔여 호출을 중단한다 — 장애 중 남은 건들이
-   * 타임아웃을 반복하며 톰캣 스레드를 n×2초씩 붙잡는 것을 막는다. 실패한 공연은 맵에서 빠진다.
+   * <p>중단 조건이 둘이다. <b>통신 실패(5xx·타임아웃)</b>는 서비스 장애로 보고 잔여 호출을 접는다 — 장애 중 남은 건들이 타임아웃을 반복하며 톰캣 스레드를
+   * 건당 예산만큼 더 붙잡는 것을 막는다. 4xx(삭제된 공연 등)는 해당 건만 비우고 계속 간다.
+   *
+   * <p><b>벽시계 예산</b>은 그것만으로 부족해서 둔다. performance-service가 살아 있으면서 느리기만 하면(건당 read 예산 미만) 예외가 나지 않아
+   * 위 중단이 돌지 않고, 페이지 상한 50건이 그대로 누적돼 요청 하나가 스레드를 수십 초 붙잡는다. 예산을 넘기면 잔여 공연 필드를 비운 채 응답한다 — 부분 응답 정책이
+   * 이미 허용하는 결과다.
+   *
+   * <p>실패했거나 예산에 걸려 건너뛴 공연은 맵에서 빠진다.
    */
   public Map<Long, PerformanceInfoResponse> getPerformances(Collection<Long> performanceIds) {
     Map<Long, PerformanceInfoResponse> result = new HashMap<>();
+    long deadline = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(bulkBudgetMs);
+
     for (Long performanceId : performanceIds) {
+      if (System.nanoTime() >= deadline) {
+        log.warn(
+            "[PerformanceRestClient] 보강 예산({}ms) 초과, 잔여 공연 필드를 비웁니다. 조회 성공 {}/{}건",
+            bulkBudgetMs,
+            result.size(),
+            performanceIds.size());
+        break;
+      }
+
       try {
         PerformanceInfoResponse info = fetch(performanceId);
         if (info != null) {

--- a/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/out/apiclient/SeatRestClient.java
+++ b/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/out/apiclient/SeatRestClient.java
@@ -5,8 +5,10 @@ import com.ticketrush.boundedcontext.booking.app.dto.request.SeatSoldConfirmRequ
 import com.ticketrush.boundedcontext.booking.out.apiclient.dto.SeatNumberInfoResponse;
 import com.ticketrush.boundedcontext.booking.out.apiclient.dto.SeatNumbersApiResponse;
 import com.ticketrush.global.config.CustomSecurityProperties;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -22,6 +24,10 @@ public class SeatRestClient {
   private static final String INTERNAL_TOKEN_HEADER = "X-Internal-Token";
 
   private final RestClient seatServiceRestClient;
+
+  /** 조회 전용 클라이언트. 쓰기(SOLD 확정·반납)와 타임아웃 예산이 다르다 — {@code RestClientConfig} 참고. */
+  private final RestClient seatQueryRestClient;
+
   private final CustomSecurityProperties customSecurityProperties;
 
   /**
@@ -80,15 +86,17 @@ public class SeatRestClient {
    * 없으면 seat-service가 404(SEAT_NOT_FOUND)로 전체 실패시키므로 그때도 빈 맵이다 — 해당 페이지의 좌석 번호가 전부 비지만, 프론트는
    * seatId로 재조회할 수 있다.
    */
-  // ponytail: 공용 3s/10s 빈 재사용(요청당 1회 호출이라 곱해지지 않음) — 이 경로가 p99를 끌면 전용 1s/2s 빈 분리
   public Map<Long, String> getSeatNumbers(List<Long> seatIds) {
-    if (seatIds.isEmpty()) {
+    // 중복 제거를 호출 측에 맡기지 않는다 — 중복이 오면 seat-service 요청만 길어지고, 응답 매핑도 같은 키를
+    // 두 번 만난다. 계약을 이 안에서 닫아 둔다.
+    List<Long> distinctSeatIds = seatIds.stream().filter(Objects::nonNull).distinct().toList();
+    if (distinctSeatIds.isEmpty()) {
       return Map.of();
     }
 
     try {
       SeatNumbersApiResponse response =
-          seatServiceRestClient
+          seatQueryRestClient
               .get()
               .uri(
                   uriBuilder ->
@@ -96,7 +104,7 @@ public class SeatRestClient {
                           .path("/api/v1/seat/numbers")
                           .queryParam(
                               "seatIds",
-                              seatIds.stream()
+                              distinctSeatIds.stream()
                                   .map(String::valueOf)
                                   .collect(Collectors.joining(",")))
                           .build())
@@ -108,9 +116,16 @@ public class SeatRestClient {
         return Map.of();
       }
 
-      return response.result().stream()
-          .collect(
-              Collectors.toMap(SeatNumberInfoResponse::seatId, SeatNumberInfoResponse::seatNumber));
+      // 계약을 이 안에서 닫는다. toMap은 키 중복이면 IllegalStateException, 키·값이 null이면 NPE를 던지는데
+      // 둘 다 RestClientException이 아니라 아래 catch를 뚫고 500이 된다 — 부분 응답 정책이 여기서만 깨진다.
+      // 지금 안 터지는 건 seat 스키마가 NOT NULL이고 호출 측이 distinct를 주기 때문일 뿐이라, 그 전제에 기대지 않는다.
+      Map<Long, String> seatNumbers = new HashMap<>();
+      for (SeatNumberInfoResponse seat : response.result()) {
+        if (seat.seatId() != null && seat.seatNumber() != null) {
+          seatNumbers.put(seat.seatId(), seat.seatNumber());
+        }
+      }
+      return seatNumbers;
     } catch (RestClientException e) {
       log.warn("[SeatRestClient] 좌석 번호 조회 실패, seat_number는 null로 응답합니다. seatIds={}", seatIds, e);
       return Map.of();

--- a/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/out/apiclient/SeatRestClient.java
+++ b/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/out/apiclient/SeatRestClient.java
@@ -2,7 +2,12 @@ package com.ticketrush.boundedcontext.booking.out.apiclient;
 
 import com.ticketrush.boundedcontext.booking.app.dto.request.SeatHoldReleaseRequest;
 import com.ticketrush.boundedcontext.booking.app.dto.request.SeatSoldConfirmRequest;
+import com.ticketrush.boundedcontext.booking.out.apiclient.dto.SeatNumberInfoResponse;
+import com.ticketrush.boundedcontext.booking.out.apiclient.dto.SeatNumbersApiResponse;
 import com.ticketrush.global.config.CustomSecurityProperties;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -65,6 +70,50 @@ public class SeatRestClient {
           bookingNumber,
           seatId,
           e);
+    }
+  }
+
+  /**
+   * 예매 조회 응답 보강용 좌석 번호 벌크 조회 (#560). seat-service의 <b>공개</b> API라 내부 토큰이 없다.
+   *
+   * <p><b>실패해도 예외를 밖으로 내지 않는다(부분 응답 정책).</b> 실패 시 빈 맵으로 수렴해 좌석 번호 필드만 null이 된다. 요청 seatId 중 하나라도
+   * 없으면 seat-service가 404(SEAT_NOT_FOUND)로 전체 실패시키므로 그때도 빈 맵이다 — 해당 페이지의 좌석 번호가 전부 비지만, 프론트는
+   * seatId로 재조회할 수 있다.
+   */
+  // ponytail: 공용 3s/10s 빈 재사용(요청당 1회 호출이라 곱해지지 않음) — 이 경로가 p99를 끌면 전용 1s/2s 빈 분리
+  public Map<Long, String> getSeatNumbers(List<Long> seatIds) {
+    if (seatIds.isEmpty()) {
+      return Map.of();
+    }
+
+    try {
+      SeatNumbersApiResponse response =
+          seatServiceRestClient
+              .get()
+              .uri(
+                  uriBuilder ->
+                      uriBuilder
+                          .path("/api/v1/seat/numbers")
+                          .queryParam(
+                              "seatIds",
+                              seatIds.stream()
+                                  .map(String::valueOf)
+                                  .collect(Collectors.joining(",")))
+                          .build())
+              .retrieve()
+              .body(SeatNumbersApiResponse.class);
+
+      if (response == null || response.result() == null) {
+        log.warn("[SeatRestClient] 좌석 번호 조회 200 응답이나 result가 비어 있음 seatIds={}", seatIds);
+        return Map.of();
+      }
+
+      return response.result().stream()
+          .collect(
+              Collectors.toMap(SeatNumberInfoResponse::seatId, SeatNumberInfoResponse::seatNumber));
+    } catch (RestClientException e) {
+      log.warn("[SeatRestClient] 좌석 번호 조회 실패, seat_number는 null로 응답합니다. seatIds={}", seatIds, e);
+      return Map.of();
     }
   }
 }

--- a/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/out/apiclient/dto/PerformanceApiResponse.java
+++ b/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/out/apiclient/dto/PerformanceApiResponse.java
@@ -1,0 +1,8 @@
+package com.ticketrush.boundedcontext.booking.out.apiclient.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/** performance-service의 공통 ApiResponse 래퍼 중 booking-service가 사용하는 필드만 매핑한다. */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record PerformanceApiResponse(@JsonProperty("result") PerformanceInfoResponse result) {}

--- a/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/out/apiclient/dto/PerformanceApiResponse.java
+++ b/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/out/apiclient/dto/PerformanceApiResponse.java
@@ -1,8 +1,12 @@
 package com.ticketrush.boundedcontext.booking.out.apiclient.dto;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
 
-/** performance-service의 공통 ApiResponse 래퍼 중 booking-service가 사용하는 필드만 매핑한다. */
+/**
+ * performance-service의 공통 ApiResponse 래퍼 중 booking-service가 사용하는 필드만 매핑한다.
+ *
+ * <p>{@code TicketApiResponse}와 달리 {@code code}를 매핑하지 않는다 — 그쪽은 404를 "입장권 미발급"으로 해석해도 되는지 가리는 데 코드가
+ * 필요했지만, 여기서는 모든 실패가 동일하게 빈 결과로 수렴해 구분할 이유가 없다.
+ */
 @JsonIgnoreProperties(ignoreUnknown = true)
-public record PerformanceApiResponse(@JsonProperty("result") PerformanceInfoResponse result) {}
+public record PerformanceApiResponse(PerformanceInfoResponse result) {}

--- a/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/out/apiclient/dto/PerformanceInfoResponse.java
+++ b/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/out/apiclient/dto/PerformanceInfoResponse.java
@@ -1,0 +1,19 @@
+package com.ticketrush.boundedcontext.booking.out.apiclient.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+/**
+ * performance-service 공연 상세 응답(PerformanceDetailResponse) 중 예매 조회 보강에 쓰는 필드만 매핑한다.
+ *
+ * <p>{@code price}가 결제 금액의 원본이다 — 공연당 단일가·1인 1매 확정이라 실제 결제액과 같다(#560).
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record PerformanceInfoResponse(
+    @JsonProperty("title") String title,
+    @JsonProperty("show_date") LocalDate showDate,
+    @JsonProperty("show_time") LocalTime showTime,
+    @JsonProperty("address") String address,
+    @JsonProperty("price") Long price) {}

--- a/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/out/apiclient/dto/PerformanceInfoResponse.java
+++ b/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/out/apiclient/dto/PerformanceInfoResponse.java
@@ -10,10 +10,12 @@ import java.time.LocalTime;
  *
  * <p>{@code price}가 결제 금액의 원본이다 — 공연당 단일가·1인 1매 확정이라 실제 결제액과 같다(#560).
  */
+// 이 DTO는 RestClient.builder() 정적 팩토리로 만든 클라이언트가 쓰므로 앱의 JacksonConfig(SNAKE_CASE)를 타지
+// 않는다. 그래서 레코드 컴포넌트명과 다른 키에만 @JsonProperty가 필요하다(붙은 것이 곧 실제로 일하는 것이다).
 @JsonIgnoreProperties(ignoreUnknown = true)
 public record PerformanceInfoResponse(
-    @JsonProperty("title") String title,
+    String title,
     @JsonProperty("show_date") LocalDate showDate,
     @JsonProperty("show_time") LocalTime showTime,
-    @JsonProperty("address") String address,
-    @JsonProperty("price") Long price) {}
+    String address,
+    Long price) {}

--- a/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/out/apiclient/dto/SeatNumberInfoResponse.java
+++ b/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/out/apiclient/dto/SeatNumberInfoResponse.java
@@ -1,0 +1,9 @@
+package com.ticketrush.boundedcontext.booking.out.apiclient.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/** seat-service 좌석 번호 벌크 조회(SeatNumberResponse) 응답 항목. */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record SeatNumberInfoResponse(
+    @JsonProperty("seat_id") Long seatId, @JsonProperty("seat_number") String seatNumber) {}

--- a/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/out/apiclient/dto/SeatNumbersApiResponse.java
+++ b/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/out/apiclient/dto/SeatNumbersApiResponse.java
@@ -1,0 +1,9 @@
+package com.ticketrush.boundedcontext.booking.out.apiclient.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+
+/** seat-service의 공통 ApiResponse 래퍼 중 booking-service가 사용하는 필드만 매핑한다. */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record SeatNumbersApiResponse(@JsonProperty("result") List<SeatNumberInfoResponse> result) {}

--- a/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/out/apiclient/dto/SeatNumbersApiResponse.java
+++ b/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/out/apiclient/dto/SeatNumbersApiResponse.java
@@ -1,9 +1,8 @@
 package com.ticketrush.boundedcontext.booking.out.apiclient.dto;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
 
 /** seat-service의 공통 ApiResponse 래퍼 중 booking-service가 사용하는 필드만 매핑한다. */
 @JsonIgnoreProperties(ignoreUnknown = true)
-public record SeatNumbersApiResponse(@JsonProperty("result") List<SeatNumberInfoResponse> result) {}
+public record SeatNumbersApiResponse(List<SeatNumberInfoResponse> result) {}

--- a/booking-service/src/main/java/com/ticketrush/global/config/RestClientConfig.java
+++ b/booking-service/src/main/java/com/ticketrush/global/config/RestClientConfig.java
@@ -20,6 +20,22 @@ public class RestClientConfig {
   }
 
   /**
+   * 예매 조회 보강(좌석 번호) 전용 클라이언트 (#560). 쓰기용 {@code seatServiceRestClient}와 달리 공용 예산(3s/10s)을 쓰지 않는다 —
+   * 같은 요청 안에서 공연 보강 예산 위에 얹히므로, 둘을 합치면 조회 하나가 톰캣 스레드를 13초까지 붙잡을 수 있다(ADR 0005가 경고한 그 값이다). 실패해도 부분
+   * 응답으로 계속 가는 경로라 공연 쪽과 같은 논리로 빨리 포기한다.
+   */
+  @Bean
+  public RestClient seatQueryRestClient(
+      @Value("${service.seat.url}") String seatServiceUrl,
+      @Value("${service.seat.query-connect-timeout-ms:1000}") long connectTimeoutMs,
+      @Value("${service.seat.query-read-timeout-ms:2000}") long readTimeoutMs) {
+    return RestClient.builder()
+        .baseUrl(seatServiceUrl)
+        .requestFactory(RestClientFactorySupport.withTimeouts(connectTimeoutMs, readTimeoutMs))
+        .build();
+  }
+
+  /**
    * 예매 조회 보강(공연 필드) 전용 클라이언트 (#560). 공용 타임아웃(3s/10s) 대신 짧은 예산을 쓴다 — 실패해도 부분 응답(공연 필드 null)으로 계속 가는
    * 경로라 빨리 포기하는 것이 옳고, 목록 조회는 공연 수만큼 순차 호출하므로 건당 예산이 그대로 곱해진다.
    */

--- a/booking-service/src/main/java/com/ticketrush/global/config/RestClientConfig.java
+++ b/booking-service/src/main/java/com/ticketrush/global/config/RestClientConfig.java
@@ -20,6 +20,21 @@ public class RestClientConfig {
   }
 
   /**
+   * 예매 조회 보강(공연 필드) 전용 클라이언트 (#560). 공용 타임아웃(3s/10s) 대신 짧은 예산을 쓴다 — 실패해도 부분 응답(공연 필드 null)으로 계속 가는
+   * 경로라 빨리 포기하는 것이 옳고, 목록 조회는 공연 수만큼 순차 호출하므로 건당 예산이 그대로 곱해진다.
+   */
+  @Bean
+  public RestClient performanceServiceRestClient(
+      @Value("${service.performance.url}") String performanceServiceUrl,
+      @Value("${service.performance.connect-timeout-ms:1000}") long connectTimeoutMs,
+      @Value("${service.performance.read-timeout-ms:2000}") long readTimeoutMs) {
+    return RestClient.builder()
+        .baseUrl(performanceServiceUrl)
+        .requestFactory(RestClientFactorySupport.withTimeouts(connectTimeoutMs, readTimeoutMs))
+        .build();
+  }
+
+  /**
    * 취소 경로의 입장권 판정 전용 클라이언트. 공용 타임아웃(3s/10s)이 아니라 훨씬 짧은 예산을 쓴다 — 판정에 필요한 건 단일 행 조회 하나인데,
    * ticket-service가 느려질 때 취소 요청 하나가 톰캣 스레드를 13초까지 붙잡으면 예매 경로 전체가 함께 마른다.
    */

--- a/booking-service/src/main/java/com/ticketrush/global/config/SecurityConfig.java
+++ b/booking-service/src/main/java/com/ticketrush/global/config/SecurityConfig.java
@@ -3,6 +3,7 @@ package com.ticketrush.global.config;
 import com.ticketrush.global.filter.GatewayHeaderFilter;
 import com.ticketrush.global.security.InternalApiTokenFilter;
 import com.ticketrush.global.status.ErrorStatus;
+import java.nio.charset.StandardCharsets;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.security.autoconfigure.SecurityProperties;
@@ -50,6 +51,8 @@ public class SecurityConfig {
                     (request, response, authException) -> {
                       response.setStatus(ErrorStatus.UNAUTHORIZED.getHttpStatus().value());
                       response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+                      // 지정하지 않으면 서블릿 기본값 ISO-8859-1로 나가 한글 메시지가 '?'로 파괴된다.
+                      response.setCharacterEncoding(StandardCharsets.UTF_8.name());
                       response
                           .getWriter()
                           .write(

--- a/booking-service/src/main/java/com/ticketrush/global/config/SecurityConfig.java
+++ b/booking-service/src/main/java/com/ticketrush/global/config/SecurityConfig.java
@@ -8,7 +8,6 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.boot.security.autoconfigure.SecurityProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -61,13 +60,14 @@ public class SecurityConfig {
         .authorizeHttpRequests(
             auth ->
                 auth.requestMatchers("/v3/api-docs/**", "/swagger-ui/**", "/swagger-ui.html")
-                    // TODO: 인증 이후 허용 범위 수정
                     .permitAll()
                     .requestMatchers("/api/v1/internal/booking/**")
                     .hasRole("INTERNAL")
                     .requestMatchers("/api/v1/booking/admin/**")
                     .hasRole("ADMIN")
-                    .requestMatchers(HttpMethod.POST, "/api/v1/booking")
+                    // BookingController의 모든 엔드포인트가 user.getUserId()를 즉시 참조한다 — 개별 매처(기존 POST 하나)로
+                    // 열거하면 빠진 경로가 미인증 통과 후 NPE(500)로 터진다(#560). internal·admin은 앞 매처가 선점한다.
+                    .requestMatchers("/api/v1/booking/**")
                     .authenticated()
                     .anyRequest()
                     .permitAll());

--- a/booking-service/src/main/resources/application-prod.yml
+++ b/booking-service/src/main/resources/application-prod.yml
@@ -17,6 +17,10 @@ spring:
       password: ${REDIS_PASSWORD}
 
 service:
+  performance:
+    # 운영은 performance-service URL을 반드시 주입(base의 localhost 기본값 오버라이드, 미주입 시 fail-fast).
+    # 기본값을 남겨두면 컨테이너가 자기 자신을 호출해 예매 조회의 공연 필드가 전부 null이 되는데, 기동은 성공해 조용히 깨진다.
+    url: ${PERFORMANCE_SERVICE_URL}
   ticket:
     # 운영은 ticket-service URL을 반드시 주입(base의 localhost 기본값 오버라이드, 미주입 시 fail-fast).
     # 기본값을 남겨두면 컨테이너가 자기 자신을 호출해 취소·재환불이 전부 503이 되는데, 기동은 성공해 조용히 깨진다.

--- a/booking-service/src/main/resources/application.yml
+++ b/booking-service/src/main/resources/application.yml
@@ -31,6 +31,10 @@ service:
     # 목록 조회는 공연 수만큼 순차 호출이라 건당 예산이 그대로 곱해지므로 공용 예산(3s/10s)을 쓰지 않는다.
     connect-timeout-ms: ${PERFORMANCE_HTTP_CONNECT_TIMEOUT_MS:1000}
     read-timeout-ms: ${PERFORMANCE_HTTP_READ_TIMEOUT_MS:2000}
+    # 목록 보강 전체(순차 호출 합)에 허용하는 벽시계 예산. 건당 타임아웃만으로는 부족하다 —
+    # performance-service가 살아 있으면서 느리기만 하면 예외가 없어 통신 실패 중단이 돌지 않고,
+    # 페이지 상한(50건)이 그대로 누적된다. 초과하면 잔여 공연 필드를 비운 채 응답한다.
+    bulk-budget-ms: ${PERFORMANCE_BULK_BUDGET_MS:3000}
   ticket:
     url: ${TICKET_SERVICE_URL:http://localhost:8087}
     # 취소 경로의 입장권 판정 전용. 단일 행 조회이므로 공용 예산(3s/10s)을 쓰지 않는다 —

--- a/booking-service/src/main/resources/application.yml
+++ b/booking-service/src/main/resources/application.yml
@@ -25,6 +25,12 @@ spring:
 service:
   seat:
     url: ${SEAT_SERVICE_URL:http://localhost:8086}
+  performance:
+    url: ${PERFORMANCE_SERVICE_URL:http://localhost:8083}
+    # 예매 조회 보강(공연 필드) 전용 (#560). 실패해도 부분 응답(null)으로 계속 가는 경로라 빨리 포기한다 —
+    # 목록 조회는 공연 수만큼 순차 호출이라 건당 예산이 그대로 곱해지므로 공용 예산(3s/10s)을 쓰지 않는다.
+    connect-timeout-ms: ${PERFORMANCE_HTTP_CONNECT_TIMEOUT_MS:1000}
+    read-timeout-ms: ${PERFORMANCE_HTTP_READ_TIMEOUT_MS:2000}
   ticket:
     url: ${TICKET_SERVICE_URL:http://localhost:8087}
     # 취소 경로의 입장권 판정 전용. 단일 행 조회이므로 공용 예산(3s/10s)을 쓰지 않는다 —

--- a/booking-service/src/main/resources/application.yml
+++ b/booking-service/src/main/resources/application.yml
@@ -25,6 +25,10 @@ spring:
 service:
   seat:
     url: ${SEAT_SERVICE_URL:http://localhost:8086}
+    # 예매 조회 보강(좌석 번호) 전용. 쓰기 경로(SOLD 확정·반납)의 공용 예산(3s/10s)과 분리한다 —
+    # 같은 요청 안에서 공연 보강 예산 위에 얹혀, 합치면 조회 하나가 톰캣 스레드를 13초까지 붙잡는다.
+    query-connect-timeout-ms: ${SEAT_QUERY_CONNECT_TIMEOUT_MS:1000}
+    query-read-timeout-ms: ${SEAT_QUERY_READ_TIMEOUT_MS:2000}
   performance:
     url: ${PERFORMANCE_SERVICE_URL:http://localhost:8083}
     # 예매 조회 보강(공연 필드) 전용 (#560). 실패해도 부분 응답(null)으로 계속 가는 경로라 빨리 포기한다 —

--- a/booking-service/src/test/java/com/ticketrush/boundedcontext/booking/app/facade/BookingFacadeTest.java
+++ b/booking-service/src/test/java/com/ticketrush/boundedcontext/booking/app/facade/BookingFacadeTest.java
@@ -13,12 +13,14 @@ import static org.mockito.Mockito.verifyNoInteractions;
 
 import com.ticketrush.boundedcontext.booking.app.dto.request.BookingCreateRequest;
 import com.ticketrush.boundedcontext.booking.app.dto.response.BookingCountResponse;
+import com.ticketrush.boundedcontext.booking.app.dto.response.BookingDetailResponse;
 import com.ticketrush.boundedcontext.booking.app.dto.response.BookingPendingResponse;
 import com.ticketrush.boundedcontext.booking.app.dto.response.BookingSummaryResponse;
 import com.ticketrush.boundedcontext.booking.app.usecase.BookingAdminRetryRefundUseCase;
 import com.ticketrush.boundedcontext.booking.app.usecase.BookingCancelMyBookingUseCase;
 import com.ticketrush.boundedcontext.booking.app.usecase.BookingCountUseCase;
 import com.ticketrush.boundedcontext.booking.app.usecase.BookingCreateUseCase;
+import com.ticketrush.boundedcontext.booking.app.usecase.BookingGetMyBookingUseCase;
 import com.ticketrush.boundedcontext.booking.app.usecase.BookingGetMyBookingsUseCase;
 import com.ticketrush.boundedcontext.booking.app.usecase.BookingGetRefundingStuckBookingsUseCase;
 import com.ticketrush.boundedcontext.booking.app.usecase.BookingIssueNumberUseCase;
@@ -27,11 +29,17 @@ import com.ticketrush.boundedcontext.booking.app.usecase.BookingValidateSeatAvai
 import com.ticketrush.boundedcontext.booking.app.usecase.BookingValidateTicketNotUsedUseCase;
 import com.ticketrush.boundedcontext.booking.domain.entity.Booking;
 import com.ticketrush.boundedcontext.booking.domain.types.BookingStatus;
+import com.ticketrush.boundedcontext.booking.out.apiclient.PerformanceRestClient;
 import com.ticketrush.boundedcontext.booking.out.apiclient.SeatRestClient;
+import com.ticketrush.boundedcontext.booking.out.apiclient.dto.PerformanceInfoResponse;
 import com.ticketrush.global.dto.request.OffsetPageRequest;
 import com.ticketrush.global.exception.BusinessException;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -49,7 +57,9 @@ class BookingFacadeTest {
 
   @Mock private BookingIssueNumberUseCase bookingIssueNumberUseCase;
   @Mock private BookingCreateUseCase bookingCreateUseCase;
+  @Mock private BookingGetMyBookingUseCase bookingGetMyBookingUseCase;
   @Mock private BookingGetMyBookingsUseCase bookingGetMyBookingsUseCase;
+  @Mock private PerformanceRestClient performanceRestClient;
   @Mock private BookingCountUseCase bookingCountUseCase;
   @Mock private BookingCancelMyBookingUseCase bookingCancelMyBookingUseCase;
   @Mock private BookingValidateReferencesUseCase bookingValidateReferencesUseCase;
@@ -58,6 +68,87 @@ class BookingFacadeTest {
   @Mock private BookingValidateTicketNotUsedUseCase bookingValidateTicketNotUsedUseCase;
   @Mock private BookingAdminRetryRefundUseCase bookingAdminRetryRefundUseCase;
   @Mock private SeatRestClient seatRestClient;
+
+  private static Booking myBooking(Long userId, String bookingNumber) {
+    return Booking.builder()
+        .userId(userId)
+        .performanceId(2L)
+        .seatId(3L)
+        .bookingNumber(bookingNumber)
+        .bookingStatus(BookingStatus.CONFIRMED)
+        .build();
+  }
+
+  private static PerformanceInfoResponse performanceInfo() {
+    return new PerformanceInfoResponse(
+        "오페라의 유령", LocalDate.of(2026, 5, 22), LocalTime.of(19, 30), "서울 예술의전당 오페라극장", 150000L);
+  }
+
+  @Test
+  @DisplayName("성공: 단건 조회는 공연·좌석을 보강해 모든 필드를 채운다")
+  void getMyBooking_enriches_all_fields() {
+    // given
+    Long userId = 1L;
+    String bookingNumber = "X7B29-KLPW1";
+    given(bookingGetMyBookingUseCase.execute(userId, bookingNumber))
+        .willReturn(myBooking(userId, bookingNumber));
+    given(performanceRestClient.getPerformance(2L)).willReturn(Optional.of(performanceInfo()));
+    given(seatRestClient.getSeatNumbers(List.of(3L))).willReturn(Map.of(3L, "A-1"));
+
+    // when
+    BookingDetailResponse response = bookingFacade.getMyBooking(userId, bookingNumber);
+
+    // then
+    assertThat(response.bookingNumber()).isEqualTo(bookingNumber);
+    assertThat(response.performanceTitle()).isEqualTo("오페라의 유령");
+    assertThat(response.performanceDate()).isEqualTo(LocalDate.of(2026, 5, 22));
+    assertThat(response.performanceTime()).isEqualTo(LocalTime.of(19, 30));
+    assertThat(response.performanceAddress()).isEqualTo("서울 예술의전당 오페라극장");
+    assertThat(response.paymentAmount()).isEqualTo(150000L);
+    assertThat(response.seatNumber()).isEqualTo("A-1");
+  }
+
+  @Test
+  @DisplayName("부분 응답: 공연 조회 실패는 공연 필드·결제 금액만 비우고 좌석 번호는 남긴다 — 실패 격리")
+  void getMyBooking_isolates_performance_failure() {
+    // given
+    Long userId = 1L;
+    String bookingNumber = "X7B29-KLPW1";
+    given(bookingGetMyBookingUseCase.execute(userId, bookingNumber))
+        .willReturn(myBooking(userId, bookingNumber));
+    given(performanceRestClient.getPerformance(2L)).willReturn(Optional.empty());
+    given(seatRestClient.getSeatNumbers(List.of(3L))).willReturn(Map.of(3L, "A-1"));
+
+    // when
+    BookingDetailResponse response = bookingFacade.getMyBooking(userId, bookingNumber);
+
+    // then
+    assertThat(response.performanceTitle()).isNull();
+    assertThat(response.paymentAmount()).isNull();
+    assertThat(response.performanceId()).isEqualTo(2L); // 프론트 재조회 키는 유지
+    assertThat(response.seatNumber()).isEqualTo("A-1");
+    assertThat(response.bookingNumber()).isEqualTo(bookingNumber);
+  }
+
+  @Test
+  @DisplayName("부분 응답: 좌석 조회 실패는 좌석 번호만 비운다")
+  void getMyBooking_isolates_seat_failure() {
+    // given
+    Long userId = 1L;
+    String bookingNumber = "X7B29-KLPW1";
+    given(bookingGetMyBookingUseCase.execute(userId, bookingNumber))
+        .willReturn(myBooking(userId, bookingNumber));
+    given(performanceRestClient.getPerformance(2L)).willReturn(Optional.of(performanceInfo()));
+    given(seatRestClient.getSeatNumbers(List.of(3L))).willReturn(Map.of());
+
+    // when
+    BookingDetailResponse response = bookingFacade.getMyBooking(userId, bookingNumber);
+
+    // then
+    assertThat(response.seatNumber()).isNull();
+    assertThat(response.seatId()).isEqualTo(3L); // 프론트 재조회 키는 유지
+    assertThat(response.performanceTitle()).isEqualTo("오페라의 유령");
+  }
 
   @Test
   @DisplayName("성공: 참조 검증 후 예약번호를 발급하고 예매를 생성한다")

--- a/booking-service/src/test/java/com/ticketrush/boundedcontext/booking/app/facade/BookingFacadeTest.java
+++ b/booking-service/src/test/java/com/ticketrush/boundedcontext/booking/app/facade/BookingFacadeTest.java
@@ -14,6 +14,7 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import com.ticketrush.boundedcontext.booking.app.dto.request.BookingCreateRequest;
 import com.ticketrush.boundedcontext.booking.app.dto.response.BookingCountResponse;
 import com.ticketrush.boundedcontext.booking.app.dto.response.BookingDetailResponse;
+import com.ticketrush.boundedcontext.booking.app.dto.response.BookingMySummaryResponse;
 import com.ticketrush.boundedcontext.booking.app.dto.response.BookingPendingResponse;
 import com.ticketrush.boundedcontext.booking.app.dto.response.BookingSummaryResponse;
 import com.ticketrush.boundedcontext.booking.app.usecase.BookingAdminRetryRefundUseCase;
@@ -40,6 +41,7 @@ import java.time.LocalTime;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -228,37 +230,79 @@ class BookingFacadeTest {
     verifyNoInteractions(bookingIssueNumberUseCase, bookingCreateUseCase);
   }
 
+  private static BookingSummaryResponse summary(Long bookingId, Long performanceId, Long seatId) {
+    return new BookingSummaryResponse(
+        bookingId,
+        "BOOK-" + bookingId,
+        1L,
+        performanceId,
+        seatId,
+        BookingStatus.CONFIRMED,
+        LocalDateTime.of(2026, 5, 22, 10, 30),
+        null,
+        null,
+        null);
+  }
+
   @Test
-  @DisplayName("성공: 회원 예매 내역 조회를 위임한다")
-  void getMyBookings_success() {
+  @DisplayName("성공: 회원 예매 내역을 공연·좌석으로 보강한다 — 같은 공연은 distinct로 묶어 한 번만 조회한다")
+  void getMyBookings_enriches_with_distinct_performance_ids() {
     // given
     Long userId = 1L;
-    BookingSummaryResponse response =
-        new BookingSummaryResponse(
-            100L,
-            "BOOK-1234",
-            userId,
-            2L,
-            3L,
-            BookingStatus.CONFIRMED,
-            LocalDateTime.of(2026, 5, 22, 10, 30),
-            null,
-            null,
-            null);
+    List<BookingSummaryResponse> summaries =
+        List.of(summary(100L, 2L, 3L), summary(101L, 2L, 4L), summary(102L, 2L, 5L));
 
     given(
             bookingGetMyBookingsUseCase.execute(
                 userId, BookingStatus.CONFIRMED, new OffsetPageRequest(0, 10)))
-        .willReturn(new PageImpl<>(List.of(response)));
+        .willReturn(new PageImpl<>(summaries));
+    given(performanceRestClient.getPerformances(Set.of(2L)))
+        .willReturn(Map.of(2L, performanceInfo()));
+    given(seatRestClient.getSeatNumbers(List.of(3L, 4L, 5L)))
+        .willReturn(Map.of(3L, "A-1", 4L, "A-2", 5L, "A-3"));
 
     // when
-    Page<BookingSummaryResponse> result =
+    Page<BookingMySummaryResponse> result =
+        bookingFacade.getMyBookings(userId, BookingStatus.CONFIRMED, new OffsetPageRequest(0, 10));
+
+    // then — 같은 공연 3건이 distinct 1개로 묶여 전달됐는지는 위 given의 Set.of(2L) 매칭이 검증한다
+    assertThat(result.getContent()).hasSize(3);
+    assertThat(result.getContent().get(0).performanceTitle()).isEqualTo("오페라의 유령");
+    assertThat(result.getContent().get(0).performanceDate()).isEqualTo(LocalDate.of(2026, 5, 22));
+    assertThat(result.getContent().get(0).performanceAddress()).isEqualTo("서울 예술의전당 오페라극장");
+    assertThat(result.getContent().get(0).paymentAmount()).isEqualTo(150000L);
+    assertThat(result.getContent().get(0).seatNumber()).isEqualTo("A-1");
+    assertThat(result.getContent().get(1).seatNumber()).isEqualTo("A-2");
+    assertThat(result.getContent().get(2).seatNumber()).isEqualTo("A-3");
+    verify(performanceRestClient).getPerformances(Set.of(2L));
+    verify(seatRestClient).getSeatNumbers(List.of(3L, 4L, 5L));
+  }
+
+  @Test
+  @DisplayName("부분 응답: 벌크 조회에서 누락된 공연만 해당 건의 공연 필드가 비고 나머지는 채워진다")
+  void getMyBookings_fills_only_resolved_performances() {
+    // given
+    Long userId = 1L;
+    List<BookingSummaryResponse> summaries = List.of(summary(100L, 2L, 3L), summary(101L, 7L, 4L));
+
+    given(
+            bookingGetMyBookingsUseCase.execute(
+                userId, BookingStatus.CONFIRMED, new OffsetPageRequest(0, 10)))
+        .willReturn(new PageImpl<>(summaries));
+    // 공연 7은 조회 실패(fail-fast 중단 등)로 맵에서 빠졌다
+    given(performanceRestClient.getPerformances(Set.of(2L, 7L)))
+        .willReturn(Map.of(2L, performanceInfo()));
+    given(seatRestClient.getSeatNumbers(List.of(3L, 4L))).willReturn(Map.of(3L, "A-1", 4L, "A-2"));
+
+    // when
+    Page<BookingMySummaryResponse> result =
         bookingFacade.getMyBookings(userId, BookingStatus.CONFIRMED, new OffsetPageRequest(0, 10));
 
     // then
-    assertThat(result.getContent()).containsExactly(response);
-    verify(bookingGetMyBookingsUseCase)
-        .execute(userId, BookingStatus.CONFIRMED, new OffsetPageRequest(0, 10));
+    assertThat(result.getContent().get(0).performanceTitle()).isEqualTo("오페라의 유령");
+    assertThat(result.getContent().get(1).performanceTitle()).isNull();
+    assertThat(result.getContent().get(1).performanceId()).isEqualTo(7L); // 프론트 재조회 키는 유지
+    assertThat(result.getContent().get(1).seatNumber()).isEqualTo("A-2"); // 좌석은 실패 격리로 생존
   }
 
   @Test

--- a/booking-service/src/test/java/com/ticketrush/boundedcontext/booking/app/facade/BookingFacadeTest.java
+++ b/booking-service/src/test/java/com/ticketrush/boundedcontext/booking/app/facade/BookingFacadeTest.java
@@ -21,7 +21,7 @@ import com.ticketrush.boundedcontext.booking.app.usecase.BookingAdminRetryRefund
 import com.ticketrush.boundedcontext.booking.app.usecase.BookingCancelMyBookingUseCase;
 import com.ticketrush.boundedcontext.booking.app.usecase.BookingCountUseCase;
 import com.ticketrush.boundedcontext.booking.app.usecase.BookingCreateUseCase;
-import com.ticketrush.boundedcontext.booking.app.usecase.BookingGetMyBookingUseCase;
+import com.ticketrush.boundedcontext.booking.app.usecase.BookingGetMyBookingDetailUseCase;
 import com.ticketrush.boundedcontext.booking.app.usecase.BookingGetMyBookingsUseCase;
 import com.ticketrush.boundedcontext.booking.app.usecase.BookingGetRefundingStuckBookingsUseCase;
 import com.ticketrush.boundedcontext.booking.app.usecase.BookingIssueNumberUseCase;
@@ -59,7 +59,7 @@ class BookingFacadeTest {
 
   @Mock private BookingIssueNumberUseCase bookingIssueNumberUseCase;
   @Mock private BookingCreateUseCase bookingCreateUseCase;
-  @Mock private BookingGetMyBookingUseCase bookingGetMyBookingUseCase;
+  @Mock private BookingGetMyBookingDetailUseCase bookingGetMyBookingDetailUseCase;
   @Mock private BookingGetMyBookingsUseCase bookingGetMyBookingsUseCase;
   @Mock private PerformanceRestClient performanceRestClient;
   @Mock private BookingCountUseCase bookingCountUseCase;
@@ -92,7 +92,7 @@ class BookingFacadeTest {
     // given
     Long userId = 1L;
     String bookingNumber = "X7B29-KLPW1";
-    given(bookingGetMyBookingUseCase.execute(userId, bookingNumber))
+    given(bookingGetMyBookingDetailUseCase.execute(userId, bookingNumber))
         .willReturn(myBooking(userId, bookingNumber));
     given(performanceRestClient.getPerformance(2L)).willReturn(Optional.of(performanceInfo()));
     given(seatRestClient.getSeatNumbers(List.of(3L))).willReturn(Map.of(3L, "A-1"));
@@ -116,7 +116,7 @@ class BookingFacadeTest {
     // given
     Long userId = 1L;
     String bookingNumber = "X7B29-KLPW1";
-    given(bookingGetMyBookingUseCase.execute(userId, bookingNumber))
+    given(bookingGetMyBookingDetailUseCase.execute(userId, bookingNumber))
         .willReturn(myBooking(userId, bookingNumber));
     given(performanceRestClient.getPerformance(2L)).willReturn(Optional.empty());
     given(seatRestClient.getSeatNumbers(List.of(3L))).willReturn(Map.of(3L, "A-1"));
@@ -138,7 +138,7 @@ class BookingFacadeTest {
     // given
     Long userId = 1L;
     String bookingNumber = "X7B29-KLPW1";
-    given(bookingGetMyBookingUseCase.execute(userId, bookingNumber))
+    given(bookingGetMyBookingDetailUseCase.execute(userId, bookingNumber))
         .willReturn(myBooking(userId, bookingNumber));
     given(performanceRestClient.getPerformance(2L)).willReturn(Optional.of(performanceInfo()));
     given(seatRestClient.getSeatNumbers(List.of(3L))).willReturn(Map.of());
@@ -150,6 +150,30 @@ class BookingFacadeTest {
     assertThat(response.seatNumber()).isNull();
     assertThat(response.seatId()).isEqualTo(3L); // 프론트 재조회 키는 유지
     assertThat(response.performanceTitle()).isEqualTo("오페라의 유령");
+  }
+
+  @Test
+  @DisplayName("부분 응답: 공연·좌석이 동시에 실패해도 booking 코어 필드는 전부 살아남는다")
+  void getMyBooking_keeps_core_fields_when_all_enrichment_fails() {
+    // given
+    Long userId = 1L;
+    String bookingNumber = "X7B29-KLPW1";
+    given(bookingGetMyBookingDetailUseCase.execute(userId, bookingNumber))
+        .willReturn(myBooking(userId, bookingNumber));
+    given(performanceRestClient.getPerformance(2L)).willReturn(Optional.empty());
+    given(seatRestClient.getSeatNumbers(List.of(3L))).willReturn(Map.of());
+
+    // when
+    BookingDetailResponse response = bookingFacade.getMyBooking(userId, bookingNumber);
+
+    // then — 보강 필드는 모두 비지만 코어와 재조회 키는 남는다
+    assertThat(response.performanceTitle()).isNull();
+    assertThat(response.seatNumber()).isNull();
+    assertThat(response.paymentAmount()).isNull();
+    assertThat(response.bookingNumber()).isEqualTo(bookingNumber);
+    assertThat(response.bookingStatus()).isEqualTo(BookingStatus.CONFIRMED);
+    assertThat(response.performanceId()).isEqualTo(2L);
+    assertThat(response.seatId()).isEqualTo(3L);
   }
 
   @Test

--- a/booking-service/src/test/java/com/ticketrush/boundedcontext/booking/app/usecase/BookingGetMyBookingDetailUseCaseTest.java
+++ b/booking-service/src/test/java/com/ticketrush/boundedcontext/booking/app/usecase/BookingGetMyBookingDetailUseCaseTest.java
@@ -18,12 +18,12 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
-class BookingGetMyBookingUseCaseTest {
+class BookingGetMyBookingDetailUseCaseTest {
 
   private static final Long USER_ID = 1L;
   private static final String BOOKING_NUMBER = "X7B29-KLPW1";
 
-  @InjectMocks private BookingGetMyBookingUseCase useCase;
+  @InjectMocks private BookingGetMyBookingDetailUseCase useCase;
 
   @Mock private BookingRepository bookingRepository;
 

--- a/booking-service/src/test/java/com/ticketrush/boundedcontext/booking/app/usecase/BookingGetMyBookingUseCaseTest.java
+++ b/booking-service/src/test/java/com/ticketrush/boundedcontext/booking/app/usecase/BookingGetMyBookingUseCaseTest.java
@@ -1,0 +1,61 @@
+package com.ticketrush.boundedcontext.booking.app.usecase;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+import com.ticketrush.boundedcontext.booking.domain.entity.Booking;
+import com.ticketrush.boundedcontext.booking.domain.types.BookingStatus;
+import com.ticketrush.boundedcontext.booking.out.repository.BookingRepository;
+import com.ticketrush.global.exception.BusinessException;
+import com.ticketrush.global.status.ErrorStatus;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class BookingGetMyBookingUseCaseTest {
+
+  private static final Long USER_ID = 1L;
+  private static final String BOOKING_NUMBER = "X7B29-KLPW1";
+
+  @InjectMocks private BookingGetMyBookingUseCase useCase;
+
+  @Mock private BookingRepository bookingRepository;
+
+  @Test
+  @DisplayName("성공: 본인 예매를 예매번호로 조회한다")
+  void execute_returns_own_booking() {
+    // given
+    Booking booking =
+        Booking.builder()
+            .userId(USER_ID)
+            .performanceId(2L)
+            .seatId(3L)
+            .bookingNumber(BOOKING_NUMBER)
+            .bookingStatus(BookingStatus.CONFIRMED)
+            .build();
+    given(bookingRepository.findByBookingNumberAndUserId(BOOKING_NUMBER, USER_ID))
+        .willReturn(Optional.of(booking));
+
+    // when & then
+    assertThat(useCase.execute(USER_ID, BOOKING_NUMBER)).isSameAs(booking);
+  }
+
+  @Test
+  @DisplayName("실패: 타인 예매와 미존재 예매는 같은 경로(빈 조회)로 404를 던진다 — 존재 여부 비노출")
+  void execute_throws_404_for_missing_or_others_booking() {
+    // given
+    given(bookingRepository.findByBookingNumberAndUserId(BOOKING_NUMBER, USER_ID))
+        .willReturn(Optional.empty());
+
+    // when & then
+    assertThatThrownBy(() -> useCase.execute(USER_ID, BOOKING_NUMBER))
+        .isInstanceOf(BusinessException.class)
+        .hasFieldOrPropertyWithValue("errorStatus", ErrorStatus.BOOKING_NOT_FOUND);
+  }
+}

--- a/booking-service/src/test/java/com/ticketrush/boundedcontext/booking/in/api/v1/BookingControllerTest.java
+++ b/booking-service/src/test/java/com/ticketrush/boundedcontext/booking/in/api/v1/BookingControllerTest.java
@@ -24,7 +24,6 @@ import com.ticketrush.global.dto.request.OffsetPageRequest;
 import com.ticketrush.global.exception.BusinessException;
 import com.ticketrush.global.filter.GatewayHeaderFilter;
 import com.ticketrush.global.status.ErrorStatus;
-import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -280,20 +279,25 @@ class BookingControllerTest {
     verifyNoInteractions(bookingFacade);
   }
 
+  /**
+   * 401 본문은 한글이라 응답이 UTF-8을 <b>명시적으로 선언</b>해야 한다. 선언하지 않으면 실제 서블릿 컨테이너가 기본값 ISO-8859-1로 써서 메시지가
+   * '?'로 파괴된다(로컬 시연에서 실제로 확인했다).
+   *
+   * <p>본문 바이트를 비교하는 방식으로는 이 회귀를 못 잡는다 — MockMvc의 가짜 응답은 컨테이너와 달리 기본 인코딩이 UTF-8이라 수정이 없어도 통과한다.
+   * 컨테이너와 무관하게 갈리는 지점은 응답이 charset을 선언했는지 여부뿐이라 그것을 검증한다.
+   */
   @Test
-  @DisplayName("401 본문의 한글 메시지가 깨지지 않는다 — charset 미지정 시 ISO-8859-1로 나가 '?'가 된다")
-  void unauthorized_response_body_is_utf8() throws Exception {
-    byte[] body =
+  @DisplayName("401 응답이 charset=UTF-8을 명시한다 — 미지정 시 컨테이너 기본값으로 한글이 파괴된다")
+  void unauthorized_response_declares_utf8_charset() throws Exception {
+    String contentType =
         mockMvc
             .perform(get("/api/v1/booking/me"))
             .andExpect(status().isUnauthorized())
             .andReturn()
             .getResponse()
-            .getContentAsByteArray();
+            .getContentType();
 
-    // jsonPath는 code(ASCII)만 봐서 이 회귀를 놓친다. 실제 바이트를 UTF-8로 읽어 메시지를 비교한다.
-    assertThat(new String(body, StandardCharsets.UTF_8))
-        .contains(ErrorStatus.UNAUTHORIZED.getMessage());
+    assertThat(contentType).containsIgnoringCase("charset=utf-8");
   }
 
   @Test

--- a/booking-service/src/test/java/com/ticketrush/boundedcontext/booking/in/api/v1/BookingControllerTest.java
+++ b/booking-service/src/test/java/com/ticketrush/boundedcontext/booking/in/api/v1/BookingControllerTest.java
@@ -12,8 +12,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.ticketrush.boundedcontext.booking.app.dto.response.BookingCountResponse;
 import com.ticketrush.boundedcontext.booking.app.dto.response.BookingDetailResponse;
+import com.ticketrush.boundedcontext.booking.app.dto.response.BookingMySummaryResponse;
 import com.ticketrush.boundedcontext.booking.app.dto.response.BookingPendingResponse;
-import com.ticketrush.boundedcontext.booking.app.dto.response.BookingSummaryResponse;
 import com.ticketrush.boundedcontext.booking.app.facade.BookingFacade;
 import com.ticketrush.boundedcontext.booking.domain.types.BookingStatus;
 import com.ticketrush.global.config.CustomSecurityProperties;
@@ -91,12 +91,12 @@ class BookingControllerTest {
   }
 
   @Test
-  @DisplayName("인증 principal의 userId로 내 예매 내역을 조회한다")
+  @DisplayName("인증 principal의 userId로 내 예매 내역을 조회한다 — 공연·좌석·금액 보강 필드 포함")
   void getMyBookings_uses_authenticated_user_id() throws Exception {
     // given
     Long userId = 1L;
-    BookingSummaryResponse response =
-        new BookingSummaryResponse(
+    BookingMySummaryResponse response =
+        new BookingMySummaryResponse(
             100L,
             "BOOK-1234",
             userId,
@@ -106,7 +106,12 @@ class BookingControllerTest {
             LocalDateTime.of(2026, 5, 22, 10, 30),
             null,
             null,
-            null);
+            null,
+            "오페라의 유령",
+            LocalDate.of(2026, 5, 22),
+            "서울 예술의전당 오페라극장",
+            "A-1",
+            150000L);
 
     given(
             bookingFacade.getMyBookings(
@@ -128,6 +133,11 @@ class BookingControllerTest {
         .andExpect(jsonPath("$.result[0].seat_id").value(3))
         .andExpect(jsonPath("$.result[0].booking_status").value("CONFIRMED"))
         .andExpect(jsonPath("$.result[0].confirmed_at").value("2026-05-22 10:30:00"))
+        .andExpect(jsonPath("$.result[0].performance_title").value("오페라의 유령"))
+        .andExpect(jsonPath("$.result[0].performance_date").value("2026-05-22"))
+        .andExpect(jsonPath("$.result[0].performance_address").value("서울 예술의전당 오페라극장"))
+        .andExpect(jsonPath("$.result[0].seat_number").value("A-1"))
+        .andExpect(jsonPath("$.result[0].payment_amount").value(150000))
         .andExpect(jsonPath("$.pagination_info.page_index").value(0))
         .andExpect(jsonPath("$.pagination_info.size").value(10))
         .andExpect(jsonPath("$.pagination_info.total_elements").value(1))

--- a/booking-service/src/test/java/com/ticketrush/boundedcontext/booking/in/api/v1/BookingControllerTest.java
+++ b/booking-service/src/test/java/com/ticketrush/boundedcontext/booking/in/api/v1/BookingControllerTest.java
@@ -166,6 +166,7 @@ class BookingControllerTest {
             3L,
             "A-1",
             LocalDateTime.of(2026, 5, 22, 10, 30),
+            null,
             150000L);
 
     given(bookingFacade.getMyBooking(userId, bookingNumber)).willReturn(response);
@@ -214,6 +215,7 @@ class BookingControllerTest {
             3L,
             "A-1",
             LocalDateTime.of(2026, 5, 22, 10, 30),
+            null,
             null);
 
     given(bookingFacade.getMyBooking(userId, bookingNumber)).willReturn(response);

--- a/booking-service/src/test/java/com/ticketrush/boundedcontext/booking/in/api/v1/BookingControllerTest.java
+++ b/booking-service/src/test/java/com/ticketrush/boundedcontext/booking/in/api/v1/BookingControllerTest.java
@@ -1,5 +1,6 @@
 package com.ticketrush.boundedcontext.booking.in.api.v1;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
@@ -23,6 +24,7 @@ import com.ticketrush.global.dto.request.OffsetPageRequest;
 import com.ticketrush.global.exception.BusinessException;
 import com.ticketrush.global.filter.GatewayHeaderFilter;
 import com.ticketrush.global.status.ErrorStatus;
+import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -276,6 +278,22 @@ class BookingControllerTest {
         .andExpect(jsonPath("$.code").value(ErrorStatus.UNAUTHORIZED.getCode()));
 
     verifyNoInteractions(bookingFacade);
+  }
+
+  @Test
+  @DisplayName("401 본문의 한글 메시지가 깨지지 않는다 — charset 미지정 시 ISO-8859-1로 나가 '?'가 된다")
+  void unauthorized_response_body_is_utf8() throws Exception {
+    byte[] body =
+        mockMvc
+            .perform(get("/api/v1/booking/me"))
+            .andExpect(status().isUnauthorized())
+            .andReturn()
+            .getResponse()
+            .getContentAsByteArray();
+
+    // jsonPath는 code(ASCII)만 봐서 이 회귀를 놓친다. 실제 바이트를 UTF-8로 읽어 메시지를 비교한다.
+    assertThat(new String(body, StandardCharsets.UTF_8))
+        .contains(ErrorStatus.UNAUTHORIZED.getMessage());
   }
 
   @Test

--- a/booking-service/src/test/java/com/ticketrush/boundedcontext/booking/in/api/v1/BookingControllerTest.java
+++ b/booking-service/src/test/java/com/ticketrush/boundedcontext/booking/in/api/v1/BookingControllerTest.java
@@ -11,6 +11,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.ticketrush.boundedcontext.booking.app.dto.response.BookingCountResponse;
+import com.ticketrush.boundedcontext.booking.app.dto.response.BookingDetailResponse;
 import com.ticketrush.boundedcontext.booking.app.dto.response.BookingPendingResponse;
 import com.ticketrush.boundedcontext.booking.app.dto.response.BookingSummaryResponse;
 import com.ticketrush.boundedcontext.booking.app.facade.BookingFacade;
@@ -19,9 +20,12 @@ import com.ticketrush.global.config.CustomSecurityProperties;
 import com.ticketrush.global.config.JacksonConfig;
 import com.ticketrush.global.config.SecurityConfig;
 import com.ticketrush.global.dto.request.OffsetPageRequest;
+import com.ticketrush.global.exception.BusinessException;
 import com.ticketrush.global.filter.GatewayHeaderFilter;
 import com.ticketrush.global.status.ErrorStatus;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -131,6 +135,135 @@ class BookingControllerTest {
 
     verify(bookingFacade)
         .getMyBookings(eq(userId), eq(BookingStatus.CONFIRMED), eq(new OffsetPageRequest(0, 10)));
+  }
+
+  @Test
+  @DisplayName("인증 principal의 userId로 예매 단건을 조회한다 — 공연·좌석 보강 필드 포함")
+  void getMyBooking_uses_authenticated_user_id() throws Exception {
+    // given
+    Long userId = 1L;
+    String bookingNumber = "X7B29-KLPW1";
+    BookingDetailResponse response =
+        new BookingDetailResponse(
+            100L,
+            bookingNumber,
+            BookingStatus.CONFIRMED,
+            2L,
+            "오페라의 유령",
+            LocalDate.of(2026, 5, 22),
+            LocalTime.of(19, 30),
+            "서울 예술의전당 오페라극장",
+            3L,
+            "A-1",
+            LocalDateTime.of(2026, 5, 22, 10, 30),
+            150000L);
+
+    given(bookingFacade.getMyBooking(userId, bookingNumber)).willReturn(response);
+
+    // when & then
+    mockMvc
+        .perform(
+            get("/api/v1/booking/{bookingNumber}", bookingNumber)
+                .header("X-Gateway-Token", INTERNAL_TOKEN)
+                .header("X-User-Id", userId)
+                .header("X-User-Role", "USER"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.is_success").value(true))
+        .andExpect(jsonPath("$.result.booking_id").value(100))
+        .andExpect(jsonPath("$.result.booking_number").value(bookingNumber))
+        .andExpect(jsonPath("$.result.booking_status").value("CONFIRMED"))
+        .andExpect(jsonPath("$.result.performance_id").value(2))
+        .andExpect(jsonPath("$.result.performance_title").value("오페라의 유령"))
+        .andExpect(jsonPath("$.result.performance_date").value("2026-05-22"))
+        .andExpect(jsonPath("$.result.performance_time").value("19:30:00"))
+        .andExpect(jsonPath("$.result.performance_address").value("서울 예술의전당 오페라극장"))
+        .andExpect(jsonPath("$.result.seat_id").value(3))
+        .andExpect(jsonPath("$.result.seat_number").value("A-1"))
+        .andExpect(jsonPath("$.result.confirmed_at").value("2026-05-22 10:30:00"))
+        .andExpect(jsonPath("$.result.payment_amount").value(150000));
+
+    verify(bookingFacade).getMyBooking(eq(userId), eq(bookingNumber));
+  }
+
+  @Test
+  @DisplayName("부분 응답: 공연 조회가 실패해도 booking 코어 필드와 좌석 번호는 내려간다")
+  void getMyBooking_returns_partial_response_when_performance_missing() throws Exception {
+    // given
+    Long userId = 1L;
+    String bookingNumber = "X7B29-KLPW1";
+    BookingDetailResponse response =
+        new BookingDetailResponse(
+            100L,
+            bookingNumber,
+            BookingStatus.CONFIRMED,
+            2L,
+            null,
+            null,
+            null,
+            null,
+            3L,
+            "A-1",
+            LocalDateTime.of(2026, 5, 22, 10, 30),
+            null);
+
+    given(bookingFacade.getMyBooking(userId, bookingNumber)).willReturn(response);
+
+    // when & then
+    mockMvc
+        .perform(
+            get("/api/v1/booking/{bookingNumber}", bookingNumber)
+                .header("X-Gateway-Token", INTERNAL_TOKEN)
+                .header("X-User-Id", userId)
+                .header("X-User-Role", "USER"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.result.booking_id").value(100))
+        .andExpect(jsonPath("$.result.performance_id").value(2))
+        .andExpect(jsonPath("$.result.performance_title").doesNotExist())
+        .andExpect(jsonPath("$.result.payment_amount").doesNotExist())
+        .andExpect(jsonPath("$.result.seat_number").value("A-1"));
+  }
+
+  @Test
+  @DisplayName("타인 예매·미존재 예매는 동일하게 404를 반환한다")
+  void getMyBooking_returns_404_for_missing_or_others_booking() throws Exception {
+    // given
+    Long userId = 1L;
+    String bookingNumber = "X7B29-KLPW1";
+    given(bookingFacade.getMyBooking(userId, bookingNumber))
+        .willThrow(new BusinessException(ErrorStatus.BOOKING_NOT_FOUND));
+
+    // when & then
+    mockMvc
+        .perform(
+            get("/api/v1/booking/{bookingNumber}", bookingNumber)
+                .header("X-Gateway-Token", INTERNAL_TOKEN)
+                .header("X-User-Id", userId)
+                .header("X-User-Role", "USER"))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.is_success").value(false))
+        .andExpect(jsonPath("$.code").value(ErrorStatus.BOOKING_NOT_FOUND.getCode()));
+  }
+
+  @Test
+  @DisplayName("인증 principal이 없으면 예매 단건 조회는 401 Unauthorized를 반환한다")
+  void getMyBooking_fails_when_principal_missing() throws Exception {
+    mockMvc
+        .perform(get("/api/v1/booking/{bookingNumber}", "X7B29-KLPW1"))
+        .andExpect(status().isUnauthorized())
+        .andExpect(jsonPath("$.code").value(ErrorStatus.UNAUTHORIZED.getCode()));
+
+    verifyNoInteractions(bookingFacade);
+  }
+
+  @Test
+  @DisplayName("인증 principal이 없으면 내 예매 내역 조회는 401 Unauthorized를 반환한다 — 매처 확대(#560) 검증")
+  void getMyBookings_fails_when_principal_missing() throws Exception {
+    mockMvc
+        .perform(get("/api/v1/booking/me"))
+        .andExpect(status().isUnauthorized())
+        .andExpect(jsonPath("$.code").value(ErrorStatus.UNAUTHORIZED.getCode()));
+
+    verifyNoInteractions(bookingFacade);
   }
 
   @Test

--- a/booking-service/src/test/java/com/ticketrush/boundedcontext/booking/out/apiclient/PerformanceRestClientTest.java
+++ b/booking-service/src/test/java/com/ticketrush/boundedcontext/booking/out/apiclient/PerformanceRestClientTest.java
@@ -154,6 +154,17 @@ class PerformanceRestClientTest {
   }
 
   @Test
+  @DisplayName("성공: 본문이 JSON이 아니어도 원시 예외가 새지 않고 빈 Optional로 수렴한다")
+  void getPerformance_returns_empty_on_unparsable_body() {
+    mockServer
+        .expect(requestTo(requestUrl(PERFORMANCE_ID)))
+        .andRespond(withSuccess("<html>gateway error</html>", MediaType.TEXT_HTML));
+
+    assertThat(client.getPerformance(PERFORMANCE_ID)).isEmpty();
+    mockServer.verify();
+  }
+
+  @Test
   @DisplayName("성공: 벽시계 예산이 소진되면 호출 없이 잔여 공연 필드를 비운다 — 느린(예외 없는) 응답에서도 스레드를 놓아준다")
   void getPerformances_stops_when_budget_exhausted() {
     // given — 예산 0이면 첫 건부터 예산 초과다. 기대를 등록하지 않아 요청이 나가면 즉시 실패한다.

--- a/booking-service/src/test/java/com/ticketrush/boundedcontext/booking/out/apiclient/PerformanceRestClientTest.java
+++ b/booking-service/src/test/java/com/ticketrush/boundedcontext/booking/out/apiclient/PerformanceRestClientTest.java
@@ -1,0 +1,154 @@
+package com.ticketrush.boundedcontext.booking.out.apiclient;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withServerError;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withStatus;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+import com.ticketrush.boundedcontext.booking.out.apiclient.dto.PerformanceInfoResponse;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestClient;
+
+class PerformanceRestClientTest {
+
+  private static final String BASE_URL = "http://localhost:8083";
+  private static final long PERFORMANCE_ID = 10L;
+
+  private MockRestServiceServer mockServer;
+  private PerformanceRestClient client;
+
+  @BeforeEach
+  void setUp() {
+    RestClient.Builder builder = RestClient.builder().baseUrl(BASE_URL);
+    mockServer = MockRestServiceServer.bindTo(builder).build();
+
+    client = new PerformanceRestClient(builder.build());
+  }
+
+  private static String requestUrl(long performanceId) {
+    return BASE_URL + "/api/v1/performance/" + performanceId;
+  }
+
+  /** performance-service 공통 ApiResponse 형식. 날짜·시간은 JacksonConfig의 실제 직렬 형식을 그대로 쓴다. */
+  private static String successBody(long performanceId) {
+    return String.join(
+        "\n",
+        "{",
+        "  \"is_success\": true,",
+        "  \"code\": \"COMMON_200\",",
+        "  \"message\": \"성공입니다.\",",
+        "  \"result\": {",
+        "    \"performance_id\": " + performanceId + ",",
+        "    \"title\": \"오페라의 유령\",",
+        "    \"performer\": \"극단 A\",",
+        "    \"show_date\": \"2026-05-22\",",
+        "    \"show_time\": \"19:30:00\",",
+        "    \"price\": 150000,",
+        "    \"address\": \"서울 예술의전당 오페라극장\"",
+        "  }",
+        "}");
+  }
+
+  @Test
+  @DisplayName("성공: 래핑 응답에서 공연 필드를 파싱한다 — snake_case 키와 날짜·시간 직렬 형식")
+  void getPerformance_parses_wrapped_response() {
+    mockServer
+        .expect(requestTo(requestUrl(PERFORMANCE_ID)))
+        .andExpect(method(HttpMethod.GET))
+        .andRespond(withSuccess(successBody(PERFORMANCE_ID), MediaType.APPLICATION_JSON));
+
+    Optional<PerformanceInfoResponse> result = client.getPerformance(PERFORMANCE_ID);
+
+    assertThat(result).isPresent();
+    assertThat(result.get().title()).isEqualTo("오페라의 유령");
+    assertThat(result.get().showDate()).isEqualTo(LocalDate.of(2026, 5, 22));
+    assertThat(result.get().showTime()).isEqualTo(LocalTime.of(19, 30));
+    assertThat(result.get().address()).isEqualTo("서울 예술의전당 오페라극장");
+    assertThat(result.get().price()).isEqualTo(150000L);
+    mockServer.verify();
+  }
+
+  @Test
+  @DisplayName("성공: 404는 빈 Optional로 수렴한다 — 예외를 밖으로 내지 않는다(부분 응답 정책)")
+  void getPerformance_returns_empty_on_404() {
+    mockServer
+        .expect(requestTo(requestUrl(PERFORMANCE_ID)))
+        .andExpect(method(HttpMethod.GET))
+        .andRespond(withStatus(HttpStatus.NOT_FOUND));
+
+    assertThat(client.getPerformance(PERFORMANCE_ID)).isEmpty();
+    mockServer.verify();
+  }
+
+  @Test
+  @DisplayName("성공: 5xx도 빈 Optional로 수렴한다")
+  void getPerformance_returns_empty_on_5xx() {
+    mockServer
+        .expect(requestTo(requestUrl(PERFORMANCE_ID)))
+        .andExpect(method(HttpMethod.GET))
+        .andRespond(withServerError());
+
+    assertThat(client.getPerformance(PERFORMANCE_ID)).isEmpty();
+    mockServer.verify();
+  }
+
+  @Test
+  @DisplayName("성공: 200이지만 result가 비어 있으면 빈 Optional로 수렴한다")
+  void getPerformance_returns_empty_on_null_result() {
+    mockServer
+        .expect(requestTo(requestUrl(PERFORMANCE_ID)))
+        .andExpect(method(HttpMethod.GET))
+        .andRespond(
+            withSuccess(
+                "{\"is_success\": true, \"code\": \"COMMON_200\", \"result\": null}",
+                MediaType.APPLICATION_JSON));
+
+    assertThat(client.getPerformance(PERFORMANCE_ID)).isEmpty();
+    mockServer.verify();
+  }
+
+  @Test
+  @DisplayName("성공: 벌크 조회에서 4xx는 해당 건만 비우고 계속 간다")
+  void getPerformances_skips_only_4xx_item() {
+    mockServer
+        .expect(requestTo(requestUrl(1L)))
+        .andRespond(withSuccess(successBody(1L), MediaType.APPLICATION_JSON));
+    mockServer.expect(requestTo(requestUrl(2L))).andRespond(withStatus(HttpStatus.NOT_FOUND));
+    mockServer
+        .expect(requestTo(requestUrl(3L)))
+        .andRespond(withSuccess(successBody(3L), MediaType.APPLICATION_JSON));
+
+    Map<Long, PerformanceInfoResponse> result = client.getPerformances(List.of(1L, 2L, 3L));
+
+    assertThat(result).containsOnlyKeys(1L, 3L);
+    mockServer.verify();
+  }
+
+  @Test
+  @DisplayName("성공: 벌크 조회에서 5xx(서비스 장애)는 잔여 호출을 중단한다 — 장애 중 타임아웃이 n번 곱해지지 않게")
+  void getPerformances_stops_remaining_on_5xx() {
+    mockServer
+        .expect(requestTo(requestUrl(1L)))
+        .andRespond(withSuccess(successBody(1L), MediaType.APPLICATION_JSON));
+    mockServer.expect(requestTo(requestUrl(2L))).andRespond(withServerError());
+    // 3번 공연에 대한 기대를 등록하지 않는다 — 요청이 가면 mockServer.verify()가 아니라 호출 시점에 실패한다.
+
+    Map<Long, PerformanceInfoResponse> result = client.getPerformances(List.of(1L, 2L, 3L));
+
+    assertThat(result).containsOnlyKeys(1L);
+    mockServer.verify();
+  }
+}

--- a/booking-service/src/test/java/com/ticketrush/boundedcontext/booking/out/apiclient/PerformanceRestClientTest.java
+++ b/booking-service/src/test/java/com/ticketrush/boundedcontext/booking/out/apiclient/PerformanceRestClientTest.java
@@ -26,6 +26,7 @@ class PerformanceRestClientTest {
 
   private static final String BASE_URL = "http://localhost:8083";
   private static final long PERFORMANCE_ID = 10L;
+  private static final long BULK_BUDGET_MS = 3000;
 
   private MockRestServiceServer mockServer;
   private PerformanceRestClient client;
@@ -35,7 +36,7 @@ class PerformanceRestClientTest {
     RestClient.Builder builder = RestClient.builder().baseUrl(BASE_URL);
     mockServer = MockRestServiceServer.bindTo(builder).build();
 
-    client = new PerformanceRestClient(builder.build());
+    client = new PerformanceRestClient(builder.build(), BULK_BUDGET_MS);
   }
 
   private static String requestUrl(long performanceId) {
@@ -150,5 +151,21 @@ class PerformanceRestClientTest {
 
     assertThat(result).containsOnlyKeys(1L);
     mockServer.verify();
+  }
+
+  @Test
+  @DisplayName("성공: 벽시계 예산이 소진되면 호출 없이 잔여 공연 필드를 비운다 — 느린(예외 없는) 응답에서도 스레드를 놓아준다")
+  void getPerformances_stops_when_budget_exhausted() {
+    // given — 예산 0이면 첫 건부터 예산 초과다. 기대를 등록하지 않아 요청이 나가면 즉시 실패한다.
+    RestClient.Builder builder = RestClient.builder().baseUrl(BASE_URL);
+    MockRestServiceServer strictServer = MockRestServiceServer.bindTo(builder).build();
+    PerformanceRestClient budgetlessClient = new PerformanceRestClient(builder.build(), 0);
+
+    // when
+    Map<Long, PerformanceInfoResponse> result = budgetlessClient.getPerformances(List.of(1L, 2L));
+
+    // then
+    assertThat(result).isEmpty();
+    strictServer.verify();
   }
 }

--- a/booking-service/src/test/java/com/ticketrush/boundedcontext/booking/out/apiclient/SeatRestClientTest.java
+++ b/booking-service/src/test/java/com/ticketrush/boundedcontext/booking/out/apiclient/SeatRestClientTest.java
@@ -1,0 +1,87 @@
+package com.ticketrush.boundedcontext.booking.out.apiclient;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.headerDoesNotExist;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withServerError;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+import com.ticketrush.global.config.CustomSecurityProperties;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestClient;
+
+class SeatRestClientTest {
+
+  private static final String BASE_URL = "http://localhost:8086";
+  private static final String REQUEST_URL = BASE_URL + "/api/v1/seat/numbers?seatIds=100,101";
+
+  private MockRestServiceServer mockServer;
+  private SeatRestClient client;
+
+  @BeforeEach
+  void setUp() {
+    RestClient.Builder builder = RestClient.builder().baseUrl(BASE_URL);
+    mockServer = MockRestServiceServer.bindTo(builder).build();
+
+    CustomSecurityProperties customSecurityProperties = new CustomSecurityProperties();
+    customSecurityProperties.setInternalToken("test-token");
+
+    client = new SeatRestClient(builder.build(), customSecurityProperties);
+  }
+
+  private static String successBody() {
+    return String.join(
+        "\n",
+        "{",
+        "  \"is_success\": true,",
+        "  \"code\": \"COMMON_200\",",
+        "  \"message\": \"성공입니다.\",",
+        "  \"result\": [",
+        "    {\"seat_id\": 100, \"seat_number\": \"A-1\"},",
+        "    {\"seat_id\": 101, \"seat_number\": \"A-2\"}",
+        "  ]",
+        "}");
+  }
+
+  @Test
+  @DisplayName("성공: 좌석 번호를 맵으로 변환하고, 공개 API라 X-Internal-Token을 보내지 않는다")
+  void getSeatNumbers_returns_map_without_internal_token() {
+    mockServer
+        .expect(requestTo(REQUEST_URL))
+        .andExpect(method(HttpMethod.GET))
+        .andExpect(headerDoesNotExist("X-Internal-Token"))
+        .andRespond(withSuccess(successBody(), MediaType.APPLICATION_JSON));
+
+    Map<Long, String> result = client.getSeatNumbers(List.of(100L, 101L));
+
+    assertThat(result).containsExactlyInAnyOrderEntriesOf(Map.of(100L, "A-1", 101L, "A-2"));
+    mockServer.verify();
+  }
+
+  @Test
+  @DisplayName("성공: 5xx는 빈 맵으로 수렴한다 — 예외를 밖으로 내지 않는다(부분 응답 정책)")
+  void getSeatNumbers_returns_empty_map_on_5xx() {
+    mockServer
+        .expect(requestTo(REQUEST_URL))
+        .andExpect(method(HttpMethod.GET))
+        .andRespond(withServerError());
+
+    assertThat(client.getSeatNumbers(List.of(100L, 101L))).isEmpty();
+    mockServer.verify();
+  }
+
+  @Test
+  @DisplayName("성공: 빈 seatIds는 호출 없이 빈 맵을 반환한다")
+  void getSeatNumbers_returns_empty_map_without_call_for_empty_input() {
+    assertThat(client.getSeatNumbers(List.of())).isEmpty();
+    mockServer.verify(); // 등록된 기대가 없으므로 어떤 요청도 나가지 않았음을 검증
+  }
+}

--- a/booking-service/src/test/java/com/ticketrush/boundedcontext/booking/out/apiclient/SeatRestClientTest.java
+++ b/booking-service/src/test/java/com/ticketrush/boundedcontext/booking/out/apiclient/SeatRestClientTest.java
@@ -5,6 +5,7 @@ import static org.springframework.test.web.client.match.MockRestRequestMatchers.
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
 import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
 import static org.springframework.test.web.client.response.MockRestResponseCreators.withServerError;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withStatus;
 import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
 
 import com.ticketrush.global.config.CustomSecurityProperties;
@@ -14,6 +15,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.client.MockRestServiceServer;
 import org.springframework.web.client.RestClient;
@@ -34,7 +36,7 @@ class SeatRestClientTest {
     CustomSecurityProperties customSecurityProperties = new CustomSecurityProperties();
     customSecurityProperties.setInternalToken("test-token");
 
-    client = new SeatRestClient(builder.build(), customSecurityProperties);
+    client = new SeatRestClient(builder.build(), builder.build(), customSecurityProperties);
   }
 
   private static String successBody() {
@@ -83,5 +85,61 @@ class SeatRestClientTest {
   void getSeatNumbers_returns_empty_map_without_call_for_empty_input() {
     assertThat(client.getSeatNumbers(List.of())).isEmpty();
     mockServer.verify(); // 등록된 기대가 없으므로 어떤 요청도 나가지 않았음을 검증
+  }
+
+  @Test
+  @DisplayName("성공: 좌석 한 건이 없어 seat이 404로 전체 실패시키면 빈 맵으로 수렴한다 — all-or-nothing 거동 고정")
+  void getSeatNumbers_returns_empty_map_when_any_seat_missing() {
+    // seat-service는 요청 seatId 중 하나라도 없으면 SEAT_NOT_FOUND로 전체를 실패시킨다.
+    mockServer
+        .expect(requestTo(REQUEST_URL))
+        .andExpect(method(HttpMethod.GET))
+        .andRespond(
+            withStatus(HttpStatus.NOT_FOUND)
+                .contentType(MediaType.APPLICATION_JSON)
+                .body("{\"is_success\": false, \"code\": \"SEAT_404_001\"}"));
+
+    assertThat(client.getSeatNumbers(List.of(100L, 101L))).isEmpty();
+    mockServer.verify();
+  }
+
+  @Test
+  @DisplayName("성공: 200이지만 result가 비어 있으면 빈 맵으로 수렴한다")
+  void getSeatNumbers_returns_empty_map_on_null_result() {
+    mockServer
+        .expect(requestTo(REQUEST_URL))
+        .andRespond(
+            withSuccess(
+                "{\"is_success\": true, \"code\": \"COMMON_200\", \"result\": null}",
+                MediaType.APPLICATION_JSON));
+
+    assertThat(client.getSeatNumbers(List.of(100L, 101L))).isEmpty();
+    mockServer.verify();
+  }
+
+  @Test
+  @DisplayName("성공: 본문이 JSON이 아니어도 원시 예외가 새지 않고 빈 맵으로 수렴한다")
+  void getSeatNumbers_returns_empty_map_on_unparsable_body() {
+    mockServer
+        .expect(requestTo(REQUEST_URL))
+        .andRespond(withSuccess("<html>gateway error</html>", MediaType.TEXT_HTML));
+
+    assertThat(client.getSeatNumbers(List.of(100L, 101L))).isEmpty();
+    mockServer.verify();
+  }
+
+  @Test
+  @DisplayName("성공: 중복 seatId는 클라이언트가 접어 한 번만 요청하고 매핑도 깨지지 않는다")
+  void getSeatNumbers_collapses_duplicate_seat_ids() {
+    mockServer
+        .expect(requestTo(REQUEST_URL))
+        .andExpect(method(HttpMethod.GET))
+        .andRespond(withSuccess(successBody(), MediaType.APPLICATION_JSON));
+
+    // 같은 seatId가 두 번 들어와도 쿼리는 "100,101" 하나이며 toMap 중복 키 예외도 나지 않는다.
+    Map<Long, String> result = client.getSeatNumbers(List.of(100L, 101L, 100L));
+
+    assertThat(result).containsExactlyInAnyOrderEntriesOf(Map.of(100L, "A-1", 101L, "A-2"));
+    mockServer.verify();
   }
 }

--- a/booking-service/src/test/java/com/ticketrush/global/config/RestClientConfigTest.java
+++ b/booking-service/src/test/java/com/ticketrush/global/config/RestClientConfigTest.java
@@ -1,0 +1,52 @@
+package com.ticketrush.global.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.ticketrush.boundedcontext.booking.out.apiclient.SeatRestClient;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.web.client.RestClient;
+
+/**
+ * RestClient 빈이 4개(seat 쓰기·seat 조회·ticket·performance)라 주입은 타입이 아니라 <b>이름</b>으로 갈린다. 특히 {@link
+ * SeatRestClient}는 한 생성자에 RestClient를 둘 받으므로, 이름이 어긋나면 애플리케이션이 기동 시점에 죽는다 — 기존 {@code contextLoads}
+ * 테스트는 실제 설정을 로드하지 않아 이것을 잡지 못한다.
+ */
+class RestClientConfigTest {
+
+  private final ApplicationContextRunner contextRunner =
+      new ApplicationContextRunner()
+          .withUserConfiguration(RestClientConfig.class, CustomSecurityProperties.class)
+          .withPropertyValues(
+              "service.seat.url=http://localhost:8086",
+              "service.ticket.url=http://localhost:8087",
+              "service.performance.url=http://localhost:8083");
+
+  @Test
+  @DisplayName("성공: 서비스별 RestClient 빈이 모두 생성된다")
+  void creates_all_rest_client_beans() {
+    contextRunner.run(
+        context ->
+            assertThat(context)
+                .hasNotFailed()
+                .hasBean("seatServiceRestClient")
+                .hasBean("seatQueryRestClient")
+                .hasBean("ticketServiceRestClient")
+                .hasBean("performanceServiceRestClient"));
+  }
+
+  @Test
+  @DisplayName("성공: RestClient 후보가 여럿이어도 SeatRestClient의 두 클라이언트가 이름으로 갈려 주입된다")
+  void injects_distinct_seat_clients_by_name() {
+    contextRunner
+        .withUserConfiguration(SeatRestClient.class)
+        .run(
+            context -> {
+              assertThat(context).hasNotFailed().hasSingleBean(SeatRestClient.class);
+              // 쓰기용(3s/10s)과 조회용(1s/2s)이 서로 다른 인스턴스여야 예산 분리가 실제로 성립한다.
+              assertThat(context.getBean("seatServiceRestClient", RestClient.class))
+                  .isNotSameAs(context.getBean("seatQueryRestClient", RestClient.class));
+            });
+  }
+}

--- a/deploy/.env.prod.example
+++ b/deploy/.env.prod.example
@@ -35,6 +35,9 @@ SEAT_SERVICE_URL=
 BOOKING_SERVICE_URL=
 # booking-service는 prod에서 기본값 없이 요구한다(미주입 시 fail-fast). 취소·재환불 경로가 이 값에 의존한다.
 TICKET_SERVICE_URL=
+# booking-service가 prod에서 기본값 없이 요구한다(미주입 시 fail-fast). 예매 조회의 공연 필드 보강이 이 값에 의존한다.
+# 예: http://performance-service:8083
+PERFORMANCE_SERVICE_URL=
 
 # ==================================================
 # 관측 스택 (Grafana) — ADR 0007

--- a/ticket-service/src/main/java/com/ticketrush/global/config/SecurityConfig.java
+++ b/ticket-service/src/main/java/com/ticketrush/global/config/SecurityConfig.java
@@ -3,6 +3,7 @@ package com.ticketrush.global.config;
 import com.ticketrush.global.filter.GatewayHeaderFilter;
 import com.ticketrush.global.security.InternalApiTokenFilter;
 import com.ticketrush.global.status.ErrorStatus;
+import java.nio.charset.StandardCharsets;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.security.autoconfigure.SecurityProperties;
@@ -49,6 +50,8 @@ public class SecurityConfig {
                         (request, response, authException) -> {
                           response.setStatus(ErrorStatus.UNAUTHORIZED.getHttpStatus().value());
                           response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+                          // 지정하지 않으면 서블릿 기본값 ISO-8859-1로 나가 한글 메시지가 '?'로 파괴된다.
+                          response.setCharacterEncoding(StandardCharsets.UTF_8.name());
                           response
                               .getWriter()
                               .write(
@@ -63,6 +66,8 @@ public class SecurityConfig {
                         (request, response, accessDeniedException) -> {
                           response.setStatus(ErrorStatus.FORBIDDEN.getHttpStatus().value());
                           response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+                          // 위와 같은 이유. 403 본문도 한글이라 charset을 지정해야 한다.
+                          response.setCharacterEncoding(StandardCharsets.UTF_8.name());
                           response
                               .getWriter()
                               .write(

--- a/ticket-service/src/test/java/com/ticketrush/boundedcontext/ticket/in/api/v1/EntryControllerTest.java
+++ b/ticket-service/src/test/java/com/ticketrush/boundedcontext/ticket/in/api/v1/EntryControllerTest.java
@@ -1,5 +1,6 @@
 package com.ticketrush.boundedcontext.ticket.in.api.v1;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -122,6 +123,45 @@ class EntryControllerTest {
         .andExpect(jsonPath("$.code").value(ErrorStatus.FORBIDDEN.getCode()));
 
     verifyNoInteractions(entryVerifyUseCase, entryCheckInUseCase);
+  }
+
+  /**
+   * 401·403 본문은 한글이라 응답이 UTF-8을 <b>명시적으로 선언</b>해야 한다. 선언하지 않으면 실제 서블릿 컨테이너가 기본값 ISO-8859-1로 써서 메시지가
+   * '?'로 파괴된다.
+   *
+   * <p>본문 바이트를 비교하는 방식으로는 이 회귀를 못 잡는다 — MockMvc의 가짜 응답은 컨테이너와 달리 기본 인코딩이 UTF-8이라 수정이 없어도 통과한다(실제로
+   * 확인했다). 컨테이너와 무관하게 갈리는 지점은 응답이 charset을 선언했는지 여부뿐이라 그것을 검증한다.
+   */
+  @Test
+  @DisplayName("401·403 응답이 charset=UTF-8을 명시한다 — 미지정 시 컨테이너 기본값으로 한글이 파괴된다")
+  void error_responses_declare_utf8_charset() throws Exception {
+    String unauthorizedContentType =
+        mockMvc
+            .perform(
+                post("/api/v1/entries/verify")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(BODY))
+            .andExpect(status().isUnauthorized())
+            .andReturn()
+            .getResponse()
+            .getContentType();
+
+    String forbiddenContentType =
+        mockMvc
+            .perform(
+                post("/api/v1/entries/verify")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(BODY)
+                    .header("X-Gateway-Token", INTERNAL_TOKEN)
+                    .header("X-User-Id", 1L)
+                    .header("X-User-Role", "USER"))
+            .andExpect(status().isForbidden())
+            .andReturn()
+            .getResponse()
+            .getContentType();
+
+    assertThat(unauthorizedContentType).containsIgnoringCase("charset=utf-8");
+    assertThat(forbiddenContentType).containsIgnoringCase("charset=utf-8");
   }
 
   @Test


### PR DESCRIPTION
## 🔗 관련 이슈

- close #560

---

> 초안 작성 후 독립 리뷰와 로컬 수동 시연을 거쳐 지적·발견 사항을 반영했다. 반영 내역은 아래 "상세 구현 내용"과 "테스트" 절에 녹였다.

## 📌 주요 변경 사항

- `GET /api/v1/booking/{bookingNumber}` 단건 조회를 추가한다. 본인 예매만 조회되고, 타인 예매와 미존재는 동일하게 404다.
- 단건 응답에 `booking_id`(입장권 QR 키)와 공연 이름·날짜·시간·장소, 좌석 번호, 예매 일시, 결제 마감 시각, 결제 금액을 싣는다.
- `GET /api/v1/booking/me` 목록 응답을 같은 축으로 보강한다(공연 이름·날짜·장소, 좌석 번호, 결제 금액).
- 타 도메인 데이터는 DB 조인이 아니라 performance·seat의 공개 API 호출로 조합한다(ADR 0003).
- `SecurityConfig`의 예매 API 인증 매처를 `/api/v1/booking/**`로 확대해 기존 GET·DELETE의 미인증 통과 구멍을 함께 막는다.

---

## 🛠 상세 구현 내용

### 조합 위치와 실패 정책

착수 전 결정이 필요하다고 이슈에 표시된 두 항목의 결론이다.

- **조합은 booking-service가 직접 한다.** 이번 응답에 ticket 데이터가 필요 없어 ADR 0005 L127이 경고한 `booking ↔ ticket` 순환 동기 의존은 확대되지 않는다.
- **부분 응답을 택했다.** booking 코어 필드(`booking_id`·`booking_number`·상태·예매 일시)는 DB에서 이미 확정되므로 항상 내려가고, performance·seat 조회가 실패하면 그 도메인 필드만 응답에서 빠진다. 함께 내려가는 `performance_id`·`seat_id`가 프론트의 재조회 키다.
  - 기존 동기 호출(`TicketRestClient.isTicketUsed`)의 503 fail-closed 관행은 따르지 않았다. 그 근거는 "환불 오판정으로 착석한 좌석이 재판매되는 것을 막는다"는 **쓰기 경로** 논리인데, 단건 조회에는 되돌릴 수 없는 행위가 없다. 조회에까지 503을 쓰면 performance-service 한 대가 흔들릴 때 예매 조회와 QR 진입(`booking_id` 회수)까지 함께 죽는다.

### 실패 격리

`catch`를 클라이언트 안에만 둬서 한 도메인의 실패가 다른 도메인 필드에 닿는 경로 자체를 없앴다. `PerformanceRestClient`는 모든 실패를 `Optional.empty()`로, `SeatRestClient.getSeatNumbers`는 빈 맵으로 수렴시키고, `BookingFacade`에는 `catch`가 없다.

좌석 응답 매핑은 `Collectors.toMap` 대신 명시적 루프를 쓴다. `toMap`은 키 중복에 `IllegalStateException`, 키·값이 null이면 NPE를 던지는데 둘 다 `RestClientException`이 아니라 `catch`를 뚫고 500이 된다 — 부분 응답 정책이 거기서만 깨진다. 지금 터지지 않는 건 seat 스키마가 `NOT NULL`이고 호출 측이 distinct를 주기 때문일 뿐이라, 그 외부 전제에 기대지 않고 중복 제거까지 클라이언트 안에서 닫았다.

### 순차 호출의 이중 상한

공개 API에 공연 벌크 엔드포인트가 없어 목록 보강은 distinct 공연 수만큼 순차 호출한다. 여기에 상한을 둘로 걸었다.

- **통신 실패(5xx·타임아웃)** — 서비스 장애로 보고 잔여 호출을 접는다. 4xx(삭제된 공연 등)는 해당 건만 비우고 계속 간다.
- **벽시계 예산(기본 3s)** — 위 중단만으로는 부족하다. performance-service가 살아 있으면서 느리기만 하면(건당 read 예산 2s 미만) 예외가 나지 않아 중단이 돌지 않고, 페이지 상한 50건이 그대로 누적돼 요청 하나가 톰캣 스레드를 수십 초 붙잡는다. 예산을 넘기면 잔여 공연 필드를 비운 채 응답한다.

공연·좌석 조회 모두 공용 예산(3s/10s)이 아니라 전용 1s/2s를 쓴다. 실패해도 null로 계속 가는 경로라 빨리 포기하는 편이 옳고, 공연은 순차 호출이라 건당 예산이 그대로 곱해진다. 좌석 조회는 쓰기 경로(`confirmSold`·`releaseHold`)와 클라이언트를 분리했다 — 공용 예산을 그대로 두면 같은 요청 안에서 공연 보강 예산 위에 얹혀 조회 하나가 톰캣 스레드를 13초까지 붙잡는데, ADR 0005가 경고한 값이 정확히 그것이다.

보강이 중간에 끊길 때 어느 행이 채워지는지는 페이지 순서로 고정했다(`LinkedHashSet`). `HashSet`이면 순회 순서가 비결정적이라 새로고침마다 다른 행의 공연 정보가 나타났다 사라진다.

### 응답 DTO

- 단건은 `BookingDetailResponse`를 새로 만들었다. 이 API는 스스로 "예매번호만 든 화면(딥링크·새로고침)에서 되찾는" 용도라고 문서화하므로 `expires_at`도 싣는다 — 없으면 PENDING 예매를 딥링크로 열었을 때 결제 카운트다운(#559)을 복원할 수 없어 목록을 한 번 더 불러야 한다.
- 목록은 `BookingSummaryResponse`를 건드리지 않고 `BookingMySummaryResponse`를 새로 뒀다. 기존 DTO는 관리자 목록 2곳(`refund-failed`·`refunding-stuck`)과 공유라 직접 보강하면 enrichment 없는 관리자 응답까지 바뀐다. 기존 10필드는 그대로 유지했다.
- 부분 응답은 중첩 객체가 아니라 평탄화된 nullable 필드로 표현했다(기존 응답 DTO가 모두 flat record다). 전역 Jackson 설정이 `NON_NULL`이라 비는 필드는 응답에서 생략된다.

### 완료 조건 중 범위를 조정한 항목

- **예매자 이름·이메일은 응답에 넣지 않았다.** 본인 조회이므로 프론트가 기존 `GET /api/v1/user/me`로 조합한다. 서버에서 채우려면 user-service에 신규 internal API가 필요한데, 기존 `/{userId}/auth-info`는 `passwordHash`를 동봉하고 소셜 가입자에게 404를 던져 재사용할 수 없다.
- **공연 장소는 `Performance.address`를 쓴다.** Performance 도메인에 venue 컬럼이 존재하지 않아(도메인 전체 검색 0건) 컬럼 신설은 performance 담당 협의가 필요하다. 이번 범위에서는 최근사 필드를 재사용했다.
- **결제 금액은 `Performance.price`를 쓴다.** 공연당 단일가·1인 1매가 확정이라 실제 결제액과 같다. 다만 price는 불변이 아니라 관리자가 가격을 바꾸면 과거 예매의 금액이 소급 변경되므로, 실제 결제액의 SSOT가 payment-service임을 Swagger 설명에 명시했다. payment-service는 internal API 인프라(`InternalApiTokenFilter` 포함)가 통째로 없어 근본 해결은 이번 범위 밖이다.
- 위 조정 근거는 [이슈 코멘트](https://github.com/TicketRush/TicketRush-backend/issues/560#issuecomment-5156386017)에 남겼다.

### 그 밖에

- 예매번호 생성 규칙(`BookingNumberGenerator`)은 이슈가 규정한 "영문 대문자·숫자 10자리를 5자리씩 하이픈" 형식과 부합한다 — 오입력 방지로 `0·1·O·I·L`을 뺀 부분집합이다. 코드 변경은 없고 Swagger 설명에만 형식을 적었다.
- `PathVariable`에 `@Pattern` 검증은 걸지 않았다. 기존 테스트·시드에 `BOOK-1234` 같은 규격 밖 값이 있어 지금 걸면 깨진다.
- `GET /{bookingNumber}`와 `/me`는 매핑이 충돌하지 않는다(Spring이 리터럴 패턴을 우선한다).
- 와이어 DTO에서 레코드 컴포넌트명과 같은 `@JsonProperty`를 걷어냈다. 이 클라이언트들은 `RestClient.builder()` 정적 팩토리라 앱의 전역 SNAKE_CASE 설정을 타지 않아 어노테이션이 실제로 일하는데, 무의미한 것이 섞여 있으면 어느 것이 필수인지 보이지 않는다.

---

## ✅ 테스트

### 테스트 방법

```
./gradlew :booking-service:test
./gradlew build -x test
```

작성한 테스트:

- `PerformanceRestClientTest` (신규, `MockRestServiceServer`) — 래핑 응답 파싱(snake_case 키, `LocalDate`/`LocalTime` 직렬 형식 왕복), 404·5xx·`result` 결손·본문 파싱 실패가 각각 빈 `Optional`로 수렴, 벌크에서 4xx는 해당 건만 건너뛰고 5xx는 잔여 호출 중단(3번째 요청이 나가지 않음을 검증), 벽시계 예산 소진 시 호출 없이 중단
- `SeatRestClientTest` (신규) — 좌석 번호 맵 변환과 **`X-Internal-Token` 미전송 검증**(공개 API), 5xx·404(전부-아니면-전무)·`result` null·파싱 실패가 모두 빈 맵으로 수렴, 중복 `seatId`를 클라이언트가 접어 한 번만 요청, 빈 입력은 호출 없이 빈 맵
- `RestClientConfigTest` (신규, `ApplicationContextRunner`) — RestClient 빈 4개 생성과 **이름 기반 주입** 검증. `SeatRestClient`가 한 생성자에 RestClient를 둘 받는데, 기존 `contextLoads`는 실제 설정을 로드하지 않아 기동 실패를 잡지 못한다
- `BookingGetMyBookingDetailUseCaseTest` (신규) — 본인 예매 조회 성공, 빈 조회(타인·미존재 동일 경로)에서 `BOOKING_NOT_FOUND`
- `BookingFacadeTest` (보강) — 단건 전체 보강, **공연 실패 시 좌석 번호 생존**·**좌석 실패 시 공연 필드 생존**·**둘 다 실패해도 코어 필드 생존**(실패 격리), 같은 공연 3건이 distinct 1개로 묶여 전달, 벌크 부분 결손 시 해당 건만 비움
- `BookingControllerTest` (보강) — 단건 조회 성공(snake_case jsonPath 전 필드), 부분 응답(공연 필드 부재·코어 필드 존재), 404, 미인증 401, `GET /me` 보강 필드, `GET /me` 미인증 401(매처 확대 검증)

### 테스트 결과

- `./gradlew :booking-service:test` — **통과**(전체 그린)
- `./gradlew build -x test` — **통과**(타 모듈 컴파일 회귀 없음)

**로컬 수동 시연** — booking(8084)·performance(8083)·seat(8086)를 로컬 프로파일로 띄우고 실제 HTTP로 호출했다. 시드는 `9560xx` 대역(공연 1건·좌석 A-7·예매 3건)을 넣고 시연 후 되돌렸다.

| # | 시나리오 | 결과 |
|---|---|---|
| 1 | 본인 단건 조회 (3개 서비스 UP) | 200. 공연 이름·날짜·시간·장소, 좌석 번호 `A-7`, 결제 금액 `150000`, `booking_id`까지 전부 채워짐 |
| 2 | 타인 예매(`Z4M88-QRTV2`) 조회 | 404 `BOOKING_404_001` |
| 3 | 미존재 예매번호 조회 | **2번과 완전히 동일한** 404 본문 — 존재 여부가 새지 않음 |
| 4 | 미인증 요청 | 401 `COMMON_401` (기존엔 이 경로가 permitAll이라 NPE 500이었다) |
| 5 | `GET /me` 목록 | 200. 공연 이름·날짜·장소, 좌석 번호, 결제 금액 보강 확인 |
| 6 | **performance UP / seat DOWN** | 200. 공연 필드는 모두 채워지고 `seat_number`만 생략, `seat_id`는 유지 — 실패 격리가 실제로 성립 |
| 7 | **performance·seat 둘 다 DOWN** | 200(503 아님). 코어 필드와 재조회 키 `performance_id`·`seat_id`만 남고 보강 필드 전부 생략 |
| 8 | PENDING 예매 딥링크 조회 | `expires_at` 포함 — 목록을 다시 부르지 않고 결제 카운트다운 복원 가능 |

부수 확인: `LocalDate`/`LocalTime`이 performance-service 실제 응답과 왕복됨(`2026-09-12`, `19:30:00`)을 확인했다 — 리뷰에서 "코드만으로는 단정 못 한다"고 지적된 항목이다.

### 시연에서 찾은 결함: 에러 응답 본문의 한글 파괴

4번에서 401 본문이 `{"message":"??? ?????."}`로 나갔다. 콘솔 표시 문제가 아니라 `Content-Type: application/json;charset=ISO-8859-1`로 나가며 실제 바이트가 파괴된 것이었다(`od -c`로 확인). `authenticationEntryPoint`가 charset을 지정하지 않아 `response.getWriter()`가 서블릿 기본값을 쓴 탓이다.

코드는 이전부터 있었지만 매처 확대 전에는 해당 경로들이 이 엔트리포인트에 닿지 않았으므로, 노출 범위를 넓힌 이 PR에서 함께 고쳤다(payment-service의 기존 처리 방식을 따름).

전 서비스를 훑어보니 커스텀 에러 핸들러를 가진 곳은 booking·payment·ticket 셋뿐이고, payment는 이미 charset을 지정하고 있었다. **ticket-service는 401과 403 양쪽에 같은 구멍이 있어 함께 고쳤다** — 같은 결함의 나머지 절반이고 담당자도 같아, 이슈 스킬의 "한두 파일짜리 수정을 별도 이슈로 쪼개지 않는다" 규칙에 따라 이 PR에 담았다. 이것으로 저장소에 남은 같은 구멍은 없다.

**처음 추가한 회귀 테스트는 실효가 없어 교체했다.** 응답 바이트를 UTF-8로 읽어 메시지를 비교하는 방식이었는데, 수정을 제거하고 돌려보니 그대로 통과했다 — MockMvc의 가짜 응답은 실제 컨테이너와 달리 기본 인코딩이 UTF-8이라 이 회귀를 재현하지 못한다. 통과만 하고 회귀는 못 잡는 테스트는 없는 것만 못하므로, 컨테이너와 무관하게 갈리는 지점인 "응답이 `charset=UTF-8`을 선언하는가"로 바꿨다. **양쪽 서비스 모두 수정을 빼면 실패하고 넣으면 통과하는 것을 확인했다.**

<!--
### 📸 스크린샷

- 백엔드 API 변경이라 UI 스크린샷은 없다. 필요하면 이 주석을 풀고 사용한다.
-->

---

## 👀 리뷰 요청 사항

- **부분 응답 정책**이 이 저장소의 기존 관행(동기 호출 실패는 503 fail-closed)과 갈립니다. 조회 경로에는 쓰기 경로의 "알 수 없으면 막는다" 논리가 적용되지 않는다고 판단했는데, 이견이 있으면 지적해 주시기 바랍니다.
- **`SecurityConfig` 매처를 `/api/v1/booking/**`로 확대**한 부분을 확인 부탁드립니다. 기존 `POST /api/v1/booking` 단일 매처를 대체하며, 그 결과 GET·DELETE도 인증이 필요해집니다. `internal`·`admin` 매처가 앞에 있어 권한 하향은 없다고 봤고 로컬에서 401 전환을 확인했습니다. 이 변경으로 예매 API 중 비인증 접근이 필요한 경로가 있는지 판단을 부탁드립니다.
- **ticket-service 수정이 이 PR에 함께 들어간 것**을 봐주시기 바랍니다. 같은 결함의 나머지 절반이고 담당자도 같아 이슈를 쪼개지 않았는데, 별도 이슈·PR로 분리하는 편이 낫다고 보시면 알려주시기 바랍니다.
- **공연 장소를 `Performance.address`로 대체**한 결정에 performance 담당자 의견이 필요합니다. 별도 `venueName` 컬럼이 필요하다면 후속 이슈로 다루겠습니다.
- **좌석 벌크 조회의 전부-아니면-전무 거동**을 봐주시기 바랍니다. seat-service는 요청한 `seatIds` 중 하나라도 없으면 `SEAT_NOT_FOUND`로 전체를 실패시켜, 그때는 해당 페이지의 좌석 번호가 모두 빕니다. 좌석이 삭제되는 운영이 없다고 보고 건별 폴백은 넣지 않았고, 대신 이 거동을 테스트로 고정해 뒀습니다.
- **`payment_amount`의 출처**를 확인 부탁드립니다. `Performance.price`는 불변이 아니라 관리자가 가격을 바꾸면 과거 예매의 금액이 소급 변경됩니다. SSOT가 payment-service임을 Swagger에 명시해 뒀지만 근본 해결은 payment internal API 신설이라 범위 밖으로 뒀습니다. 별도 이슈가 필요하다고 보시면 알려주시기 바랍니다.
- **app 응답 DTO의 팩토리가 out 계층 와이어 DTO(`PerformanceInfoResponse`)를 직접 받습니다.** 중간 타입을 하나 더 두는 것보다 낫다고 판단했는데, performance 응답 계약이 바뀌면 app 응답 DTO 시그니처까지 흔들린다는 지적이 있었습니다. 판단을 부탁드립니다.
- 타임아웃 기본값이 적절한지 봐주시면 좋겠습니다. 실측 없이 정한 값이라 모두 환경변수로 조정 가능하게 뒀습니다 — 보강 벽시계 예산 3s(`PERFORMANCE_BULK_BUDGET_MS`), 공연 조회 1s/2s, 좌석 조회 1s/2s(`SEAT_QUERY_*_TIMEOUT_MS`).

---

## ⚠️ 배포 시 주의사항

- **`PERFORMANCE_SERVICE_URL` 환경변수를 반드시 주입해야 한다.** `application-prod.yml`은 기본값 없이 선언해 미주입 시 기동에 실패한다(fail-fast). 기본값을 남기면 컨테이너가 자기 자신을 호출해 공연 필드가 조용히 전부 비게 된다. `deploy/.env.prod.example`에 항목을 추가해 뒀으니 **서버의 실제 `.env`에도 값을 채워야 한다**(예: `http://performance-service:8083`).
- **`GET /api/v1/booking/me`의 응답 스키마가 바뀐다.** 기존 필드는 모두 유지되고 필드만 추가되지만, 프론트 배포 순서를 확인하는 편이 안전하다.
- **기존 GET·DELETE 예매 API가 인증 필수로 바뀐다.** 지금까지 미인증 요청은 컨트롤러에서 NPE(500)로 떨어졌으므로 정상 동작하던 클라이언트는 영향이 없지만, 응답 코드가 500에서 401로 바뀐다.
- 선택 설정: `PERFORMANCE_HTTP_CONNECT_TIMEOUT_MS`(기본 1000), `PERFORMANCE_HTTP_READ_TIMEOUT_MS`(기본 2000), `PERFORMANCE_BULK_BUDGET_MS`(기본 3000), `SEAT_QUERY_CONNECT_TIMEOUT_MS`(기본 1000), `SEAT_QUERY_READ_TIMEOUT_MS`(기본 2000).
