### PR TITLE
[Fix] #583 배포 이미지 태그 동기화 및 드리프트 검증

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -46,6 +46,11 @@ jobs:
           test -f Dockerfile
           test -f deploy/docker-compose.prod.yml
           test -f deploy/.env.prod.example
+          test -x deploy/scripts/check-image-tag-drift.sh
+          test -x deploy/scripts/update-image-tag.sh
+
+          bash -n deploy/scripts/check-image-tag-drift.sh
+          bash -n deploy/scripts/update-image-tag.sh
 
           if [[ -f deploy/.env ]]; then
             echo "::error::deploy/.env must not be committed."
@@ -299,6 +304,65 @@ jobs:
           done
 
           "${COMPOSE[@]}" config -q
+
+          # pull/up 전에 기존 애플리케이션 실행 상태를 검증한다.
+          echo "Validating current release state before deployment."
+
+          RUNNING_APPLICATION_COUNT=0
+          TOTAL_APPLICATION_COUNT="${#APPLICATION_SERVICES[@]}"
+
+          for SERVICE in "${APPLICATION_SERVICES[@]}"; do
+            if docker inspect "${SERVICE}" > /dev/null 2>&1; then
+              IS_RUNNING="$(
+                docker inspect --format '{{.State.Running}}' "${SERVICE}"
+              )"
+
+              if [[ "${IS_RUNNING}" == "true" ]]; then
+                RUNNING_APPLICATION_COUNT=$((RUNNING_APPLICATION_COUNT + 1))
+              fi
+            fi
+          done
+
+          echo             "Running application containers: ${RUNNING_APPLICATION_COUNT}/${TOTAL_APPLICATION_COUNT}"
+
+          if [[ -f deploy/CURRENT_RELEASE ]]; then
+            # 기존 릴리스 기록이 있으면 실행 중인 8개 컨테이너가
+            # 모두 해당 릴리스와 일치해야 다음 배포를 진행한다.
+            if (( RUNNING_APPLICATION_COUNT != TOTAL_APPLICATION_COUNT )); then
+              echo                 "::error::CURRENT_RELEASE exists, but not all application containers are running."
+              exit 1
+            fi
+
+            CURRENT_RUNNING_RELEASE="$(
+              tr -d '\r\n' < deploy/CURRENT_RELEASE
+            )"
+
+            if [[ -z "${CURRENT_RUNNING_RELEASE}" ]]; then
+              echo "::error::deploy/CURRENT_RELEASE is empty."
+              exit 1
+            fi
+
+            EXPECTED_IMAGE_TAG="${CURRENT_RUNNING_RELEASE}"               deploy/scripts/check-image-tag-drift.sh
+
+            # 실행 상태가 CURRENT_RELEASE와 일치할 때만
+            # 뒤처진 .env의 IMAGE_TAG를 현재 릴리스로 복구한다.
+            deploy/scripts/update-image-tag.sh               "${CURRENT_RUNNING_RELEASE}"
+
+            deploy/scripts/check-image-tag-drift.sh
+          elif (( RUNNING_APPLICATION_COUNT == 0 )); then
+            # 새 호스트의 최초 배포에서는 비교할 기존 컨테이너가 없다.
+            echo               "No existing application containers or CURRENT_RELEASE; skipping pre-deployment drift validation."
+          elif (( RUNNING_APPLICATION_COUNT != TOTAL_APPLICATION_COUNT )); then
+            # 릴리스 기록 없이 일부 컨테이너만 존재하면 기준을 확정할 수 없다.
+            echo               "::error::Partial application deployment exists without CURRENT_RELEASE."
+            exit 1
+          else
+            # 릴리스 기록은 없지만 기존 8개 컨테이너가 모두 있다면
+            # .env와 실행 상태가 이미 일치하는 경우에만 진행한다.
+            deploy/scripts/check-image-tag-drift.sh
+          fi
+
+          echo "Current release state validated successfully."
 
           echo "Snapshotting container restart counts before deployment."
 
@@ -707,20 +771,42 @@ jobs:
 
           echo "Local Nginx HTTPS health check passed."
 
+          # 모든 health 검증이 끝난 뒤 실행 중 애플리케이션이
+          # 이번 배포 태그로 교체됐는지 확인한다.
+          echo "Validating deployed application image tags."
+
+          EXPECTED_IMAGE_TAG="${IMAGE_TAG}" deploy/scripts/check-image-tag-drift.sh
 
           PREVIOUS_RELEASE=""
 
           if [[ -f deploy/CURRENT_RELEASE ]]; then
