### PR TITLE
[Feat] #562 관리자 예매 단건 조회 API

### DIFF
--- a/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/app/facade/BookingFacade.java
+++ b/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/app/facade/BookingFacade.java
@@ -13,6 +13,7 @@ import com.ticketrush.boundedcontext.booking.app.usecase.BookingAdminRetryRefund
 import com.ticketrush.boundedcontext.booking.app.usecase.BookingCancelMyBookingUseCase;
 import com.ticketrush.boundedcontext.booking.app.usecase.BookingCountUseCase;
 import com.ticketrush.boundedcontext.booking.app.usecase.BookingCreateUseCase;
+import com.ticketrush.boundedcontext.booking.app.usecase.BookingGetAdminBookingUseCase;
 import com.ticketrush.boundedcontext.booking.app.usecase.BookingGetAdminBookingsUseCase;
 import com.ticketrush.boundedcontext.booking.app.usecase.BookingGetAdminStatsUseCase;
 import com.ticketrush.boundedcontext.booking.app.usecase.BookingGetMyBookingDetailUseCase;
@@ -60,6 +61,7 @@ public class BookingFacade {
   private final BookingGetRefundingStuckBookingsUseCase bookingGetRefundingStuckBookingsUseCase;
   private final BookingAdminRetryRefundUseCase bookingAdminRetryRefundUseCase;
   private final BookingGetAdminBookingsUseCase bookingGetAdminBookingsUseCase;
+  private final BookingGetAdminBookingUseCase bookingGetAdminBookingUseCase;
   private final BookingGetAdminStatsUseCase bookingGetAdminStatsUseCase;
   private final BookingAdminRefundUseCase bookingAdminRefundUseCase;
   private final UserRestClient userRestClient;
@@ -204,6 +206,35 @@ public class BookingFacade {
                 performances.get(booking.getPerformanceId()),
                 seatNumbers.get(booking.getSeatId()),
                 users.get(booking.getUserId())));
+  }
+
+  /**
+   * 관리자 예매 단건 조회 (#562). 좌석 관리자 화면이 좌석의 {@code bookingNumber}로 예매자를 조합하는 창구다.
+   *
+   * <p>보강 축은 목록과 같지만 전부 1건짜리 호출이다 — 목록의 벌크 조회를 재사용하려고 1건을 리스트에 싸서 넘기면 공연만 단건 API를 갖고 나머지 둘은 벌크 API라
+   * 형태가 갈린다. {@code getMyBooking}(#560)이 이미 같은 조합을 쓰고 있어 그쪽과 축을 맞춘다.
+   *
+   * <p>보강 실패는 각 클라이언트가 흡수하므로 여기에 catch가 없다(부분 응답). 한 도메인의 실패가 다른 도메인 필드에 닿는 경로도 없다.
+   *
+   * <p><b>조회 사실을 감사 로그로 남긴다.</b> 목록과 같은 이유이며 남기는 것은 조회자와 대상 키뿐이다 — 응답 내용(이름·이메일)을 찍으면 로그가 두 번째 개인정보
+   * 저장소가 된다.
+   */
+  public BookingAdminSummaryResponse getAdminBooking(Long adminId, String bookingNumber) {
+    Booking booking = bookingGetAdminBookingUseCase.execute(bookingNumber);
+
+    log.info(
+        "[ADMIN-AUDIT] 관리자 예매 단건 조회(예매자 개인정보 포함). adminId: {}, bookingNumber: {}",
+        adminId,
+        bookingNumber);
+
+    PerformanceInfoResponse performance =
+        performanceRestClient.getPerformance(booking.getPerformanceId()).orElse(null);
+    String seatNumber =
+        seatRestClient.getSeatNumbers(List.of(booking.getSeatId())).get(booking.getSeatId());
+    UserSummaryInfoResponse user =
+        userRestClient.getUsers(List.of(booking.getUserId())).get(booking.getUserId());
+
+    return BookingAdminSummaryResponse.of(booking, performance, seatNumber, user);
   }
 
   /** 관리자 예매 요약 통계 (#561). <b>원격 호출이 없다</b> — 매출이 예매가 보유한 결제 금액의 합이라 DB 집계 한 번으로 끝난다. */

