### PR TITLE
[Fix] #579 인증 방식별 사용자 권한 값 통일

### DIFF
--- a/auth-service/src/main/java/com/ticketrush/boundedcontext/auth/app/usecase/DevTokenIssueUseCase.java
+++ b/auth-service/src/main/java/com/ticketrush/boundedcontext/auth/app/usecase/DevTokenIssueUseCase.java
@@ -22,20 +22,20 @@ public class DevTokenIssueUseCase {
   public LoginResponse execute(DevTokenIssueRequest request) {
     UserServiceAuthInfoResponse user = userServiceClient.getUserAuthInfoByUserId(request.userId());
 
-    String normalizedRole = normalizeRole(user.role());
+    String role = validateRole(user.role());
 
-    String accessToken = jwtTokenProvider.createAccessToken(user.userId(), normalizedRole);
+    String accessToken = jwtTokenProvider.createAccessToken(user.userId(), role);
+
     String refreshToken = jwtTokenProvider.createRefreshToken(user.userId());
 
-    return new LoginResponse(
-        user.userId(), user.email(), normalizedRole, accessToken, refreshToken);
+    return new LoginResponse(user.userId(), user.email(), role, accessToken, refreshToken);
   }
 
-  private String normalizeRole(String role) {
-    return switch (role) {
-      case "MEMBER" -> "USER";
-      case "ADMIN" -> "ADMIN";
-      default -> throw new IllegalArgumentException("지원하지 않는 사용자 역할입니다: " + role);
-    };
+  private String validateRole(String role) {
+    if (!"MEMBER".equals(role) && !"ADMIN".equals(role)) {
+      throw new IllegalArgumentException("지원하지 않는 사용자 역할입니다: " + role);
+    }
+
+    return role;
   }
 }

--- a/auth-service/src/main/java/com/ticketrush/boundedcontext/auth/app/usecase/DevTokenIssueUseCase.java
+++ b/auth-service/src/main/java/com/ticketrush/boundedcontext/auth/app/usecase/DevTokenIssueUseCase.java
@@ -33,7 +33,8 @@ public class DevTokenIssueUseCase {
 
   private String validateRole(String role) {
     if (!"MEMBER".equals(role) && !"ADMIN".equals(role)) {
-      throw new IllegalArgumentException("지원하지 않는 사용자 역할입니다: " + role);
+      throw new com.ticketrush.global.exception.BusinessException(
+          com.ticketrush.global.status.ErrorStatus.BAD_REQUEST, "지원하지 않는 사용자 역할입니다: " + role);
     }
 
     return role;

--- a/auth-service/src/main/java/com/ticketrush/boundedcontext/auth/app/usecase/LoginUseCase.java
+++ b/auth-service/src/main/java/com/ticketrush/boundedcontext/auth/app/usecase/LoginUseCase.java
@@ -26,21 +26,20 @@ public class LoginUseCase {
       throw new BusinessException(ErrorStatus.AUTH_LOGIN_FAILED);
     }
 
-    String normalizedRole = normalizeRole(user.role());
+    String role = validateRole(user.role());
 
-    String accessToken = jwtTokenProvider.createAccessToken(user.userId(), normalizedRole);
+    String accessToken = jwtTokenProvider.createAccessToken(user.userId(), role);
 
     String refreshToken = jwtTokenProvider.createRefreshToken(user.userId());
 
-    return new LoginResponse(
-        user.userId(), user.email(), normalizedRole, accessToken, refreshToken);
+    return new LoginResponse(user.userId(), user.email(), role, accessToken, refreshToken);
   }
 
-  private String normalizeRole(String role) {
-    return switch (role) {
-      case "MEMBER" -> "USER";
-      case "ADMIN" -> "ADMIN";
-      default -> throw new IllegalArgumentException("지원하지 않는 사용자 역할입니다: " + role);
-    };
+  private String validateRole(String role) {
+    if (!"MEMBER".equals(role) && !"ADMIN".equals(role)) {
+      throw new IllegalArgumentException("지원하지 않는 사용자 역할입니다: " + role);
+    }
+
+    return role;
   }
 }

--- a/auth-service/src/main/java/com/ticketrush/boundedcontext/auth/app/usecase/LoginUseCase.java
+++ b/auth-service/src/main/java/com/ticketrush/boundedcontext/auth/app/usecase/LoginUseCase.java
@@ -37,7 +37,7 @@ public class LoginUseCase {
 
   private String validateRole(String role) {
     if (!"MEMBER".equals(role) && !"ADMIN".equals(role)) {
-      throw new IllegalArgumentException("지원하지 않는 사용자 역할입니다: " + role);
+      throw new BusinessException(ErrorStatus.BAD_REQUEST, "지원하지 않는 사용자 역할입니다: " + role);
     }
 
     return role;

--- a/auth-service/src/main/java/com/ticketrush/boundedcontext/auth/app/usecase/SocialOauthLoginUseCase.java
+++ b/auth-service/src/main/java/com/ticketrush/boundedcontext/auth/app/usecase/SocialOauthLoginUseCase.java
@@ -2,6 +2,7 @@ package com.ticketrush.boundedcontext.auth.app.usecase;
 
 import com.ticketrush.boundedcontext.auth.app.dto.request.SocialOauthLoginRequest;
 import com.ticketrush.boundedcontext.auth.app.dto.request.UserServiceSocialLoginRequest;
+import com.ticketrush.boundedcontext.auth.app.dto.response.login.UserServiceAuthInfoResponse;
 import com.ticketrush.boundedcontext.auth.app.dto.response.social.OauthLoginResponse;
 import com.ticketrush.boundedcontext.auth.app.dto.response.social.UserServiceSocialLoginResponse;
 import com.ticketrush.boundedcontext.auth.domain.types.SocialUserInfo;
@@ -21,7 +22,8 @@ import org.springframework.stereotype.Component;
 1. provider에 맞는 OAuth 서비스 선택
 2. 인가 코드로 소셜 사용자 정보 조회
 3. user-service에 회원 식별/생성 요청
-4. 최종 응답 반환
+4. 사용자의 실제 권한 조회
+5. JWT 생성 및 최종 응답 반환
  */
 public class SocialOauthLoginUseCase {
 
@@ -37,7 +39,7 @@ public class SocialOauthLoginUseCase {
 
     SocialUserInfo socialUserInfo = oauthClient.getUserInfo(request.code());
 
-    // 2. user-service 호출
+    // 2. user-service에 소셜 회원 식별 또는 생성 요청
     UserServiceSocialLoginResponse userResponse =
         userServiceClient.socialLogin(
             new UserServiceSocialLoginRequest(
@@ -48,16 +50,21 @@ public class SocialOauthLoginUseCase {
 
     Long userId = userResponse.userId();
 
-    // 3. JWT 생성
-    String accessToken = jwtTokenProvider.createAccessToken(userId, "USER");
+    // 3. 사용자 실제 권한 조회
+    UserServiceAuthInfoResponse userAuthInfo = userServiceClient.getUserAuthInfoByUserId(userId);
+
+    String role = validateRole(userAuthInfo.role());
+
+    // 4. JWT 생성
+    String accessToken = jwtTokenProvider.createAccessToken(userId, role);
 
     String refreshToken = jwtTokenProvider.createRefreshToken(userId);
 
-    // 4. Redis 저장
+    // 5. Redis에 Refresh Token 저장
     redisRepository.saveRefreshToken(
         userId, refreshToken, jwtTokenProvider.getRefreshTokenExpiration());
 
-    // 5. 응답 반환
+    // 6. 응답 반환
     return new OauthLoginResponse(
         userId,
         userResponse.name(),
@@ -66,5 +73,13 @@ public class SocialOauthLoginUseCase {
         refreshToken,
         jwtTokenProvider.getAccessTokenExpiration(),
         jwtTokenProvider.getRefreshTokenExpiration());
+  }
+
+  private String validateRole(String role) {
+    if (!"MEMBER".equals(role) && !"ADMIN".equals(role)) {
+      throw new IllegalArgumentException("지원하지 않는 사용자 역할입니다: " + role);
+    }
+
+    return role;
   }
 }

--- a/auth-service/src/main/java/com/ticketrush/boundedcontext/auth/app/usecase/SocialOauthLoginUseCase.java
+++ b/auth-service/src/main/java/com/ticketrush/boundedcontext/auth/app/usecase/SocialOauthLoginUseCase.java
@@ -77,7 +77,8 @@ public class SocialOauthLoginUseCase {
 
   private String validateRole(String role) {
     if (!"MEMBER".equals(role) && !"ADMIN".equals(role)) {
-      throw new IllegalArgumentException("지원하지 않는 사용자 역할입니다: " + role);
+      throw new com.ticketrush.global.exception.BusinessException(
+          com.ticketrush.global.status.ErrorStatus.BAD_REQUEST, "지원하지 않는 사용자 역할입니다: " + role);
     }
 
     return role;

--- a/auth-service/src/main/java/com/ticketrush/boundedcontext/auth/app/usecase/TokenReissueUseCase.java
+++ b/auth-service/src/main/java/com/ticketrush/boundedcontext/auth/app/usecase/TokenReissueUseCase.java
@@ -1,6 +1,8 @@
 package com.ticketrush.boundedcontext.auth.app.usecase;
 
+import com.ticketrush.boundedcontext.auth.app.dto.response.login.UserServiceAuthInfoResponse;
 import com.ticketrush.boundedcontext.auth.app.dto.response.social.TokenReissueResponse;
+import com.ticketrush.boundedcontext.auth.out.apiclient.UserServiceClient;
 import com.ticketrush.boundedcontext.auth.out.repository.RedisRepository;
 import com.ticketrush.global.exception.BusinessException;
 import com.ticketrush.global.security.JwtTokenProvider;
@@ -18,35 +20,50 @@ public class TokenReissueUseCase {
 
   private final JwtTokenProvider jwtTokenProvider;
   private final RedisRepository redisRepository;
+  private final UserServiceClient userServiceClient;
 
   public TokenReissueResponse execute(String refreshToken) {
 
-    // 1. refresh token 검증
+    // 1. Refresh Token 검증
     if (!jwtTokenProvider.validateToken(refreshToken)) {
       throw new BusinessException(ErrorStatus.AUTH_INVALID_REFRESH_TOKEN);
     }
 
-    // 2. userId 추출
+    // 2. Refresh Token에서 userId 추출
     Long userId = jwtTokenProvider.getUserId(refreshToken);
 
-    // 3. Redis 검증
+    // 3. Redis에 저장된 Refresh Token과 일치하는지 검증
     if (!redisRepository.isValidRefreshToken(userId, refreshToken)) {
       throw new BusinessException(ErrorStatus.AUTH_INVALID_REFRESH_TOKEN);
     }
 
-    // 4. 새 토큰 발급
-    String newAccessToken = jwtTokenProvider.createAccessToken(userId, "USER");
+    // 4. user-service에서 현재 사용자 권한 조회
+    UserServiceAuthInfoResponse user = userServiceClient.getUserAuthInfoByUserId(userId);
+
+    String role = validateRole(user.role());
+
+    // 5. 현재 사용자 권한으로 새 토큰 발급
+    String newAccessToken = jwtTokenProvider.createAccessToken(userId, role);
+
     String newRefreshToken = jwtTokenProvider.createRefreshToken(userId);
 
-    // 5. Redis 갱신
+    // 6. Redis의 Refresh Token 갱신
     redisRepository.saveRefreshToken(
         userId, newRefreshToken, jwtTokenProvider.getRefreshTokenExpiration());
 
-    // 6. 응답
+    // 7. 응답 반환
     return new TokenReissueResponse(
         newAccessToken,
         newRefreshToken,
         jwtTokenProvider.getAccessTokenExpiration(),
         jwtTokenProvider.getRefreshTokenExpiration());
+  }
+
+  private String validateRole(String role) {
+    if (!"MEMBER".equals(role) && !"ADMIN".equals(role)) {
+      throw new IllegalArgumentException("지원하지 않는 사용자 역할입니다: " + role);
+    }
+
+    return role;
   }
 }

--- a/auth-service/src/main/java/com/ticketrush/boundedcontext/auth/app/usecase/TokenReissueUseCase.java
+++ b/auth-service/src/main/java/com/ticketrush/boundedcontext/auth/app/usecase/TokenReissueUseCase.java
@@ -61,7 +61,7 @@ public class TokenReissueUseCase {
 
   private String validateRole(String role) {
     if (!"MEMBER".equals(role) && !"ADMIN".equals(role)) {
-      throw new IllegalArgumentException("지원하지 않는 사용자 역할입니다: " + role);
+      throw new BusinessException(ErrorStatus.BAD_REQUEST, "지원하지 않는 사용자 역할입니다: " + role);
     }
 
     return role;

--- a/auth-service/src/test/java/com/ticketrush/boundedcontext/auth/app/usecase/DevTokenIssueUseCaseTest.java
+++ b/auth-service/src/test/java/com/ticketrush/boundedcontext/auth/app/usecase/DevTokenIssueUseCaseTest.java
@@ -101,8 +101,7 @@ class DevTokenIssueUseCaseTest {
 
     // when & then
     assertThatThrownBy(() -> devTokenIssueUseCase.execute(request))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("지원하지 않는 사용자 역할입니다");
+        .isInstanceOf(BusinessException.class);
 
     verify(userServiceClient).getUserAuthInfoByUserId(userId);
     verify(jwtTokenProvider, never()).createAccessToken(anyLong(), anyString());

--- a/auth-service/src/test/java/com/ticketrush/boundedcontext/auth/app/usecase/DevTokenIssueUseCaseTest.java
+++ b/auth-service/src/test/java/com/ticketrush/boundedcontext/auth/app/usecase/DevTokenIssueUseCaseTest.java
@@ -32,22 +32,21 @@ class DevTokenIssueUseCaseTest {
   @InjectMocks private DevTokenIssueUseCase devTokenIssueUseCase;
 
   @Test
-  @DisplayName("userId로 회원 정보를 조회한 뒤 테스트용 토큰을 발급한다")
+  @DisplayName("userId로 회원 정보를 조회한 뒤 실제 권한으로 테스트용 토큰을 발급한다")
   void issueDevToken_success() {
     // given
     Long userId = 1L;
     String email = "test@example.com";
     String passwordHash = "$2a$10$encoded-password";
-    String userServiceRole = "MEMBER";
-    String tokenRole = "USER";
+    String role = "MEMBER";
 
     DevTokenIssueRequest request = new DevTokenIssueRequest(userId);
 
     UserServiceAuthInfoResponse userInfo =
-        new UserServiceAuthInfoResponse(userId, email, passwordHash, userServiceRole);
+        new UserServiceAuthInfoResponse(userId, email, passwordHash, role);
 
     when(userServiceClient.getUserAuthInfoByUserId(userId)).thenReturn(userInfo);
-    when(jwtTokenProvider.createAccessToken(userId, tokenRole)).thenReturn("access-token");
+    when(jwtTokenProvider.createAccessToken(userId, role)).thenReturn("access-token");
     when(jwtTokenProvider.createRefreshToken(userId)).thenReturn("refresh-token");
 
     // when
@@ -56,12 +55,12 @@ class DevTokenIssueUseCaseTest {
     // then
     assertThat(response.userId()).isEqualTo(userId);
     assertThat(response.email()).isEqualTo(email);
-    assertThat(response.role()).isEqualTo(tokenRole);
+    assertThat(response.role()).isEqualTo(role);
     assertThat(response.accessToken()).isEqualTo("access-token");
     assertThat(response.refreshToken()).isEqualTo("refresh-token");
 
     verify(userServiceClient).getUserAuthInfoByUserId(userId);
-    verify(jwtTokenProvider).createAccessToken(userId, tokenRole);
+    verify(jwtTokenProvider).createAccessToken(userId, role);
     verify(jwtTokenProvider).createRefreshToken(userId);
   }
 

--- a/auth-service/src/test/java/com/ticketrush/boundedcontext/auth/app/usecase/LoginUseCaseTest.java
+++ b/auth-service/src/test/java/com/ticketrush/boundedcontext/auth/app/usecase/LoginUseCaseTest.java
@@ -137,9 +137,7 @@ class LoginUseCaseTest {
     when(passwordEncoder.matches(rawPassword, passwordHash)).thenReturn(true);
 
     // when & then
-    assertThatThrownBy(() -> loginUseCase.execute(request))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("지원하지 않는 사용자 역할입니다");
+    assertThatThrownBy(() -> loginUseCase.execute(request)).isInstanceOf(BusinessException.class);
 
     verify(userServiceClient).getUserAuthInfoByEmail(email);
     verify(passwordEncoder).matches(rawPassword, passwordHash);

--- a/auth-service/src/test/java/com/ticketrush/boundedcontext/auth/app/usecase/LoginUseCaseTest.java
+++ b/auth-service/src/test/java/com/ticketrush/boundedcontext/auth/app/usecase/LoginUseCaseTest.java
@@ -35,24 +35,23 @@ class LoginUseCaseTest {
   @InjectMocks private LoginUseCase loginUseCase;
 
   @Test
-  @DisplayName("이메일과 비밀번호가 일치하면 로그인에 성공하고 토큰을 반환한다")
+  @DisplayName("이메일과 비밀번호가 일치하면 실제 권한으로 로그인 토큰을 발급한다")
   void login_success() {
     // given
     String email = "test@example.com";
     String rawPassword = "Password123!";
     String passwordHash = "$2a$10$encoded-password";
     Long userId = 1L;
-    String userServiceRole = "MEMBER";
-    String tokenRole = "USER";
+    String role = "MEMBER";
 
     LoginRequest request = new LoginRequest(email, rawPassword);
 
     UserServiceAuthInfoResponse userInfo =
-        new UserServiceAuthInfoResponse(userId, email, passwordHash, userServiceRole);
+        new UserServiceAuthInfoResponse(userId, email, passwordHash, role);
 
     when(userServiceClient.getUserAuthInfoByEmail(email)).thenReturn(userInfo);
     when(passwordEncoder.matches(rawPassword, passwordHash)).thenReturn(true);
-    when(jwtTokenProvider.createAccessToken(userId, tokenRole)).thenReturn("access-token");
+    when(jwtTokenProvider.createAccessToken(userId, role)).thenReturn("access-token");
     when(jwtTokenProvider.createRefreshToken(userId)).thenReturn("refresh-token");
 
     // when
@@ -61,13 +60,13 @@ class LoginUseCaseTest {
     // then
     assertThat(response.userId()).isEqualTo(userId);
     assertThat(response.email()).isEqualTo(email);
-    assertThat(response.role()).isEqualTo(tokenRole);
+    assertThat(response.role()).isEqualTo(role);
     assertThat(response.accessToken()).isEqualTo("access-token");
     assertThat(response.refreshToken()).isEqualTo("refresh-token");
 
     verify(userServiceClient).getUserAuthInfoByEmail(email);
     verify(passwordEncoder).matches(rawPassword, passwordHash);
-    verify(jwtTokenProvider).createAccessToken(userId, tokenRole);
+    verify(jwtTokenProvider).createAccessToken(userId, role);
     verify(jwtTokenProvider).createRefreshToken(userId);
   }
 
@@ -79,12 +78,12 @@ class LoginUseCaseTest {
     String rawPassword = "WrongPassword123!";
     String passwordHash = "$2a$10$encoded-password";
     Long userId = 1L;
-    String userServiceRole = "MEMBER";
+    String role = "MEMBER";
 
     LoginRequest request = new LoginRequest(email, rawPassword);
 
     UserServiceAuthInfoResponse userInfo =
-        new UserServiceAuthInfoResponse(userId, email, passwordHash, userServiceRole);
+        new UserServiceAuthInfoResponse(userId, email, passwordHash, role);
 
     when(userServiceClient.getUserAuthInfoByEmail(email)).thenReturn(userInfo);
     when(passwordEncoder.matches(rawPassword, passwordHash)).thenReturn(false);
@@ -115,6 +114,35 @@ class LoginUseCaseTest {
 
     verify(userServiceClient).getUserAuthInfoByEmail(email);
     verify(passwordEncoder, never()).matches(anyString(), anyString());
+    verify(jwtTokenProvider, never()).createAccessToken(anyLong(), anyString());
+    verify(jwtTokenProvider, never()).createRefreshToken(anyLong());
+  }
+
+  @Test
+  @DisplayName("지원하지 않는 role이면 로그인 토큰 발급에 실패한다")
+  void login_fail_whenUnsupportedRole() {
+    // given
+    String email = "test@example.com";
+    String rawPassword = "Password123!";
+    String passwordHash = "$2a$10$encoded-password";
+    Long userId = 1L;
+    String unsupportedRole = "MANAGER";
+
+    LoginRequest request = new LoginRequest(email, rawPassword);
+
+    UserServiceAuthInfoResponse userInfo =
+        new UserServiceAuthInfoResponse(userId, email, passwordHash, unsupportedRole);
+
+    when(userServiceClient.getUserAuthInfoByEmail(email)).thenReturn(userInfo);
+    when(passwordEncoder.matches(rawPassword, passwordHash)).thenReturn(true);
+
+    // when & then
+    assertThatThrownBy(() -> loginUseCase.execute(request))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("지원하지 않는 사용자 역할입니다");
+
+    verify(userServiceClient).getUserAuthInfoByEmail(email);
+    verify(passwordEncoder).matches(rawPassword, passwordHash);
     verify(jwtTokenProvider, never()).createAccessToken(anyLong(), anyString());
     verify(jwtTokenProvider, never()).createRefreshToken(anyLong());
   }

--- a/auth-service/src/test/java/com/ticketrush/boundedcontext/auth/in/api/v1/DevTokenControllerTest.java
+++ b/auth-service/src/test/java/com/ticketrush/boundedcontext/auth/in/api/v1/DevTokenControllerTest.java
@@ -49,7 +49,7 @@ class DevTokenControllerTest {
     Long userId = 1L;
 
     LoginResponse response =
-        new LoginResponse(userId, "test@example.com", "USER", "access-token", "refresh-token");
+        new LoginResponse(userId, "test@example.com", "MEMBER", "access-token", "refresh-token");
 
     given(devAuthFacade.issueDevToken(any(DevTokenIssueRequest.class))).willReturn(response);
 
@@ -72,7 +72,7 @@ class DevTokenControllerTest {
         .andExpect(jsonPath("$.message").value("성공입니다."))
         .andExpect(jsonPath("$.result.user_id").value(userId))
         .andExpect(jsonPath("$.result.email").value("test@example.com"))
-        .andExpect(jsonPath("$.result.role").value("USER"))
+        .andExpect(jsonPath("$.result.role").value("MEMBER"))
         .andExpect(jsonPath("$.result.access_token").value("access-token"))
         .andExpect(jsonPath("$.result.refresh_token").value("refresh-token"));
   }


### PR DESCRIPTION
## 🔗 관련 이슈

* close #579

---

## 📌 주요 변경 사항

* 인증 방식별 사용자 권한 값을 `MEMBER | ADMIN`으로 통일
* 이메일·소셜 로그인 및 토큰 재발급 시 실제 사용자 권한을 JWT에 반영
* 기존 `MEMBER → USER` 변환 로직과 `USER` 하드코딩 제거

---

## 🛠 상세 구현 내용

* 이메일 로그인 시 user-service에서 전달받은 `MEMBER | ADMIN` 값을 로그인 응답과 Access Token에 그대로 반영
* 개발용 토큰 발급 시 `MEMBER`를 `USER`로 변환하던 정규화 로직 제거
* 소셜 로그인 완료 후 user-service에서 실제 사용자 권한을 조회하여 Access Token 생성
* Refresh Token 재발급 시 user-service에서 현재 사용자 권한을 조회하여 새 Access Token에 반영
* 지원하지 않는 권한 값이 전달될 경우 예외가 발생하도록 권한 검증 로직 적용
* 변경된 권한 규격에 맞게 로그인 및 개발용 토큰 관련 테스트 수정
* 테스트 코드에 남아 있던 `USER` 응답 기대값을 `MEMBER`로 변경

---

## ✅ 테스트

### 테스트 방법

* auth-service 코드 및 테스트에서 `USER`, `normalizeRole` 잔여 여부 확인
* Spotless 포맷 적용
* auth-service 테스트 및 빌드 실행
* user-service 테스트 및 빌드 실행

```bash
grep -RniE '"USER"|normalizeRole|normalizedRole' \
  auth-service/src/main \
  auth-service/src/test \
  --exclude-dir=build

./gradlew spotlessApply
./gradlew :auth-service:clean :auth-service:check
./gradlew :auth-service:clean :auth-service:build
./gradlew :user-service:clean :user-service:check
./gradlew :user-service:clean :user-service:build
```

### 테스트 결과

* auth-service 내 `USER` 하드코딩 및 role 정규화 로직 제거 확인
* `spotlessApply` 성공
* `auth-service:check` 성공
* `auth-service:build` 성공
* `user-service:check` 성공
* `user-service:build` 성공
* 전체 실행 결과 `BUILD SUCCESSFUL`
