### PR TITLE
[Chore] #584 Docker 컨테이너 로그 로테이션 설정

### DIFF
--- a/deploy/docker-compose.prod.yml
+++ b/deploy/docker-compose.prod.yml
@@ -1,7 +1,14 @@
 name: ticketrush-prod
 
+x-default-logging: &default-logging
+  driver: json-file
+  options:
+    max-size: "10m"
+    max-file: "5"
+
 services:
   mysql:
+    logging: *default-logging
     image: mysql:8.0
     container_name: ticketrush-mysql
     mem_limit: 768m
@@ -32,6 +39,7 @@ services:
       - ticketrush-network
 
   redis:
+    logging: *default-logging
     image: redis:7-alpine
     container_name: ticketrush-redis
     # 실측 최대 4.1 MiB / 상한의 3.20%로 여유가 30배다(ADR 0006). 상향 근거가 없어 유지한다.
@@ -80,6 +88,7 @@ services:
   # Redis 지표 수집 경로가 없어 장애를 사후에 500 로그로만 인지했다(ADR 0008).
   # SPOF를 수용하는 이상 죽었을 때 즉시 아는 것이 유일한 대응책이므로 redis_up을 Grafana 알림에 물린다.
   redis-exporter:
+    logging: *default-logging
     image: oliver006/redis_exporter:v1.62.0-alpine
     container_name: ticketrush-redis-exporter
     mem_limit: 32m
@@ -103,6 +112,7 @@ services:
   # 단일 EC2에 앱 8개 + 인프라가 전부 올라가 CPU 경합이 1차 병목 후보인데, 호스트 자원 지표를
   # 수집하는 주체가 없었다(#465). 부하 테스트(#348)의 병목 판정 근거가 여기서 나온다.
   node-exporter:
+    logging: *default-logging
     image: prom/node-exporter:v1.8.2
     container_name: ticketrush-node-exporter
     mem_limit: 32m
@@ -160,6 +170,7 @@ services:
   #
   # 예산: 32 MiB. cAdvisor 는 128 MiB 를 먹고도 데이터를 못 줬다(ADR 0006 재평가 반영).
   container-mem-sampler:
+    logging: *default-logging
     image: alpine:3.21
     container_name: ticketrush-container-mem-sampler
     mem_limit: 32m
@@ -186,6 +197,7 @@ services:
     network_mode: none
 
   kafka-volume-init:
+    logging: *default-logging
     image: apache/kafka:3.7.0
     container_name: ticketrush-kafka-volume-init
     user: "0:0"
@@ -199,6 +211,7 @@ services:
     restart: "no"
 
   kafka:
+    logging: *default-logging
     image: apache/kafka:3.7.0
     container_name: ticketrush-kafka
     mem_limit: 1024m
@@ -238,6 +251,7 @@ services:
       - ticketrush-network
 
   user-service:
+    logging: *default-logging
     image: ${ECR_REGISTRY}/ticketrush/user-service:${IMAGE_TAG}
     platform: linux/amd64
     container_name: user-service
@@ -258,6 +272,7 @@ services:
       - ticketrush-network
 
   auth-service:
+    logging: *default-logging
     image: ${ECR_REGISTRY}/ticketrush/auth-service:${IMAGE_TAG}
     platform: linux/amd64
     container_name: auth-service
@@ -280,6 +295,7 @@ services:
       - ticketrush-network
 
   performance-service:
+    logging: *default-logging
     image: ${ECR_REGISTRY}/ticketrush/performance-service:${IMAGE_TAG}
     platform: linux/amd64
     container_name: performance-service
@@ -300,6 +316,7 @@ services:
       - ticketrush-network
 
   booking-service:
+    logging: *default-logging
     image: ${ECR_REGISTRY}/ticketrush/booking-service:${IMAGE_TAG}
     platform: linux/amd64
     container_name: booking-service
@@ -324,6 +341,7 @@ services:
       - ticketrush-network
 
   payment-service:
+    logging: *default-logging
     image: ${ECR_REGISTRY}/ticketrush/payment-service:${IMAGE_TAG}
     platform: linux/amd64
     container_name: payment-service
@@ -346,6 +364,7 @@ services:
       - ticketrush-network
 
   seat-service:
+    logging: *default-logging
     image: ${ECR_REGISTRY}/ticketrush/seat-service:${IMAGE_TAG}
     platform: linux/amd64
     container_name: seat-service
@@ -393,6 +412,7 @@ services:
       - ticketrush-network
 
   ticket-service:
+    logging: *default-logging
     image: ${ECR_REGISTRY}/ticketrush/ticket-service:${IMAGE_TAG}
     platform: linux/amd64
     container_name: ticket-service
@@ -417,6 +437,7 @@ services:
       - ticketrush-network
 
   gateway-service:
+    logging: *default-logging
     image: ${ECR_REGISTRY}/ticketrush/gateway-service:${IMAGE_TAG}
     platform: linux/amd64
     container_name: gateway-service
@@ -453,6 +474,7 @@ services:
       - ticketrush-network
 
   prometheus:
+    logging: *default-logging
     image: prom/prometheus:v2.53.0
     container_name: prometheus
     mem_limit: 384m
@@ -486,6 +508,7 @@ services:
       - ticketrush-network
 
   grafana:
+    logging: *default-logging
     # 11.1.0은 CVE-2024-9264(인증 후 명령 주입) 영향 범위다. 11.1.7이 그 라인의 수정 버전이다.
     image: grafana/grafana:11.1.7
     container_name: grafana


### PR DESCRIPTION
## 🔗 관련 이슈

- close #584

---

## 📌 주요 변경 사항

- Docker Compose 공통 로그 로테이션 설정 추가
- 운영 Compose 서비스 17개에 `json-file` 로그 크기 및 보관 개수 제한 적용
- YAML anchor를 사용해 서비스별 중복 설정 제거

---

## 🛠 상세 구현 내용

- `deploy/docker-compose.prod.yml`에 공통 로그 설정인 `x-default-logging` 추가
  - 로그 드라이버: `json-file`
  - 로그 파일 최대 크기: `10m`
  - 로그 파일 최대 보관 개수: `5`
- `logging: *default-logging`을 다음 17개 서비스에 적용
  - MySQL
  - Redis
  - Redis Exporter
  - Node Exporter
  - Container Memory Sampler
  - Kafka Volume Init
  - Kafka
  - Gateway Service
  - Auth Service
  - User Service
  - Booking Service
  - Payment Service
  - Performance Service
  - Ticket Service
  - Seat Service
  - Prometheus
  - Grafana
- 호스트의 `/etc/docker/daemon.json`을 직접 수정하지 않고 저장소의 Compose 설정을 통해 로그 정책을 관리하도록 구성
- 장기간 실행 또는 오류 로그 급증 시 Docker 로그가 무제한으로 증가해 EC2 디스크를 고갈시키는 문제를 방지

---

## ✅ 테스트

### 테스트 방법

- 임시 `deploy/.env`를 생성하여 Docker Compose 설정 문법 검사
- `docker compose config --format json` 결과에서 각 서비스의 로그 설정 확인
- 공통 로그 설정이 적용된 서비스 개수 확인
- Git diff 형식 및 공백 오류 검사

### 테스트 결과

- `docker compose config -q` 통과
- 총 17개 서비스 모두 다음 설정이 적용된 것을 확인
  - `driver: json-file`
  - `max-size: 10m`
  - `max-file: 5`
- `logging: *default-logging` 적용 개수 17개 확인
- `git diff --check` 통과
- 실제 운영 컨테이너의 `docker inspect` 검증은 `main` 병합 후 CD 배포 완료 뒤 진행 예정