--- a/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/app/usecase/BookingGetAdminBookingUseCase.java
+++ b/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/app/usecase/BookingGetAdminBookingUseCase.java
@@ -1,0 +1,32 @@
+package com.ticketrush.boundedcontext.booking.app.usecase;
+
+import com.ticketrush.boundedcontext.booking.domain.entity.Booking;
+import com.ticketrush.boundedcontext.booking.out.repository.BookingRepository;
+import com.ticketrush.global.exception.BusinessException;
+import com.ticketrush.global.status.ErrorStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 관리자가 예매 번호로 예매 1건을 조회한다 (#562).
+ *
+ * <p><b>왜 목록 API로 대신할 수 없는가.</b> {@code BookingGetAdminBookingsUseCase}는 검색·필터 없이 페이징만 제공하므로, 좌석
+ * 관리자 화면이 좌석의 {@code bookingNumber} 하나로 예매자를 찾으려면 전체 페이지를 순차로 훑어야 한다 — 그 자체가 개인정보 전량 열람이다.
+ *
+ * <p>{@code BookingGetAdminBookingsUseCase}와 같은 규율로 엔티티를 반환한다. 타 도메인 보강(공연·좌석·예매자)은 트랜잭션 밖인 파사드가
+ * 맡고, {@code Booking}에는 지연 로딩 연관이 없어 트랜잭션 밖 접근이 안전하다.
+ */
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class BookingGetAdminBookingUseCase {
+
+  private final BookingRepository bookingRepository;
+
+  public Booking execute(String bookingNumber) {
+    return bookingRepository
+        .findByBookingNumber(bookingNumber)
+        .orElseThrow(() -> new BusinessException(ErrorStatus.BOOKING_NOT_FOUND));
+  }
+}

--- a/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/in/api/v1/BookingAdminController.java
+++ b/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/in/api/v1/BookingAdminController.java
@@ -61,6 +61,34 @@ public class BookingAdminController {
   }
 
   @Operation(
+      summary = "예매 단건 조회",
+      description =
+          """
+          예매 번호로 예매 1건을 조회합니다. 응답 형태는 목록과 동일합니다 — 1인 1매라 목록 필드가 곧 상세 필드입니다.
+
+          **좌석 관리자 화면(#562)이 이 API로 예매자를 조합합니다.** 좌석 조회 API는 좌석의 `booking_number`까지만 내리고
+          예매자 이름·이메일은 내리지 않습니다. 좌석 도메인이 예매자 정보를 보유하지도, 조회하지도 않게 하려는 경계이며,
+          프론트가 좌석 상세의 `booking_number`로 이 API를 호출해 두 화면 데이터를 합칩니다.
+
+          공연 이름·날짜, 예매자 이름·이메일, 좌석 번호는 각각 performance·user·seat-service에서 보강합니다.
+          **해당 서비스 장애 시 그 필드만 null로 내려가고 조회 자체는 성공합니다** — 프론트는 `performance_id`·`user_id`·`seat_id`로
+          재조회할 수 있습니다.
+
+          존재하지 않는 예매 번호는 `BOOKING_404_001`로 거절합니다.
+
+          예매자 개인정보가 포함되므로 조회 사실이 ADMIN-AUDIT 로그에 남습니다(조회자와 예매 번호만 기록하며 응답 내용은 남기지 않습니다).
+          """)
+  @GetMapping("/bookings/{bookingNumber}")
+  public ResponseEntity<ApiResponse<BookingAdminSummaryResponse>> getBooking(
+      @AuthenticationPrincipal CustomUserDetails admin,
+      @Parameter(description = "예매 번호") @PathVariable String bookingNumber) {
+    BookingAdminSummaryResponse response =
+        bookingFacade.getAdminBooking(admin.getUserId(), bookingNumber);
+
+    return ApiResponse.onSuccess(SuccessStatus.OK, response);
+  }
+
+  @Operation(
       summary = "예매 요약 통계 조회",
       description =
           """

--- a/booking-service/src/test/java/com/ticketrush/boundedcontext/booking/app/facade/BookingFacadeTest.java
+++ b/booking-service/src/test/java/com/ticketrush/boundedcontext/booking/app/facade/BookingFacadeTest.java
@@ -24,6 +24,7 @@ import com.ticketrush.boundedcontext.booking.app.usecase.BookingAdminRetryRefund
 import com.ticketrush.boundedcontext.booking.app.usecase.BookingCancelMyBookingUseCase;
 import com.ticketrush.boundedcontext.booking.app.usecase.BookingCountUseCase;
 import com.ticketrush.boundedcontext.booking.app.usecase.BookingCreateUseCase;
+import com.ticketrush.boundedcontext.booking.app.usecase.BookingGetAdminBookingUseCase;
 import com.ticketrush.boundedcontext.booking.app.usecase.BookingGetAdminBookingsUseCase;
 import com.ticketrush.boundedcontext.booking.app.usecase.BookingGetAdminStatsUseCase;
 import com.ticketrush.boundedcontext.booking.app.usecase.BookingGetMyBookingDetailUseCase;
@@ -78,6 +79,7 @@ class BookingFacadeTest {
   @Mock private BookingAdminRetryRefundUseCase bookingAdminRetryRefundUseCase;
   @Mock private SeatRestClient seatRestClient;
   @Mock private BookingGetAdminBookingsUseCase bookingGetAdminBookingsUseCase;
+  @Mock private BookingGetAdminBookingUseCase bookingGetAdminBookingUseCase;
   @Mock private BookingGetAdminStatsUseCase bookingGetAdminStatsUseCase;
   @Mock private BookingAdminRefundUseCase bookingAdminRefundUseCase;
   @Mock private UserRestClient userRestClient;
@@ -586,6 +588,48 @@ class BookingFacadeTest {
 
     // then
     BookingAdminSummaryResponse response = page.getContent().get(0);
+    assertThat(response.bookerName()).isNull();
+    assertThat(response.bookerEmail()).isNull();
+    assertThat(response.userId()).isEqualTo(5L); // 프론트 재조회 키는 남는다
+    assertThat(response.performanceTitle()).isEqualTo("오페라의 유령");
+    assertThat(response.seatNumber()).isEqualTo("A-1");
+  }
+
+  @Test
+  @DisplayName("성공: 관리자 단건 조회도 공연·좌석·예매자 세 축을 보강한다")
+  void getAdminBooking_enriches_all_three_axes() {
+    // given: 좌석 관리자 화면이 booking_number로 예매자를 조합하는 경로 (#562)
+    Booking booking = confirmedAdminBooking(5L, 2L, 3L);
+    given(bookingGetAdminBookingUseCase.execute("BK-5")).willReturn(booking);
+    given(performanceRestClient.getPerformance(2L)).willReturn(Optional.of(performanceInfo()));
+    given(seatRestClient.getSeatNumbers(List.of(3L))).willReturn(Map.of(3L, "A-1"));
+    given(userRestClient.getUsers(List.of(5L)))
+        .willReturn(Map.of(5L, new UserSummaryInfoResponse(5L, "김소희", "user@example.com")));
+
+    // when
+    BookingAdminSummaryResponse response = bookingFacade.getAdminBooking(ADMIN_ID, "BK-5");
+
+    // then
+    assertThat(response.bookingNumber()).isEqualTo("BK-5");
+    assertThat(response.performanceTitle()).isEqualTo("오페라의 유령");
+    assertThat(response.seatNumber()).isEqualTo("A-1");
+    assertThat(response.bookerName()).isEqualTo("김소희");
+    assertThat(response.paymentAmount()).isEqualTo(150000L);
+  }
+
+  @Test
+  @DisplayName("성공: 관리자 단건 조회에서 예매자 조회가 실패해도 그 필드만 비고 나머지는 살아 있다")
+  void getAdminBooking_isolates_user_failure() {
+    // given: user-service만 실패해 빈 맵을 돌려준다(부분 응답)
+    given(bookingGetAdminBookingUseCase.execute("BK-5")).willReturn(adminBooking(5L, 2L, 3L));
+    given(performanceRestClient.getPerformance(2L)).willReturn(Optional.of(performanceInfo()));
+    given(seatRestClient.getSeatNumbers(List.of(3L))).willReturn(Map.of(3L, "A-1"));
+    given(userRestClient.getUsers(List.of(5L))).willReturn(Map.of());
+
+    // when
+    BookingAdminSummaryResponse response = bookingFacade.getAdminBooking(ADMIN_ID, "BK-5");
+
+    // then
     assertThat(response.bookerName()).isNull();
     assertThat(response.bookerEmail()).isNull();
     assertThat(response.userId()).isEqualTo(5L); // 프론트 재조회 키는 남는다

--- a/booking-service/src/test/java/com/ticketrush/boundedcontext/booking/in/api/v1/BookingAdminControllerTest.java
+++ b/booking-service/src/test/java/com/ticketrush/boundedcontext/booking/in/api/v1/BookingAdminControllerTest.java
@@ -1,6 +1,9 @@
 package com.ticketrush.boundedcontext.booking.in.api.v1;
 
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -17,7 +20,9 @@ import com.ticketrush.global.config.CustomSecurityProperties;
 import com.ticketrush.global.config.JacksonConfig;
 import com.ticketrush.global.config.SecurityConfig;
 import com.ticketrush.global.dto.request.OffsetPageRequest;
+import com.ticketrush.global.exception.BusinessException;
 import com.ticketrush.global.filter.GatewayHeaderFilter;
+import com.ticketrush.global.status.ErrorStatus;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -205,6 +210,95 @@ class BookingAdminControllerTest {
   }
 
   @Test
+  @DisplayName("ADMIN이 예매 번호로 단건을 조회하면 목록과 같은 보강 필드가 응답된다")
+  void getBooking_returns_enriched_booking() throws Exception {
+    // given: 좌석 관리자 화면이 좌석의 booking_number로 예매자를 조합하는 창구 (#562)
+    BookingAdminSummaryResponse response =
+        new BookingAdminSummaryResponse(
+            100L,
+            BOOKING_NUMBER,
+            5L,
+            2L,
+            3L,
+            BookingStatus.PENDING,
+            LocalDateTime.of(2026, 5, 22, 10, 30),
+            "오페라의 유령",
+            LocalDate.of(2026, 5, 22),
+            "김소희",
+            "user@example.com",
+            "A-1",
+            1,
+            null);
+
+    given(bookingFacade.getAdminBooking(42L, BOOKING_NUMBER)).willReturn(response);
+
+    // when & then
+    mockMvc
+        .perform(
+            get("/api/v1/booking/admin/bookings/{bookingNumber}", BOOKING_NUMBER)
+                .header("X-Gateway-Token", INTERNAL_TOKEN)
+                .header("X-User-Id", 42L)
+                .header("X-User-Role", "ADMIN"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.is_success").value(true))
+        .andExpect(jsonPath("$.result.booking_number").value(BOOKING_NUMBER))
+        .andExpect(jsonPath("$.result.seat_id").value(3))
+        .andExpect(jsonPath("$.result.booking_status").value("PENDING"))
+        .andExpect(jsonPath("$.result.booker_name").value("김소희"))
+        .andExpect(jsonPath("$.result.seat_number").value("A-1"));
+
+    verify(bookingFacade).getAdminBooking(42L, BOOKING_NUMBER);
+  }
+
+  @Test
+  @DisplayName("존재하지 않는 예매 번호로 단건을 조회하면 404로 거절된다")
+  void getBooking_returns_404_for_unknown_booking_number() throws Exception {
+    // given
+    given(bookingFacade.getAdminBooking(1L, "NOPE-0000"))
+        .willThrow(new BusinessException(ErrorStatus.BOOKING_NOT_FOUND));
+
+    // when & then
+    mockMvc
+        .perform(
+            get("/api/v1/booking/admin/bookings/{bookingNumber}", "NOPE-0000")
+                .header("X-Gateway-Token", INTERNAL_TOKEN)
+                .header("X-User-Id", 1L)
+                .header("X-User-Role", "ADMIN"))
+        .andExpect(status().isNotFound())
+        .andExpect(jsonPath("$.is_success").value(false))
+        .andExpect(jsonPath("$.code").value(ErrorStatus.BOOKING_NOT_FOUND.getCode()));
+  }
+
+  @Test
+  @DisplayName("정적 경로가 단건 조회의 경로 변수보다 우선한다")
+  void staticPaths_take_precedence_over_booking_number_variable() throws Exception {
+    // given: /bookings/{bookingNumber}가 추가되면서 stats·refund-failed·refunding-stuck을 삼킬 수 있다.
+    // Spring의 리터럴 우선 매칭에 의존하고 있으므로 그 전제를 여기서 고정한다 (#562).
+    given(bookingFacade.getAdminBookingStats())
+        .willReturn(new BookingAdminStatsResponse(0, 0, 0, 0L, true, 0));
+    given(bookingFacade.getRefundFailedBookings(new OffsetPageRequest(0, 10)))
+        .willReturn(new PageImpl<>(List.of(), PageRequest.of(0, 10), 0));
+    given(bookingFacade.getRefundingStuckBookings(new OffsetPageRequest(0, 10)))
+        .willReturn(new PageImpl<>(List.of(), PageRequest.of(0, 10), 0));
+
+    // when & then
+    for (String staticPath : List.of("stats", "refund-failed", "refunding-stuck")) {
+      mockMvc
+          .perform(
+              get("/api/v1/booking/admin/bookings/" + staticPath)
+                  .header("X-Gateway-Token", INTERNAL_TOKEN)
+                  .header("X-User-Id", 1L)
+                  .header("X-User-Role", "ADMIN"))
+          .andExpect(status().isOk());
+    }
+
+    verify(bookingFacade).getAdminBookingStats();
+    verify(bookingFacade).getRefundFailedBookings(new OffsetPageRequest(0, 10));
+    verify(bookingFacade).getRefundingStuckBookings(new OffsetPageRequest(0, 10));
+    verify(bookingFacade, never()).getAdminBooking(anyLong(), anyString());
+  }
+
+  @Test
   @DisplayName("ADMIN이 요약 통계를 조회하면 카운트 3종과 총 매출이 응답된다")
   void getBookingStats_returns_summary() throws Exception {
     // given
@@ -286,6 +380,14 @@ class BookingAdminControllerTest {
     mockMvc
         .perform(
             post("/api/v1/booking/admin/{bookingNumber}/refund", BOOKING_NUMBER)
+                .header("X-Gateway-Token", INTERNAL_TOKEN)
+                .header("X-User-Id", 1L)
+                .header("X-User-Role", "USER"))
+        .andExpect(status().isForbidden());
+
+    mockMvc
+        .perform(
+            get("/api/v1/booking/admin/bookings/{bookingNumber}", BOOKING_NUMBER)
                 .header("X-Gateway-Token", INTERNAL_TOKEN)
                 .header("X-User-Id", 1L)
                 .header("X-User-Role", "USER"))


### PR DESCRIPTION
## 🔗 관련 이슈

- #562

> 이 PR은 #562의 선행 절반입니다. 이슈 종료(`close`)는 좌석 API PR에서 합니다.

---

## 📌 주요 변경 사항

- `GET /api/v1/booking/admin/bookings/{bookingNumber}` 관리자 예매 단건 조회를 추가한다
- 좌석 관리자 화면(#562)이 좌석의 `booking_number`로 예매자 정보를 조합할 창구다
- 응답은 기존 `BookingAdminSummaryResponse`를 그대로 쓴다 — 1인 1매라 목록 필드가 곧 상세 필드다

---

## 🛠 상세 구현 내용

- `BookingGetAdminBookingUseCase` 신규. 기존 `findByBookingNumber`를 재사용하고 없으면 `BOOKING_404_001`로 거절한다. `BookingGetAdminBookingsUseCase`와 같은 규율로 엔티티를 반환하고, 타 도메인 보강은 트랜잭션 밖인 파사드가 맡는다
- `BookingFacade.getAdminBooking` — 보강 축은 목록과 같지만 전부 1건짜리 호출이다(`getMyBooking`과 같은 조합). 보강 실패는 각 클라이언트가 흡수해 그 필드만 null이다(부분 응답)
- **왜 좌석 API가 예매자 이름을 직접 내리지 않는가.** 좌석은 `bookingNumber`만 보유하고 회원 정보를 알지 못한다. seat가 이름을 실으려면 booking을 동기로 호출해야 하는데 현재 의존은 booking→seat 단방향이다. 화면 한 칸 때문에 순환 의존과 booking 장애 전파 경로를 만들지 않고, 프론트가 두 응답을 합친다
- **왜 기존 목록 API로 대신할 수 없는가.** 목록은 검색·필터 없이 페이징만 제공하므로 좌석 하나의 예매자를 찾으려면 전체 페이지를 순차로 훑어야 하는데, 그 자체가 개인정보 전량 열람이다
- 개인정보를 내리므로 조회 사실을 `[ADMIN-AUDIT]`로 남긴다. 조회자와 예매 번호만 찍고 응답 내용은 남기지 않는다
- `/bookings/{bookingNumber}`가 기존 `stats`·`refund-failed`·`refunding-stuck`을 삼킬 수 있다. Spring의 리터럴 우선 매칭에 의존하고 있으므로 그 전제를 테스트로 고정했다

---

## ✅ 테스트

### 테스트 방법

- `./gradlew :booking-service:test`
- `BookingAdminControllerTest` 3건 추가 — 단건 조회 200과 보강 필드, 없는 예매 번호 404(`BOOKING_404_001`), 정적 경로 우선 매칭(`stats`·`refund-failed`·`refunding-stuck`이 경로 변수에 안 먹히는지). 기존 비ADMIN 403 테스트에 신규 경로를 추가
- `BookingFacadeTest` 2건 추가 — 공연·좌석·예매자 3축 보강, user-service 실패 시 그 필드만 null이고 나머지는 유지

### 테스트 결과

- `./gradlew :booking-service:test` — 39개 클래스 **218건 전부 통과**(실패 0, 에러 0, 스킵 0)
- `./gradlew build`(전 모듈), `checkstyleMain`·`checkstyleTest`·`spotlessCheck` 통과

<!--
### 📸 스크린샷
-->

---

## 👀 리뷰 요청 사항

- 예매자 이름을 좌석 응답에 싣지 않고 프론트가 `booking_number`로 조합하게 한 결정을 봐 주시기 바랍니다. seat→booking 역방향 동기 의존을 만들지 않으려는 선택인데, 이견이 있으면 지적해 주시기 바랍니다
- 조회 경로를 `/bookings/{bookingNumber}`로 둬 기존 `/{bookingNumber}/refund`와 세그먼트가 갈립니다. 신규 쪽이 `stats` 등과 네임스페이스가 맞다고 판단했으나, 통일이 낫다면 알려 주시기 바랍니다

---

## ⚠️ 배포 시 주의사항

- 조회 API 추가뿐이라 스키마·설정 변경이 없다
- **좌석 관리자 PR보다 먼저 머지되어야 한다.** 그쪽 Swagger가 이 엔드포인트를 예매자 조회 창구로 안내한다