-            PREVIOUS_RELEASE="$(cat deploy/CURRENT_RELEASE)"
+            PREVIOUS_RELEASE="$(
+              tr -d '\r\n' < deploy/CURRENT_RELEASE
+            )"
           fi
 
           if [[ -n "${PREVIOUS_RELEASE}" && "${PREVIOUS_RELEASE}" != "${IMAGE_TAG}" ]]; then
-            printf '%s\n' "${PREVIOUS_RELEASE}" \
-              > deploy/PREVIOUS_RELEASE
+            printf '%s\n' "${PREVIOUS_RELEASE}" > deploy/PREVIOUS_RELEASE
           fi
 
-          printf '%s\n' "${IMAGE_TAG}" \
-            > deploy/CURRENT_RELEASE
+          # CURRENT_RELEASE를 먼저 갱신한다.
+          # 이후 .env 갱신에 실패해도 다음 배포에서 이 값을 기준으로 복구할 수 있다.
+          CURRENT_RELEASE_TEMP="$(
+            mktemp deploy/CURRENT_RELEASE.tmp.XXXXXX
+          )"
+
+          printf '%s\n' "${IMAGE_TAG}" > "${CURRENT_RELEASE_TEMP}"
+          mv "${CURRENT_RELEASE_TEMP}" deploy/CURRENT_RELEASE
+
+          # 실행 상태 검증에 성공한 경우에만 .env의 IMAGE_TAG를 갱신한다.
+          echo "Persisting deployed IMAGE_TAG to deploy/.env."
+
+          deploy/scripts/update-image-tag.sh "${IMAGE_TAG}"
+
+          # .env에 기록된 IMAGE_TAG와 실행 상태가 일치하는지 최종 확인한다.
+          deploy/scripts/check-image-tag-drift.sh
+
+          echo "IMAGE_TAG synchronization completed."
 
           echo "Deployment completed."
           echo "Current release: ${IMAGE_TAG}"

--- a/deploy/scripts/check-image-tag-drift.sh
+++ b/deploy/scripts/check-image-tag-drift.sh
@@ -2,11 +2,6 @@
 
 set -euo pipefail
 
-if ! command -v docker >/dev/null 2>&1; then
-  echo "ERROR: docker 명령을 찾을 수 없습니다. Docker가 설치된 호스트에서 실행하세요." >&2
-  exit 2
-fi
-
 SCRIPT_DIR="$(
   cd "$(dirname "${BASH_SOURCE[0]}")"
   pwd
@@ -14,6 +9,7 @@ SCRIPT_DIR="$(
 
 DEPLOY_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 ENV_FILE="${ENV_FILE:-$DEPLOY_DIR/.env}"
+EXPECTED_IMAGE_TAG="${EXPECTED_IMAGE_TAG:-}"
 
 APP_CONTAINERS=(
   auth-service
@@ -26,32 +22,46 @@ APP_CONTAINERS=(
   user-service
 )
 
-if [ ! -f "$ENV_FILE" ]; then
-  echo "ERROR: 환경파일을 찾을 수 없습니다: $ENV_FILE" >&2
+trim_value() {
+  local value="$1"
+
+  value="${value#"${value%%[![:space:]]*}"}"
+  value="${value%"${value##*[![:space:]]}"}"
+  value="${value%\"}"
+  value="${value#\"}"
+  value="${value%\'}"
+  value="${value#\'}"
+
+  printf '%s' "$value"
+}
+
+if [[ -n "${EXPECTED_IMAGE_TAG}" ]]; then
+  expected_tag="$(trim_value "${EXPECTED_IMAGE_TAG}")"
+  expected_source="EXPECTED_IMAGE_TAG"
+else
+  if [[ ! -f "${ENV_FILE}" ]]; then
+    echo "ERROR: 환경파일을 찾을 수 없습니다: ${ENV_FILE}" >&2
+    exit 2
+  fi
+
+  expected_tag="$(
+    sed -nE \
+      's/^[[:space:]]*IMAGE_TAG[[:space:]]*=[[:space:]]*(.*)$/\1/p' \
+      "${ENV_FILE}" \
+      | tail -n 1 \
+      | tr -d '\r'
+  )"
+
+  expected_tag="$(trim_value "${expected_tag}")"
+  expected_source="${ENV_FILE}"
+fi
+
+if [[ -z "${expected_tag}" ]]; then
+  echo "ERROR: 비교할 IMAGE_TAG가 없습니다." >&2
   exit 2
 fi
 
-expected_tag="$(
-  sed -nE \
-    's/^[[:space:]]*IMAGE_TAG[[:space:]]*=[[:space:]]*(.*)$/\1/p' \
-    "$ENV_FILE" \
-    | tail -n 1 \
-    | tr -d '\r'
-)"
-
-expected_tag="${expected_tag#"${expected_tag%%[![:space:]]*}"}"
-expected_tag="${expected_tag%"${expected_tag##*[![:space:]]}"}"
-expected_tag="${expected_tag%\"}"
-expected_tag="${expected_tag#\"}"
-expected_tag="${expected_tag%\'}"
-expected_tag="${expected_tag#\'}"
-
-if [ -z "$expected_tag" ]; then
-  echo "ERROR: $ENV_FILE에 IMAGE_TAG가 없습니다." >&2
-  exit 2
-fi
-
-echo "환경파일 IMAGE_TAG: $expected_tag"
+echo "기준 IMAGE_TAG (${expected_source}): ${expected_tag}"
 echo
 
 printf '%-24s %-42s %-10s\n' \
@@ -64,9 +74,9 @@ runtime_error=0
 
 for container in "${APP_CONTAINERS[@]}"
 do
-  if ! docker inspect "$container" >/dev/null 2>&1; then
+  if ! docker inspect "${container}" >/dev/null 2>&1; then
     printf '%-24s %-42s %-10s\n' \
-      "$container" \
+      "${container}" \
       "-" \
       "NOT_FOUND"
 
@@ -77,12 +87,12 @@ do
   is_running="$(
     docker inspect \
       --format '{{.State.Running}}' \
-      "$container"
+      "${container}"
   )"
 
