### PR TITLE
[Fix] #572 결제 확정 예매 소유자 대조 — 남의 예매로 결제가 귀속되던 결함 차단

### DIFF
--- a/common/src/main/java/com/ticketrush/global/constants/MetricNames.java
+++ b/common/src/main/java/com/ticketrush/global/constants/MetricNames.java
@@ -49,10 +49,12 @@ public class MetricNames {
   // 결제 확정 전 예매 상태 동기 확인이 PG 승인을 차단한 횟수(#490). 이 가드가 막는 건은 원래
   // "과금됐는데 좌석이 없는" 상태로 끝나던 것이라, 차단 건수가 곧 방지한 사고 건수다. 로그로는
   // 대량 만료 구간의 규모를 집계할 수 없어 이 카운터가 유일한 관측 축이다(서킷브레이커 미도입).
-  // reason 태그는 세 갈래이며 모두 유한 집합이다 — booking-service BookingStatus 이름(상태 때문에
+  // reason 태그는 네 갈래이며 모두 유한 집합이다 — booking-service BookingStatus 이름(상태 때문에
   // 막힌 건), unknown(모르는 상태 문자열·null), lookup_failed/not_found(상태 판정에 도달하지 못하고
-  // 조회 단계에서 막힌 건). 마지막 갈래를 함께 세지 않으면 booking 장애로 결제가 전건 거부되는
-  // 구간에서 이 카운터가 0으로 평평해 장애가 관측되지 않는다.
+  // 조회 단계에서 막힌 건), owner_mismatch/owner_unknown(소유자 대조에서 막힌 건, #572). 세 번째
+  // 갈래를 함께 세지 않으면 booking 장애로 결제가 전건 거부되는 구간에서 이 카운터가 0으로 평평해
+  // 장애가 관측되지 않는다. 네 번째 갈래는 응답이 "예매 없음"·"통신 실패"로 동일화돼 있어(#572)
+  // 이 태그가 소유자 차단을 구분하는 유일한 축이다.
   public static final String PAYMENT_CONFIRM_BOOKING_GUARD_BLOCKED =
       "ticketrush.payment.confirm.booking_guard.blocked";
 

--- a/docs/adr/0011-verify-booking-owner-at-caller.md
+++ b/docs/adr/0011-verify-booking-owner-at-caller.md
@@ -1,0 +1,56 @@
+# 11. 내부 API 응답의 소유자 대조는 호출자가 하고, 불일치는 존재를 숨기는 코드로 접는다
+
+날짜: 2026-08-04
+
+## 상태
+
+승인됨
+
+[ADR 0002](0002-external-internal-api-url-separation.md)가 정한 내부 API 경계를 전제로 한다. 그 ADR이 "누가 내부 API를 호출할 수 있는가"(경로·라우트·토큰)를 정했다면, 이 ADR은 "호출해서 받은 데이터가 요청자의 것인지 누가 확인하는가"를 정한다.
+
+## 맥락
+
+내부(서비스 간) API는 **식별자만으로 조회된다.** booking-service의 `BookingGetInternalUseCase.execute(Long bookingId)`는 `findById` 단독이고 소유자 파라미터 자체가 없다. 접근 통제는 `hasRole("INTERNAL")` + `X-Internal-Token`뿐이라, **내부 토큰을 가진 서비스는 임의의 `bookingId`를 조회할 수 있다.** 이는 결함이 아니라 의도된 설계다 — 내부 API는 신뢰 경계 안에서 여러 호출자에게 서비스하며, 어떤 호출자에게는 소유자 개념 자체가 없다(예: 이벤트 리스너의 보상 처리).
+
+문제는 그 결과 **소유자 검증의 책임이 어디에도 명시되지 않았다**는 것이다. payment-service의 결제 확정(`PaymentConfirmUseCase`)은 인증 주체의 `userId`를 인자로 받으면서도 그 값을 검증에 쓰지 않고 `Payment.userId`로 저장하기만 했다. 그래서 인증된 사용자가 남의 `bookingId`로 결제를 확정하면 **그 결제가 요청자 앞으로 귀속되고**(#572), 결제 취소·환불이 `Payment.userId` 기준으로 권한을 판단하므로 취소 권한까지 함께 넘어갔다.
+
+같은 선택이 이미 두 곳에서 각자 내려져 있었고, 문서는 없었다.
+
+- ticket-service `BookingRestClient`는 booking 404를 `TICKET_NOT_FOUND`로 통일한다 — "다른 사용자 예매의 존재 여부 노출을 막는다"고 javadoc에 적혀 있다.
+- payment-service는 `findByIdAndUserId(...).orElseThrow(PAYMENT_NOT_FOUND)`로 "남의 것 = 없는 것" 관례를 쓴다(`PaymentCancelUseCase`, `PaymentGetDetailUseCase`).
+
+즉 팀은 이미 같은 판단을 두 번 했지만, 세 번째 상황(#572)에서 그 판단을 다시 처음부터 해야 했다. 예매 ID가 순번에 가까운 이 시스템에서는 응답이 존재 여부를 구분해 주기만 해도 훑어서 열거할 수 있다는 점도 함께 고려됐다.
+
+## 결정
+
+**내부 API 응답의 소유자 대조는 호출자가 한다.** 내부 API에 소유자 파라미터를 추가하지 않는다 — 소유자 개념이 없는 호출자(이벤트 리스너 등)까지 그 계약을 지게 되고, 신뢰 경계 안의 API가 호출자별 권한 모델을 알아야 하는 역전이 생긴다.
+
+호출자는 사용자 요청 경로에서 아래를 지킨다.
+
+1. **소유자 대조를 다른 정책 판정보다 먼저 한다.** 상태·기한 같은 판정이 먼저 오면 남의 리소스에 그 판정 결과가 응답으로 나가 존재와 상태가 함께 샌다.
+2. **불일치는 "없음"과 같은 응답으로 접는다.** 결제 확정은 `BOOKING_NOT_FOUND`(404)를 쓴다. 전용 403을 만들면 "존재하지만 네 것이 아님"을 그대로 알려 주게 된다.
+3. **소유자를 판정할 수 없으면 "없음"이 아니라 "판정 불가"로 끊는다.** 응답에 소유자 필드가 null이면(계약 붕괴·배포 불일치) `PAYMENT_BOOKING_COMMUNICATION_FAILED`(503) + `log.error`로 처리한다. 이 경우를 404로 접으면 전건 실패가 "예매를 찾을 수 없습니다"로 나가 배포 사고가 데이터 문제로 오진단된다.
+4. **응답을 동일화한 대가는 로그와 메트릭으로 보전한다.** 차단 시 `bookingId`·요청자·소유자를 로그에 남기고, 차단 메트릭의 `reason` 태그를 사용자 오류(`owner_mismatch`)와 계약 결함(`owner_unknown`)으로 가른다. 합치면 배포 사고가 사용자 오류 시계열에 묻힌다.
+
+## 결과
+
+- 남의 예매로 결제가 귀속되는 경로가 PG 호출 **전에** 닫힌다. 과금이 일어나지 않으므로 보상(#492)도 필요 없다.
+- **응답만으로는 원인을 구분할 수 없다.** "남의 예매", "존재하지 않는 예매", "오타 `bookingId`"가 모두 404로 수렴한다. CS 진단은 전적으로 로그와 `reason` 태그에 의존하며, 이것이 열거 방어의 대가다.
+- **잔여 오라클이 남는다.** 결제 확정의 앞선 두 가드(로컬 DB만 보는 COMPLETED 중복 차단, 만료 fast-path)는 `bookingId`만으로 판정하므로, 남의 예매라도 이미 결제됐으면 `PAYMENT_ALREADY_COMPLETED`가, 만료 기록이 있으면 `BOOKING_EXPIRED`가 나간다. 소유자 대조를 그 앞으로 올리면 닫히지만, 그러면 중복·만료 요청에도 booking 왕복이 붙고 booking 장애 시 로컬로 끝나던 경로까지 503이 된다. **새는 것이 소유자 귀속 정보가 아니라 상태 2비트**라 이 비용을 치르지 않기로 했다. 이후 이 판단을 뒤집으려면 왕복 비용과 fail-closed 결합을 함께 재검토해야 한다.
+- **내부 API 응답 계약이 곧 보안 경계가 된다.** booking이 `user_id` 필드를 이름 변경·삭제하면 payment의 매핑이 `@JsonIgnoreProperties(ignoreUnknown = true)` 때문에 조용히 null이 되고, 결제 확정이 **전건 503**이 된다. 이를 잡는 계약 테스트는 없으며, 관측 축은 `owner_unknown` 메트릭과 그 분기의 `log.error` 두 가지다 — **알람은 메트릭에 걸되**, 로그 쪽은 전건 실패를 배포 직후 눈에 띄게 하는 역할이라 레벨을 낮추지 않는다.
+- **이 결정은 앞으로의 경로만 닫는다. 이미 잘못 귀속된 `payment` row는 스스로 풀리지 않는다.** 결함이 있던 기간에 만들어진 row가 남아 있으면, 진짜 소유자는 결제 확정의 COMPLETED 중복 가드에 걸려 영구히 `PAYMENT_ALREADY_COMPLETED`(409)로 막히고, 잘못 귀속받은 쪽은 `findByIdAndUserId` 기준의 취소·환불 권한을 계속 보유한다. 어느 쪽도 애플리케이션 경로로는 복구되지 않으므로, 배포와 별개로 `payment`와 `booking`의 `user_id`를 대조해 불일치 건수를 실측해야 한다. 0건이 아니면 복구는 별도 이슈가 된다.
+- **대리 결제·양도처럼 "결제자 ≠ 예매 소유자"인 기능이 생기면 이 결정이 그 기능을 막는다.** 현재 그런 경로는 없다. 그때는 이 ADR을 개정해 "소유자"를 "결제 권한 보유자"로 넓히는 편이, 가드를 예외 처리로 우회하는 것보다 낫다.
+
+### 결제 진입점 점검 결과 (#572 시점)
+
+`bookingId`를 외부 입력으로 받는 경로만 이 대조가 필요하다. 나머지는 조회 자체가 `userId` 복합 조건이라 구조적으로 안전하다.
+
+| 진입점 | 외부 `bookingId` 수용 | 소유자 검증 |
+|---|---|---|
+| `POST /api/v1/payment/confirm` | O | **이 ADR로 추가됨** |
+| confirm 멱등 fallback | O(내부 전달) | 위 가드 통과가 도달의 선행 조건 — `saveAndFlush`가 유일한 `DataIntegrityViolationException` 발생 지점이다 |
+| `POST /api/v1/payment/{paymentId}/cancel` | X | `findByIdAndUserId` |
+| `GET /api/v1/payment` | X | `findByUserIdAndStatus` |
+| `GET /api/v1/payment/{paymentId}` | X | `findByIdAndUserId` |
+| `POST /api/v1/payment/webhook` | X (`bookingId` 필드 없음) | PG 콜백이라 인증 주체 없음, 진위는 `paymentKey` 재조회로 검증 |
+| 이벤트 리스너 3종 | 내부 신뢰 경계 | 사용자 입력이 아니므로 대상 아님 |

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -16,6 +16,7 @@ TicketRush의 아키텍처 결정을 번호 매긴 Markdown으로 축적하는 �
 - [8. Redis 단일 인스턴스 SPOF를 수용하고, 장애 시 전면 차단(fail-closed)한다](0008-accept-redis-spof-with-fail-closed.md)
 - [9. 대기열을 게이트웨이 안의 모듈로 두고, 서버가 지시하는 폴링으로 1만 VU 유입을 제어한다](0009-virtual-waiting-room-with-server-directed-polling.md)
 - [10. 1만 VU 회차의 부하 생성기를 AWS 안의 임시 EC2로 옮긴다](0010-in-aws-load-generator-for-ten-thousand-vu.md)
+- [11. 내부 API 응답의 소유자 대조는 호출자가 하고, 불일치는 존재를 숨기는 코드로 접는다](0011-verify-booking-owner-at-caller.md)
 
 ## 사용법
 

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentConfirmUseCase.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentConfirmUseCase.java
@@ -11,6 +11,7 @@ import com.ticketrush.boundedcontext.payment.out.apiclient.PaymentApprovalClient
 import com.ticketrush.boundedcontext.payment.out.apiclient.PaymentApprovalRequest;
 import com.ticketrush.boundedcontext.payment.out.apiclient.PaymentApprovalResponse;
 import com.ticketrush.boundedcontext.payment.out.apiclient.PgRejectionException;
+import com.ticketrush.boundedcontext.payment.out.apiclient.dto.BookingInfoResponse;
 import com.ticketrush.boundedcontext.payment.out.repository.ExpiredBookingRepository;
 import com.ticketrush.boundedcontext.payment.out.repository.PaymentRepository;
 import com.ticketrush.global.constants.MetricNames;
@@ -54,6 +55,14 @@ import org.springframework.stereotype.Service;
  * <p>3번의 판정은 <b>허용 목록</b>이다 — {@code PENDING}만 통과시키고 나머지는 전부 막는다. 차단 목록(예: EXPIRED만 거부)으로 짜면 #559가
  * 추가한 사용자 PENDING 즉시 취소 경로(CANCELED)가 그대로 샌다. 기본이 거부라 booking이 상태를 추가해도 payment는 컴파일 에러 없이 자동으로
  * 막는다.
+ *
+ * <p><b>3번은 상태를 보기 전에 소유자를 먼저 대조한다 (#572).</b> 같은 왕복의 응답에 소유자가 이미 실려 오므로 비용이 늘지 않는다. 순서가 뒤집히면 남의
+ * EXPIRED 예매에 "만료된 예매"라고 답하게 되어 그 예매의 존재와 상태가 함께 새므로, 순서 자체가 계약이다({@link #assertBookingOwnedBy}).
+ *
+ * <p><b>다만 1·2번이 남기는 누출까지 닫지는 못한다.</b> 둘은 로컬 DB만 보고 {@code bookingId}만으로 판정하므로, 남의 예매라도 이미 결제됐으면
+ * {@code PAYMENT_ALREADY_COMPLETED}가, 만료 기록이 있으면 {@code BOOKING_EXPIRED}가 그대로 나간다. 소유자 대조를 이 둘보다
+ * 앞으로 올리면 닫히지만, 그러면 중복·만료 요청에도 booking 왕복이 붙고 booking이 죽어 있을 때 로컬로 끝나던 경로까지 503이 된다(위 "싼 것부터" 순서와
+ * 2번을 남긴 이유를 동시에 뒤집는다). 새는 것이 소유자 귀속 정보가 아니라 상태 2비트라 이 비용을 치르지 않는다 — ADR 0011 결과 절에 감수 사실로 남겼다.
  */
 @Slf4j
 @Service
@@ -121,6 +130,18 @@ public class PaymentConfirmUseCase {
 
   private static final String REASON_BOOKING_NOT_FOUND = "not_found";
 
+  /** 예매 소유자가 아닌 사용자의 결제 확정을 막은 건의 사유 태그 (#572). */
+  private static final String REASON_OWNER_MISMATCH = "owner_mismatch";
+
+  /**
+   * 예매 응답에 소유자가 없어 대조 자체가 불가능했던 건의 사유 태그 (#572).
+   *
+   * <p>{@code owner_mismatch}와 가르는 이유는 원인이 다르기 때문이다. 불일치는 사용자 요청의 문제지만, 소유자 없음은 booking이 {@code
+   * user_id}를 바꾸거나 지워 매핑이 끊긴 <b>우리 쪽 계약 결함</b>이고 그 순간 결제 확정이 전건 실패한다. 한 태그로 합치면 배포 사고가 사용자 오류 시계열에
+   * 묻힌다.
+   */
+  private static final String REASON_OWNER_UNKNOWN = "owner_unknown";
+
   private final PaymentRepository paymentRepository;
   private final PaymentApprovalClientRouter paymentApprovalClientRouter;
   private final PaymentEventPublisher paymentEventPublisher;
@@ -143,7 +164,7 @@ public class PaymentConfirmUseCase {
 
     // 이벤트 도착과 무관하게 '지금'의 예매 상태를 확인한다(결정적 방어선, #490).
     // 위 fast-path는 이벤트가 늦으면 통과시키는데, 대량 만료 구간에서 그 창이 분 단위임이 실측됐다(#345).
-    assertBookingIsPayable(request.bookingId());
+    assertBookingIsPayable(request.bookingId(), userId);
 
     String orderId = generateOrderId(request.bookingId());
 
@@ -217,6 +238,12 @@ public class PaymentConfirmUseCase {
    * <p>동시 confirm 요청이 unique 제약에 막혔을 때, 먼저 확정된 COMPLETED 결제를 돌려주기 위해 {@link
    * com.ticketrush.boundedcontext.payment.app.facade.PaymentFacade}의 멱등 fallback에서 호출한다. bookingId
    * 기준 조회는 paymentKey 충돌의 상위집합이라, 동일 paymentKey 재수신과 동일 booking·다른 paymentKey 충돌을 모두 흡수한다(#296).
+   *
+   * <p><b>{@code userId} 조건이 없어도 남의 결제가 새지 않는다 (#572).</b> 이 메서드는 {@code execute}가 {@code
+   * DataIntegrityViolationException}을 던졌을 때만 호출되는데, 그 예외가 밖으로 나올 수 있는 지점은 {@code saveAndFlush}
+   * 하나뿐이고({@link #recordFailedPayment}의 저장 실패는 그 안에서 삼켜진다) 거기에 도달하려면 {@link #assertBookingOwnedBy}를
+   * 이미 통과했어야 한다. 즉 <b>소유자 대조 통과가 이 경로의 선행 조건</b>이고, 그 불변식이 성립하는 한 {@code userId} 조건을 덧붙여도 조회 결과가
+   * 달라지지 않는다. 없어도 되는 조건이라 덧붙이지 않는 것이지 덧붙이면 위험해서가 아니다. 가드를 옮기거나 지우면 이 전제가 깨진다.
    */
   public PaymentConfirmResponse getConfirmedResponseByBookingId(Long bookingId) {
     Payment payment =
@@ -240,11 +267,14 @@ public class PaymentConfirmUseCase {
    * <p>조회 자체가 실패하면 {@link com.ticketrush.boundedcontext.payment.out.apiclient.BookingRestClient}가
    * 예외로 끊으므로 이 메서드는 통과시키지 않는다 (fail-closed 근거는 그 클래스 javadoc 참고). 그 예외는 PG 호출 try 블록 <b>밖</b>에서 나므로
    * {@link #recordFailedPayment} 경로를 타지 않는다 — 과금이 일어나지 않은 차단이라 FAILED 이력을 남길 이유가 없고, 화이트리스트에도 없다.
+   *
+   * <p>같은 응답으로 <b>소유자 대조를 먼저</b> 수행한다({@link #assertBookingOwnedBy}, #572). 상태 판정은 그 대조를 통과한 요청에만
+   * 도달하므로, 아래의 상태별 사유 코드는 "본인 예매"에 대해서만 노출된다.
    */
-  private void assertBookingIsPayable(Long bookingId) {
-    String bookingStatus;
+  private void assertBookingIsPayable(Long bookingId, Long userId) {
+    BookingInfoResponse booking;
     try {
-      bookingStatus = bookingRestClient.getBooking(bookingId).bookingStatus();
+      booking = bookingRestClient.getBooking(bookingId);
     } catch (BusinessException e) {
       // 조회 실패로 막힌 건도 이 가드가 차단한 건이다. 여기서 세지 않으면 booking이 느려지거나 죽은 구간에서
       // 결제가 전건 거부되는 동안 차단 카운터가 0으로 평평해, 서킷이 없는 지금 관측 축이 통째로 빈다.
@@ -255,6 +285,13 @@ public class PaymentConfirmUseCase {
       throw e;
     }
 
+    // 상태보다 소유자를 먼저 본다. 순서를 뒤집으면 남의 예매에도 상태별 사유가 나가 존재가 샌다(#572).
+    // 응답의 bookingId 에코는 대조하지 않는다 — 요청자가 조종할 수 없는 값이고, 경로 오설정이 만드는
+    // 404(BOOKING_404_001이 아닌 404)는 이미 BookingRestClient가 503으로 거른다. 검증 대상은
+    // "누구 것인가"뿐이다.
+    assertBookingOwnedBy(bookingId, booking.userId(), userId);
+
+    String bookingStatus = booking.bookingStatus();
     if (BOOKING_STATUS_PENDING.equals(bookingStatus)) {
       return;
     }
@@ -271,6 +308,48 @@ public class PaymentConfirmUseCase {
         bookingStatus);
 
     throw new BusinessException(errorStatus);
+  }
+
+  /**
+   * 예매 소유자와 결제를 요청한 인증 주체가 같은지 대조한다 (#572).
+   *
+   * <p>booking internal API는 소유자 검증 없이 {@code bookingId}만으로 조회되므로({@code
+   * BookingGetInternalUseCase}) 대조는 호출자인 payment 몫이다. 이 가드가 없으면 남의 예매로 확정한 결제가 요청자 앞으로 귀속되고, 그 결제의
+   * 취소 권한까지 함께 넘어간다.
+   *
+   * <p><b>불일치를 {@code BOOKING_NOT_FOUND}로 접는다.</b> "당신 예매가 아니다"라고 답하면 그 {@code bookingId}가 존재한다는
+   * 사실이 응답으로 새고, 예매 ID가 순번에 가까운 이 시스템에서는 훑기만 해도 타인의 예매 존재를 열거할 수 있다. 없는 예매와 같은 답으로 수렴시켜 그 차이를 지운다 —
+   * payment가 이미 쓰는 관례({@code findByIdAndUserId} → {@code PAYMENT_NOT_FOUND})와 ticket-service의 404
+   * 통일 선례를 따른다. 응답으로 원인을 가릴 수 없게 되므로 진단은 아래 로그와 {@code reason} 태그가 맡는다. 근거는 ADR 0011.
+   *
+   * <p><b>소유자가 없으면 503으로 끊는다.</b> booking의 {@code user_id}는 {@code nullable = false}라 정상 경로에서 null이
+   * 될 수 없다. null이 왔다면 booking이 필드를 바꿔 매핑이 끊긴 것이고({@code @JsonIgnoreProperties(ignoreUnknown =
+   * true)}라 조용히 null이 된다) 그 순간 결제 확정은 전건 실패한다. 이를 404로 접으면 전건이 "예매를 찾을 수 없습니다"로 나가 배포 사고가 예매 데이터
+   * 문제로 오진단되므로, 판정 불가는 판정 불가대로 보이게 한다({@code BookingRestClient}의 fail-closed 수렴 규칙과 같은 축).
+   */
+  private void assertBookingOwnedBy(Long bookingId, Long ownerId, Long requesterId) {
+    if (ownerId == null) {
+      incrementGuardBlocked(REASON_OWNER_UNKNOWN);
+      // FAILED 이력 억제(아래 recordFailedPayment)는 같은 반복을 debug로 낮췄지만 여기는 error를 유지한다.
+      // 그쪽은 정상 운영 중 사용자 재시도로 반복되는 것이라 억제해도 메트릭이 남지만, 이 조건은 배포 직후
+      // 전건이 무너진 상태라 즉시 롤백 판단이 필요하다. 로그가 쌓이는 것 자체가 그 신호다.
+      log.error(
+          "예매 응답에 소유자가 없어 결제 확정을 차단합니다. booking 응답 계약 확인이 필요합니다. bookingId={}, requesterId={}",
+          bookingId,
+          requesterId);
+      throw new BusinessException(ErrorStatus.PAYMENT_BOOKING_COMMUNICATION_FAILED);
+    }
+
+    if (!ownerId.equals(requesterId)) {
+      incrementGuardBlocked(REASON_OWNER_MISMATCH);
+      // 응답을 "예매 없음"으로 동일화했으므로, 실제 원인을 아는 경로는 이 로그뿐이다(CS 진단용).
+      log.warn(
+          "예매 소유자가 아니라 PG 승인 전에 차단합니다. bookingId={}, requesterId={}, ownerId={}",
+          bookingId,
+          requesterId,
+          ownerId);
+      throw new BusinessException(ErrorStatus.BOOKING_NOT_FOUND);
+    }
   }
 
   private void incrementGuardBlocked(String reason) {

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/out/apiclient/dto/BookingInfoResponse.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/out/apiclient/dto/BookingInfoResponse.java
@@ -9,9 +9,12 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  * <p>{@code bookingStatus}는 booking-service {@code BookingStatus}의 이름이 문자열로 건너온 값이다. 어떤 상태에서 결제를
  * 허용할지는 정책이므로 여기서 판정하지 않는다({@code PaymentConfirmUseCase}가 판정한다).
  *
- * <p>{@code userId}는 이번 범위에서 쓰지 않지만 매핑해 둔다. booking internal API는 소유자 검증 없이 bookingId만으로 조회하므로 대조는
- * 호출자 몫인데, 그 가드는 만료 창과 원인·실패 모드가 다른 별개 결함이라 후속 이슈로 분리했다(#490). 필드를 미리 받아 두면 그때 클라이언트 변경 없이 가드만 추가하면
- * 된다.
+ * <p>{@code userId}는 예매 소유자다. booking internal API는 소유자 검증 없이 bookingId만으로 조회하므로 대조는 호출자 몫이며,
+ * {@code PaymentConfirmUseCase}가 결제 확정 요청자와 이 값을 대조해 남의 예매로의 결제 귀속을 막는다(#572, ADR 0011). #490에서 필드만
+ * 먼저 매핑해 둔 덕에 클라이언트 변경 없이 가드만 추가됐다.
+ *
+ * <p>세 필드 모두 박스 타입이라 null이 될 수 있다. 특히 {@code @JsonIgnoreProperties(ignoreUnknown = true)}라 booking이
+ * 필드명을 바꾸면 예외 대신 조용히 null이 되므로, 판정하는 쪽이 null을 "통과"가 아니라 "판정 불가"로 다뤄야 한다.
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public record BookingInfoResponse(

--- a/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentConfirmUseCaseTest.java
+++ b/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentConfirmUseCaseTest.java
@@ -47,6 +47,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class PaymentConfirmUseCaseTest {
 
+  /** 픽스처가 세우는 예매의 소유자. 모든 기존 케이스가 이 값으로 결제를 요청한다. */
+  private static final Long DEFAULT_OWNER_ID = 10L;
+
   @Mock private PaymentRepository paymentRepository;
   @Mock private PaymentApprovalClientRouter paymentApprovalClientRouter;
   @Mock private PaymentEventPublisher paymentEventPublisher;
@@ -79,10 +82,26 @@ class PaymentConfirmUseCaseTest {
    * 통과하는 상황이 이 가드(#490)가 실제로 겨냥한 창이다.
    */
   private void givenPreConfirmGuards(Long bookingId, String bookingStatus) {
+    givenPreConfirmGuards(bookingId, DEFAULT_OWNER_ID, bookingStatus);
+  }
+
+  /**
+   * 예매 소유자까지 지정해야 하는 케이스(#572)를 위한 오버로드.
+   *
+   * <p>기본 오버로드는 소유자를 {@link #DEFAULT_OWNER_ID}로 고정하고 모든 기존 케이스가 그 값으로 요청하므로, 소유자 가드는 기존 케이스의 판정에
+   * 영향을 주지 않는다.
+   */
+  private void givenPreConfirmGuards(Long bookingId, Long ownerUserId, String bookingStatus) {
     given(paymentRepository.existsByBookingIdAndStatus(bookingId, PaymentStatus.COMPLETED))
         .willReturn(false);
     given(bookingRestClient.getBooking(bookingId))
-        .willReturn(new BookingInfoResponse(bookingId, 10L, bookingStatus));
+        .willReturn(new BookingInfoResponse(bookingId, ownerUserId, bookingStatus));
+  }
+
+  private double guardBlockedCount(String reason) {
+    return meterRegistry
+        .counter(MetricNames.PAYMENT_CONFIRM_BOOKING_GUARD_BLOCKED, MetricNames.TAG_REASON, reason)
+        .count();
   }
 
   @Test
@@ -659,6 +678,79 @@ class PaymentConfirmUseCaseTest {
                     "lookup_failed")
                 .count())
         .isEqualTo(1.0);
+  }
+
+  @Test
+  @DisplayName("예매 소유자가 아니면 BOOKING_404_001로 막고 PG 승인·저장·이벤트가 모두 없다")
+  void execute_fail_when_booking_owner_mismatch() {
+    // given: 인증 주체(99L)와 예매 소유자(10L)가 다르다. 상태는 정상(PENDING)이라 소유자 가드만이 이 요청을 막는다.
+    Long requesterId = 99L;
+    Long bookingId = 100L;
+    PaymentConfirmRequest request =
+        new PaymentConfirmRequest(bookingId, 200L, PaymentProvider.TOSS, 55_000L, "pgKey_xyz");
+
+    givenPreConfirmGuards(bookingId, DEFAULT_OWNER_ID, "PENDING");
+
+    // when & then: 남의 예매 존재가 새지 않도록 "없는 예매"와 같은 응답으로 수렴한다.
+    assertThatThrownBy(() -> paymentConfirmUseCase.execute(requesterId, request))
+        .isInstanceOf(BusinessException.class)
+        .extracting("errorStatus")
+        .isEqualTo(ErrorStatus.BOOKING_NOT_FOUND);
+
+    // 과금·귀속이 시작조차 되지 않아야 한다. 하나라도 새면 이 이슈가 막으려던 결과가 그대로 만들어진다.
+    verify(paymentApprovalClientRouter, never()).approve(any());
+    verify(paymentRepository, never()).saveAndFlush(any(Payment.class));
+    verify(paymentEventPublisher, never())
+        .publishConfirmed(any(), any(), any(), any(), any(), any());
+    // 응답이 "예매 없음"으로 동일화됐으므로 소유자 차단을 구분하는 축은 이 태그뿐이다.
+    assertThat(guardBlockedCount("owner_mismatch")).isEqualTo(1.0);
+  }
+
+  @Test
+  @DisplayName("남의 예매가 EXPIRED여도 404로 막는다 — 상태를 먼저 보면 예매의 존재와 상태가 함께 샌다")
+  void execute_fail_when_owner_mismatch_precedes_status_check() {
+    // given: 소유자도 다르고 상태도 결제 불가(EXPIRED)라, 어느 가드가 먼저 끊는지가 응답으로 드러난다.
+    Long requesterId = 99L;
+    Long bookingId = 100L;
+    PaymentConfirmRequest request =
+        new PaymentConfirmRequest(bookingId, 200L, PaymentProvider.TOSS, 55_000L, "pgKey_xyz");
+
+    givenPreConfirmGuards(bookingId, DEFAULT_OWNER_ID, "EXPIRED");
+
+    // when & then: BOOKING_EXPIRED("만료된 예매입니다")가 나가면 남의 예매가 존재하고 만료됐다는 사실이 새어 나간다.
+    assertThatThrownBy(() -> paymentConfirmUseCase.execute(requesterId, request))
+        .isInstanceOf(BusinessException.class)
+        .extracting("errorStatus")
+        .isEqualTo(ErrorStatus.BOOKING_NOT_FOUND);
+
+    verify(paymentApprovalClientRouter, never()).approve(any());
+    // 상태 갈래로는 세지 않는다 — 소유자 대조가 먼저 끊었기 때문이다. 순서가 뒤집히면 이 단언이 깨진다.
+    assertThat(guardBlockedCount("EXPIRED")).isEqualTo(0.0);
+    assertThat(guardBlockedCount("owner_mismatch")).isEqualTo(1.0);
+  }
+
+  @Test
+  @DisplayName("예매 응답에 소유자가 없으면 503으로 끊는다 — 계약 결함을 '예매 없음'으로 감추지 않는다")
+  void execute_fail_when_booking_owner_unknown() {
+    // given: booking이 user_id 필드를 바꾸거나 지우면 ignoreUnknown 매핑이라 예외 없이 조용히 null이 된다.
+    Long requesterId = 99L;
+    Long bookingId = 100L;
+    PaymentConfirmRequest request =
+        new PaymentConfirmRequest(bookingId, 200L, PaymentProvider.TOSS, 55_000L, "pgKey_xyz");
+
+    givenPreConfirmGuards(bookingId, null, "PENDING");
+
+    // when & then: 대조가 불가능한 것이지 예매가 없는 게 아니다. 404로 접으면 전건 실패가 예매 데이터 문제로 오진단된다.
+    assertThatThrownBy(() -> paymentConfirmUseCase.execute(requesterId, request))
+        .isInstanceOf(BusinessException.class)
+        .extracting("errorStatus")
+        .isEqualTo(ErrorStatus.PAYMENT_BOOKING_COMMUNICATION_FAILED);
+
+    verify(paymentApprovalClientRouter, never()).approve(any());
+    verify(paymentRepository, never()).saveAndFlush(any(Payment.class));
+    // 사용자 오류(owner_mismatch)와 갈라 세야 배포 사고가 사용자 오류 시계열에 묻히지 않는다.
+    assertThat(guardBlockedCount("owner_unknown")).isEqualTo(1.0);
+    assertThat(guardBlockedCount("owner_mismatch")).isEqualTo(0.0);
   }
 
   @Test


### PR DESCRIPTION
## 🔗 관련 이슈

- close #572

---

## 📌 주요 변경 사항

- 결제 확정(`POST /api/v1/payment/confirm`)에 **예매 소유자 대조**를 추가해, 남의 `bookingId`로 확정한 결제가 요청자 앞으로 귀속되던 결함을 PG 호출 전에 막는다.
- 대조는 **상태 판정보다 먼저** 수행한다. 순서 자체가 계약이며 테스트로 고정했다.
- 불일치는 `BOOKING_NOT_FOUND`(404)로 접어 예매 존재를 숨기고, 소유자를 판정할 수 없으면 503으로 끊는다.
- 차단 사유 메트릭을 `owner_mismatch`(사용자 오류) / `owner_unknown`(계약 결함)으로 분리한다.
- 소유자 대조 책임과 응답 수위 결정을 **ADR 0011**로 남긴다.

---

## 🛠 상세 구현 내용

**대조 지점** — `PaymentConfirmUseCase.assertBookingIsPayable`이 이미 하고 있던 booking 동기 조회(#490)의 응답에 소유자가 실려 오므로 **추가 왕복이 없다**. 기존에 `.bookingStatus()`만 꺼내던 것을 DTO 통째로 받아 소유자를 먼저 대조한다.

**순서를 소유자 우선으로 둔 이유** — 상태를 먼저 보면 남의 EXPIRED 예매에 "만료된 예매입니다"라고 답하게 되어 그 예매의 **존재와 상태가 함께 샌다**. 예매 ID가 순번에 가까워 훑기만 해도 열거가 가능하다.

**불일치를 404로 접은 이유** — "당신 예매가 아니다"라고 답하면 존재가 그대로 새어 나간다. ticket-service가 404를 `TICKET_NOT_FOUND`로 통일한 선례와, payment가 이미 쓰는 `findByIdAndUserId` → `PAYMENT_NOT_FOUND` 관례를 따랐다. 응답으로 원인을 가릴 수 없게 되므로 진단은 `log.warn(bookingId, requesterId, ownerId)`와 `reason` 태그가 맡는다.

**소유자 null을 503으로 끊은 이유** — booking의 `user_id`는 `nullable = false`라 정상 경로에서 null이 될 수 없다. null이면 booking이 필드를 바꿔 매핑이 끊긴 것이고(`@JsonIgnoreProperties(ignoreUnknown = true)`라 조용히 null이 된다) 그 순간 결제 확정이 **전건 실패**한다. 404로 접으면 배포 사고가 "예매 데이터 문제"로 오진단되므로 판정 불가는 판정 불가대로 보이게 했다.

**멱등 fallback에 `userId` 조건을 넣지 않은 이유** — `getConfirmedResponseByBookingId`는 `DataIntegrityViolationException`일 때만 호출되고, 그 예외가 `execute` 밖으로 나올 수 있는 지점은 `saveAndFlush` 하나뿐이며(`recordFailedPayment`의 저장 실패는 내부에서 삼켜진다) 거기 도달하려면 소유자 대조를 이미 통과했어야 한다. 불변식이 성립하는 한 조건을 붙여도 결과가 같아 붙이지 않았고, 그 전제를 javadoc에 고정했다.

**감수한 것** — 앞선 두 가드(COMPLETED 중복 차단, 만료 fast-path)는 로컬 DB만 보고 `bookingId`만으로 판정하므로, 남의 예매라도 이미 결제됐으면 `PAYMENT_ALREADY_COMPLETED`가, 만료 기록이 있으면 `BOOKING_EXPIRED`가 나간다. 대조를 그 앞으로 올리면 닫히지만 중복·만료 요청에도 booking 왕복이 붙고 booking 장애 시 로컬로 끝나던 경로까지 503이 된다. 새는 것이 소유자 귀속 정보가 아니라 **상태 2비트**라 이 비용을 치르지 않았다.

**진입점 점검(완료 조건 3)** — `bookingId`를 외부 입력으로 받는 경로는 confirm뿐이다. 취소·목록·상세는 `paymentId + userId` 복합 조회라 구조적으로 안전하고, 웹훅은 `bookingId` 필드 자체가 없으며, 이벤트 리스너 3종은 신뢰 경계 안이다. 표는 ADR 0011에 있다.

---

## ✅ 테스트

### 테스트 방법

- `./gradlew test` (전체 모듈 — `common`의 `MetricNames` 주석이 변경돼 승격)
- `./gradlew spotlessApply checkstyleMain checkstyleTest compileJava :payment-service:test`
- `PaymentConfirmUseCaseTest`에 추가한 케이스 3건
  - `예매 소유자가 아니면 BOOKING_404_001로 막고 PG 승인·저장·이벤트가 모두 없다`
  - `남의 예매가 EXPIRED여도 404로 막는다 — 상태를 먼저 보면 예매의 존재와 상태가 함께 샌다`
  - `예매 응답에 소유자가 없으면 503으로 끊는다 — 계약 결함을 '예매 없음'으로 감추지 않는다`

### 테스트 결과

- **전체 `./gradlew test` BUILD SUCCESSFUL** (2분 50초, Docker 기동 상태에서 Testcontainers 포함 전 모듈 통과)
- `PaymentConfirmUseCaseTest`: **24개 전부 통과** (기존 21 + 신규 3, failures 0)
- 기존 #490 가드 케이스 8건 무회귀 — 픽스처에 소유자 오버로드를 더하고 기존 2인자 호출은 기본 소유자로 위임해, 기존 케이스는 한 줄도 수정하지 않았다
- checkstyle·spotless 위반 0건

<!--
### 📸 스크린샷
백엔드 로직 변경이라 UI 스크린샷 없음. 필요 시 주석을 풀고 추가.
-->

---

## 👀 리뷰 요청 사항

- **잔여 누출을 감수한 판단**을 봐주시기 바랍니다. 앞선 두 가드가 "결제됨 / 만료됨" 2비트를 남기는데, 이를 닫는 비용(중복·만료 요청마다 booking 왕복 + booking 장애 시 503 확대)이 이득보다 크다고 봤습니다. 이견이 있으면 지적해 주시기 바랍니다.
- **소유자 null을 404가 아니라 503으로 끊은 선택**에 대한 판단을 부탁드립니다. 사용자 계약을 단일화하는 쪽(404)과, 계약 결함을 감추지 않는 쪽(503)의 트레이드오프입니다.
- **멱등 fallback에 `userId` 조건을 넣지 않은 논증**이 성립하는지 확인이 필요합니다. `DataIntegrityViolationException`의 발생 지점이 정말 `saveAndFlush` 하나뿐인지가 전제입니다.
- ADR 0011의 결정이 payment 국소가 아니라 **다른 서비스에도 적용할 규칙**으로 적절한지 의견을 부탁드립니다.

---

## ⚠️ 배포 시 주의사항

- **신규 에러 코드 없음**(breaking change 아님). 다만 기존 코드의 **발생 조건이 넓어진다** — 남의 `bookingId`·오타도 `404 BOOKING_404_001`, booking 응답 계약 붕괴 시 `503 PAYMENT_503_003`. #490 공지에 이어 프론트에 한 줄 전달이 필요하다.
- **`owner_unknown` 메트릭을 알람에 등록해야 한다.** 이 값이 0이 아니면 booking 응답 계약이 깨져 결제 확정이 전건 실패 중이라는 뜻이고, 즉시 롤백 대상이다.
- **이미 잘못 귀속된 `payment` row 실측이 필요하다.** 이 수정은 앞으로의 경로만 닫는다. 결함 기간에 만들어진 row가 있으면 진짜 소유자는 `PAYMENT_ALREADY_COMPLETED`(409)로 영구 차단되고 잘못 귀속받은 쪽은 취소·환불 권한을 유지하며, 애플리케이션 경로로는 복구되지 않는다. `payment`와 `booking`의 `user_id` 대조로 불일치 건수를 확인하고, 0건이 아니면 별도 이슈로 복구해야 한다.
- 스키마 변경 없음 → prod 수동 DDL 불필요. revert 1회로 완전 원복 가능.
