### PR TITLE
[Fix] #490 결제 확정 전 예매 상태 동기 확인 — 만료 창의 과금 후 좌석 미확정 차단

### DIFF
--- a/common/src/main/java/com/ticketrush/global/constants/MetricNames.java
+++ b/common/src/main/java/com/ticketrush/global/constants/MetricNames.java
@@ -46,6 +46,15 @@ public class MetricNames {
   // booking당 FAILED 이력 상한 초과로 기록을 억제한 횟수(#333).
   public static final String PAYMENT_FAILED_RECORD_SUPPRESSED =
       "ticketrush.payment.failed_record.suppressed";
+  // 결제 확정 전 예매 상태 동기 확인이 PG 승인을 차단한 횟수(#490). 이 가드가 막는 건은 원래
+  // "과금됐는데 좌석이 없는" 상태로 끝나던 것이라, 차단 건수가 곧 방지한 사고 건수다. 로그로는
+  // 대량 만료 구간의 규모를 집계할 수 없어 이 카운터가 유일한 관측 축이다(서킷브레이커 미도입).
+  // reason 태그는 세 갈래이며 모두 유한 집합이다 — booking-service BookingStatus 이름(상태 때문에
+  // 막힌 건), unknown(모르는 상태 문자열·null), lookup_failed/not_found(상태 판정에 도달하지 못하고
+  // 조회 단계에서 막힌 건). 마지막 갈래를 함께 세지 않으면 booking 장애로 결제가 전건 거부되는
+  // 구간에서 이 카운터가 0으로 평평해 장애가 관측되지 않는다.
+  public static final String PAYMENT_CONFIRM_BOOKING_GUARD_BLOCKED =
+      "ticketrush.payment.confirm.booking_guard.blocked";
 
   // ticket
   public static final String TICKET_ISSUE = "ticketrush.ticket.issue";

--- a/common/src/main/java/com/ticketrush/global/status/ErrorStatus.java
+++ b/common/src/main/java/com/ticketrush/global/status/ErrorStatus.java
@@ -203,6 +203,8 @@ public enum ErrorStatus {
       HttpStatus.SERVICE_UNAVAILABLE, "PAYMENT_503_001", "PG사와 통신에 실패했습니다."),
   PAYMENT_TICKET_COMMUNICATION_FAILED(
       HttpStatus.SERVICE_UNAVAILABLE, "PAYMENT_503_002", "입장권 정보 조회에 실패했습니다. 잠시 후 다시 시도해 주세요."),
+  PAYMENT_BOOKING_COMMUNICATION_FAILED(
+      HttpStatus.SERVICE_UNAVAILABLE, "PAYMENT_503_003", "예매 정보 조회에 실패했습니다. 잠시 후 다시 시도해 주세요."),
 
   // Ticket 400
   TICKET_QR_INVALID(HttpStatus.BAD_REQUEST, "TICKET_400_001", "유효하지 않은 QR입니다."),

--- a/deploy/.env.prod.example
+++ b/deploy/.env.prod.example
@@ -32,6 +32,9 @@ SWAGGER_SERVER_URL=https://api.ticketrush.store
 AUTH_SERVICE_URL=
 USER_SERVICE_URL=
 SEAT_SERVICE_URL=
+# ticket-service와 payment-service가 prod에서 기본값 없이 요구한다(미주입 시 fail-fast).
+# payment는 결제 확정 전 예매 상태 확인(#490)에 쓰며 fail-closed라, 값이 비면 부팅이 실패한다.
+# 예: http://booking-service:8084
 BOOKING_SERVICE_URL=
 # booking-service는 prod에서 기본값 없이 요구한다(미주입 시 fail-fast). 취소·재환불 경로가 이 값에 의존한다.
 TICKET_SERVICE_URL=

--- a/docs/backend-convention.md
+++ b/docs/backend-convention.md
@@ -169,9 +169,10 @@ GitHub 마크다운은 `~텍스트~`를 **취소선**으로 렌더링합니다. 
     * `<name>` 은 호출 대상 서비스의 **단축명**(`-service` 접미사 제외): `auth`, `user`, `seat` 등
     * 값은 **환경변수 오버라이드** 형태: `${<NAME>_SERVICE_URL:http://localhost:<port>}`
     * 예: `service.auth.url: ${AUTH_SERVICE_URL:http://localhost:8082}`
-* **공통 타임아웃 키:** 모듈당 호출 대상이 1개이므로 모듈 공통 1쌍으로 둡니다.
+* **공통 타임아웃 키:** 호출 대상이 1개인 모듈은 모듈 공통 1쌍으로 둡니다.
     * `service.http.connect-timeout-ms: ${SERVICE_HTTP_CONNECT_TIMEOUT_MS:3000}`
     * `service.http.read-timeout-ms: ${SERVICE_HTTP_READ_TIMEOUT_MS:10000}`
+* **호출 대상이 2개 이상인 모듈은 대상별 키(`service.<name>.connect-timeout-ms` / `read-timeout-ms`)를 둡니다.** 위 공통 1쌍은 "모듈당 대상 1개"를 전제로 한 단축이며, 대상이 늘면 그 전제가 깨집니다. 대상마다 지연 특성과 실패 시 정책(fail-open/fail-closed)이 달라 한쪽만 조일 수 있어야 합니다. 예: payment-service 는 ticket(취소 경로 판정)과 booking(결제 확정 전 상태 확인, [#490](https://github.com/TicketRush/TicketRush-backend/issues/490))을 각각 호출하므로 `service.ticket.*` / `service.booking.*` 로 나눕니다.
 * **타임아웃 적용:** `RestClient` 빈은 공통 모듈의 `RestClientFactorySupport.withTimeouts(connectMs, readMs)`(`common/.../global/config`)로 생성한 `ClientHttpRequestFactory` 를 반드시 적용합니다. 타임아웃 미설정 시 상대 서비스 지연이 Kafka 컨슈머 스레드 등을 장시간 블로킹할 수 있습니다.
 * **타임아웃 값은 실측 근거가 있으면 서비스별로 낮출 수 있습니다.** 위 3000/10000 은 근거가 없을 때의 출발점이지 상한이 아닙니다. read-timeout 은 곧 요청당 톰캣 스레드 점유 시간이라 값이 클수록 상대 서비스 지연이 이쪽 스레드 고갈로 번지기 쉽습니다. 낮출 때는 **근거가 된 실측치를 yml 주석에 남깁니다**(예: ticket-service 는 #402 실측 왕복 3.20ms 를 근거로 1000/1000, [#496](https://github.com/TicketRush/TicketRush-backend/issues/496)).
 

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentConfirmUseCase.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentConfirmUseCase.java
@@ -6,6 +6,7 @@ import com.ticketrush.boundedcontext.payment.app.mapper.PaymentMapper;
 import com.ticketrush.boundedcontext.payment.app.support.PaymentEventPublisher;
 import com.ticketrush.boundedcontext.payment.domain.entity.Payment;
 import com.ticketrush.boundedcontext.payment.domain.types.PaymentStatus;
+import com.ticketrush.boundedcontext.payment.out.apiclient.BookingRestClient;
 import com.ticketrush.boundedcontext.payment.out.apiclient.PaymentApprovalClientRouter;
 import com.ticketrush.boundedcontext.payment.out.apiclient.PaymentApprovalRequest;
 import com.ticketrush.boundedcontext.payment.out.apiclient.PaymentApprovalResponse;
@@ -31,6 +32,28 @@ import org.springframework.stereotype.Service;
  * 안에 가두지 않아 DB 커넥션을 장시간 점유하지 않는다. 이벤트는 saveAndFlush(자체 트랜잭션 커밋) 성공 이후에 호출되므로, 커밋에 성공한 데이터만 외부로
  * 전파된다. (ID 전략이 IDENTITY라 {@code save}만으로도 INSERT가 즉시 실행되지만, 동시 confirm 시 unique 위반을 이벤트 발행 이전에
  * 표면화한다는 의도를 명시하고 취소 경로({@code PaymentCancelPersister})와 일관성을 맞추기 위해 saveAndFlush를 쓴다, #296.)
+ *
+ * <h2>PG 호출 전 가드 계층 (#490)</h2>
+ *
+ * <p>PG 승인은 되돌릴 수 없는 부작용(과금)이므로 그 앞의 가드는 <b>싼 것부터 순서대로</b> 둔다. 셋 다 목적이 다르며 하나가 다른 하나를 대체하지 않는다.
+ *
+ * <ol>
+ *   <li><b>COMPLETED 중복</b>(로컬 DB) — 이미 확정된 결제의 재요청을 막는다(#296).
+ *   <li><b>{@code expired_booking} fast-path</b>(로컬 DB) — 만료 이벤트를 <b>이미 수신한</b> booking을 네트워크 왕복 없이
+ *       거른다. 도착에 의존하므로 best-effort이며(#224), 이벤트가 늦으면 그냥 통과한다.
+ *   <li><b>예매 상태 동기 확인</b>(booking-service 호출) — 이벤트 도착과 무관하게 <b>지금</b>의 상태를 보는 방어선이다(#490). 대량 만료
+ *       구간에서 outbox 릴레이가 밀려 2번이 분 단위로 무력화된 것이 실측됐고(#345, 약 13분), 그 창에서 과금 후 좌석 미확정이 발생했다.
+ * </ol>
+ *
+ * <p><b>3번도 창을 없애지는 못한다.</b> 상태를 읽은 뒤 PG 승인이 끝나기까지 사이에 만료가 일어나면 같은 결과가 나온다 — 분 단위였던 창이 왕복 한 번(수십
+ * ms~1s)으로 줄어든 것이지 사라진 것이 아니다. 그 잔여 창에서 과금이 나면 되돌릴 자동 보상 경로는 아직 없다(#492). 이 가드를 완전 해결로 읽으면 안 된다.
+ *
+ * <p>2번을 남긴 이유는 3번이 네트워크 왕복이기 때문이다. 이미 만료가 확정된 건은 로컬 조회 하나로 끝내는 편이 싸고, booking-service가 죽어 있어도 그
+ * 경로는 계속 동작한다.
+ *
+ * <p>3번의 판정은 <b>허용 목록</b>이다 — {@code PENDING}만 통과시키고 나머지는 전부 막는다. 차단 목록(예: EXPIRED만 거부)으로 짜면 #559가
+ * 추가한 사용자 PENDING 즉시 취소 경로(CANCELED)가 그대로 샌다. 기본이 거부라 booking이 상태를 추가해도 payment는 컴파일 에러 없이 자동으로
+ * 막는다.
  */
 @Slf4j
 @Service
@@ -66,10 +89,43 @@ public class PaymentConfirmUseCase {
    */
   private static final long MAX_FAILED_HISTORY_PER_BOOKING = 5;
 
+  /**
+   * 결제 확정을 허용하는 유일한 예매 상태 (#490).
+   *
+   * <p>booking-service {@code BookingStatus}의 이름이 문자열로 건너오므로 컴파일러가 지켜주지 못한다. 그래서 판정을 "이 값이 아니면 거부"로
+   * 짜, 상대가 값을 바꾸거나 추가해도 통과가 아니라 차단으로 기울게 한다.
+   */
+  private static final String BOOKING_STATUS_PENDING = "PENDING";
+
+  private static final String BOOKING_STATUS_EXPIRED = "EXPIRED";
+
+  /**
+   * 차단 메트릭의 {@code reason} 태그로 그대로 쓸 수 있는 상태 값 (#490).
+   *
+   * <p>태그 값은 카디널리티가 폭발하지 않도록 유한 집합이어야 하는데, 상태는 외부 서비스가 주는 문자열이라 그 보장이 코드에 없다. 알려진 값만 통과시키고 나머지는
+   * {@code unknown}으로 접어 상한을 만든다.
+   */
+  private static final Set<String> KNOWN_BOOKING_STATUSES =
+      Set.of(
+          BOOKING_STATUS_PENDING,
+          "CONFIRMED",
+          "CANCELED",
+          "REFUNDING",
+          "REFUNDED",
+          BOOKING_STATUS_EXPIRED);
+
+  private static final String BOOKING_STATUS_UNKNOWN = "unknown";
+
+  /** 상태 판정에 도달하지 못하고 조회 단계에서 막힌 건의 사유 태그. */
+  private static final String REASON_LOOKUP_FAILED = "lookup_failed";
+
+  private static final String REASON_BOOKING_NOT_FOUND = "not_found";
+
   private final PaymentRepository paymentRepository;
   private final PaymentApprovalClientRouter paymentApprovalClientRouter;
   private final PaymentEventPublisher paymentEventPublisher;
   private final ExpiredBookingRepository expiredBookingRepository;
+  private final BookingRestClient bookingRestClient;
   private final PaymentMapper paymentMapper;
   private final MeterRegistry meterRegistry;
 
@@ -80,9 +136,14 @@ public class PaymentConfirmUseCase {
     }
 
     // 만료 이벤트를 이미 수신한 booking이면 PG 호출 전 차단한다(best-effort 방어선, #224).
+    // 로컬 조회라 아래 동기 확인보다 싸고, booking-service가 죽어 있어도 계속 동작한다.
     if (expiredBookingRepository.existsByBookingId(request.bookingId())) {
       throw new BusinessException(ErrorStatus.BOOKING_EXPIRED);
     }
+
+    // 이벤트 도착과 무관하게 '지금'의 예매 상태를 확인한다(결정적 방어선, #490).
+    // 위 fast-path는 이벤트가 늦으면 통과시키는데, 대량 만료 구간에서 그 창이 분 단위임이 실측됐다(#345).
+    assertBookingIsPayable(request.bookingId());
 
     String orderId = generateOrderId(request.bookingId());
 
@@ -163,6 +224,74 @@ public class PaymentConfirmUseCase {
             .findFirstByBookingIdAndStatus(bookingId, PaymentStatus.COMPLETED)
             .orElseThrow(() -> new BusinessException(ErrorStatus.PAYMENT_NOT_FOUND));
     return paymentMapper.toConfirmResponse(payment);
+  }
+
+  /**
+   * PG 호출 전에 예매가 아직 결제 가능한 상태인지 booking-service에 동기 확인한다 (#490).
+   *
+   * <p><b>{@code PENDING}만 통과시키는 허용 목록이다.</b> 만료(EXPIRED)뿐 아니라 사용자 자가 취소(CANCELED, #559), 이미 확정된
+   * 예매(CONFIRMED), 환불 진행/완료(REFUNDING·REFUNDED)가 모두 여기서 막힌다. 거절 사유 코드만 상태에 따라 가르는데, 기본값이 {@code
+   * BOOKING_CONFIRM_NOT_ALLOWED}라 booking이 상태를 추가해도 payment는 자동으로 차단한다.
+   *
+   * <p>사유 코드는 booking 도메인의 {@code Booking.confirm()} 규칙과 같은 언어를 쓴다 — EXPIRED만 "만료된 예매"이고 나머지는 "확정할
+   * 수 없는 예매 상태"다. 전부 {@code BOOKING_EXPIRED}로 뭉개면 사용자가 방금 직접 취소한 예매에도 "만료됐다"고 답하게 되어 사실이 아니고, CS
+   * 문의가 오진단된다.
+   *
+   * <p>조회 자체가 실패하면 {@link com.ticketrush.boundedcontext.payment.out.apiclient.BookingRestClient}가
+   * 예외로 끊으므로 이 메서드는 통과시키지 않는다 (fail-closed 근거는 그 클래스 javadoc 참고). 그 예외는 PG 호출 try 블록 <b>밖</b>에서 나므로
+   * {@link #recordFailedPayment} 경로를 타지 않는다 — 과금이 일어나지 않은 차단이라 FAILED 이력을 남길 이유가 없고, 화이트리스트에도 없다.
+   */
+  private void assertBookingIsPayable(Long bookingId) {
+    String bookingStatus;
+    try {
+      bookingStatus = bookingRestClient.getBooking(bookingId).bookingStatus();
+    } catch (BusinessException e) {
+      // 조회 실패로 막힌 건도 이 가드가 차단한 건이다. 여기서 세지 않으면 booking이 느려지거나 죽은 구간에서
+      // 결제가 전건 거부되는 동안 차단 카운터가 0으로 평평해, 서킷이 없는 지금 관측 축이 통째로 빈다.
+      incrementGuardBlocked(
+          ErrorStatus.BOOKING_NOT_FOUND == e.getErrorStatus()
+              ? REASON_BOOKING_NOT_FOUND
+              : REASON_LOOKUP_FAILED);
+      throw e;
+    }
+
+    if (BOOKING_STATUS_PENDING.equals(bookingStatus)) {
+      return;
+    }
+
+    ErrorStatus errorStatus =
+        BOOKING_STATUS_EXPIRED.equals(bookingStatus)
+            ? ErrorStatus.BOOKING_EXPIRED
+            : ErrorStatus.BOOKING_CONFIRM_NOT_ALLOWED;
+
+    incrementGuardBlocked(metricReasonOf(bookingStatus));
+    log.warn(
+        "결제 가능한 예매 상태가 아니라 PG 승인 전에 차단합니다. bookingId={}, bookingStatus={}",
+        bookingId,
+        bookingStatus);
+
+    throw new BusinessException(errorStatus);
+  }
+
+  private void incrementGuardBlocked(String reason) {
+    Counter.builder(MetricNames.PAYMENT_CONFIRM_BOOKING_GUARD_BLOCKED)
+        .tag(MetricNames.TAG_REASON, reason)
+        .register(meterRegistry)
+        .increment();
+  }
+
+  /**
+   * 알려진 상태만 태그로 내보내 메트릭 카디널리티를 유계로 만든다.
+   *
+   * <p>{@code null}을 먼저 거른다 — {@code Set.of(...)}가 만드는 불변 Set은 {@code contains(null)}에 NPE를 던진다. 응답
+   * DTO가 {@code ignoreUnknown = true}라 booking이 필드명을 바꾸거나 URL이 다른 200 응답을 주는 엔드포인트로 오설정되면 상태가 조용히
+   * null이 되는데, 그때 차단은 되더라도 사용자에게 409/503이 아닌 원시 500이 나가면 {@code BookingRestClient}가 약속한 "판정 불가는 모두
+   * 503으로 수렴"이 이 지점에서 깨진다.
+   */
+  private String metricReasonOf(String bookingStatus) {
+    return bookingStatus != null && KNOWN_BOOKING_STATUSES.contains(bookingStatus)
+        ? bookingStatus
+        : BOOKING_STATUS_UNKNOWN;
   }
 
   /**

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/in/api/v1/PaymentController.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/in/api/v1/PaymentController.java
@@ -45,7 +45,14 @@ public class PaymentController {
       summary = "결제 Confirm",
       description =
           "PG사 결제 인증 후 넘어온 데이터를 검증하고 결제를 확정한다. "
-              + "성공 시 PaymentConfirmedEvent를 발행하여 후속 도메인이 처리하도록 한다.")
+              + "성공 시 PaymentConfirmedEvent를 발행하여 후속 도메인이 처리하도록 한다.\n\n"
+              + "PG 승인 전에 예매가 아직 결제 가능한 상태(PENDING)인지 booking-service에 동기 확인한다(#490). "
+              + "그래서 다음 실패 응답이 나갈 수 있다.\n"
+              + "- `BOOKING_409_003`(만료된 예매) / `BOOKING_409_002`(취소·확정·환불 등 결제할 수 없는 상태)\n"
+              + "- `BOOKING_404_001`(존재하지 않는 예매)\n"
+              + "- `PAYMENT_503_003`(예매 정보 조회 실패) — **자동 재시도 대상이 아니다.** "
+              + "조회가 불가능한 동안은 결제를 통과시키지 않는 fail-closed 설계라, 재시도해도 같은 응답이 반복되며 "
+              + "요청당 스레드 점유만 늘어난다.")
   @PostMapping("/confirm")
   public ResponseEntity<ApiResponse<PaymentConfirmResponse>> confirm(
       @AuthenticationPrincipal CustomUserDetails user,

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/out/apiclient/BookingRestClient.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/out/apiclient/BookingRestClient.java
@@ -1,0 +1,131 @@
+package com.ticketrush.boundedcontext.payment.out.apiclient;
+
+import com.ticketrush.boundedcontext.payment.out.apiclient.dto.BookingApiResponse;
+import com.ticketrush.boundedcontext.payment.out.apiclient.dto.BookingInfoResponse;
+import com.ticketrush.global.config.CustomSecurityProperties;
+import com.ticketrush.global.exception.BusinessException;
+import com.ticketrush.global.status.ErrorStatus;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
+
+/**
+ * 결제 확정 경로에서 예매 상태를 판정하기 위해 booking-service를 동기 조회하는 클라이언트 (#490).
+ *
+ * <p>기존 만료 가드는 {@code expired_booking} 테이블에 의존했는데, 그 테이블은 {@code BookingExpiredEvent}가 outbox 릴레이를
+ * 두 홉(seat→booking, booking→payment) 타야 채워진다. 대량 만료 구간에서 그 전파가 밀리면(#345 실측 약 13분) 이미 만료된 예매의 PG 승인이
+ * 통과해 <b>과금은 됐는데 좌석이 확정되지 않는</b> 상태로 끝났다. 이 클라이언트는 그 판정을 이벤트 도착이 아니라 동기 조회로 바꿔, 되돌릴 수 없는 부작용(과금) 전에
+ * 결정적으로 막는 방어선을 만든다.
+ *
+ * <p><b>조회할 수 없으면 결제를 막는다(fail-closed).</b> 판정 불가한 응답은 모두 {@code
+ * PAYMENT_BOOKING_COMMUNICATION_FAILED}(503)로 수렴시킨다. 그 대가로 <b>booking-service 장애가 결제 확정 API의 전면
+ * 503으로 번진다</b>는 점을 분명히 해 둔다. 그럼에도 fail-closed인 이유는 셋이다.
+ *
+ * <ul>
+ *   <li>PG 승인은 되돌릴 수 없는 부작용(과금)이고, 그 뒤 좌석이 없을 때 자동으로 되돌리는 보상 경로는 아직 없다(#492).
+ *   <li>fail-open으로 통과시켜도 결과가 나아지지 않는다. booking-service가 죽으면 {@code PaymentConfirmedEvent}를 소비해 예매를
+ *       확정하고 좌석을 SOLD로 굳히는 주체 자체가 없어, 통과의 귀결이 이 이슈가 고치려는 바로 그 상태다.
+ *   <li>ADR 0008이 "가용성 손실이 정합성 손실보다 낫다"를 팀 결정으로 못박았고, 같은 축의 선례가 이미 둘이다 — payment의 {@code
+ *       TicketRestClient}, ticket-service의 동명 클라이언트.
+ * </ul>
+ *
+ * <p>서킷브레이커는 이번 범위에 넣지 않았다. ticket-service의 임계값은 그쪽 실측 왕복(#402, 3.20ms)에 맞춰 잡은 값이라 근거 없이 복사하면 오탐
+ * open이 나고, fail-closed와 겹치면 그 오탐이 곧 결제 전면 중단이 된다. payment→booking 경로의 부하 실측 뒤 후속 이슈로 다룬다. 그때까지 유일한
+ * 완화 수단은 짧은 read-timeout이다({@code service.booking.read-timeout-ms}).
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class BookingRestClient {
+
+  private static final String INTERNAL_TOKEN_HEADER = "X-Internal-Token";
+
+  private final RestClient bookingServiceRestClient;
+  private final CustomSecurityProperties customSecurityProperties;
+
+  /**
+   * 예매 정보를 booking-service에 동기 조회한다 (#490).
+   *
+   * <p>상태 문자열을 그대로 담은 DTO를 돌려줄 뿐 <b>결제 가능 여부를 판정하지 않는다</b>. 어떤 상태를 통과시킬지는 결제 정책이라 {@code
+   * PaymentConfirmUseCase}가 허용 목록으로 판정한다.
+   *
+   * <p>정상 반환하는 경로는 200 + {@code result}가 있는 경우 하나뿐이다. 나머지는 전부 예외로 끊는다.
+   *
+   * @throws BusinessException {@code BOOKING_NOT_FOUND}(404) — booking-service가 {@code
+   *     BOOKING_404_001}로 응답한 경우. 없는 예매로 결제를 진행시킬 수는 없으므로 이 역시 결제를 막는다.
+   * @throws BusinessException {@code PAYMENT_BOOKING_COMMUNICATION_FAILED}(503) — 그 밖의 모든 판정 불가 응답
+   */
+  public BookingInfoResponse getBooking(Long bookingId) {
+    BookingApiResponse response;
+    try {
+      response =
+          bookingServiceRestClient
+              .get()
+              .uri("/api/v1/internal/booking/{bookingId}", bookingId)
+              .header(INTERNAL_TOKEN_HEADER, customSecurityProperties.getInternalToken())
+              .retrieve()
+              .onStatus(
+                  status -> status.isError() && status.value() != 404,
+                  (request, clientResponse) -> {
+                    log.warn(
+                        "[BookingRestClient] booking-service 비정상 응답 status={}, bookingId={}",
+                        clientResponse.getStatusCode(),
+                        bookingId);
+                    throw new BusinessException(ErrorStatus.PAYMENT_BOOKING_COMMUNICATION_FAILED);
+                  })
+              .body(BookingApiResponse.class);
+    } catch (HttpClientErrorException.NotFound e) {
+      throw notFoundToBusinessException(e, bookingId);
+    } catch (RestClientException e) {
+      // 연결 실패·타임아웃(ResourceAccessException), 본문이 JSON이 아닌 경우(UnknownContentTypeException) 등
+      // 남은 통신 실패 전반. 하나라도 새어 나가면 사용자에게 원시 500이 노출되므로 여기서 모두 503으로 수렴시킨다.
+      log.warn("[BookingRestClient] booking-service 통신 실패 bookingId={}", bookingId, e);
+      throw new BusinessException(ErrorStatus.PAYMENT_BOOKING_COMMUNICATION_FAILED);
+    }
+
+    if (response == null || response.result() == null) {
+      log.warn(
+          "[BookingRestClient] booking-service 200 응답이나 result 본문이 비어 있음 bookingId={}", bookingId);
+      throw new BusinessException(ErrorStatus.PAYMENT_BOOKING_COMMUNICATION_FAILED);
+    }
+
+    return response.result();
+  }
+
+  /**
+   * booking-service가 의도적으로 낸 404(예매 없음)와 그 밖의 404를 가른다.
+   *
+   * <p>어느 쪽이든 결제는 막히므로 정합성은 같지만, 응답 코드를 갈라 두면 <b>설정 오류가 조용히 묻히지 않는다</b>. {@code
+   * BOOKING_SERVICE_URL}을 게이트웨이 주소로 잘못 넣으면 내부 경로가 라우팅되지 않아(ADR 0002) 모든 요청이 404가 되는데, 이를 도메인 404와
+   * 같이 취급하면 전건이 "예매를 찾을 수 없습니다"로 거절되면서 원인이 드러나지 않는다.
+   */
+  private BusinessException notFoundToBusinessException(
+      HttpClientErrorException.NotFound e, Long bookingId) {
+    String code = errorCodeOf(e);
+
+    if (ErrorStatus.BOOKING_NOT_FOUND.getCode().equals(code)) {
+      log.warn("[BookingRestClient] 존재하지 않는 예매입니다. bookingId={}", bookingId);
+      return new BusinessException(ErrorStatus.BOOKING_NOT_FOUND);
+    }
+
+    log.warn(
+        "[BookingRestClient] 예매 없음(BOOKING_404_001)이 아닌 404입니다. 경로·배포 설정을 확인하세요. "
+            + "bookingId={}, code={}",
+        bookingId,
+        code);
+    return new BusinessException(ErrorStatus.PAYMENT_BOOKING_COMMUNICATION_FAILED);
+  }
+
+  /** 에러 응답 본문에서 code를 꺼낸다. 본문이 없거나 파싱되지 않으면 null(= 의도된 404가 아님)로 본다. */
+  private String errorCodeOf(HttpClientErrorException.NotFound e) {
+    try {
+      BookingApiResponse body = e.getResponseBodyAs(BookingApiResponse.class);
+      return (body != null) ? body.code() : null;
+    } catch (RestClientException parseFailure) {
+      return null;
+    }
+  }
+}

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/out/apiclient/dto/BookingApiResponse.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/out/apiclient/dto/BookingApiResponse.java
@@ -1,0 +1,16 @@
+package com.ticketrush.boundedcontext.payment.out.apiclient.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * booking-service의 공통 ApiResponse 래퍼 중 payment-service가 사용하는 필드만 매핑한다.
+ *
+ * <p>{@code code}는 성공 응답뿐 아니라 <b>에러 응답 본문</b>에도 실린다. 404를 "예매 없음"으로 해석해도 되는지 가리는 데 쓴다 — 경로 오설정 등으로
+ * 발생한 404는 이 코드가 없거나 다르다.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record BookingApiResponse(
+    @JsonProperty("is_success") boolean isSuccess,
+    @JsonProperty("code") String code,
+    @JsonProperty("result") BookingInfoResponse result) {}

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/out/apiclient/dto/BookingInfoResponse.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/out/apiclient/dto/BookingInfoResponse.java
@@ -1,0 +1,20 @@
+package com.ticketrush.boundedcontext.payment.out.apiclient.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * booking-service internal 조회 API 응답의 result 본문(snake_case JSON)을 매핑한다.
+ *
+ * <p>{@code bookingStatus}는 booking-service {@code BookingStatus}의 이름이 문자열로 건너온 값이다. 어떤 상태에서 결제를
+ * 허용할지는 정책이므로 여기서 판정하지 않는다({@code PaymentConfirmUseCase}가 판정한다).
+ *
+ * <p>{@code userId}는 이번 범위에서 쓰지 않지만 매핑해 둔다. booking internal API는 소유자 검증 없이 bookingId만으로 조회하므로 대조는
+ * 호출자 몫인데, 그 가드는 만료 창과 원인·실패 모드가 다른 별개 결함이라 후속 이슈로 분리했다(#490). 필드를 미리 받아 두면 그때 클라이언트 변경 없이 가드만 추가하면
+ * 된다.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record BookingInfoResponse(
+    @JsonProperty("booking_id") Long bookingId,
+    @JsonProperty("user_id") Long userId,
+    @JsonProperty("booking_status") String bookingStatus) {}

--- a/payment-service/src/main/java/com/ticketrush/global/config/RestClientConfig.java
+++ b/payment-service/src/main/java/com/ticketrush/global/config/RestClientConfig.java
@@ -66,4 +66,27 @@ public class RestClientConfig {
         .requestFactory(RestClientFactorySupport.withTimeouts(connectTimeoutMs, readTimeoutMs))
         .build();
   }
+
+  /**
+   * 결제 확정 경로의 예매 상태 판정 전용 클라이언트 (#490). 단일 행 조회 하나라 ticket 클라이언트와 같은 짧은 예산을 쓴다.
+   *
+   * <p>URL이 비면 <b>기동을 실패시킨다.</b> {@code env_file}로 빈 값이 주입되면 변수는 "정의됨"이라 {@code
+   * ${BOOKING_SERVICE_URL:...}}의 기본값 대체가 일어나지 않는데, 이 클라이언트는 fail-closed라 그 상태가 곧 <b>결제 확정 전건
+   * 503</b>이 된다. 런타임에 조용히 새는 것보다 기동 시점에 드러나는 편이 낫다(toss 클라이언트와 같은 규율).
+   */
+  @Bean
+  public RestClient bookingServiceRestClient(
+      @Value("${service.booking.url:}") String bookingServiceUrl,
+      @Value("${service.booking.connect-timeout-ms:1000}") long connectTimeoutMs,
+      @Value("${service.booking.read-timeout-ms:1000}") long readTimeoutMs) {
+    if (!StringUtils.hasText(bookingServiceUrl)) {
+      throw new IllegalStateException(
+          "service.booking.url 이 비어있습니다. BOOKING_SERVICE_URL 환경변수를 "
+              + "booking-service '직접' 주소로 설정하세요(게이트웨이는 내부 API를 라우팅하지 않습니다).");
+    }
+    return RestClient.builder()
+        .baseUrl(bookingServiceUrl)
+        .requestFactory(RestClientFactorySupport.withTimeouts(connectTimeoutMs, readTimeoutMs))
+        .build();
+  }
 }

--- a/payment-service/src/main/resources/application-prod.yml
+++ b/payment-service/src/main/resources/application-prod.yml
@@ -20,6 +20,12 @@ service:
     # 반드시 ticket-service '직접' 주소를 주입한다 — 내부 API는 게이트웨이 미라우팅(#367)이라
     # 게이트웨이 주소로 오설정하면 404가 나 취소가 조용히 전건 503 거부된다.
     url: ${TICKET_SERVICE_URL}
+  booking:
+    # 결제 확정 전 예매 상태 동기 확인 대상 (#490). ticket과 같은 규율으로 기본값 없이 요구한다.
+    # base의 기본값(localhost:8084)이 prod에 남으면 컨테이너 자기 자신을 가리켜 연결이 거부되는데,
+    # 이 조회는 fail-closed라 그 상태가 곧 결제 확정 전건 503이 된다. 기동 시점에 드러나는 편이 낫다.
+    # 반드시 booking-service '직접' 주소를 주입한다 — 내부 API는 게이트웨이 미라우팅(ADR 0002)이다.
+    url: ${BOOKING_SERVICE_URL}
 
 custom:
   security:

--- a/payment-service/src/main/resources/application.yml
+++ b/payment-service/src/main/resources/application.yml
@@ -37,6 +37,17 @@ service:
     # ticket-service가 느려질 때 취소 요청이 톰캣 스레드를 오래 붙잡아 결제 경로까지 마르는 것을 막는다.
     connect-timeout-ms: ${TICKET_HTTP_CONNECT_TIMEOUT_MS:1000}
     read-timeout-ms: ${TICKET_HTTP_READ_TIMEOUT_MS:2000}
+  booking:
+    # 결제 확정 전 예매 상태 동기 확인 전용 (#490).
+    # ticket과 마찬가지로 내부 API(/api/v1/internal/booking/**)는 게이트웨이가 라우팅하지 않으므로
+    # (ADR 0002) booking-service '직접' 주소여야 한다. 게이트웨이 주소로 넣으면 라우트 없음 404가 나
+    # 예매 없음(BOOKING_404_001)이 아닌 404로 결제 확정이 전건 503 거부된다.
+    url: ${BOOKING_SERVICE_URL:http://localhost:8084}
+    # 단일 행 조회이므로 공용 예산(3s/10s)을 쓰지 않는다. read-timeout은 곧 톰캣 스레드의 최대 점유
+    # 시간이고, 이 조회는 fail-closed라 booking이 느려지면 결제 경로가 그대로 마른다. 1s 근거는
+    # ticket-service가 같은 엔드포인트에 쓰는 값과 그 근거인 #402 실측 왕복 3.20ms다.
+    connect-timeout-ms: ${BOOKING_HTTP_CONNECT_TIMEOUT_MS:1000}
+    read-timeout-ms: ${BOOKING_HTTP_READ_TIMEOUT_MS:1000}
 
 custom:
   global:

--- a/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentConfirmUseCaseTest.java
+++ b/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentConfirmUseCaseTest.java
@@ -16,10 +16,12 @@ import com.ticketrush.boundedcontext.payment.app.support.PaymentEventPublisher;
 import com.ticketrush.boundedcontext.payment.domain.entity.Payment;
 import com.ticketrush.boundedcontext.payment.domain.types.PaymentProvider;
 import com.ticketrush.boundedcontext.payment.domain.types.PaymentStatus;
+import com.ticketrush.boundedcontext.payment.out.apiclient.BookingRestClient;
 import com.ticketrush.boundedcontext.payment.out.apiclient.PaymentApprovalClientRouter;
 import com.ticketrush.boundedcontext.payment.out.apiclient.PaymentApprovalRequest;
 import com.ticketrush.boundedcontext.payment.out.apiclient.PaymentApprovalResponse;
 import com.ticketrush.boundedcontext.payment.out.apiclient.PgRejectionException;
+import com.ticketrush.boundedcontext.payment.out.apiclient.dto.BookingInfoResponse;
 import com.ticketrush.boundedcontext.payment.out.repository.ExpiredBookingRepository;
 import com.ticketrush.boundedcontext.payment.out.repository.PaymentRepository;
 import com.ticketrush.global.constants.MetricNames;
@@ -33,6 +35,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mapstruct.factory.Mappers;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InOrder;
@@ -47,6 +51,7 @@ class PaymentConfirmUseCaseTest {
   @Mock private PaymentApprovalClientRouter paymentApprovalClientRouter;
   @Mock private PaymentEventPublisher paymentEventPublisher;
   @Mock private ExpiredBookingRepository expiredBookingRepository;
+  @Mock private BookingRestClient bookingRestClient;
 
   @Spy private PaymentMapper paymentMapper = Mappers.getMapper(PaymentMapper.class);
 
@@ -62,15 +67,29 @@ class PaymentConfirmUseCaseTest {
             paymentApprovalClientRouter,
             paymentEventPublisher,
             expiredBookingRepository,
+            bookingRestClient,
             paymentMapper,
             meterRegistry);
+  }
+
+  /**
+   * PG 호출 앞의 선행 가드 둘(COMPLETED 중복·예매 상태 동기 확인)을 지정한 상태로 세운다.
+   *
+   * <p>{@code expired_booking} fast-path는 mock 기본값이 false라 따로 스텁하지 않는다 — 이벤트가 아직 도착하지 않아 fast-path가
+   * 통과하는 상황이 이 가드(#490)가 실제로 겨냥한 창이다.
+   */
+  private void givenPreConfirmGuards(Long bookingId, String bookingStatus) {
+    given(paymentRepository.existsByBookingIdAndStatus(bookingId, PaymentStatus.COMPLETED))
+        .willReturn(false);
+    given(bookingRestClient.getBooking(bookingId))
+        .willReturn(new BookingInfoResponse(bookingId, 10L, bookingStatus));
   }
 
   @Test
   @DisplayName("PG 승인 성공 시 Payment를 COMPLETED 상태로 저장하고 PaymentConfirmedEvent를 발행한다")
   void execute_success() throws Exception {
     // given
-    Long userId = 10L;
+    final Long userId = 10L;
     Long bookingId = 100L;
     Long seatId = 200L;
     Long amount = 55_000L;
@@ -78,11 +97,10 @@ class PaymentConfirmUseCaseTest {
     String approvalNumber = "APR-123";
     Long savedPaymentId = 999L;
     LocalDateTime approvedAt = LocalDateTime.of(2025, 1, 15, 10, 0);
-    PaymentConfirmRequest request =
+    final PaymentConfirmRequest request =
         new PaymentConfirmRequest(bookingId, seatId, PaymentProvider.TOSS, amount, paymentKey);
 
-    given(paymentRepository.existsByBookingIdAndStatus(bookingId, PaymentStatus.COMPLETED))
-        .willReturn(false);
+    givenPreConfirmGuards(bookingId, "PENDING");
     given(paymentApprovalClientRouter.approve(any()))
         .willReturn(new PaymentApprovalResponse(approvalNumber, amount, approvedAt));
     given(paymentRepository.saveAndFlush(any(Payment.class)))
@@ -167,8 +185,7 @@ class PaymentConfirmUseCaseTest {
         new PaymentConfirmRequest(
             bookingId, seatId, PaymentProvider.KAKAO, requestAmount, "pgKey_xyz");
 
-    given(paymentRepository.existsByBookingIdAndStatus(bookingId, PaymentStatus.COMPLETED))
-        .willReturn(false);
+    givenPreConfirmGuards(bookingId, "PENDING");
     given(paymentApprovalClientRouter.approve(any()))
         .willReturn(new PaymentApprovalResponse("APR-123", approvedAmount, LocalDateTime.now()));
 
@@ -192,8 +209,7 @@ class PaymentConfirmUseCaseTest {
     PaymentConfirmRequest request =
         new PaymentConfirmRequest(bookingId, 200L, PaymentProvider.TOSS, 55_000L, "pgKey_xyz");
 
-    given(paymentRepository.existsByBookingIdAndStatus(bookingId, PaymentStatus.COMPLETED))
-        .willReturn(false);
+    givenPreConfirmGuards(bookingId, "PENDING");
     given(paymentApprovalClientRouter.approve(any()))
         .willThrow(new BusinessException(ErrorStatus.PAYMENT_ALREADY_COMPLETED));
 
@@ -219,8 +235,7 @@ class PaymentConfirmUseCaseTest {
     PaymentConfirmRequest request =
         new PaymentConfirmRequest(bookingId, seatId, PaymentProvider.TOSS, amount, "pgKey_xyz");
 
-    given(paymentRepository.existsByBookingIdAndStatus(bookingId, PaymentStatus.COMPLETED))
-        .willReturn(false);
+    givenPreConfirmGuards(bookingId, "PENDING");
     given(paymentApprovalClientRouter.approve(any()))
         .willThrow(
             new PgRejectionException(
@@ -272,8 +287,7 @@ class PaymentConfirmUseCaseTest {
     PaymentConfirmRequest request =
         new PaymentConfirmRequest(bookingId, 200L, PaymentProvider.TOSS, 55_000L, "pgKey_xyz");
 
-    given(paymentRepository.existsByBookingIdAndStatus(bookingId, PaymentStatus.COMPLETED))
-        .willReturn(false);
+    givenPreConfirmGuards(bookingId, "PENDING");
     given(paymentApprovalClientRouter.approve(any()))
         .willThrow(new BusinessException(ErrorStatus.PAYMENT_LIMIT_EXCEEDED));
 
@@ -296,13 +310,12 @@ class PaymentConfirmUseCaseTest {
   @DisplayName("booking당 FAILED 이력이 상한에 도달하면 화이트리스트 실패라도 저장하지 않고 억제 메트릭만 남긴다(#333)")
   void execute_does_not_record_failed_when_cap_reached() {
     // given
-    Long userId = 10L;
+    final Long userId = 10L;
     Long bookingId = 100L;
-    PaymentConfirmRequest request =
+    final PaymentConfirmRequest request =
         new PaymentConfirmRequest(bookingId, 200L, PaymentProvider.TOSS, 55_000L, "pgKey_xyz");
 
-    given(paymentRepository.existsByBookingIdAndStatus(bookingId, PaymentStatus.COMPLETED))
-        .willReturn(false);
+    givenPreConfirmGuards(bookingId, "PENDING");
     given(paymentApprovalClientRouter.approve(any()))
         .willThrow(new BusinessException(ErrorStatus.PAYMENT_METHOD_REJECTED));
     // 이미 상한(5)만큼 FAILED 이력이 쌓여 있다.
@@ -332,13 +345,12 @@ class PaymentConfirmUseCaseTest {
   @DisplayName("booking당 FAILED 이력이 상한 직전(4건)이면 이번 실패는 저장되고 억제 메트릭은 증가하지 않는다(#333 경계)")
   void execute_records_failed_when_below_cap() {
     // given
-    Long userId = 10L;
+    final Long userId = 10L;
     Long bookingId = 100L;
-    PaymentConfirmRequest request =
+    final PaymentConfirmRequest request =
         new PaymentConfirmRequest(bookingId, 200L, PaymentProvider.TOSS, 55_000L, "pgKey_xyz");
 
-    given(paymentRepository.existsByBookingIdAndStatus(bookingId, PaymentStatus.COMPLETED))
-        .willReturn(false);
+    givenPreConfirmGuards(bookingId, "PENDING");
     given(paymentApprovalClientRouter.approve(any()))
         .willThrow(new BusinessException(ErrorStatus.PAYMENT_METHOD_REJECTED));
     // 상한(5) 직전인 4건 → 이번 실패는 5번째로 기록되어야 한다.
@@ -374,8 +386,7 @@ class PaymentConfirmUseCaseTest {
     PaymentConfirmRequest request =
         new PaymentConfirmRequest(bookingId, 200L, PaymentProvider.TOSS, 55_000L, "pgKey_xyz");
 
-    given(paymentRepository.existsByBookingIdAndStatus(bookingId, PaymentStatus.COMPLETED))
-        .willReturn(false);
+    givenPreConfirmGuards(bookingId, "PENDING");
     given(paymentApprovalClientRouter.approve(any()))
         .willThrow(new BusinessException(ErrorStatus.PAYMENT_PG_COMMUNICATION_FAILED));
 
@@ -412,10 +423,13 @@ class PaymentConfirmUseCaseTest {
     verify(paymentRepository, never()).saveAndFlush(any(Payment.class));
     verify(paymentEventPublisher, never())
         .publishConfirmed(any(), any(), any(), any(), any(), any());
+    // 첫 가드에서 끝나므로 booking-service까지 가지 않는다.
+    verify(bookingRestClient, never()).getBooking(any());
   }
 
   @Test
-  @DisplayName("만료된 booking이면 BOOKING_409_003 예외가 발생하고 PG 승인을 호출하지 않는다")
+  @DisplayName(
+      "expired_booking fast-path가 적중하면 BOOKING_409_003으로 막고 booking-service를 호출하지 않는다(#490 역할 구분)")
   void execute_fail_when_booking_expired() {
     // given
     Long userId = 10L;
@@ -437,6 +451,214 @@ class PaymentConfirmUseCaseTest {
     verify(paymentRepository, never()).saveAndFlush(any(Payment.class));
     verify(paymentEventPublisher, never())
         .publishConfirmed(any(), any(), any(), any(), any(), any());
+    // 로컬 조회로 이미 걸러진 건은 네트워크 왕복을 쓰지 않는다 — fast-path를 남겨 둔 이유다.
+    verify(bookingRestClient, never()).getBooking(any());
+  }
+
+  @Test
+  @DisplayName("동기 확인에서 EXPIRED면 BOOKING_409_003으로 막고 PG 승인을 호출하지 않는다(#490)")
+  void execute_fail_when_booking_status_expired() {
+    // given: 만료 이벤트가 아직 도착하지 않아 fast-path는 통과하는 상황
+    Long userId = 10L;
+    Long bookingId = 100L;
+    PaymentConfirmRequest request =
+        new PaymentConfirmRequest(bookingId, 200L, PaymentProvider.TOSS, 55_000L, "pgKey_xyz");
+
+    givenPreConfirmGuards(bookingId, "EXPIRED");
+
+    // when & then
+    assertThatThrownBy(() -> paymentConfirmUseCase.execute(userId, request))
+        .isInstanceOf(BusinessException.class)
+        .extracting("errorStatus")
+        .isEqualTo(ErrorStatus.BOOKING_EXPIRED);
+
+    verify(paymentApprovalClientRouter, never()).approve(any());
+    verify(paymentRepository, never()).saveAndFlush(any(Payment.class));
+    verify(paymentEventPublisher, never())
+        .publishConfirmed(any(), any(), any(), any(), any(), any());
+    assertThat(
+            meterRegistry
+                .counter(
+                    MetricNames.PAYMENT_CONFIRM_BOOKING_GUARD_BLOCKED,
+                    MetricNames.TAG_REASON,
+                    "EXPIRED")
+                .count())
+        .isEqualTo(1.0);
+  }
+
+  @Test
+  @DisplayName("사용자가 직접 취소한 CANCELED 예매도 막는다 — 차단 목록이었다면 샜을 경로다(#559)")
+  void execute_fail_when_booking_status_canceled() {
+    // given
+    Long userId = 10L;
+    Long bookingId = 100L;
+    PaymentConfirmRequest request =
+        new PaymentConfirmRequest(bookingId, 200L, PaymentProvider.TOSS, 55_000L, "pgKey_xyz");
+
+    givenPreConfirmGuards(bookingId, "CANCELED");
+
+    // when & then: 만료가 아니므로 "만료된 예매"가 아니라 "확정할 수 없는 예매 상태"로 답한다.
+    assertThatThrownBy(() -> paymentConfirmUseCase.execute(userId, request))
+        .isInstanceOf(BusinessException.class)
+        .extracting("errorStatus")
+        .isEqualTo(ErrorStatus.BOOKING_CONFIRM_NOT_ALLOWED);
+
+    verify(paymentApprovalClientRouter, never()).approve(any());
+    verify(paymentRepository, never()).saveAndFlush(any(Payment.class));
+    assertThat(
+            meterRegistry
+                .counter(
+                    MetricNames.PAYMENT_CONFIRM_BOOKING_GUARD_BLOCKED,
+                    MetricNames.TAG_REASON,
+                    "CANCELED")
+                .count())
+        .isEqualTo(1.0);
+  }
+
+  @ParameterizedTest(name = "bookingStatus={0}")
+  @ValueSource(strings = {"CONFIRMED", "REFUNDING", "REFUNDED"})
+  @DisplayName("PENDING이 아닌 나머지 상태는 모두 BOOKING_409_002로 막는다(허용 목록)")
+  void execute_fail_when_booking_status_not_pending(String bookingStatus) {
+    // given
+    Long userId = 10L;
+    Long bookingId = 100L;
+    PaymentConfirmRequest request =
+        new PaymentConfirmRequest(bookingId, 200L, PaymentProvider.TOSS, 55_000L, "pgKey_xyz");
+
+    givenPreConfirmGuards(bookingId, bookingStatus);
+
+    // when & then
+    assertThatThrownBy(() -> paymentConfirmUseCase.execute(userId, request))
+        .isInstanceOf(BusinessException.class)
+        .extracting("errorStatus")
+        .isEqualTo(ErrorStatus.BOOKING_CONFIRM_NOT_ALLOWED);
+
+    verify(paymentApprovalClientRouter, never()).approve(any());
+    verify(paymentRepository, never()).saveAndFlush(any(Payment.class));
+  }
+
+  @Test
+  @DisplayName("알 수 없는 상태 문자열도 막고 메트릭은 unknown으로 접는다 — booking이 상태를 늘려도 통과하지 않는다")
+  void execute_fail_when_booking_status_unknown() {
+    // given
+    Long userId = 10L;
+    Long bookingId = 100L;
+    PaymentConfirmRequest request =
+        new PaymentConfirmRequest(bookingId, 200L, PaymentProvider.TOSS, 55_000L, "pgKey_xyz");
+
+    givenPreConfirmGuards(bookingId, "SOMETHING_NEW");
+
+    // when & then
+    assertThatThrownBy(() -> paymentConfirmUseCase.execute(userId, request))
+        .isInstanceOf(BusinessException.class)
+        .extracting("errorStatus")
+        .isEqualTo(ErrorStatus.BOOKING_CONFIRM_NOT_ALLOWED);
+
+    verify(paymentApprovalClientRouter, never()).approve(any());
+    // 태그 카디널리티가 외부 문자열을 따라 늘지 않도록 알려지지 않은 값은 unknown으로 접는다.
+    assertThat(
+            meterRegistry
+                .counter(
+                    MetricNames.PAYMENT_CONFIRM_BOOKING_GUARD_BLOCKED,
+                    MetricNames.TAG_REASON,
+                    "unknown")
+                .count())
+        .isEqualTo(1.0);
+  }
+
+  @Test
+  @DisplayName("상태 문자열이 null이어도 409로 막는다 — 원시 500이 새면 fail-closed 계약이 깨진다")
+  void execute_fail_when_booking_status_null() {
+    // given: booking이 필드명을 바꾸거나 URL 오설정으로 다른 200 응답이 오면 상태가 조용히 null이 된다.
+    Long userId = 10L;
+    Long bookingId = 100L;
+    PaymentConfirmRequest request =
+        new PaymentConfirmRequest(bookingId, 200L, PaymentProvider.TOSS, 55_000L, "pgKey_xyz");
+
+    givenPreConfirmGuards(bookingId, null);
+
+    // when & then: NPE(500)가 아니라 BusinessException(409)이어야 한다.
+    assertThatThrownBy(() -> paymentConfirmUseCase.execute(userId, request))
+        .isInstanceOf(BusinessException.class)
+        .extracting("errorStatus")
+        .isEqualTo(ErrorStatus.BOOKING_CONFIRM_NOT_ALLOWED);
+
+    verify(paymentApprovalClientRouter, never()).approve(any());
+    assertThat(
+            meterRegistry
+                .counter(
+                    MetricNames.PAYMENT_CONFIRM_BOOKING_GUARD_BLOCKED,
+                    MetricNames.TAG_REASON,
+                    "unknown")
+                .count())
+        .isEqualTo(1.0);
+  }
+
+  @Test
+  @DisplayName("존재하지 않는 예매면 BOOKING_404_001이 그대로 전파되고 not_found로 집계된다")
+  void execute_fail_when_booking_not_found() {
+    // given
+    Long userId = 10L;
+    Long bookingId = 100L;
+    PaymentConfirmRequest request =
+        new PaymentConfirmRequest(bookingId, 200L, PaymentProvider.TOSS, 55_000L, "pgKey_xyz");
+
+    given(paymentRepository.existsByBookingIdAndStatus(bookingId, PaymentStatus.COMPLETED))
+        .willReturn(false);
+    given(bookingRestClient.getBooking(bookingId))
+        .willThrow(new BusinessException(ErrorStatus.BOOKING_NOT_FOUND));
+
+    // when & then
+    assertThatThrownBy(() -> paymentConfirmUseCase.execute(userId, request))
+        .isInstanceOf(BusinessException.class)
+        .extracting("errorStatus")
+        .isEqualTo(ErrorStatus.BOOKING_NOT_FOUND);
+
+    verify(paymentApprovalClientRouter, never()).approve(any());
+    assertThat(
+            meterRegistry
+                .counter(
+                    MetricNames.PAYMENT_CONFIRM_BOOKING_GUARD_BLOCKED,
+                    MetricNames.TAG_REASON,
+                    "not_found")
+                .count())
+        .isEqualTo(1.0);
+  }
+
+  @Test
+  @DisplayName("예매 조회가 실패하면(fail-closed) 503이 전파되고 PG 승인도 FAILED 이력도 남지 않는다")
+  void execute_fail_when_booking_lookup_failed() {
+    // given
+    Long userId = 10L;
+    Long bookingId = 100L;
+    PaymentConfirmRequest request =
+        new PaymentConfirmRequest(bookingId, 200L, PaymentProvider.TOSS, 55_000L, "pgKey_xyz");
+
+    given(paymentRepository.existsByBookingIdAndStatus(bookingId, PaymentStatus.COMPLETED))
+        .willReturn(false);
+    given(bookingRestClient.getBooking(bookingId))
+        .willThrow(new BusinessException(ErrorStatus.PAYMENT_BOOKING_COMMUNICATION_FAILED));
+
+    // when & then
+    assertThatThrownBy(() -> paymentConfirmUseCase.execute(userId, request))
+        .isInstanceOf(BusinessException.class)
+        .extracting("errorStatus")
+        .isEqualTo(ErrorStatus.PAYMENT_BOOKING_COMMUNICATION_FAILED);
+
+    verify(paymentApprovalClientRouter, never()).approve(any());
+    // 가드는 PG 호출 try 블록 밖이라 과금이 없고, 따라서 FAILED 이력 기록 경로를 타지 않는다.
+    verify(paymentRepository, never()).saveAndFlush(any(Payment.class));
+    verify(paymentEventPublisher, never())
+        .publishConfirmed(any(), any(), any(), any(), any(), any());
+    // 조회 실패로 막힌 건도 차단 카운터에 잡혀야 booking 장애 구간이 관측된다.
+    assertThat(
+            meterRegistry
+                .counter(
+                    MetricNames.PAYMENT_CONFIRM_BOOKING_GUARD_BLOCKED,
+                    MetricNames.TAG_REASON,
+                    "lookup_failed")
+                .count())
+        .isEqualTo(1.0);
   }
 
   @Test

--- a/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/out/apiclient/BookingRestClientTest.java
+++ b/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/out/apiclient/BookingRestClientTest.java
@@ -1,0 +1,304 @@
+package com.ticketrush.boundedcontext.payment.out.apiclient;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.header;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withServerError;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withStatus;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+import com.ticketrush.boundedcontext.payment.out.apiclient.dto.BookingInfoResponse;
+import com.ticketrush.global.config.CustomSecurityProperties;
+import com.ticketrush.global.exception.BusinessException;
+import com.ticketrush.global.status.ErrorStatus;
+import java.io.IOException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestClient;
+
+class BookingRestClientTest {
+
+  private static final String BASE_URL = "http://localhost:8084";
+  private static final String INTERNAL_TOKEN = "test-token";
+  private static final long BOOKING_ID = 100L;
+  private static final String REQUEST_URL = BASE_URL + "/api/v1/internal/booking/" + BOOKING_ID;
+
+  private MockRestServiceServer mockServer;
+  private BookingRestClient client;
+
+  @BeforeEach
+  void setUp() {
+    RestClient.Builder builder = RestClient.builder().baseUrl(BASE_URL);
+    mockServer = MockRestServiceServer.bindTo(builder).build();
+
+    CustomSecurityProperties customSecurityProperties = new CustomSecurityProperties();
+    customSecurityProperties.setInternalToken(INTERNAL_TOKEN);
+
+    client = new BookingRestClient(builder.build(), customSecurityProperties);
+  }
+
+  private static String successBody(String bookingStatus) {
+    return String.join(
+        "\n",
+        "{",
+        "  \"is_success\": true,",
+        "  \"code\": \"COMMON_200\",",
+        "  \"message\": \"성공입니다.\",",
+        "  \"result\": {",
+        "    \"booking_id\": 100,",
+        "    \"user_id\": 10,",
+        "    \"booking_status\": \"" + bookingStatus + "\"",
+        "  }",
+        "}");
+  }
+
+  /** booking-service가 예매 없음 시 내려주는 에러 본문(공통 ApiResponse 형식). */
+  private static String bookingNotFoundBody() {
+    return String.join(
+        "\n",
+        "{",
+        "  \"is_success\": false,",
+        "  \"code\": \"BOOKING_404_001\",",
+        "  \"message\": \"해당 예매를 찾을 수 없습니다.\"",
+        "}");
+  }
+
+  private void expectGetAndRespondWith(String bookingStatus) {
+    mockServer
+        .expect(requestTo(REQUEST_URL))
+        .andExpect(method(HttpMethod.GET))
+        .andExpect(header("X-Internal-Token", INTERNAL_TOKEN))
+        .andRespond(withSuccess(successBody(bookingStatus), MediaType.APPLICATION_JSON));
+  }
+
+  private void expectGetAndRespondWithStatus(HttpStatus status) {
+    mockServer
+        .expect(requestTo(REQUEST_URL))
+        .andExpect(method(HttpMethod.GET))
+        .andExpect(header("X-Internal-Token", INTERNAL_TOKEN))
+        .andRespond(withStatus(status));
+  }
+
+  @Test
+  @DisplayName("성공: PENDING 예매를 조회하고 X-Internal-Token을 전송한다")
+  void getBooking_returns_pending_booking() {
+    expectGetAndRespondWith("PENDING");
+
+    BookingInfoResponse result = client.getBooking(BOOKING_ID);
+
+    assertThat(result.bookingId()).isEqualTo(BOOKING_ID);
+    assertThat(result.userId()).isEqualTo(10L);
+    assertThat(result.bookingStatus()).isEqualTo("PENDING");
+
+    mockServer.verify();
+  }
+
+  @Test
+  @DisplayName("성공: EXPIRED 상태도 그대로 반환한다 — 결제 허용 여부 판정은 UseCase의 책임이다")
+  void getBooking_returns_expired_status_as_is() {
+    expectGetAndRespondWith("EXPIRED");
+
+    assertThat(client.getBooking(BOOKING_ID).bookingStatus()).isEqualTo("EXPIRED");
+
+    mockServer.verify();
+  }
+
+  @Test
+  @DisplayName("성공: CANCELED 상태도 그대로 반환한다")
+  void getBooking_returns_canceled_status_as_is() {
+    expectGetAndRespondWith("CANCELED");
+
+    assertThat(client.getBooking(BOOKING_ID).bookingStatus()).isEqualTo("CANCELED");
+
+    mockServer.verify();
+  }
+
+  @Test
+  @DisplayName("성공: 알 수 없는 상태 문자열도 클라이언트는 거르지 않는다 — 차단은 UseCase의 허용 목록이 한다")
+  void getBooking_returns_unknown_status_as_is() {
+    expectGetAndRespondWith("SOMETHING_NEW");
+
+    assertThat(client.getBooking(BOOKING_ID).bookingStatus()).isEqualTo("SOMETHING_NEW");
+
+    mockServer.verify();
+  }
+
+  @Test
+  @DisplayName("실패: BOOKING_404_001(예매 없음)은 BOOKING_NOT_FOUND로 전파한다")
+  void getBooking_maps_booking_not_found_code_to_booking_not_found() {
+    mockServer
+        .expect(requestTo(REQUEST_URL))
+        .andExpect(method(HttpMethod.GET))
+        .andExpect(header("X-Internal-Token", INTERNAL_TOKEN))
+        .andRespond(
+            withStatus(HttpStatus.NOT_FOUND)
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(bookingNotFoundBody()));
+
+    assertThatThrownBy(() -> client.getBooking(BOOKING_ID))
+        .isInstanceOf(BusinessException.class)
+        .hasFieldOrPropertyWithValue("errorStatus", ErrorStatus.BOOKING_NOT_FOUND);
+
+    mockServer.verify();
+  }
+
+  @Test
+  @DisplayName("실패: 본문 없는 404(경로·라우팅 오설정)는 예매 없음으로 해석하지 않는다 — 설정 오류가 묻히면 안 된다")
+  void getBooking_maps_404_without_body_to_communication_failed() {
+    expectGetAndRespondWithStatus(HttpStatus.NOT_FOUND);
+
+    assertThatThrownBy(() -> client.getBooking(BOOKING_ID))
+        .isInstanceOf(BusinessException.class)
+        .hasFieldOrPropertyWithValue(
+            "errorStatus", ErrorStatus.PAYMENT_BOOKING_COMMUNICATION_FAILED);
+
+    mockServer.verify();
+  }
+
+  @Test
+  @DisplayName("실패: 다른 code의 404도 예매 없음으로 해석하지 않는다")
+  void getBooking_maps_404_with_other_code_to_communication_failed() {
+    mockServer
+        .expect(requestTo(REQUEST_URL))
+        .andExpect(method(HttpMethod.GET))
+        .andExpect(header("X-Internal-Token", INTERNAL_TOKEN))
+        .andRespond(
+            withStatus(HttpStatus.NOT_FOUND)
+                .contentType(MediaType.APPLICATION_JSON)
+                .body("{\"is_success\": false, \"code\": \"COMMON_404\"}"));
+
+    assertThatThrownBy(() -> client.getBooking(BOOKING_ID))
+        .isInstanceOf(BusinessException.class)
+        .hasFieldOrPropertyWithValue(
+            "errorStatus", ErrorStatus.PAYMENT_BOOKING_COMMUNICATION_FAILED);
+
+    mockServer.verify();
+  }
+
+  @Test
+  @DisplayName("실패: 토큰 불일치(403)는 통신 실패로 매핑해 결제를 거부한다(조회 불가면 막는다)")
+  void getBooking_maps_403_to_communication_failed() {
+    expectGetAndRespondWithStatus(HttpStatus.FORBIDDEN);
+
+    assertThatThrownBy(() -> client.getBooking(BOOKING_ID))
+        .isInstanceOf(BusinessException.class)
+        .hasFieldOrPropertyWithValue(
+            "errorStatus", ErrorStatus.PAYMENT_BOOKING_COMMUNICATION_FAILED);
+
+    mockServer.verify();
+  }
+
+  @Test
+  @DisplayName("실패: booking-service 5xx는 통신 실패로 매핑한다")
+  void getBooking_maps_5xx_to_communication_failed() {
+    mockServer
+        .expect(requestTo(REQUEST_URL))
+        .andExpect(method(HttpMethod.GET))
+        .andExpect(header("X-Internal-Token", INTERNAL_TOKEN))
+        .andRespond(withServerError());
+
+    assertThatThrownBy(() -> client.getBooking(BOOKING_ID))
+        .isInstanceOf(BusinessException.class)
+        .hasFieldOrPropertyWithValue(
+            "errorStatus", ErrorStatus.PAYMENT_BOOKING_COMMUNICATION_FAILED);
+
+    mockServer.verify();
+  }
+
+  @Test
+  @DisplayName("실패: 200이지만 본문이 JSON이 아니면 원시 500이 아니라 통신 실패로 매핑한다")
+  void getBooking_maps_unparsable_body_to_communication_failed() {
+    mockServer
+        .expect(requestTo(REQUEST_URL))
+        .andExpect(method(HttpMethod.GET))
+        .andExpect(header("X-Internal-Token", INTERNAL_TOKEN))
+        .andRespond(withSuccess("<html>gateway error</html>", MediaType.TEXT_HTML));
+
+    assertThatThrownBy(() -> client.getBooking(BOOKING_ID))
+        .isInstanceOf(BusinessException.class)
+        .hasFieldOrPropertyWithValue(
+            "errorStatus", ErrorStatus.PAYMENT_BOOKING_COMMUNICATION_FAILED);
+
+    mockServer.verify();
+  }
+
+  @Test
+  @DisplayName("성공: booking_status 필드가 없으면 null로 매핑한다 — 판정은 UseCase가 하고 500으로 새지 않아야 한다")
+  void getBooking_maps_missing_status_field_to_null() {
+    String responseBody =
+        String.join(
+            "\n",
+            "{",
+            "  \"is_success\": true,",
+            "  \"code\": \"COMMON_200\",",
+            "  \"result\": {",
+            "    \"booking_id\": 100,",
+            "    \"user_id\": 10",
+            "  }",
+            "}");
+
+    mockServer
+        .expect(requestTo(REQUEST_URL))
+        .andExpect(method(HttpMethod.GET))
+        .andExpect(header("X-Internal-Token", INTERNAL_TOKEN))
+        .andRespond(withSuccess(responseBody, MediaType.APPLICATION_JSON));
+
+    assertThat(client.getBooking(BOOKING_ID).bookingStatus()).isNull();
+
+    mockServer.verify();
+  }
+
+  @Test
+  @DisplayName("실패: 연결 실패·타임아웃도 통신 실패로 매핑한다 — fail-closed가 가장 자주 타는 경로다")
+  void getBooking_maps_connection_failure_to_communication_failed() {
+    mockServer
+        .expect(requestTo(REQUEST_URL))
+        .andExpect(method(HttpMethod.GET))
+        .andExpect(header("X-Internal-Token", INTERNAL_TOKEN))
+        .andRespond(
+            request -> {
+              throw new IOException("connection refused");
+            });
+
+    assertThatThrownBy(() -> client.getBooking(BOOKING_ID))
+        .isInstanceOf(BusinessException.class)
+        .hasFieldOrPropertyWithValue(
+            "errorStatus", ErrorStatus.PAYMENT_BOOKING_COMMUNICATION_FAILED);
+
+    mockServer.verify();
+  }
+
+  @Test
+  @DisplayName("실패: 200이지만 result 본문이 비어 있으면 통신 실패로 매핑한다")
+  void getBooking_maps_empty_result_to_communication_failed() {
+    String responseBody =
+        String.join(
+            "\n",
+            "{",
+            "  \"is_success\": true,",
+            "  \"code\": \"COMMON_200\",",
+            "  \"message\": \"성공입니다.\",",
+            "  \"result\": null",
+            "}");
+
+    mockServer
+        .expect(requestTo(REQUEST_URL))
+        .andExpect(method(HttpMethod.GET))
+        .andExpect(header("X-Internal-Token", INTERNAL_TOKEN))
+        .andRespond(withSuccess(responseBody, MediaType.APPLICATION_JSON));
+
+    assertThatThrownBy(() -> client.getBooking(BOOKING_ID))
+        .isInstanceOf(BusinessException.class)
+        .hasFieldOrPropertyWithValue(
+            "errorStatus", ErrorStatus.PAYMENT_BOOKING_COMMUNICATION_FAILED);
+
+    mockServer.verify();
+  }
+}


### PR DESCRIPTION
## 🔗 관련 이슈

- close #490

---

## 📌 주요 변경 사항

- PG 승인 **전에** booking-service 내부 API로 예매 상태를 동기 확인하는 가드를 추가했습니다. `PENDING`일 때만 통과시키는 **허용 목록**입니다.
- 조회 불가는 모두 `PAYMENT_503_003`으로 수렴시킵니다(**fail-closed**). 근거와 그 대가를 `BookingRestClient` javadoc에 남겼습니다.
- `expired_booking` fast-path는 남기고, 두 가드의 역할 구분을 문서화했습니다.
- 차단 건수를 메트릭으로 관측합니다.
- **스키마 변경 없음** — 수동 DDL이 필요 없습니다.

---

## 🛠 상세 구현 내용

- **`BookingRestClient` 신설** — `GET /api/v1/internal/booking/{bookingId}`를 호출합니다. 정상 반환 경로는 "200 + `result` 있음" 하나뿐이고, `onStatus`(404 제외 에러) → 404 분기 → `RestClientException` → 본문 null 순으로 나머지를 전부 끊습니다.
- **404는 본문 `code`로 가릅니다.** `BOOKING_404_001`만 `BOOKING_NOT_FOUND`로 전파하고 그 외 404는 503 + warn으로 남깁니다. 어느 쪽이든 결제는 차단되지만, `BOOKING_SERVICE_URL`을 게이트웨이 주소로 오설정하면 내부 경로가 라우팅되지 않아(ADR 0002) 전건이 "예매 없음"으로 거절되면서 원인이 묻히기 때문입니다.
- **허용 목록 판정** — `PENDING`이 아니면 거부하고, 거절 사유만 상태에 따라 가릅니다(EXPIRED → `BOOKING_409_003`, 나머지 → `BOOKING_409_002`). 매핑 기본값이 거부라 booking이 `BookingStatus`에 값을 추가해도 payment는 컴파일 에러 없이 자동 차단합니다. 사유 코드는 `Booking.confirm()`의 도메인 규칙과 같은 언어를 씁니다 — 전부 `BOOKING_EXPIRED`로 뭉개면 사용자가 방금 직접 취소한 예매(#559)에도 "만료됐다"고 답하게 되어 CS 문의가 오진단됩니다.
- **가드는 PG 호출 try 블록 밖**에 둡니다. 과금이 일어나지 않은 차단이라 FAILED 이력(#297)을 남기지 않으며, 화이트리스트에도 없어 이중으로 안전합니다.
- **메트릭** `ticketrush.payment.confirm.booking_guard.blocked` — `reason` 태그는 상태 이름 / `unknown`(모르는 문자열·null) / `lookup_failed`·`not_found`(조회 단계 차단)입니다. 조회 실패까지 세지 않으면 booking 장애로 결제가 전건 거부되는 동안 카운터가 0으로 평평해져 장애가 관측되지 않습니다. 태그 값은 유한 집합으로 접어 카디널리티를 유계로 만듭니다.
- **설정** — `service.booking.*` 대상별 키(1000/1000, 근거는 ticket-service가 같은 엔드포인트에 쓰는 값과 #402 실측 왕복 3.20ms). prod는 기본값 없이 `${BOOKING_SERVICE_URL}`을 요구하고, 빈 값이면 기동을 실패시킵니다.
- **컨벤션 문서** — "모듈당 호출 대상이 1개이므로 공통 1쌍"이라는 전제가 이번에 깨져(payment의 호출 대상이 ticket·booking 2개), 대상이 2개 이상인 모듈은 대상별 키를 둔다는 단서를 추가했습니다.

---

## ✅ 테스트

### 테스트 방법

- `./gradlew :payment-service:spotlessApply` → `:common:checkstyleMain :payment-service:checkstyleMain :payment-service:checkstyleTest` → `:common:test :payment-service:test`
- Testcontainers 테스트가 있어 Docker를 기동한 상태에서 실행했습니다.

### 테스트 결과

- **`common` + `payment-service` 전체 302개 통과, 실패 0건**

- **`BookingRestClientTest` 13개 (신규)** — PENDING/EXPIRED/CANCELED/미지 문자열을 그대로 반환, `booking_status` 누락 시 null 매핑, `BOOKING_404_001` 404, 본문 없는 404, 다른 code의 404, 403, 5xx, 연결 실패, 비JSON 200, `result` null

- **`PaymentConfirmUseCaseTest` 21개 (기존 12 + 신규 9)**
  - 동기 확인에서 EXPIRED 차단
  - **CANCELED 차단 — #559 회귀 방지의 핵심 케이스**
  - CONFIRMED·REFUNDING·REFUNDED 파라미터화 차단
  - 미지 상태 문자열 차단(메트릭 `unknown`)
  - **상태가 null이어도 원시 500이 아니라 409** — fail-closed 계약 고정
  - `BOOKING_404_001` 전파(메트릭 `not_found`)
  - 조회 실패 시 503 전파 + PG 미호출 + FAILED 이력 미기록(메트릭 `lookup_failed`)
  - **fast-path 적중 시 booking-service를 호출하지 않음** — 두 가드의 역할 구분 고정

- `PaymentServiceApplicationTests`(전체 컨텍스트 로딩) 통과 — 새 빈이 기동을 깨지 않음을 확인했습니다.

---

## 👀 리뷰 요청 사항

- **fail-closed 선택**을 봐주세요. booking 장애가 결제 확정 전면 503으로 번지는 대가가 있습니다. 그럼에도 이 방향인 이유는 ①PG 승인은 되돌릴 수 없는 과금이고 자동 보상 경로가 아직 없으며(#492), ②fail-open으로 통과시켜도 booking이 죽으면 `PaymentConfirmedEvent`를 소비해 예매를 확정하고 좌석을 SOLD로 굳힐 주체가 없어 결과가 이 이슈가 고치려는 상태와 같고, ③ADR 0008이 "가용성 손실이 정합성 손실보다 낫다"를 팀 결정으로 두었기 때문입니다. 동의하시는지 궁금합니다.
- **서킷브레이커는 이번에 넣지 않았습니다.** ticket #496의 임계값은 그쪽 실측(왕복 3.20ms) 기반이라 근거 없이 복사하면 오탐 open이 나고, fail-closed와 겹치면 그 오탐이 곧 결제 전면 중단이 됩니다. payment→booking 경로의 부하 실측 뒤 후속 이슈로 다루려 합니다.
- **`expired_booking` fast-path를 남긴 판단**도 봐주세요. 로컬 조회라 왕복 비용이 없고 booking-service가 죽어 있어도 동작합니다.

---

## ⚠️ 배포 시 주의사항

### 1. `BOOKING_SERVICE_URL` 확인 필수

prod에서 기본값 없이 요구하도록 바꿨고, 빈 값이면 **payment-service 기동이 실패**합니다.

- ticket-service가 이미 같은 변수를 쓰고 있어 채워져 있을 가능성이 높지만, 배포 전 `grep BOOKING_SERVICE_URL deploy/.env`로 실측 확인이 필요합니다.
- 값은 `http://booking-service:8084` 형태의 **직접 주소**여야 합니다. 게이트웨이는 내부 API를 라우팅하지 않습니다(ADR 0002).
- 기동 실패를 택한 이유: base 기본값(`localhost:8084`)이 prod에 남으면 컨테이너 자기 자신을 가리켜 연결이 거부되는데, 이 조회는 fail-closed라 그 상태가 곧 **결제 확정 전건 503**이 됩니다. 런타임에 조용히 새는 것보다 기동 시점에 드러나는 편이 낫다고 판단했습니다.

### 2. 프론트 공지 대상 — confirm 응답 코드 추가

지금까지 `POST /api/v1/payment/confirm`의 실패 응답은 `PAYMENT_409_001`·`BOOKING_409_003` 둘뿐이었습니다. 아래가 새로 나갈 수 있습니다.

| 코드 | 상황 |
|---|---|
| `BOOKING_409_002` | 취소·확정·환불 등 결제할 수 없는 예매 상태 |
| `BOOKING_404_001` | 존재하지 않는 예매 |
| `PAYMENT_503_003` | 예매 정보 조회 실패 |

**`PAYMENT_503_003`은 자동 재시도 대상이 아닙니다.** 조회가 불가능한 동안은 결제를 통과시키지 않는 fail-closed 설계라, 재시도해도 같은 응답이 반복되며 요청당 스레드 점유만 늘어납니다. Swagger `@Operation` 설명에도 명시해 두었습니다.

정상 흐름(PENDING 예매의 결제)은 응답이 그대로이므로 영향이 없습니다.

### 3. 스키마

변경 없음 — 수동 DDL이 필요하지 않습니다.

---

## 후속 이슈 예정

1. payment→booking 동기 호출 서킷브레이커 도입 (부하 실측 근거로)
2. 결제 확정 시 예매 소유자 대조 누락 — 내부 API가 `user_id`를 주지만 대조하지 않습니다. DTO에는 필드를 미리 매핑해 두어 가드만 추가하면 됩니다.
3. `RestClientConfig` 빈 URL fail-fast 분기 테스트 (booking-service `RestClientConfigTest` 선례 있음)