-  if [ "$is_running" != "true" ]; then
+  if [[ "${is_running}" != "true" ]]; then
     printf '%-24s %-42s %-10s\n' \
-      "$container" \
+      "${container}" \
       "-" \
       "STOPPED"
 
@@ -93,10 +103,10 @@ do
   image="$(
     docker inspect \
       --format '{{.Config.Image}}' \
-      "$container"
+      "${container}"
   )"
 
-  case "$image" in
+  case "${image}" in
     *@sha256:*)
       running_tag="${image##*@}"
       ;;
@@ -108,7 +118,7 @@ do
       ;;
   esac
 
-  if [ "$running_tag" = "$expected_tag" ]; then
+  if [[ "${running_tag}" == "${expected_tag}" ]]; then
     result="OK"
   else
     result="DRIFT"
@@ -116,21 +126,21 @@ do
   fi
 
   printf '%-24s %-42s %-10s\n' \
-    "$container" \
-    "$running_tag" \
-    "$result"
+    "${container}" \
+    "${running_tag}" \
+    "${result}"
 done
 
 echo
 
-if [ "$runtime_error" -ne 0 ]; then
+if [[ "${runtime_error}" -ne 0 ]]; then
   echo "ERROR: 일부 애플리케이션 컨테이너를 확인할 수 없습니다." >&2
   exit 2
 fi
 
-if [ "$drift_found" -ne 0 ]; then
-  echo "FAIL: .env IMAGE_TAG와 실행 중 애플리케이션 이미지 태그가 다릅니다." >&2
+if [[ "${drift_found}" -ne 0 ]]; then
+  echo "FAIL: 기준 IMAGE_TAG와 실행 중 애플리케이션 이미지 태그가 다릅니다." >&2
   exit 1
 fi
 
-echo "OK: .env IMAGE_TAG와 실행 중 애플리케이션 이미지 태그가 일치합니다."
+echo "OK: 기준 IMAGE_TAG와 실행 중 애플리케이션 이미지 태그가 일치합니다."

--- a/deploy/scripts/update-image-tag.sh
+++ b/deploy/scripts/update-image-tag.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(
+  cd "$(dirname "${BASH_SOURCE[0]}")"
+  pwd
+)"
+
+DEPLOY_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+ENV_FILE="${ENV_FILE:-$DEPLOY_DIR/.env}"
+NEW_IMAGE_TAG="${1:-${IMAGE_TAG:-}}"
+
+if [[ -z "${NEW_IMAGE_TAG}" ]]; then
+  echo "ERROR: 새 IMAGE_TAG를 인자로 전달해야 합니다." >&2
+  exit 2
+fi
+
+if [[ ! "${NEW_IMAGE_TAG}" =~ ^[A-Za-z0-9_][A-Za-z0-9_.-]{0,127}$ ]]; then
+  echo "ERROR: 유효하지 않은 Docker 이미지 태그입니다." >&2
+  exit 2
+fi
+
+if [[ ! -f "${ENV_FILE}" ]]; then
+  echo "ERROR: 환경파일을 찾을 수 없습니다: ${ENV_FILE}" >&2
+  exit 2
+fi
+
+TEMP_FILE="$(mktemp "${ENV_FILE}.tmp.XXXXXX")"
+
+cleanup() {
+  rm -f "${TEMP_FILE}"
+}
+
+trap cleanup EXIT
+
+awk -v image_tag="${NEW_IMAGE_TAG}" '
+  BEGIN {
+    updated = 0
+  }
+
+  /^[[:space:]]*IMAGE_TAG[[:space:]]*=/ {
+    if (!updated) {
+      print "IMAGE_TAG=" image_tag
+      updated = 1
+    }
+
+    next
+  }
+
+  {
+    print
+  }
+
+  END {
+    if (!updated) {
+      print "IMAGE_TAG=" image_tag
+    }
+  }
+' "${ENV_FILE}" > "${TEMP_FILE}"
+
+chmod 600 "${TEMP_FILE}"
+mv "${TEMP_FILE}" "${ENV_FILE}"
+
+trap - EXIT
+
+echo "IMAGE_TAG를 ${ENV_FILE}에 반영했습니다."


