### PR TITLE
[Feat] #558 /api/v1/user/me 응답에 role 필드 추가

### DIFF
--- a/user-service/src/main/java/com/ticketrush/boundedcontext/user/app/dto/response/UserMeResponse.java
+++ b/user-service/src/main/java/com/ticketrush/boundedcontext/user/app/dto/response/UserMeResponse.java
@@ -2,4 +2,4 @@ package com.ticketrush.boundedcontext.user.app.dto.response;
 
 import java.time.LocalDateTime;
 
-public record UserMeResponse(String name, String email, LocalDateTime createdAt) {}
+public record UserMeResponse(String name, String email, LocalDateTime createdAt, String role) {}

--- a/user-service/src/main/java/com/ticketrush/boundedcontext/user/app/usecase/GetUserMeUseCase.java
+++ b/user-service/src/main/java/com/ticketrush/boundedcontext/user/app/usecase/GetUserMeUseCase.java
@@ -22,6 +22,7 @@ public class GetUserMeUseCase {
             .findById(userId)
             .orElseThrow(() -> new BusinessException(ErrorStatus.USER_NOT_FOUND));
 
-    return new UserMeResponse(user.getName(), user.getEmail(), user.getCreatedAt());
+    return new UserMeResponse(
+        user.getName(), user.getEmail(), user.getCreatedAt(), user.getUserRole().name());
   }
 }

--- a/user-service/src/main/java/com/ticketrush/boundedcontext/user/in/api/v1/UserController.java
+++ b/user-service/src/main/java/com/ticketrush/boundedcontext/user/in/api/v1/UserController.java
@@ -56,7 +56,7 @@ public class UserController {
     return ApiResponse.onSuccess(SuccessStatus.OK, response);
   }
 
-  @Operation(summary = "내 회원 정보 조회", description = "로그인한 회원의 이름, 이메일, 가입일을 조회합니다.")
+  @Operation(summary = "내 회원 정보 조회", description = "로그인한 회원의 이름, 이메일, 가입일, 권한을 조회합니다.")
   @GetMapping("/me")
   public ResponseEntity<ApiResponse<UserMeResponse>> getMyInfo(
       @AuthenticationPrincipal CustomUserDetails userDetails) {

--- a/user-service/src/test/java/com/ticketrush/boundedcontext/user/in/api/v1/UserControllerTest.java
+++ b/user-service/src/test/java/com/ticketrush/boundedcontext/user/in/api/v1/UserControllerTest.java
@@ -37,7 +37,13 @@ class UserControllerTest {
 
   private static final String GATEWAY_TOKEN = "test-gateway-token";
   private static final Long USER_ID = 5L;
+
+  // Gateway 인증 헤더에서 사용하는 권한
   private static final String USER_ROLE = "USER";
+
+  // /api/v1/user/me 응답에서 사용하는 실제 사용자 권한
+  private static final String RESPONSE_ROLE = "MEMBER";
+
   private static final String USER_NAME = "테스트유저";
   private static final String USER_EMAIL = "test@test.com";
   private static final LocalDateTime CREATED_AT = LocalDateTime.of(2026, 5, 30, 7, 0);
@@ -51,7 +57,7 @@ class UserControllerTest {
   void getMyInfo_success() throws Exception {
     // given
     given(userFacade.getMyInfo(USER_ID))
-        .willReturn(new UserMeResponse(USER_NAME, USER_EMAIL, CREATED_AT));
+        .willReturn(new UserMeResponse(USER_NAME, USER_EMAIL, CREATED_AT, RESPONSE_ROLE));
 
     // when & then
     mockMvc
@@ -67,6 +73,7 @@ class UserControllerTest {
         .andExpect(jsonPath("$.message").value("성공입니다."))
         .andExpect(jsonPath("$.result.name").value(USER_NAME))
         .andExpect(jsonPath("$.result.email").value(USER_EMAIL))
-        .andExpect(jsonPath("$.result.created_at").exists());
+        .andExpect(jsonPath("$.result.created_at").exists())
+        .andExpect(jsonPath("$.result.role").value(RESPONSE_ROLE));
   }
 }


### PR DESCRIPTION
## 🔗 관련 이슈

- close #558

---

## 📌 주요 변경 사항

- `GET /api/v1/user/me` 응답에 `role` 필드 추가
- 사용자 DB 권한에 따라 `MEMBER` 또는 `ADMIN` 반환
- 회원 정보 조회 API 테스트에 role 응답 검증 추가

---

## 🛠 상세 구현 내용

- `UserMeResponse`에 `role` 필드를 추가했습니다.
- `GetUserMeUseCase`에서 `user.getUserRole().name()`을 사용해 사용자 권한을 응답하도록 수정했습니다.
- Swagger 회원 정보 조회 API 설명에 권한 조회 내용을 추가했습니다.
- `UserControllerTest`의 응답 DTO 생성 부분을 수정하고 `result.role` 검증을 추가했습니다.

---

## ✅ 테스트

### 테스트 방법

- Swagger에서 로그인 후 발급받은 Access Token으로 `GET /api/v1/user/me` 호출
- `./gradlew :user-service:check :auth-service:check`
- `./gradlew :user-service:build :auth-service:build`

### 테스트 결과

- Swagger 응답에서 `role: "MEMBER"` 반환 확인
- `user-service`, `auth-service` check 성공
- `user-service`, `auth-service` build 성공
- Gateway 테스트는 로컬 Docker 미실행으로 Testcontainers 초기화 단계에서 실패했으며, 이번 변경 모듈의 테스트 및 빌드는 정상 통과