### PR TITLE
[Chore] #522 호스트 인프라 설정 감사 및 저장소 편입

### DIFF
--- a/deploy/.env.prod.example
+++ b/deploy/.env.prod.example
@@ -107,3 +107,44 @@ SLACK_ENABLED=true
 SLACK_WEBHOOK_URL=__REQUIRED__
 INBOX_RETENTION_ENABLED=true
 # INBOX_RETENTION_DAYS=30
+
+# =============================================================================
+# 배포 이미지
+# =============================================================================
+
+# AWS 리전
+AWS_REGION=
+
+# AWS ECR 주소
+# 예: <AWS_ACCOUNT_ID>.dkr.ecr.<AWS_REGION>.amazonaws.com
+ECR_REGISTRY=
+
+# 배포할 Git commit SHA 또는 이미지 태그
+IMAGE_TAG=
+
+# =============================================================================
+# 애플리케이션 런타임
+# =============================================================================
+
+# JVM 메모리 및 런타임 옵션
+JAVA_TOOL_OPTIONS=
+
+# Hibernate 스키마 처리 방식
+# 운영 환경에서는 일반적으로 validate 사용
+SPRING_JPA_HIBERNATE_DDL_AUTO=
+
+# Redis 인증 비밀번호 — 실제 값은 저장소에 커밋하지 않는다
+SPRING_DATA_REDIS_PASSWORD=
+
+# =============================================================================
+# 대기열
+# =============================================================================
+
+# 대기열 활성화 여부
+QUEUE_ENABLED=
+
+# 초당 대기열 입장 허용 수
+QUEUE_ADMIT_RATE=
+
+# 대기열 상태 조회 처리 용량
+QUEUE_STATUS_RPS_CAPACITY=

--- a/deploy/.env.prod.example
+++ b/deploy/.env.prod.example
@@ -113,11 +113,11 @@ INBOX_RETENTION_ENABLED=true
 # =============================================================================
 
 # AWS 리전
-AWS_REGION=
+AWS_REGION=__REQUIRED__
 
 # AWS ECR 주소
 # 예: <AWS_ACCOUNT_ID>.dkr.ecr.<AWS_REGION>.amazonaws.com
-ECR_REGISTRY=
+ECR_REGISTRY=__REQUIRED__
 
 # 배포할 Git commit SHA 또는 이미지 태그
 IMAGE_TAG=

--- a/deploy/.env.prod.example
+++ b/deploy/.env.prod.example
@@ -120,7 +120,7 @@ AWS_REGION=__REQUIRED__
 ECR_REGISTRY=__REQUIRED__
 
 # 배포할 Git commit SHA 또는 이미지 태그
-IMAGE_TAG=
+IMAGE_TAG=__REQUIRED__
 
 # =============================================================================
 # 애플리케이션 런타임