### PR DESCRIPTION
## 🔗 관련 이슈

- close #583

---

## 📌 주요 변경 사항

- CD 배포 전 `CURRENT_RELEASE`, 실행 중 컨테이너, `.env IMAGE_TAG` 간 드리프트 검증 추가
- 배포 성공 후 EC2 `.env`의 `IMAGE_TAG`를 실제 배포 태그로 동기화하는 스크립트 추가
- 최초 배포·기존 정상 배포·일부 컨테이너만 존재하는 비정상 상태를 구분하도록 배포 절차 보완

---

## 🛠 상세 구현 내용

- `deploy/scripts/check-image-tag-drift.sh`가 `.env`뿐 아니라 `EXPECTED_IMAGE_TAG`를 기준으로도 실행 중인 애플리케이션 컨테이너 8개의 이미지 태그를 검증하도록 수정
- `deploy/scripts/update-image-tag.sh`를 추가하여 `.env`의 `IMAGE_TAG` 한 줄만 원자적으로 갱신하고 파일 권한을 `600`으로 유지
- CD 배포 전에 다음 상태를 검증하도록 구성
  - `CURRENT_RELEASE`가 있으면 실행 중인 애플리케이션 8개가 모두 해당 태그와 일치하는지 확인
  - 검증 성공 시 뒤처진 `.env IMAGE_TAG`를 현재 릴리스로 복구
  - 컨테이너와 `CURRENT_RELEASE`가 모두 없는 최초 배포는 사전 드리프트 검사를 생략
  - 릴리스 기록 없이 일부 애플리케이션 컨테이너만 존재하면 배포 중단
- 모든 컨테이너 및 Nginx health 검증이 성공한 뒤 다음 순서로 배포 상태를 기록하도록 수정
  - 실행 중 애플리케이션 이미지 태그 검증
  - `PREVIOUS_RELEASE` 및 `CURRENT_RELEASE` 기록
  - `.env IMAGE_TAG` 갱신
  - `.env` 기준 최종 드리프트 재검증
- CD 파일 검증 단계에서 두 스크립트의 존재 여부, 실행 권한 및 Bash 문법을 검사하도록 추가

---

## ✅ 테스트

### 테스트 방법

- `check-image-tag-drift.sh`, `update-image-tag.sh` Bash 문법 검사
- GitHub Actions `cd.yml` YAML 파싱 검사
- 임시 `.env` 파일을 이용한 `IMAGE_TAG` 갱신 및 중복 방지 테스트
- EC2에서 실행 중인 애플리케이션 8개의 이미지 태그를 기준으로 드리프트 검사 실행
- EC2의 `CURRENT_RELEASE`와 실행 중인 애플리케이션 이미지 태그 비교
- Git diff 공백 및 문법 오류 검사

### 테스트 결과

- `bash -n deploy/scripts/check-image-tag-drift.sh` 통과
- `bash -n deploy/scripts/update-image-tag.sh` 통과
- `cd.yml` YAML 파싱 통과
- 임시 `.env`의 `IMAGE_TAG=old-tag`를 `IMAGE_TAG=new-tag`로 정상 교체
- 갱신 후 `.env`에 `IMAGE_TAG`가 1개만 존재함을 확인
- EC2 애플리케이션 컨테이너 8개 모두 기준 이미지 태그와 일치하여 드리프트 검사 통과
- EC2 `CURRENT_RELEASE`와 실행 중 이미지 태그가 모두 `d9808aadf88f8d9dc04b99c618995364279f28b5`로 일치함을 확인
- `git diff --check`, `git diff --cached --check` 통과
- 실제 운영 CD 전체 실행 검증은 `main` 병합 후 확인 예정