--- a/deploy/nginx/nginx.conf
+++ b/deploy/nginx/nginx.conf
@@ -1,0 +1,84 @@
+user www-data;
+worker_processes auto;
+worker_rlimit_nofile 65535;
+pid /run/nginx.pid;
+error_log /var/log/nginx/error.log;
+include /etc/nginx/modules-enabled/*.conf;
+
+events {
+	worker_connections 16384;
+	# multi_accept on;
+}
+
+http {
+
+	##
+	# Basic Settings
+	##
+
+	sendfile on;
+	tcp_nopush on;
+	types_hash_max_size 2048;
+	# server_tokens off;
+
+	# server_names_hash_bucket_size 64;
+	# server_name_in_redirect off;
+
+	include /etc/nginx/mime.types;
+	default_type application/octet-stream;
+
+	##
+	# SSL Settings
+	##
+
+	ssl_protocols TLSv1 TLSv1.1 TLSv1.2 TLSv1.3; # Dropping SSLv3, ref: POODLE
+	ssl_prefer_server_ciphers on;
+
+	##
+	# Logging Settings
+	##
+
+	access_log /var/log/nginx/access.log;
+
+	##
+	# Gzip Settings
+	##
+
+	gzip on;
+
+	# gzip_vary on;
+	# gzip_proxied any;
+	# gzip_comp_level 6;
+	# gzip_buffers 16 8k;
+	# gzip_http_version 1.1;
+	# gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript;
+
+	##
+	# Virtual Host Configs
+	##
+
+	include /etc/nginx/conf.d/*.conf;
+	include /etc/nginx/sites-enabled/*;
+}
+
+
+#mail {
+#	# See sample authentication script at:
+#	# http://wiki.nginx.org/ImapAuthenticateWithApachePhpScript
+#
+#	# auth_http localhost/auth.php;
+#	# pop3_capabilities "TOP" "USER";
+#	# imap_capabilities "IMAP4rev1" "UIDPLUS";
+#
+#	server {
+#		listen     localhost:110;
+#		protocol   pop3;
+#		proxy      on;
+#	}
+#
+#	server {
+#		listen     localhost:143;
+#		protocol   imap;
+#		proxy      on;
+#	}
+#}

--- a/deploy/scripts/check-image-tag-drift.sh
+++ b/deploy/scripts/check-image-tag-drift.sh
@@ -2,6 +2,11 @@
 
 set -euo pipefail
 
+if ! command -v docker >/dev/null 2>&1; then
+  echo "ERROR: docker 명령을 찾을 수 없습니다. Docker가 설치된 호스트에서 실행하세요." >&2
+  exit 2
+fi
+
 SCRIPT_DIR="$(
   cd "$(dirname "${BASH_SOURCE[0]}")"
   pwd

--- a/deploy/scripts/check-image-tag-drift.sh
+++ b/deploy/scripts/check-image-tag-drift.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(
+  cd "$(dirname "${BASH_SOURCE[0]}")"
+  pwd
+)"
+
+DEPLOY_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+ENV_FILE="${ENV_FILE:-$DEPLOY_DIR/.env}"
+
+APP_CONTAINERS=(
+  auth-service
+  booking-service
+  gateway-service
+  payment-service
+  performance-service
+  seat-service
+  ticket-service
+  user-service
+)
+
+if [ ! -f "$ENV_FILE" ]; then
+  echo "ERROR: 환경파일을 찾을 수 없습니다: $ENV_FILE" >&2
+  exit 2
+fi
+
+expected_tag="$(
+  sed -nE \
+    's/^[[:space:]]*IMAGE_TAG[[:space:]]*=[[:space:]]*(.*)$/\1/p' \
+    "$ENV_FILE" \
+    | tail -n 1 \
+    | tr -d '\r'
+)"
+
+expected_tag="${expected_tag#"${expected_tag%%[![:space:]]*}"}"
+expected_tag="${expected_tag%"${expected_tag##*[![:space:]]}"}"
+expected_tag="${expected_tag%\"}"
+expected_tag="${expected_tag#\"}"
+expected_tag="${expected_tag%\'}"
+expected_tag="${expected_tag#\'}"
+
+if [ -z "$expected_tag" ]; then
+  echo "ERROR: $ENV_FILE에 IMAGE_TAG가 없습니다." >&2
+  exit 2
+fi
+
+echo "환경파일 IMAGE_TAG: $expected_tag"
+echo
+
+printf '%-24s %-42s %-10s\n' \
+  "CONTAINER" \
+  "RUNNING_TAG" \
+  "RESULT"
+
+drift_found=0
+runtime_error=0
+
+for container in "${APP_CONTAINERS[@]}"
+do
+  if ! docker inspect "$container" >/dev/null 2>&1; then
+    printf '%-24s %-42s %-10s\n' \
+      "$container" \
+      "-" \
+      "NOT_FOUND"
+
+    runtime_error=1
+    continue
+  fi
+
+  is_running="$(
+    docker inspect \
+      --format '{{.State.Running}}' \
+      "$container"
+  )"
+
+  if [ "$is_running" != "true" ]; then
+    printf '%-24s %-42s %-10s\n' \
+      "$container" \
+      "-" \
+      "STOPPED"
+
+    runtime_error=1
+    continue
+  fi
+
+  image="$(
+    docker inspect \
+      --format '{{.Config.Image}}' \
+      "$container"
+  )"
+
+  case "$image" in
+    *@sha256:*)
+      running_tag="${image##*@}"
+      ;;
+    *:*)
+      running_tag="${image##*:}"
+      ;;
+    *)
+      running_tag="<태그 없음>"
+      ;;
+  esac
+
+  if [ "$running_tag" = "$expected_tag" ]; then
+    result="OK"
+  else
+    result="DRIFT"
+    drift_found=1
+  fi
+
+  printf '%-24s %-42s %-10s\n' \
+    "$container" \
+    "$running_tag" \
+    "$result"
+done
+
+echo
+
+if [ "$runtime_error" -ne 0 ]; then
+  echo "ERROR: 일부 애플리케이션 컨테이너를 확인할 수 없습니다." >&2
+  exit 2
+fi
+
+if [ "$drift_found" -ne 0 ]; then
+  echo "FAIL: .env IMAGE_TAG와 실행 중 애플리케이션 이미지 태그가 다릅니다." >&2
+  exit 1
+fi
+
+echo "OK: .env IMAGE_TAG와 실행 중 애플리케이션 이미지 태그가 일치합니다."

--- a/docs/host-config-audit.md
+++ b/docs/host-config-audit.md
@@ -1,0 +1,41 @@
+- /etc/nginx/nginx.conf
+    - 편입
+    - MD5: 2c606adc5af0a25d4503e697611d3578
+
+- /etc/nginx/sites-available/api.ticketrush.store
+    - 기존 편입본과 일치
+    - MD5: 5ef9b5bfcb2cfa8abde007145744c9ae
+
+- nginx 백업 파일
+    - 편입 제외: 일회성 호스트 백업
+
+- Certbot hook
+    - 없음
+
+- systemd
+    - Snap, Certbot, Amazon SSM 관리 파일만 존재
+    - 편입 제외
+
+- Docker daemon
+    - 설정 파일 없음
+    - 로그 로테이션 미설정은 후속 이슈
+
+- sysctl
+    - OS 및 AWS 이미지 관리 파일
+    - 편입 제외
+
+- ulimit
+    - 커스텀 파일 없음
+
+- cron
+    - 패키지 기본 cron만 존재
+    - 사용자 crontab 없음
+
+- .env
+    - 시크릿 포함으로 편입 제외
+    - 키 목록만 .env.prod.example에 반영
+
+- IMAGE_TAG
+    - .env와 실행 중 이미지 태그 불일치 발견
+    - 검사 스크립트 편입
+    - CD 동기화는 후속 fix 이슈

--- a/docs/host-config-deployment.md
+++ b/docs/host-config-deployment.md
@@ -1,0 +1,9 @@
+1. EC2 운영 설정을 직접 수정하지 않는다.
+2. deploy/ 아래 파일을 먼저 수정한다.
+3. PR 검토와 병합을 거친다.
+4. 호스트에 반영하기 전 기존 파일을 백업한다.
+5. nginx 설정은 nginx -t 통과 후 reload한다.
+6. 반영 후 health endpoint를 확인한다.
+7. 저장소와 호스트 파일의 MD5를 대조한다.
+8. Docker 재생성 전에 check-image-tag-drift.sh를 실행한다.
+9. 드리프트가 발견되면 pull 또는 force-recreate를 진행하지 않는다.


### PR DESCRIPTION
## 🔗 관련 이슈

* close #522

---

## 📌 주요 변경 사항

* EC2 호스트에만 존재하던 nginx 본체 설정을 `deploy/nginx/nginx.conf`로 편입
* 운영 `.env`와 `.env.prod.example`의 키 목록을 대조하고 누락된 운영 환경변수 키 및 용도 추가
* `.env`의 `IMAGE_TAG`와 실행 중인 애플리케이션 컨테이너 이미지 태그를 비교하는 드리프트 검사 스크립트 추가
* 호스트 설정 감사 결과와 저장소 기반 배포 절차 문서화

---

## 🛠 상세 구현 내용

* `/etc/nginx/nginx.conf`의 운영 설정을 저장소에 편입

  * `worker_connections 16384`
  * `worker_rlimit_nofile 65535`
  * `keepalive_timeout`은 별도 설정 없이 nginx 기본값 사용
* 호스트 원본과 저장소 편입본의 MD5를 대조해 바이트 동일함을 확인

  * `/etc/nginx/nginx.conf`
  * `deploy/nginx/nginx.conf`
  * MD5: `2c606adc5af0a25d4503e697611d3578`
* 기존 nginx 사이트 설정도 운영 호스트와 저장소 파일이 동일한지 재검증

  * `/etc/nginx/sites-available/api.ticketrush.store`
  * `deploy/nginx/api.ticketrush.store.conf`
  * MD5: `5ef9b5bfcb2cfa8abde007145744c9ae`
* `.env.prod.example`에 실제 운영 환경에서 사용 중인 다음 키와 용도를 추가

  * `AWS_REGION`
  * `ECR_REGISTRY`
  * `IMAGE_TAG`
  * `JAVA_TOOL_OPTIONS`
  * `SPRING_JPA_HIBERNATE_DDL_AUTO`
  * `SPRING_DATA_REDIS_PASSWORD`
  * `QUEUE_ENABLED`
  * `QUEUE_ADMIT_RATE`
  * `QUEUE_STATUS_RPS_CAPACITY`
* 실제 시크릿과 호스트 고유 값은 저장소에 편입하지 않고 키와 용도만 예제 파일에 반영
* `deploy/scripts/check-image-tag-drift.sh`를 추가해 애플리케이션 컨테이너 8개의 실행 이미지 태그와 `.env`의 `IMAGE_TAG`를 비교하도록 구현
* Certbot, systemd, sysctl, ulimit, Docker daemon 설정, cron을 점검하고 편입 여부와 제외 사유를 감사 문서에 기록
* 운영 EC2를 직접 수정하지 않고 저장소의 `deploy/` 설정을 통해 반영하는 배포·검증·롤백 절차 문서화
* 감사 과정에서 발견한 `IMAGE_TAG` 드리프트와 Docker 로그 로테이션 미설정은 후속 fix 대상으로 분리

---

## ✅ 테스트

### 테스트 방법

* 호스트 nginx 설정과 저장소 편입본의 MD5 및 바이트 일치 여부 확인
* 기존 API nginx 사이트 설정과 저장소 편입본의 MD5 대조
* 이미지 태그 드리프트 검사 스크립트의 Bash 문법 검사
* EC2에서 드리프트 검사 스크립트를 실행해 애플리케이션 컨테이너 8개 비교
* `.env.prod.example`에 추가한 환경변수 키의 중복 여부 확인
* Git staged diff의 공백 및 문법 오류 확인

### 테스트 결과

* nginx 본체 설정 MD5 일치

  * `2c606adc5af0a25d4503e697611d3578`
* API nginx 사이트 설정 MD5 일치

  * `5ef9b5bfcb2cfa8abde007145744c9ae`
* `cmp` 결과 `0`으로 호스트 nginx 본체와 저장소 파일의 바이트 동일 확인
* `bash -n deploy/scripts/check-image-tag-drift.sh` 통과
* `git diff --cached --check` 통과
* 추가한 환경변수 키가 `.env.prod.example`에 각각 1회만 존재함을 확인
* 이미지 태그 드리프트 검사에서 실제 불일치 탐지

  * `.env IMAGE_TAG`: `21d2da2d6fc2e3bfdaf27f2b1440beccaad337bf`
  * 실행 중 이미지 태그: `d9808aadf88f8d9dc04b99c618995364279f28b5`
* Certbot 커스텀 훅, 프로젝트 커스텀 systemd·sysctl·ulimit·cron 및 Docker daemon 설정은 발견되지 않음
