### PR TITLE
[Feat] #563 관리자 대시보드 집계와 공연 목록 API를 추가한다

### DIFF
--- a/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/app/dto/response/BookingDailyRevenueRow.java
+++ b/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/app/dto/response/BookingDailyRevenueRow.java
@@ -1,0 +1,12 @@
+package com.ticketrush.boundedcontext.booking.app.dto.response;
+
+import java.time.LocalDate;
+
+/**
+ * 일별 매출 한 행 (#563 관리자 대시보드).
+ *
+ * <p>날짜 축은 예매 확정 시각({@code confirmedAt})이다. 공연 날짜가 아니라 <b>돈이 들어온 날</b>을 세며, 그래야 매출 추이가 판매 활동을 반영한다.
+ *
+ * <p><b>매출이 0인 날은 행이 없다.</b> GROUP BY는 행이 있는 그룹만 만들기 때문이다. 차트에 빈 날을 0으로 그릴지는 화면의 몫이다.
+ */
+public record BookingDailyRevenueRow(LocalDate date, long revenue) {}

--- a/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/app/dto/response/BookingInternalStatsResponse.java
+++ b/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/app/dto/response/BookingInternalStatsResponse.java
@@ -1,0 +1,19 @@
+package com.ticketrush.boundedcontext.booking.app.dto.response;
+
+import java.util.List;
+
+/**
+ * 예매 집계 내부 조회 응답 (#563 관리자 대시보드).
+ *
+ * <p>요약·공연별·일별을 <b>한 응답으로 묶는다.</b> 관리자 대시보드가 이 셋을 한 화면에 함께 그리므로, 나누면 호출자가 같은 화면을 위해 세 번 왕복하고 실패 조합도
+ * 그만큼 늘어난다. 한 트랜잭션에서 뽑으므로 세 값이 같은 스냅샷을 본다는 성질도 따라온다.
+ *
+ * @param summary 전체 기간 요약. 관리자 예매 통계 API가 내리는 것과 <b>같은 유스케이스가 만든 같은 값</b>이다 — 매출 정의가 두 벌이 되지 않도록
+ *     재사용한다.
+ * @param byPerformance 공연별 예매·매출. 전체 기간이며 기간 파라미터의 영향을 받지 않는다.
+ * @param byDate 일별 매출. <b>이 목록만</b> 요청 기간으로 잘린다.
+ */
+public record BookingInternalStatsResponse(
+    BookingAdminStatsResponse summary,
+    List<BookingPerformanceStatsRow> byPerformance,
+    List<BookingDailyRevenueRow> byDate) {}

--- a/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/app/dto/response/BookingPerformanceStatsRow.java
+++ b/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/app/dto/response/BookingPerformanceStatsRow.java
@@ -1,0 +1,13 @@
+package com.ticketrush.boundedcontext.booking.app.dto.response;
+
+/**
+ * 공연 단위 예매 집계 한 행 (#563 관리자 대시보드).
+ *
+ * @param confirmedCount 확정된 예매 수. 1인 1매라 예매 건수가 곧 좌석 수지만, <b>좌석 서비스의 판매 좌석 수와 항상 같지는 않다</b> — 결제는
+ *     확정됐는데 좌석 확정에 실패해 보상 환불이 진행 중인 창(#492)에서 갈린다. 화면에 "판매된 좌석 수"로 보여줄 값은 좌석 쪽 집계이며, 이 값은 예매 관점의
+ *     수치이자 두 집계를 대조할 때 쓴다.
+ * @param confirmedRevenue 확정된 예매의 실제 결제 금액 합. {@code paidAmount}가 비어 있는 행은 0으로 더해지므로 요약의 {@code
+ *     missingAmountBookings}가 0이 아니면 이 값도 실제보다 작다.
+ */
+public record BookingPerformanceStatsRow(
+    Long performanceId, long confirmedCount, long confirmedRevenue) {}

--- a/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/app/usecase/BookingGetInternalStatsUseCase.java
+++ b/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/app/usecase/BookingGetInternalStatsUseCase.java
@@ -1,0 +1,49 @@
+package com.ticketrush.boundedcontext.booking.app.usecase;
+
+import com.ticketrush.boundedcontext.booking.app.dto.response.BookingDailyRevenueRow;
+import com.ticketrush.boundedcontext.booking.app.dto.response.BookingInternalStatsResponse;
+import com.ticketrush.boundedcontext.booking.app.dto.response.BookingPerformanceStatsRow;
+import com.ticketrush.boundedcontext.booking.domain.types.BookingStatus;
+import com.ticketrush.boundedcontext.booking.out.repository.BookingRepository;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 예매 집계 내부 조회 (#563 관리자 대시보드).
+ *
+ * <p>요약은 {@link BookingGetAdminStatsUseCase}를 <b>그대로 호출한다.</b> 같은 값을 다시 정의하면 관리자 예매 화면과 대시보드가 다른
+ * 매출을 내는 순간이 생긴다 — 어느 쪽이 맞는지 판정할 수단이 없는 종류의 불일치다. 완료·취소로 셀 상태를 그 유스케이스가 소유한다는 규율도 함께 지켜진다.
+ *
+ * <p>세 집계가 한 트랜잭션 안에서 실행되므로 같은 스냅샷을 본다. 요약의 매출과 공연별 매출의 합이 어긋나 보이는 일이 없다(단 {@code paidAmount}가 비어
+ * 있는 확정 예매는 양쪽 모두에서 0으로 더해진다 — 그 건수는 요약의 {@code missingAmountBookings}에 있다).
+ */
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class BookingGetInternalStatsUseCase {
+
+  private final BookingRepository bookingRepository;
+  private final BookingGetAdminStatsUseCase bookingGetAdminStatsUseCase;
+
+  /**
+   * 요약·공연별·일별 집계를 한 번에 반환한다.
+   *
+   * @param from 일별 매출의 시작일(포함)
+   * @param to 일별 매출의 종료일(포함). 내부에서 다음 날 0시 미만의 반열린 구간으로 바꿔 센다 — {@code confirmed_at}이 datetime이라
+   *     "종료일 끝"을 값으로 표현하려 하면 마이크로초 절삭에 기대게 되기 때문이다.
+   */
+  public BookingInternalStatsResponse execute(LocalDate from, LocalDate to) {
+    List<BookingPerformanceStatsRow> byPerformance =
+        bookingRepository.aggregateStatsByPerformance(BookingStatus.CONFIRMED);
+
+    List<BookingDailyRevenueRow> byDate =
+        bookingRepository.aggregateDailyRevenue(
+            BookingStatus.CONFIRMED, from.atStartOfDay(), to.plusDays(1).atStartOfDay());
+
+    return new BookingInternalStatsResponse(
+        bookingGetAdminStatsUseCase.execute(), byPerformance, byDate);
+  }
+}

--- a/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/in/api/v1/BookingInternalController.java
+++ b/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/in/api/v1/BookingInternalController.java
@@ -1,17 +1,22 @@
 package com.ticketrush.boundedcontext.booking.in.api.v1;
 
 import com.ticketrush.boundedcontext.booking.app.dto.response.BookingInternalResponse;
+import com.ticketrush.boundedcontext.booking.app.dto.response.BookingInternalStatsResponse;
+import com.ticketrush.boundedcontext.booking.app.usecase.BookingGetInternalStatsUseCase;
 import com.ticketrush.boundedcontext.booking.app.usecase.BookingGetInternalUseCase;
 import com.ticketrush.global.dto.response.ApiResponse;
 import com.ticketrush.global.status.SuccessStatus;
 import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @Hidden // 내부 전용 API — 공개 OpenAPI 문서(/v3/api-docs)에 노출하지 않는다.
@@ -22,6 +27,31 @@ import org.springframework.web.bind.annotation.RestController;
 public class BookingInternalController {
 
   private final BookingGetInternalUseCase bookingGetInternalUseCase;
+  private final BookingGetInternalStatsUseCase bookingGetInternalStatsUseCase;
+
+  /**
+   * 이 매핑은 {@code /{bookingId}}보다 먼저 평가된다 — Spring의 {@code PathPattern}이 리터럴 세그먼트를 변수 세그먼트보다 구체적으로
+   * 보기 때문이다. 순서에 기대는 코드라 경로를 바꿀 때 함께 확인해야 한다.
+   */
+  @Operation(
+      summary = "예매 집계 내부 조회",
+      description =
+          """
+          관리자 대시보드(#563)가 쓰는 예매 집계입니다. 요약·공연별·일별을 한 응답으로 내립니다.
+
+          **요약은 관리자 예매 통계 API(`/api/v1/booking/admin/bookings/stats`)와 같은 값입니다** —
+          같은 유스케이스를 재사용하므로 두 화면의 매출이 갈리지 않습니다.
+
+          **기간은 일별 매출에만 적용됩니다.** 요약과 공연별 집계는 전체 기간입니다.
+          기간의 기본값·상한은 이 API가 아니라 호출자(관리자 대시보드)가 정합니다.
+          """)
+  @GetMapping("/stats")
+  public ResponseEntity<ApiResponse<BookingInternalStatsResponse>> getStats(
+      @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate from,
+      @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate to) {
+    return ApiResponse.onSuccess(
+        SuccessStatus.OK, bookingGetInternalStatsUseCase.execute(from, to));
+  }
 
   @Operation(summary = "예매 소유자/상태 내부 조회", description = "예매의 소유자와 상태를 반환합니다.")
   @GetMapping("/{bookingId}")

--- a/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/out/repository/BookingRepository.java
+++ b/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/out/repository/BookingRepository.java
@@ -1,5 +1,7 @@
 package com.ticketrush.boundedcontext.booking.out.repository;
 
+import com.ticketrush.boundedcontext.booking.app.dto.response.BookingDailyRevenueRow;
+import com.ticketrush.boundedcontext.booking.app.dto.response.BookingPerformanceStatsRow;
 import com.ticketrush.boundedcontext.booking.app.dto.response.BookingStatsCounts;
 import com.ticketrush.boundedcontext.booking.domain.entity.Booking;
 import com.ticketrush.boundedcontext.booking.domain.types.BookingStatus;
@@ -63,6 +65,67 @@ public interface BookingRepository extends JpaRepository<Booking, Long> {
       @Param("confirmed") BookingStatus confirmed,
       @Param("canceled") BookingStatus canceled,
       @Param("refunded") BookingStatus refunded);
+
+  /*
+   * 공연별 예매·매출 집계 (#563 관리자 대시보드). 요약(aggregateStats)과 같은 모집단(CONFIRMED)을 보되 공연으로 묶는다.
+   * 두 쿼리의 상태 조건이 갈리면 대시보드의 카드 합과 공연 목록 합이 어긋난다.
+   *
+   * WHERE 없는 전건 GROUP BY다. 예매는 오픈런 트래픽을 받는 쓰기 핫패스라, 호출 빈도가 극히 낮은 관리자 조회를
+   * 위해 인덱스를 얹으면 그 비용을 모든 예매 INSERT/UPDATE가 상시 부담한다.
+   *
+   * 실측(로컬 MySQL, booking 3,000행 / CONFIRMED 1,000행):
+   *   Sort: performance_id <- Table scan on <temporary> <- Aggregate using temporary table
+   *     <- Table scan on b (cost=305 rows=3000)
+   * (performance_id, booking_status) 인덱스를 얹으면 임시 테이블 그룹핑을 인덱스 순회로 바꿀 수 있으나,
+   * 관리자 대시보드 1회 호출당 한 번인 비용을 줄이자고 모든 예매 쓰기에 인덱스 유지 비용을 얹는 교환이다.
+   * 공연 수가 아니라 예매 행 수에 비례해 커지므로, 느려지면 그때 이 수치와 대조해 추가한다.
+   *
+   * ORDER BY는 호출자를 위해서가 아니라 정렬 없는 GROUP BY의 순서가 실행 계획에 따라 흔들려 테스트가 간헐
+   * 실패하는 것을 막으려고 명시한다.
+   */
+  @Query(
+      "SELECT new com.ticketrush.boundedcontext.booking.app.dto.response"
+          + ".BookingPerformanceStatsRow("
+          + "b.performanceId, "
+          // SUM은 대상 행이 없으면 NULL이라 record의 long에서 NPE가 된다. aggregateStats와 같은 이유로 COALESCE.
+          + "COALESCE(SUM(CASE WHEN b.bookingStatus = :confirmed THEN 1 ELSE 0 END), 0), "
+          + "COALESCE(SUM(CASE WHEN b.bookingStatus = :confirmed "
+          + "THEN b.paidAmount ELSE 0 END), 0)) "
+          + "FROM Booking b "
+          + "GROUP BY b.performanceId "
+          + "ORDER BY b.performanceId ASC")
+  List<BookingPerformanceStatsRow> aggregateStatsByPerformance(
+      @Param("confirmed") BookingStatus confirmed);
+
+  /*
+   * 일별 매출 집계 (#563 관리자 대시보드). 확정 시각 기준이며 호출자가 넘긴 반열린 구간 [from, toExclusive)만 센다.
+   *
+   * 경계를 반열린 구간으로 받는 이유: confirmed_at은 datetime이라 "to일 23:59:59.999999까지"를 값으로 표현하려
+   * 하면 마이크로초 절삭에 기대게 된다. 다음 날 0시 미만으로 자르면 그 함정이 없다.
+   *
+   * cast(... as LocalDate)는 Hibernate가 MySQL의 DATE()로 번역한다. FUNCTION('DATE', ...)와 달리 반환
+   * 타입이 HQL 수준에서 확정되어 생성자 표현식의 LocalDate 파라미터에 그대로 들어간다.
+   *
+   * 이 쿼리는 새 인덱스 없이도 기존 (booking_status, updated_at) 인덱스의 선두 컬럼을 탄다 —
+   * 실측(로컬 MySQL, booking 3,000행 / CONFIRMED 1,000행, 30일 구간):
+   *   Index lookup on b using idx_booking_status_updated_at (booking_status='CONFIRMED')
+   *     (cost=26.1 rows=1000) -> Filter: confirmed_at 범위 (rows=111)
+   * 즉 전건 3,000행이 아니라 CONFIRMED 1,000행만 훑는다. confirmed_at은 인덱스 두 번째 컬럼이 아니라
+   * (updated_at이다) 범위 조건이 인덱스로 좁혀지지는 않지만, 상태 선별만으로 이 규모에서는 충분하다.
+   */
+  @Query(
+      "SELECT new com.ticketrush.boundedcontext.booking.app.dto.response.BookingDailyRevenueRow("
+          + "cast(b.confirmedAt as LocalDate), "
+          + "COALESCE(SUM(b.paidAmount), 0)) "
+          + "FROM Booking b "
+          + "WHERE b.bookingStatus = :confirmed "
+          + "AND b.confirmedAt >= :from AND b.confirmedAt < :toExclusive "
+          + "GROUP BY cast(b.confirmedAt as LocalDate) "
+          + "ORDER BY cast(b.confirmedAt as LocalDate) ASC")
+  List<BookingDailyRevenueRow> aggregateDailyRevenue(
+      @Param("confirmed") BookingStatus confirmed,
+      @Param("from") LocalDateTime from,
+      @Param("toExclusive") LocalDateTime toExclusive);
 
   @Query(
       "SELECT b.id FROM Booking b "

--- a/booking-service/src/test/java/com/ticketrush/boundedcontext/booking/in/api/v1/BookingInternalControllerTest.java
+++ b/booking-service/src/test/java/com/ticketrush/boundedcontext/booking/in/api/v1/BookingInternalControllerTest.java
@@ -6,13 +6,20 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.ticketrush.boundedcontext.booking.app.dto.response.BookingAdminStatsResponse;
+import com.ticketrush.boundedcontext.booking.app.dto.response.BookingDailyRevenueRow;
 import com.ticketrush.boundedcontext.booking.app.dto.response.BookingInternalResponse;
+import com.ticketrush.boundedcontext.booking.app.dto.response.BookingInternalStatsResponse;
+import com.ticketrush.boundedcontext.booking.app.dto.response.BookingPerformanceStatsRow;
+import com.ticketrush.boundedcontext.booking.app.usecase.BookingGetInternalStatsUseCase;
 import com.ticketrush.boundedcontext.booking.app.usecase.BookingGetInternalUseCase;
 import com.ticketrush.boundedcontext.booking.domain.types.BookingStatus;
 import com.ticketrush.global.config.CustomSecurityProperties;
 import com.ticketrush.global.config.JacksonConfig;
 import com.ticketrush.global.config.SecurityConfig;
 import com.ticketrush.global.filter.GatewayHeaderFilter;
+import java.time.LocalDate;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -41,6 +48,56 @@ class BookingInternalControllerTest {
   @Autowired private MockMvc mockMvc;
 
   @MockitoBean private BookingGetInternalUseCase bookingGetInternalUseCase;
+
+  @MockitoBean private BookingGetInternalStatsUseCase bookingGetInternalStatsUseCase;
+
+  /**
+   * 이 테스트가 고정하는 것은 값이 아니라 <b>JSON 키 이름</b>이다. performance-service의 클라이언트가 이 키로 매핑하는데, 그쪽은 앱의
+   * SNAKE_CASE 설정을 타지 않는 {@code RestClient.builder()}라 키가 어긋나도 예외 없이 조용히 0/null이 된다. 소비자 쪽 테스트만으로는
+   * 여기서 이름이 바뀌는 것을 잡지 못해 양쪽 테스트가 모두 초록인 채 운영만 깨진다.
+   */
+  @Test
+  @DisplayName("성공: 예매 집계를 snake_case 키로 200 반환한다 (#563 대시보드 계약)")
+  void getStats_success() throws Exception {
+    // given
+    given(
+            bookingGetInternalStatsUseCase.execute(
+                LocalDate.of(2026, 7, 9), LocalDate.of(2026, 8, 7)))
+        .willReturn(
+            new BookingInternalStatsResponse(
+                new BookingAdminStatsResponse(1250L, 980L, 120L, 147_000_000L, false, 3L),
+                List.of(new BookingPerformanceStatsRow(100L, 30L, 5_000_000L)),
+                List.of(new BookingDailyRevenueRow(LocalDate.of(2026, 8, 1), 1_000_000L))));
+
+    // when & then
+    mockMvc
+        .perform(
+            get("/api/v1/internal/booking/stats")
+                .param("from", "2026-07-09")
+                .param("to", "2026-08-07")
+                .header(INTERNAL_TOKEN_HEADER, "test-internal-token"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.result.summary.completed_bookings").value(980))
+        .andExpect(jsonPath("$.result.summary.total_revenue").value(147000000))
+        .andExpect(jsonPath("$.result.summary.revenue_complete").value(false))
+        .andExpect(jsonPath("$.result.summary.missing_amount_bookings").value(3))
+        .andExpect(jsonPath("$.result.by_performance[0].performance_id").value(100))
+        .andExpect(jsonPath("$.result.by_performance[0].confirmed_count").value(30))
+        .andExpect(jsonPath("$.result.by_performance[0].confirmed_revenue").value(5000000))
+        .andExpect(jsonPath("$.result.by_date[0].date").value("2026-08-01"))
+        .andExpect(jsonPath("$.result.by_date[0].revenue").value(1000000));
+  }
+
+  @Test
+  @DisplayName("실패: 내부 토큰 없이 예매 집계를 요청하면 403을 반환한다")
+  void getStats_withoutToken_forbidden() throws Exception {
+    mockMvc
+        .perform(
+            get("/api/v1/internal/booking/stats")
+                .param("from", "2026-07-09")
+                .param("to", "2026-08-07"))
+        .andExpect(status().isForbidden());
+  }
 
   @Test
   @DisplayName("성공: 올바른 내부 토큰이면 예매 소유자/상태를 200으로 반환한다")

--- a/booking-service/src/test/java/com/ticketrush/boundedcontext/booking/out/repository/BookingRepositoryTest.java
+++ b/booking-service/src/test/java/com/ticketrush/boundedcontext/booking/out/repository/BookingRepositoryTest.java
@@ -3,11 +3,15 @@ package com.ticketrush.boundedcontext.booking.out.repository;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.ticketrush.boundedcontext.booking.app.dto.response.BookingDailyRevenueRow;
+import com.ticketrush.boundedcontext.booking.app.dto.response.BookingPerformanceStatsRow;
 import com.ticketrush.boundedcontext.booking.app.dto.response.BookingStatsCounts;
 import com.ticketrush.boundedcontext.booking.domain.entity.Booking;
 import com.ticketrush.boundedcontext.booking.domain.types.BookingStatus;
 import com.ticketrush.global.jpa.config.JpaConfig;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -229,6 +233,91 @@ class BookingRepositoryTest {
     assertThat(counts.amountMissingCount()).isZero();
   }
 
+  @Test
+  @DisplayName("공연별 집계: 확정 예매만 공연 단위로 건수와 매출을 묶는다")
+  void aggregateStatsByPerformance_GroupsConfirmedOnly() {
+    // given: 공연 100에 확정 2건(+취소 1건), 공연 200에 확정 1건
+    bookingRepository.save(confirmedBooking("BK-P1", 100L, 10_000L));
+    bookingRepository.save(confirmedBooking("BK-P2", 100L, 25_000L));
+    bookingRepository.save(performanceBooking("BK-P3", 100L, BookingStatus.CANCELED));
+    bookingRepository.save(confirmedBooking("BK-P4", 200L, 7_000L));
+
+    // when
+    List<BookingPerformanceStatsRow> rows =
+        bookingRepository.aggregateStatsByPerformance(BookingStatus.CONFIRMED);
+
+    // then: 취소 건은 매출·건수 어디에도 잡히지 않지만 그 공연 자체는 행으로 남는다
+    assertThat(rows).hasSize(2);
+    assertThat(rows.get(0).performanceId()).isEqualTo(100L);
+    assertThat(rows.get(0).confirmedCount()).isEqualTo(2);
+    assertThat(rows.get(0).confirmedRevenue()).isEqualTo(35_000L);
+    assertThat(rows.get(1).performanceId()).isEqualTo(200L);
+    assertThat(rows.get(1).confirmedRevenue()).isEqualTo(7_000L);
+  }
+
+  @Test
+  @DisplayName("공연별 집계: 확정 예매가 하나도 없는 공연도 매출 0으로 내려간다(SUM의 NULL 방어)")
+  void aggregateStatsByPerformance_WhenNoConfirmed_ReturnsZeroNotNull() {
+    // given: 취소 예매만 있는 공연
+    bookingRepository.save(performanceBooking("BK-Z1", 300L, BookingStatus.CANCELED));
+
+    // when
+    List<BookingPerformanceStatsRow> rows =
+        bookingRepository.aggregateStatsByPerformance(BookingStatus.CONFIRMED);
+
+    // then: COALESCE가 없으면 record의 원시 long에 NULL이 들어가 NPE가 난다
+    assertThat(rows).hasSize(1);
+    assertThat(rows.get(0).confirmedCount()).isZero();
+    assertThat(rows.get(0).confirmedRevenue()).isZero();
+  }
+
+  @Test
+  @DisplayName("일별 매출: 확정일로 묶고 요청 구간 밖은 제외한다")
+  void aggregateDailyRevenue_GroupsByConfirmedDate() {
+    // given: 5/21 1건, 5/22 2건, 구간 밖(5/23) 1건
+    bookingRepository.save(
+        confirmedBookingAt("BK-D1", LocalDateTime.of(2026, 5, 21, 9, 0), 1_000L));
+    bookingRepository.save(
+        confirmedBookingAt("BK-D2", LocalDateTime.of(2026, 5, 22, 9, 0), 2_000L));
+    bookingRepository.save(
+        confirmedBookingAt("BK-D3", LocalDateTime.of(2026, 5, 22, 23, 59, 59), 3_000L));
+    bookingRepository.save(
+        confirmedBookingAt("BK-D4", LocalDateTime.of(2026, 5, 23, 0, 0), 9_000L));
+
+    // when: [5/21 00:00, 5/23 00:00) — 종료일 5/22의 다음 날 0시 미만
+    List<BookingDailyRevenueRow> rows =
+        bookingRepository.aggregateDailyRevenue(
+            BookingStatus.CONFIRMED,
+            LocalDateTime.of(2026, 5, 21, 0, 0),
+            LocalDateTime.of(2026, 5, 23, 0, 0));
+
+    // then: 반열린 구간이라 5/23 0시 정각 건은 빠지고, 5/22 23:59:59 건은 들어온다
+    assertThat(rows).hasSize(2);
+    assertThat(rows.get(0).date()).isEqualTo(LocalDate.of(2026, 5, 21));
+    assertThat(rows.get(0).revenue()).isEqualTo(1_000L);
+    assertThat(rows.get(1).date()).isEqualTo(LocalDate.of(2026, 5, 22));
+    assertThat(rows.get(1).revenue()).isEqualTo(5_000L);
+  }
+
+  @Test
+  @DisplayName("일별 매출: 확정되지 않은 예매는 세지 않는다")
+  void aggregateDailyRevenue_ExcludesNonConfirmed() {
+    // given: 확정을 거쳐 환불된 예매(confirmedAt과 금액이 남아 있다)
+    Booking refunded = confirmedBookingAt("BK-DR", LocalDateTime.of(2026, 5, 22, 9, 0), 50_000L);
+    refunded.markRefunded();
+    bookingRepository.save(refunded);
+
+    // when
+    List<BookingDailyRevenueRow> rows =
+        bookingRepository.aggregateDailyRevenue(
+            BookingStatus.CONFIRMED,
+            LocalDateTime.of(2026, 5, 1, 0, 0),
+            LocalDateTime.of(2026, 6, 1, 0, 0));
+
+    // then: 돈이 나간 예매라 매출 추이에 남으면 안 된다
+    assertThat(rows).isEmpty();
+  }
+
   private Booking booking(String bookingNumber, BookingStatus status) {
     return Booking.builder()
         .userId(1L)
@@ -243,6 +332,30 @@ class BookingRepositoryTest {
   private Booking confirmedBooking(String bookingNumber, Long paidAmount) {
     Booking booking = booking(bookingNumber, BookingStatus.PENDING);
     booking.confirm(LocalDateTime.of(2026, 5, 22, 10, 30), paidAmount);
+    return booking;
+  }
+
+  private Booking confirmedBooking(String bookingNumber, Long performanceId, Long paidAmount) {
+    Booking booking = performanceBooking(bookingNumber, performanceId, BookingStatus.PENDING);
+    booking.confirm(LocalDateTime.of(2026, 5, 22, 10, 30), paidAmount);
+    return booking;
+  }
+
+  private Booking performanceBooking(
+      String bookingNumber, Long performanceId, BookingStatus status) {
+    return Booking.builder()
+        .userId(1L)
+        .performanceId(performanceId)
+        .seatId(3L)
+        .bookingNumber(bookingNumber)
+        .bookingStatus(status)
+        .build();
+  }
+
+  private Booking confirmedBookingAt(
+      String bookingNumber, LocalDateTime confirmedAt, Long paidAmount) {
+    Booking booking = booking(bookingNumber, BookingStatus.PENDING);
+    booking.confirm(confirmedAt, paidAmount);
     return booking;
   }
 }

--- a/common/src/main/java/com/ticketrush/global/status/ErrorStatus.java
+++ b/common/src/main/java/com/ticketrush/global/status/ErrorStatus.java
@@ -141,6 +141,10 @@ public enum ErrorStatus {
   // PERFORMANCE_400_006은 정렬 파라미터 제거(#221)로 결번
   PERFORMANCE_INVALID_PRICE_RANGE(
       HttpStatus.BAD_REQUEST, "PERFORMANCE_400_007", "최소 가격은 최대 가격보다 클 수 없습니다."),
+  PERFORMANCE_INVALID_DASHBOARD_PERIOD(
+      HttpStatus.BAD_REQUEST, "PERFORMANCE_400_008", "조회 시작일은 종료일보다 늦을 수 없습니다."),
+  PERFORMANCE_DASHBOARD_PERIOD_TOO_LONG(
+      HttpStatus.BAD_REQUEST, "PERFORMANCE_400_009", "조회 기간은 최대 92일까지 지정할 수 있습니다."),
 
   // Performance 409
   PERFORMANCE_HAS_SOLD_SEATS(

--- a/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/app/dto/response/PerformanceAdminDashboardResponse.java
+++ b/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/app/dto/response/PerformanceAdminDashboardResponse.java
@@ -1,0 +1,90 @@
+package com.ticketrush.boundedcontext.performance.app.dto.response;
+
+import com.ticketrush.boundedcontext.performance.domain.types.Genre;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDate;
+import java.util.List;
+
+/**
+ * 관리자 대시보드 집계 응답 (#563).
+ *
+ * <p><b>값을 못 읽은 것과 0은 다르다.</b> 예매·좌석 서비스 조회가 실패하면 그 축의 필드만 비우고 대시보드 자체는 성공한다. 0으로 채우면 관리자가 "매출이
+ * 0원"과 "매출을 못 읽었다"를 구분할 수 없다.
+ *
+ * <p><b>비운 필드는 응답에서 키째 사라진다.</b> 공통 Jackson 설정이 {@code NON_NULL}을 전역 기본값으로 걸어 두어 null 필드는 직렬화되지
+ * 않는다. 즉 클라이언트가 보는 것은 {@code "total_revenue": null}이 아니라 <b>키의 부재</b>다 — 각 필드 설명도 그 기준으로 적었다.
+ */
+@Schema(description = "관리자 대시보드 집계 응답 DTO")
+public record PerformanceAdminDashboardResponse(
+    @Schema(description = "등록된 공연 수. 삭제된 공연만 제외하며 상태는 가리지 않는다(판매 전·취소 공연도 포함).", example = "42")
+        long registeredPerformances,
+    @Schema(
+            description =
+                "판매된 티켓 수. 확정된 예매 수이며 1인 1매라 티켓 수와 같다. " + "예매 서비스 조회에 실패하면 이 필드는 응답에서 생략된다.",
+            example = "980",
+            nullable = true)
+        Long soldTickets,
+    @Schema(
+            description =
+                "총 매출. 확정된 예매의 실제 결제 금액 합이며 전체 기간이다(조회 기간 파라미터의 영향을 받지 않는다). "
+                    + "관리자 예매 통계 API의 총 매출과 같은 값이다. 예매 서비스 조회에 실패하면 이 필드는 응답에서 생략된다.",
+            example = "147000000",
+            nullable = true)
+        Long totalRevenue,
+    @Schema(
+            description =
+                "총 매출이 완전한지 여부. 결제 금액이 기록되지 않은 확정 예매가 있으면 false이며 그 건수는 "
+                    + "`missing_amount_bookings`다. false면 표시된 매출은 실제보다 작다. "
+                    + "예매 서비스 조회에 실패하면 이 필드는 응답에서 생략된다.",
+            example = "true",
+            nullable = true)
+        Boolean revenueComplete,
+    @Schema(
+            description = "결제 금액이 비어 있어 매출에 반영되지 못한 확정 예매 수. " + "예매 서비스 조회에 실패하면 이 필드는 응답에서 생략된다.",
+            example = "0",
+            nullable = true)
+        Long missingAmountBookings,
+    @Schema(
+            description =
+                "평균 좌석 점유율(0~1, 소수점 넷째 자리 반올림). 판매가 실제로 일어나는 공연(판매중·판매종료)만 모수이며 "
+                    + "판매 전·취소 공연은 제외한다. 공연별 점유율의 산술평균이 아니라 "
+                    + "**전체 판매 좌석 ÷ 전체 좌석**이라 매출·티켓 수와 같은 축이다. "
+                    + "좌석 서비스 조회에 실패하면 이 필드는 응답에서 생략된다.",
+            example = "0.317",
+            nullable = true)
+        Double averageOccupancyRate,
+    @Schema(
+            description = "평균 점유율의 분자. 모수 공연들의 판매 좌석 합이다. 점유율과 함께 생략된다.",
+            example = "118",
+            nullable = true)
+        Long occupancySoldSeats,
+    @Schema(
+            description = "평균 점유율의 분모. 모수 공연들의 전체 좌석 합이다. 점유율과 함께 생략된다.",
+            example = "372",
+            nullable = true)
+        Long occupancyTotalSeats,
+    @Schema(
+            description =
+                "일별 매출 추이. 예매 확정일 기준이며 **이 목록만** 조회 기간으로 잘린다. "
+                    + "매출이 0인 날은 행이 없으므로 빈 날을 0으로 그릴지는 화면이 정한다. "
+                    + "예매 서비스 조회에 실패하면 이 필드는 응답에서 생략된다.",
+            nullable = true)
+        List<DailyRevenue> dailyRevenues,
+    @Schema(
+            description =
+                "장르별 매출 분포. 전체 기간이며 매출이 없는 장르도 0으로 포함해 항상 전체 장르가 내려간다. "
+                    + "예매 서비스 조회에 실패하면 이 필드는 응답에서 생략된다.",
+            nullable = true)
+        List<GenreRevenue> genreRevenues) {
+
+  @Schema(description = "일별 매출 한 행")
+  public record DailyRevenue(
+      @Schema(description = "예매 확정일", example = "2026-08-07") LocalDate date,
+      @Schema(description = "그날 확정된 예매의 결제 금액 합", example = "3200000") long revenue) {}
+
+  @Schema(description = "장르별 매출 한 행")
+  public record GenreRevenue(
+      @Schema(description = "장르 코드", example = "MUSICAL") Genre genre,
+      @Schema(description = "장르 한글명", example = "뮤지컬") String genreName,
+      @Schema(description = "해당 장르 공연들의 매출 합", example = "52000000") long revenue) {}
+}

--- a/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/app/dto/response/PerformanceAdminSummaryResponse.java
+++ b/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/app/dto/response/PerformanceAdminSummaryResponse.java
@@ -1,0 +1,47 @@
+package com.ticketrush.boundedcontext.performance.app.dto.response;
+
+import com.ticketrush.boundedcontext.performance.domain.types.Genre;
+import com.ticketrush.boundedcontext.performance.domain.types.PerformanceStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+/**
+ * 관리자 공연 목록 한 행 (#563). 공개 목록과 달리 판매·점유율·매출 같은 관리 집계 필드를 함께 내린다.
+ *
+ * <p>공연 자체 정보는 항상 채워지고, 집계 필드는 각 서비스 조회에 실패하면 비운다.
+ *
+ * <p><b>비운 필드는 응답에서 키째 사라진다.</b> 공통 Jackson 설정이 {@code NON_NULL}을 전역 기본값으로 걸어 두어 null 필드는 직렬화되지
+ * 않는다. 클라이언트가 보는 것은 {@code "revenue": null}이 아니라 <b>키의 부재</b>다.
+ */
+@Schema(description = "관리자 공연 목록 행 DTO")
+public record PerformanceAdminSummaryResponse(
+    @Schema(description = "공연 ID", example = "12") Long performanceId,
+    @Schema(description = "공연명", example = "뮤지컬 팬텀") String title,
+    @Schema(description = "장르 코드", example = "MUSICAL") Genre genre,
+    @Schema(description = "장르 한글명", example = "뮤지컬") String genreName,
+    @Schema(description = "공연 날짜", example = "2026-09-01") LocalDate showDate,
+    @Schema(description = "공연 시각", example = "19:30:00") LocalTime showTime,
+    @Schema(description = "공연 상태", example = "ON_SALE") PerformanceStatus performanceStatus,
+    @Schema(
+            description =
+                "판매된 좌석 수. **좌석 서비스의 실제 좌석 상태**이며 공연 등록 시 입력한 총 좌석 수와는 무관하다. "
+                    + "좌석 서비스 조회에 실패했거나 좌석이 아직 생성되지 않은 공연이면 생략된다.",
+            example = "38",
+            nullable = true)
+        Long soldSeats,
+    @Schema(description = "전체 좌석 수. 좌석 서비스가 실제로 생성한 좌석 수다.", example = "120", nullable = true)
+        Long totalSeats,
+    @Schema(
+            description = "좌석 점유율(0~1, 소수점 넷째 자리 반올림). 전체 좌석이 0이면 생략된다.",
+            example = "0.3167",
+            nullable = true)
+        Double occupancyRate,
+    @Schema(description = "매진 여부. 판매 좌석 수가 전체 좌석 수에 도달했는지다.", example = "false", nullable = true)
+        Boolean soldOut,
+    @Schema(
+            description =
+                "공연 매출. 확정된 예매의 실제 결제 금액 합이며 전체 기간이다. " + "예매 서비스 조회에 실패하면 생략되고, 예매가 한 건도 없으면 0이다.",
+            example = "5320000",
+            nullable = true)
+        Long revenue) {}

--- a/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/app/dto/response/PerformanceAggregateRow.java
+++ b/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/app/dto/response/PerformanceAggregateRow.java
@@ -1,0 +1,12 @@
+package com.ticketrush.boundedcontext.performance.app.dto.response;
+
+import com.ticketrush.boundedcontext.performance.domain.types.Genre;
+import com.ticketrush.boundedcontext.performance.domain.types.PerformanceStatus;
+
+/**
+ * 대시보드 집계에 필요한 공연 최소 정보 (#563). 내부 산출물이며 API로 노출되지 않는다.
+ *
+ * <p>엔티티 대신 이 프로젝션을 쓰는 이유는 대시보드가 전 공연을 훑기 때문이다. 장르별 매출은 공연을 장르로 접어야 하고 평균 점유율은 상태로 모수를 골라야 하는데,
+ * 그러자고 이미지 URL·설명 같은 큰 컬럼과 {@code @ElementCollection} 두 개까지 끌고 올 이유가 없다.
+ */
+public record PerformanceAggregateRow(Long id, Genre genre, PerformanceStatus status) {}

--- a/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/app/facade/PerformanceFacade.java
+++ b/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/app/facade/PerformanceFacade.java
@@ -3,6 +3,8 @@ package com.ticketrush.boundedcontext.performance.app.facade;
 import com.ticketrush.boundedcontext.performance.app.dto.request.PerformanceChangeStatusRequest;
 import com.ticketrush.boundedcontext.performance.app.dto.request.PerformanceCreateRequest;
 import com.ticketrush.boundedcontext.performance.app.dto.request.PerformancePatchRequest;
+import com.ticketrush.boundedcontext.performance.app.dto.response.PerformanceAdminDashboardResponse;
+import com.ticketrush.boundedcontext.performance.app.dto.response.PerformanceAdminSummaryResponse;
 import com.ticketrush.boundedcontext.performance.app.dto.response.PerformanceCreateResponse;
 import com.ticketrush.boundedcontext.performance.app.dto.response.PerformanceDetailResponse;
 import com.ticketrush.boundedcontext.performance.app.dto.response.PerformanceListResponse;
@@ -10,6 +12,8 @@ import com.ticketrush.boundedcontext.performance.app.usecase.PerformanceChangeSt
 import com.ticketrush.boundedcontext.performance.app.usecase.PerformanceClearBookingOpenAtUseCase;
 import com.ticketrush.boundedcontext.performance.app.usecase.PerformanceCreateUseCase;
 import com.ticketrush.boundedcontext.performance.app.usecase.PerformanceDeleteUseCase;
+import com.ticketrush.boundedcontext.performance.app.usecase.PerformanceGetAdminDashboardUseCase;
+import com.ticketrush.boundedcontext.performance.app.usecase.PerformanceGetAdminListUseCase;
 import com.ticketrush.boundedcontext.performance.app.usecase.PerformanceGetDetailUseCase;
 import com.ticketrush.boundedcontext.performance.app.usecase.PerformanceGetListUseCase;
 import com.ticketrush.boundedcontext.performance.app.usecase.PerformancePatchUseCase;
@@ -17,8 +21,11 @@ import com.ticketrush.boundedcontext.performance.app.usecase.PerformanceValidate
 import com.ticketrush.boundedcontext.performance.domain.types.Genre;
 import com.ticketrush.boundedcontext.performance.domain.types.PerformanceStatus;
 import com.ticketrush.global.dto.request.CursorPageRequest;
+import com.ticketrush.global.dto.request.OffsetPageRequest;
+import java.time.LocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
@@ -35,6 +42,8 @@ public class PerformanceFacade {
   private final PerformanceDeleteUseCase performanceDeleteUseCase;
   private final PerformanceValidateUseCase performanceValidateUseCase;
   private final PerformanceClearBookingOpenAtUseCase performanceClearBookingOpenAtUseCase;
+  private final PerformanceGetAdminDashboardUseCase performanceGetAdminDashboardUseCase;
+  private final PerformanceGetAdminListUseCase performanceGetAdminListUseCase;
 
   public PerformanceCreateResponse createPerformance(
       PerformanceCreateRequest request,
@@ -54,6 +63,16 @@ public class PerformanceFacade {
     return performanceGetListUseCase
         .execute(genre, minPrice, maxPrice, status, pageRequest)
         .toSlice(pageRequest.size());
+  }
+
+  /** 관리자 대시보드 집계 (#563). 기간은 일별 매출에만 적용되며 null이면 최근 30일이다. */
+  public PerformanceAdminDashboardResponse getAdminDashboard(LocalDate from, LocalDate to) {
+    return performanceGetAdminDashboardUseCase.execute(from, to);
+  }
+
+  /** 관리자 공연 목록 (#563). 판매·점유율·매출을 함께 내리며, 각 집계는 원본 서비스 조회 실패 시 null이다. */
+  public Page<PerformanceAdminSummaryResponse> getAdminPerformances(OffsetPageRequest pageRequest) {
+    return performanceGetAdminListUseCase.execute(pageRequest);
   }
 
   public PerformanceDetailResponse getPerformanceDetail(Long performanceId) {

--- a/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/app/usecase/PerformanceGetAdminDashboardUseCase.java
+++ b/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/app/usecase/PerformanceGetAdminDashboardUseCase.java
@@ -1,0 +1,215 @@
+package com.ticketrush.boundedcontext.performance.app.usecase;
+
+import com.ticketrush.boundedcontext.performance.app.dto.response.PerformanceAdminDashboardResponse;
+import com.ticketrush.boundedcontext.performance.app.dto.response.PerformanceAggregateRow;
+import com.ticketrush.boundedcontext.performance.domain.types.Genre;
+import com.ticketrush.boundedcontext.performance.domain.types.PerformanceStatus;
+import com.ticketrush.boundedcontext.performance.out.apiclient.BookingRestClient;
+import com.ticketrush.boundedcontext.performance.out.apiclient.SeatRestClient;
+import com.ticketrush.boundedcontext.performance.out.apiclient.dto.BookingStatsInfo;
+import com.ticketrush.boundedcontext.performance.out.apiclient.dto.SeatCountsInfo;
+import com.ticketrush.boundedcontext.performance.out.repository.PerformanceRepository;
+import com.ticketrush.global.exception.BusinessException;
+import com.ticketrush.global.status.ErrorStatus;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.EnumMap;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+/**
+ * 관리자 대시보드 집계 (#563).
+ *
+ * <p><b>모수가 지표마다 다르다.</b> 하나로 통일하면 어느 한쪽이 거짓말을 한다.
+ *
+ * <ul>
+ *   <li>등록 공연 수 — 삭제만 제외한 전체. 관리자가 "내가 등록한 공연이 몇 개인가"로 읽는 값이라 판매 전·취소도 센다.
+ *   <li>평균 점유율 — 판매가 실제로 일어나는 공연(판매중·판매종료)만. 판매 전 공연을 넣으면 0%가 깔려 공연을 등록할수록 지표가 나빠 보인다.
+ *   <li>매출·티켓 수 — 상태 무관 전체. 관리자 예매 통계 API와 같은 값이어야 두 화면이 갈리지 않는다.
+ * </ul>
+ *
+ * <p><b>트랜잭션을 열지 않는다.</b> DB 조회는 한 번뿐이고 그 뒤가 원격 호출 둘이라, 트랜잭션으로 감싸면 예매·좌석 서비스의 응답을 기다리는 동안 DB 커넥션을
+ * 붙잡는다. 읽기 한 번이라 트랜잭션으로 묶어 얻을 일관성도 없다.
+ */
+@Service
+@RequiredArgsConstructor
+public class PerformanceGetAdminDashboardUseCase {
+
+  /** 기간 미지정 시 오늘을 포함한 최근 30일. */
+  private static final int DEFAULT_PERIOD_DAYS = 30;
+
+  /**
+   * 일별 매출 조회 기간 상한(일). 응답 행 수와 예매 테이블 스캔량을 한 값으로 묶어 제한한다. 분기 단위 조회(약 92일)까지는 화면에서 자연스럽게 요구되므로 그 경계에
+   * 맞췄다.
+   */
+  private static final int MAX_PERIOD_DAYS = 92;
+
+  private static final int OCCUPANCY_SCALE = 4;
+
+  private final PerformanceRepository performanceRepository;
+  private final BookingRestClient bookingRestClient;
+  private final SeatRestClient seatRestClient;
+
+  public PerformanceAdminDashboardResponse execute(LocalDate from, LocalDate to) {
+    LocalDate resolvedTo = (to == null) ? LocalDate.now() : to;
+    LocalDate resolvedFrom = (from == null) ? resolvedTo.minusDays(DEFAULT_PERIOD_DAYS - 1L) : from;
+    validatePeriod(resolvedFrom, resolvedTo);
+
+    List<PerformanceAggregateRow> rows = performanceRepository.findAllAggregateRows();
+
+    Optional<BookingStatsInfo> stats = bookingRestClient.getStats(resolvedFrom, resolvedTo);
+    Map<Long, SeatCountsInfo> seatCounts = seatRestClient.getSeatCounts();
+
+    Occupancy occupancy = calculateOccupancy(rows, seatCounts);
+
+    // 요약이 비어 있으면 요약에서 파생되는 4필드를 조회 실패와 같게 다룬다. 200 + 정상 JSON인데 summary만
+    // null인 경우(예: 예매 서비스가 필드명을 바꿈)는 RestClientException도, 파싱 실패도 아니라 여기까지 그대로
+    // 도달한다. 그대로 역참조하면 fail-open이어야 할 경로가 NPE로 500이 된다.
+    // 일별·장르별은 각자의 목록이 살아 있으면 그대로 채운다 — 축별로 독립해 저하되는 편이 "각 축의 필드만
+    // 비운다"는 원칙에 맞다.
+    BookingStatsInfo.Summary summary = stats.map(BookingStatsInfo::summary).orElse(null);
+
+    return new PerformanceAdminDashboardResponse(
+        rows.size(),
+        (summary == null) ? null : summary.completedBookings(),
+        (summary == null) ? null : summary.totalRevenue(),
+        (summary == null) ? null : summary.revenueComplete(),
+        (summary == null) ? null : summary.missingAmountBookings(),
+        occupancy.rate(),
+        occupancy.soldSeats(),
+        occupancy.totalSeats(),
+        stats.map(s -> toDailyRevenues(s.byDate())).orElse(null),
+        stats.map(s -> toGenreRevenues(s.byPerformance(), rows)).orElse(null));
+  }
+
+  /**
+   * 기간을 검증한다. 상한을 넘거나 뒤집힌 구간은 400으로 거부한다 — 조용히 잘라 주면 관리자가 요청한 것과 다른 기간의 매출을 보게 되는데, 화면에는 요청한 기간이
+   * 그대로 남아 있어 그 차이를 알아챌 방법이 없다.
+   */
+  private void validatePeriod(LocalDate from, LocalDate to) {
+    if (from.isAfter(to)) {
+      throw new BusinessException(ErrorStatus.PERFORMANCE_INVALID_DASHBOARD_PERIOD);
+    }
+    if (ChronoUnit.DAYS.between(from, to) + 1 > MAX_PERIOD_DAYS) {
+      throw new BusinessException(ErrorStatus.PERFORMANCE_DASHBOARD_PERIOD_TOO_LONG);
+    }
+  }
+
+  /**
+   * 가중 평균 점유율을 계산한다 — 공연별 점유율의 산술평균이 아니라 전체 판매 좌석 ÷ 전체 좌석이다. 산술평균은 20석짜리 소규모 공연 하나가 1,000석 공연과 같은
+   * 무게를 가져 매출 규모와 방향이 어긋난다.
+   *
+   * <p><b>좌석 정보가 없는 공연은 분모에서도 빠진다.</b> 0석으로 채우면 좌석이 곧 생길 공연이 "영원히 매진 불가능한 공연"으로 평균을 끌어내린다. 좌석 생성은
+   * 공연 등록 이벤트를 받아 비동기로 일어나므로 정상 운영 중에도 잠깐 발생하는 상태다.
+   */
+  private Occupancy calculateOccupancy(
+      List<PerformanceAggregateRow> rows, Map<Long, SeatCountsInfo> seatCounts) {
+    long soldSum = 0;
+    long totalSum = 0;
+    boolean anySeatData = false;
+
+    for (PerformanceAggregateRow row : rows) {
+      if (!isOccupancyTarget(row.status())) {
+        continue;
+      }
+      SeatCountsInfo counts = seatCounts.get(row.id());
+      if (counts == null) {
+        continue;
+      }
+      anySeatData = true;
+      soldSum += counts.soldCount();
+      totalSum += counts.totalCount();
+    }
+
+    if (!anySeatData || totalSum == 0) {
+      return new Occupancy(null, null, null);
+    }
+
+    double rate =
+        BigDecimal.valueOf(soldSum)
+            .divide(BigDecimal.valueOf(totalSum), OCCUPANCY_SCALE, RoundingMode.HALF_UP)
+            .doubleValue();
+    return new Occupancy(rate, soldSum, totalSum);
+  }
+
+  private boolean isOccupancyTarget(PerformanceStatus status) {
+    return status == PerformanceStatus.ON_SALE || status == PerformanceStatus.CLOSED;
+  }
+
+  /**
+   * 일별 매출을 응답 형태로 옮긴다.
+   *
+   * <p>{@code byDate}가 null이면 <b>빈 목록이 아니라 null</b>을 낸다. 빈 목록은 "그 기간에 매출이 하루도 없었다"는 사실이고, null은 "값을
+   * 읽지 못했다"는 뜻이다 — 이 클래스가 다른 축에서 지키는 구분을 여기서만 깨뜨릴 이유가 없다. 반면 {@code toGenreRevenues}가 매출 없는 장르를 0으로
+   * 채우는 것은 차트가 전체 장르 축을 그려야 하기 때문이라, 성격이 다르다.
+   */
+  private List<PerformanceAdminDashboardResponse.DailyRevenue> toDailyRevenues(
+      List<BookingStatsInfo.DailyRevenue> byDate) {
+    if (byDate == null) {
+      return null;
+    }
+    List<PerformanceAdminDashboardResponse.DailyRevenue> result = new ArrayList<>(byDate.size());
+    for (BookingStatsInfo.DailyRevenue row : byDate) {
+      if (row != null && row.date() != null) {
+        result.add(new PerformanceAdminDashboardResponse.DailyRevenue(row.date(), row.revenue()));
+      }
+    }
+    return result;
+  }
+
+  /**
+   * 공연별 매출을 장르로 접는다. 장르는 performance만 알고 매출은 booking만 아는 값이라, 이 결합은 어느 한쪽 DB에서는 만들 수 없다(ADR 0003).
+   *
+   * <p><b>매출이 0인 장르도 내린다.</b> 차트가 전체 장르 축을 그리려면 없는 장르가 아니라 0인 장르가 필요하다. 다만 그 근거는 <b>데이터를 읽었는데 그 장르에
+   * 매출이 없는 경우</b>에만 해당한다 — 공연별 집계 자체를 못 읽었으면 {@code toDailyRevenues}와 같이 null을 낸다. 전 장르 0원으로 그리면
+   * 관리자가 "이번 기간에 아무것도 안 팔렸다"로 읽는데, 그건 사실이 아니라 모르는 것이다.
+   *
+   * <p><b>삭제된 공연의 매출은 어느 장르에도 잡히지 않는다.</b> 삭제되면 장르를 알 수 없어서다. 그래서 장르별 합이 총 매출보다 작을 수 있다 — 총 매출은 예매
+   * 기준이라 공연 삭제와 무관하게 남기 때문이다.
+   */
+  private List<PerformanceAdminDashboardResponse.GenreRevenue> toGenreRevenues(
+      List<BookingStatsInfo.PerformanceStat> byPerformance, List<PerformanceAggregateRow> rows) {
+    if (byPerformance == null) {
+      return null;
+    }
+
+    Map<Long, Genre> genreById = new HashMap<>();
+    for (PerformanceAggregateRow row : rows) {
+      genreById.put(row.id(), row.genre());
+    }
+
+    Map<Genre, Long> revenueByGenre = new EnumMap<>(Genre.class);
+    for (Genre genre : Genre.values()) {
+      revenueByGenre.put(genre, 0L);
+    }
+
+    for (BookingStatsInfo.PerformanceStat stat : byPerformance) {
+      if (stat == null || stat.performanceId() == null) {
+        continue;
+      }
+      Genre genre = genreById.get(stat.performanceId());
+      if (genre != null) {
+        revenueByGenre.merge(genre, stat.confirmedRevenue(), Long::sum);
+      }
+    }
+
+    List<PerformanceAdminDashboardResponse.GenreRevenue> result =
+        new ArrayList<>(revenueByGenre.size());
+    revenueByGenre.forEach(
+        (genre, revenue) ->
+            result.add(
+                new PerformanceAdminDashboardResponse.GenreRevenue(
+                    genre, genre.getDescription(), revenue)));
+    return result;
+  }
+
+  /** 점유율 계산 결과. 셋 다 null이거나 셋 다 값이 있다 — 분모를 모르면 비율도 의미가 없다. */
+  private record Occupancy(Double rate, Long soldSeats, Long totalSeats) {}
+}

--- a/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/app/usecase/PerformanceGetAdminListUseCase.java
+++ b/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/app/usecase/PerformanceGetAdminListUseCase.java
@@ -1,0 +1,137 @@
+package com.ticketrush.boundedcontext.performance.app.usecase;
+
+import com.ticketrush.boundedcontext.performance.app.dto.response.PerformanceAdminSummaryResponse;
+import com.ticketrush.boundedcontext.performance.domain.entity.Performance;
+import com.ticketrush.boundedcontext.performance.out.apiclient.BookingRestClient;
+import com.ticketrush.boundedcontext.performance.out.apiclient.SeatRestClient;
+import com.ticketrush.boundedcontext.performance.out.apiclient.dto.BookingStatsInfo;
+import com.ticketrush.boundedcontext.performance.out.apiclient.dto.SeatCountsInfo;
+import com.ticketrush.boundedcontext.performance.out.repository.PerformanceRepository;
+import com.ticketrush.global.dto.request.OffsetPageRequest;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.LocalDate;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+
+/**
+ * 관리자 공연 목록 조회 (#563). 공개 목록과 달리 판매·점유율·매출을 함께 내린다.
+ *
+ * <p><b>공개 목록 유스케이스를 재사용하지 않는다.</b> 그쪽은 무필터 첫 페이지를 Redis에 캐싱하는데, 캐시 키가 페이지 크기 하나뿐이라 관리자 응답과 공개 응답이
+ * 같은 키를 공유하게 된다. 캐시 값의 직렬화기도 공개 목록 DTO 타입에 고정돼 있어 집계 필드가 붙은 응답을 같은 캐시에 넣으면 역직렬화가 깨진다. 관리 화면에 stale
+ * 매출이 보이는 것도 그 자체로 결함이라, 이 경로는 캐싱하지 않는다.
+ *
+ * <p>정렬은 최신 등록순(ID 내림차순) 고정이다. 정렬 파라미터를 열면 비인덱스 컬럼 정렬을 클라이언트가 지정할 수 있게 되는데, 그 문제는 별도 이슈(#475)에서 결제
+ * 목록을 대상으로 다루는 중이라 여기서 같은 구멍을 새로 열지 않는다.
+ *
+ * <p>트랜잭션을 열지 않는 이유는 대시보드 유스케이스와 같다 — 원격 호출 대기 중에 DB 커넥션을 붙잡지 않기 위해서다.
+ *
+ * <p><b>알려진 비용: 페이지 요청 1회마다 원격 전건 집계가 2회 돈다.</b> 예매·좌석 어느 쪽도 공연 ID로 좁히는 축이 없어 매번 전체를 받아 와 현재 페이지에
+ * 해당하는 공연만 꺼내 쓴다. 관리자가 페이지를 넘길 때마다 {@code booking}·{@code seat} 두 테이블에 전건 GROUP BY가 반복되는데, 그 둘은 오픈런
+ * 트래픽을 직접 받는 쓰기 핫패스다.
+ *
+ * <p>이 이슈에서 감수한 이유는 관리자 동시 사용자가 소수이고 공연 수가 아직 작기 때문이며, <b>공연 수·예매 행 수가 늘면 성립하지 않는 전제</b>다. 해소하려면 예매
+ * 집계 API에 공연 ID 필터를 열어 현재 페이지만 조회하도록 바꿔야 하는데, 그건 이 이슈에서 "단일 엔드포인트로 전량 반환"으로 정한 계약을 바꾸는 일이라 별도 이슈로
+ * 분리한다. 그때까지의 완화 수단은 관리자 화면의 낮은 호출 빈도뿐이다.
+ */
+@Service
+@RequiredArgsConstructor
+public class PerformanceGetAdminListUseCase {
+
+  private static final int OCCUPANCY_SCALE = 4;
+
+  private final PerformanceRepository performanceRepository;
+  private final BookingRestClient bookingRestClient;
+  private final SeatRestClient seatRestClient;
+
+  public Page<PerformanceAdminSummaryResponse> execute(OffsetPageRequest pageRequest) {
+    Page<Performance> page =
+        performanceRepository.findAll(
+            PageRequest.of(
+                pageRequest.page(), pageRequest.size(), Sort.by(Sort.Direction.DESC, "id")));
+
+    Map<Long, Long> revenueByPerformance = fetchRevenueByPerformance();
+    Map<Long, SeatCountsInfo> seatCounts = seatRestClient.getSeatCounts();
+
+    return page.map(performance -> toSummary(performance, revenueByPerformance, seatCounts));
+  }
+
+  /**
+   * 공연별 매출을 가져온다.
+   *
+   * <p>기간을 <b>오늘 하루</b>로 넘기는 것은 목록이 일별 매출을 쓰지 않기 때문이다. 예매 집계 API는 요약·공연별·일별을 한 응답으로 주고 기간은 일별에만
+   * 적용되므로, 여기서 넓은 기간을 넘기면 쓰지도 않을 행을 만들어 실어 보내게 된다. 공연별 매출은 어느 기간을 넘기든 전체 기간 값이다.
+   *
+   * <p><b>조회 실패는 {@code null}, 성공은 (비어 있더라도) 맵으로 갈린다.</b> 빈 맵으로 뭉개면 "확정된 예매가 없어 매출 0원"과 "매출을 못
+   * 읽었다"가 응답에서 같은 모양이 된다 — 관리자가 구분할 수 없는 두 상태다.
+   *
+   * @return 공연 ID별 매출. 예매 서비스 조회에 실패하면 {@code null}
+   */
+  private Map<Long, Long> fetchRevenueByPerformance() {
+    LocalDate today = LocalDate.now();
+    Optional<BookingStatsInfo> stats = bookingRestClient.getStats(today, today);
+
+    if (stats.isEmpty() || stats.get().byPerformance() == null) {
+      return null;
+    }
+
+    Map<Long, Long> result = new HashMap<>();
+    for (BookingStatsInfo.PerformanceStat stat : stats.get().byPerformance()) {
+      if (stat != null && stat.performanceId() != null) {
+        result.merge(stat.performanceId(), stat.confirmedRevenue(), Long::sum);
+      }
+    }
+    return result;
+  }
+
+  private PerformanceAdminSummaryResponse toSummary(
+      Performance performance,
+      Map<Long, Long> revenueByPerformance,
+      Map<Long, SeatCountsInfo> seatCounts) {
+
+    SeatCountsInfo counts = seatCounts.get(performance.getId());
+    Long soldSeats = (counts == null) ? null : counts.soldCount();
+    Long totalSeats = (counts == null) ? null : counts.totalCount();
+    Double occupancyRate = calculateRate(counts);
+    Boolean soldOut =
+        (counts == null || counts.totalCount() == 0)
+            ? null
+            : counts.soldCount() >= counts.totalCount();
+
+    // 매출 맵이 null이면 조회 자체가 실패한 것이라 모든 공연이 null이다.
+    // 맵은 있는데 키가 없으면 그 공연에 확정된 예매가 없다는 뜻이므로 0이다.
+    Long revenue =
+        (revenueByPerformance == null)
+            ? null
+            : revenueByPerformance.getOrDefault(performance.getId(), 0L);
+
+    return new PerformanceAdminSummaryResponse(
+        performance.getId(),
+        performance.getTitle(),
+        performance.getGenre(),
+        performance.getGenre() == null ? null : performance.getGenre().getDescription(),
+        performance.getShowDate(),
+        performance.getShowTime(),
+        performance.getPerformanceStatus(),
+        soldSeats,
+        totalSeats,
+        occupancyRate,
+        soldOut,
+        revenue);
+  }
+
+  private Double calculateRate(SeatCountsInfo counts) {
+    if (counts == null || counts.totalCount() == 0) {
+      return null;
+    }
+    return BigDecimal.valueOf(counts.soldCount())
+        .divide(BigDecimal.valueOf(counts.totalCount()), OCCUPANCY_SCALE, RoundingMode.HALF_UP)
+        .doubleValue();
+  }
+}

--- a/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/in/api/v1/PerformanceAdminController.java
+++ b/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/in/api/v1/PerformanceAdminController.java
@@ -3,8 +3,10 @@ package com.ticketrush.boundedcontext.performance.in.api.v1;
 import com.ticketrush.boundedcontext.performance.app.dto.request.PerformanceChangeStatusRequest;
 import com.ticketrush.boundedcontext.performance.app.dto.request.PerformanceCreateRequest;
 import com.ticketrush.boundedcontext.performance.app.dto.request.PerformancePatchRequest;
+import com.ticketrush.boundedcontext.performance.app.dto.response.PerformanceAdminSummaryResponse;
 import com.ticketrush.boundedcontext.performance.app.dto.response.PerformanceCreateResponse;
 import com.ticketrush.boundedcontext.performance.app.facade.PerformanceFacade;
+import com.ticketrush.global.dto.request.OffsetPageRequest;
 import com.ticketrush.global.dto.response.ApiResponse;
 import com.ticketrush.global.status.SuccessStatus;
 import io.swagger.v3.oas.annotations.Operation;
@@ -18,11 +20,15 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.Positive;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.data.domain.Page;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -40,6 +46,32 @@ import org.springframework.web.multipart.MultipartFile;
 public class PerformanceAdminController {
 
   private final PerformanceFacade performanceFacade;
+
+  @Operation(
+      summary = "관리자 공연 목록 조회",
+      description =
+          """
+          전체 공연을 최신 등록순으로 페이징 조회합니다 (#563). 공개 목록과 달리 판매 좌석 수·점유율·매출 같은 관리 집계를 함께 내립니다.
+
+          **모수는 삭제된 공연만 제외한 전체입니다** — 판매 전(UPCOMING)·취소(CANCELED) 공연도 포함합니다.
+
+          **판매 좌석 수와 전체 좌석 수는 좌석 서비스의 실제 좌석 상태입니다.** 공연 등록 시 입력한 총 좌석 수와는 무관합니다.
+
+          집계 필드는 원본 서비스 조회 실패 시 **그 필드만 null**로 내려가고 목록 자체는 성공합니다 —
+          매출은 예매 서비스, 판매 좌석·점유율·매진은 좌석 서비스가 원본입니다.
+          좌석이 아직 생성되지 않은 공연(등록 직후)도 좌석 관련 필드가 null입니다.
+          `revenue`가 0과 null로 갈리는 것이 이 구분입니다: 0은 확정된 예매가 없다는 뜻이고 null은 값을 읽지 못했다는 뜻입니다.
+
+          정렬 파라미터는 받지 않습니다.
+          """)
+  @GetMapping
+  public ResponseEntity<ApiResponse<List<PerformanceAdminSummaryResponse>>> getAdminPerformances(
+      @ParameterObject @ModelAttribute OffsetPageRequest pageRequest) {
+    Page<PerformanceAdminSummaryResponse> response =
+        performanceFacade.getAdminPerformances(pageRequest);
+
+    return ApiResponse.onSuccess(SuccessStatus.OK, response);
+  }
 
   @Operation(
       summary = "공연 등록",

--- a/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/in/api/v1/PerformanceAdminDashboardController.java
+++ b/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/in/api/v1/PerformanceAdminDashboardController.java
@@ -1,0 +1,70 @@
+package com.ticketrush.boundedcontext.performance.in.api.v1;
+
+import com.ticketrush.boundedcontext.performance.app.dto.response.PerformanceAdminDashboardResponse;
+import com.ticketrush.boundedcontext.performance.app.facade.PerformanceFacade;
+import com.ticketrush.global.dto.response.ApiResponse;
+import com.ticketrush.global.status.SuccessStatus;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import java.time.LocalDate;
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 관리자 대시보드 집계 API (#563).
+ *
+ * <p><b>경로가 반드시 {@code /api/v1/performance/admin} 아래여야 한다.</b> SecurityConfig는 그 prefix만 {@code
+ * hasRole("ADMIN")}으로 걸고 나머지는 {@code anyRequest().permitAll()}이라, prefix를 벗어나면 경로 매처가 걸리지 않고 클래스
+ * 어노테이션 하나만 남는다.
+ */
+@Tag(name = "Performance Admin Dashboard", description = "공연 관리자 대시보드 API")
+@RestController
+@RequestMapping("/api/v1/performance/admin/dashboard")
+@RequiredArgsConstructor
+@PreAuthorize("hasRole('ADMIN')")
+public class PerformanceAdminDashboardController {
+
+  private final PerformanceFacade performanceFacade;
+
+  @Operation(
+      summary = "관리자 대시보드 집계 조회",
+      description =
+          """
+          대시보드 요약 카드와 매출 분석 데이터를 한 번에 조회합니다 (#563).
+
+          **지표마다 모수가 다릅니다.**
+          - 등록 공연 수 — 삭제된 공연만 제외한 전체(판매 전·취소 포함)
+          - 평균 점유율 — 판매가 실제로 일어나는 공연(ON_SALE·CLOSED)만
+          - 총 매출·판매 티켓 수 — 상태 무관 전체이며 관리자 예매 통계 API와 같은 값
+
+          **기간(`from`/`to`)은 일별 매출 추이에만 적용됩니다.** 요약 카드와 장르별 분포는 전체 기간입니다.
+          미지정 시 오늘을 포함한 최근 30일이며, 최대 92일까지 조회할 수 있습니다.
+          기간이 뒤집혔거나 상한을 넘으면 `COMMON_400`으로 거부합니다 — 조용히 잘라내면 화면에 표시된 기간과
+          실제 집계 기간이 어긋나기 때문입니다.
+
+          **평균 점유율은 가중 평균입니다** — 공연별 점유율의 산술평균이 아니라 전체 판매 좌석 ÷ 전체 좌석이라
+          매출·티켓 수와 같은 축입니다. 검증할 수 있도록 분자·분모를 함께 내립니다.
+
+          예매·좌석 서비스 조회가 실패하면 **그 축의 필드만 null**로 내려가고 대시보드 자체는 성공합니다.
+          null은 0이 아니라 "값을 읽지 못했다"는 뜻입니다.
+          """)
+  @GetMapping
+  public ResponseEntity<ApiResponse<PerformanceAdminDashboardResponse>> getDashboard(
+      @Parameter(description = "일별 매출 시작일(포함). 미지정 시 종료일 기준 최근 30일", example = "2026-07-09")
+          @RequestParam(required = false)
+          @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+          LocalDate from,
+      @Parameter(description = "일별 매출 종료일(포함). 미지정 시 오늘", example = "2026-08-07")
+          @RequestParam(required = false)
+          @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+          LocalDate to) {
+    return ApiResponse.onSuccess(SuccessStatus.OK, performanceFacade.getAdminDashboard(from, to));
+  }
+}

--- a/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/out/apiclient/BookingRestClient.java
+++ b/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/out/apiclient/BookingRestClient.java
@@ -1,0 +1,82 @@
+package com.ticketrush.boundedcontext.performance.out.apiclient;
+
+import com.ticketrush.boundedcontext.performance.out.apiclient.dto.BookingStatsApiResponse;
+import com.ticketrush.boundedcontext.performance.out.apiclient.dto.BookingStatsInfo;
+import com.ticketrush.global.config.CustomSecurityProperties;
+import com.ticketrush.global.util.ServiceUrlValidator;
+import java.time.LocalDate;
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
+
+/**
+ * 관리자 대시보드의 매출·판매 집계 조회 클라이언트 (#563).
+ *
+ * <p>booking-service의 <b>내부</b> API를 호출하므로 {@code X-Internal-Token}을 싣는다. 관리자 예매 통계
+ * API(`/api/v1/booking/admin/**`)를 부르지 않는 이유는 그쪽이 {@code hasRole("ADMIN")} 경계이고, ADMIN 권한은 게이트웨이가
+ * 사용자 헤더로만 부여하기 때문이다 — 서비스가 그 헤더를 스스로 만들면 게이트웨이 신뢰 경계를 사칭하는 셈이 된다. 값 자체는 같다(내부 API가 같은 유스케이스를
+ * 재사용한다).
+ *
+ * <p><b>실패해도 예외를 밖으로 내지 않는다.</b> 여기서 던지면 booking-service 장애가 대시보드 전체를 죽여, 공연 목록·상태 같은 performance
+ * 자체 정보까지 함께 보이지 않게 된다. 매출 관련 필드만 비운 채 응답한다(booking 관리자 목록이 보강 실패를 다루는 방식과 같다).
+ */
+@Slf4j
+@Component
+public class BookingRestClient {
+
+  private static final String INTERNAL_TOKEN_HEADER = "X-Internal-Token";
+
+  private final RestClient bookingServiceRestClient;
+  private final CustomSecurityProperties securityProperties;
+  private final boolean configured;
+
+  public BookingRestClient(
+      RestClient bookingServiceRestClient,
+      CustomSecurityProperties securityProperties,
+      @Value("${service.booking.url:}") String bookingServiceUrl) {
+    this.bookingServiceRestClient = bookingServiceRestClient;
+    this.securityProperties = securityProperties;
+    this.configured = ServiceUrlValidator.isUsable(bookingServiceUrl);
+  }
+
+  /**
+   * 요약·공연별·일별 집계를 한 번에 가져온다. 모든 실패는 {@code Optional.empty()}로 수렴한다.
+   *
+   * <p><b>쓸 수 없는 URL을 호출 전에 막는다.</b> 비어 있는 경우뿐 아니라 스킴이 빠진 경우({@code booking-service:8084})까지 막아야 한다
+   * — 둘 다 요청 시점에 {@code IllegalArgumentException}이 되는데, 그건 {@code RestClientException}이 아니라서 아래
+   * catch를 그대로 뚫고 <b>대시보드 전체가 500</b>이 된다. fail-open이 성립하려면 이 검사가 선행되어야 한다.
+   *
+   * @param from 일별 매출 시작일(포함) — 요약과 공연별 집계는 이 기간의 영향을 받지 않는다
+   * @param to 일별 매출 종료일(포함)
+   */
+  public Optional<BookingStatsInfo> getStats(LocalDate from, LocalDate to) {
+    if (!configured) {
+      return Optional.empty();
+    }
+
+    try {
+      BookingStatsApiResponse response =
+          bookingServiceRestClient
+              .get()
+              .uri(
+                  uriBuilder ->
+                      uriBuilder
+                          .path("/api/v1/internal/booking/stats")
+                          .queryParam("from", from)
+                          .queryParam("to", to)
+                          .build())
+              .header(INTERNAL_TOKEN_HEADER, securityProperties.getInternalToken())
+              .retrieve()
+              .body(BookingStatsApiResponse.class);
+
+      return Optional.ofNullable(response).map(BookingStatsApiResponse::result);
+    } catch (RestClientException e) {
+      log.warn(
+          "[BookingRestClient] 예매 집계 조회 실패, 매출 관련 필드는 null로 응답합니다. from={}, to={}", from, to, e);
+      return Optional.empty();
+    }
+  }
+}

--- a/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/out/apiclient/SeatRestClient.java
+++ b/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/out/apiclient/SeatRestClient.java
@@ -1,0 +1,84 @@
+package com.ticketrush.boundedcontext.performance.out.apiclient;
+
+import com.ticketrush.boundedcontext.performance.out.apiclient.dto.SeatCountsApiResponse;
+import com.ticketrush.boundedcontext.performance.out.apiclient.dto.SeatCountsInfo;
+import com.ticketrush.global.config.CustomSecurityProperties;
+import com.ticketrush.global.util.ServiceUrlValidator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
+
+/**
+ * 관리자 대시보드의 좌석 점유율 조회 클라이언트 (#563).
+ *
+ * <p>공연별 단건 조회(`/api/v1/seat/{id}/seat-counts`)를 공연 수만큼 반복하지 않고 <b>일괄 내부 API를 한 번</b> 부른다. 평균 점유율은
+ * 전체 공연이 모수라, 순차 호출은 공연이 늘수록 선형으로 느려지고 중간 한 건의 실패가 평균 전체를 왜곡한다.
+ *
+ * <p><b>실패해도 예외를 밖으로 내지 않는다.</b> 좌석 서비스 장애 시 점유율 관련 필드만 비고 대시보드의 나머지는 그대로 보인다.
+ */
+@Slf4j
+@Component
+public class SeatRestClient {
+
+  private static final String INTERNAL_TOKEN_HEADER = "X-Internal-Token";
+
+  private final RestClient seatServiceRestClient;
+  private final CustomSecurityProperties securityProperties;
+  private final boolean configured;
+
+  public SeatRestClient(
+      RestClient seatServiceRestClient,
+      CustomSecurityProperties securityProperties,
+      @Value("${service.seat.url:}") String seatServiceUrl) {
+    this.seatServiceRestClient = seatServiceRestClient;
+    this.securityProperties = securityProperties;
+    this.configured = ServiceUrlValidator.isUsable(seatServiceUrl);
+  }
+
+  /**
+   * 전 공연 좌석 수를 공연 ID로 색인해 반환한다. 실패하면 <b>빈 맵</b>이다.
+   *
+   * <p>빈 맵과 "좌석이 0석"은 호출자에게 같은 모양이 아니다 — 맵에 키가 없다는 것은 값을 <b>모른다</b>는 뜻이며, 호출자는 그 공연의 점유율을 0%가 아니라
+   * null로 내려야 한다. 좌석 생성은 공연 등록 이벤트를 받아 비동기로 일어나므로, 방금 등록된 공연은 정상 응답에서도 키가 없다.
+   *
+   * <p>{@code toMap()}을 쓰지 않는다. 좌석 쪽 응답에 같은 공연 ID가 두 번 들어오면 {@code IllegalStateException}이 나는데, 그건
+   * {@code RestClientException}이 아니라 아래 catch를 뚫고 500이 된다 — 부분 응답으로 살아남아야 할 경로가 전체 실패로 뒤집힌다.
+   */
+  public Map<Long, SeatCountsInfo> getSeatCounts() {
+    if (!configured) {
+      return Map.of();
+    }
+
+    try {
+      SeatCountsApiResponse response =
+          seatServiceRestClient
+              .get()
+              .uri("/api/v1/internal/seat/seat-counts")
+              .header(INTERNAL_TOKEN_HEADER, securityProperties.getInternalToken())
+              .retrieve()
+              .body(SeatCountsApiResponse.class);
+
+      List<SeatCountsInfo> rows = (response == null) ? null : response.result();
+      if (rows == null) {
+        log.warn("[SeatRestClient] 좌석 수 응답 본문이 비어 있어 점유율 필드를 null로 응답합니다.");
+        return Map.of();
+      }
+
+      Map<Long, SeatCountsInfo> result = new HashMap<>();
+      for (SeatCountsInfo row : rows) {
+        if (row != null && row.performanceId() != null) {
+          result.put(row.performanceId(), row);
+        }
+      }
+      return result;
+    } catch (RestClientException e) {
+      log.warn("[SeatRestClient] 좌석 수 조회 실패, 점유율 관련 필드는 null로 응답합니다.", e);
+      return Map.of();
+    }
+  }
+}

--- a/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/out/apiclient/dto/BookingStatsApiResponse.java
+++ b/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/out/apiclient/dto/BookingStatsApiResponse.java
@@ -1,0 +1,11 @@
+package com.ticketrush.boundedcontext.performance.out.apiclient.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+/**
+ * booking-service의 공통 {@code ApiResponse} 래퍼 중 이 서비스가 쓰는 필드만 매핑한다.
+ *
+ * <p>{@code code}를 매핑하지 않는 이유는 모든 실패가 동일하게 "매출 필드 null"로 수렴해 구분할 이유가 없기 때문이다.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record BookingStatsApiResponse(BookingStatsInfo result) {}

--- a/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/out/apiclient/dto/BookingStatsInfo.java
+++ b/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/out/apiclient/dto/BookingStatsInfo.java
@@ -1,0 +1,39 @@
+package com.ticketrush.boundedcontext.performance.out.apiclient.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.LocalDate;
+import java.util.List;
+
+/**
+ * booking-service 예매 집계 내부 API의 응답 매핑 (#563).
+ *
+ * <p>이 DTO들은 {@code RestClient.builder()} 정적 팩토리로 만든 클라이언트가 쓰므로 앱의 {@code
+ * JacksonConfig}(SNAKE_CASE)를 타지 않는다. 그래서 컴포넌트명과 다른 키에는 {@code @JsonProperty}가 반드시 필요하다 — 빠뜨리면 예외
+ * 없이 <b>조용히 null/0</b>이 되어, 매출이 0원인 대시보드가 정상 응답으로 보인다.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record BookingStatsInfo(
+    Summary summary,
+    @JsonProperty("by_performance") List<PerformanceStat> byPerformance,
+    @JsonProperty("by_date") List<DailyRevenue> byDate) {
+
+  /** 전체 기간 요약. 관리자 예매 통계 API가 내리는 것과 같은 값이다. */
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  public record Summary(
+      @JsonProperty("completed_bookings") long completedBookings,
+      @JsonProperty("total_revenue") long totalRevenue,
+      @JsonProperty("revenue_complete") boolean revenueComplete,
+      @JsonProperty("missing_amount_bookings") long missingAmountBookings) {}
+
+  /** 공연별 예매·매출. 전체 기간이며 요청 기간의 영향을 받지 않는다. */
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  public record PerformanceStat(
+      @JsonProperty("performance_id") Long performanceId,
+      @JsonProperty("confirmed_count") long confirmedCount,
+      @JsonProperty("confirmed_revenue") long confirmedRevenue) {}
+
+  /** 일별 매출. 매출이 0인 날은 행 자체가 없다. */
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  public record DailyRevenue(LocalDate date, long revenue) {}
+}

--- a/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/out/apiclient/dto/SeatCountsApiResponse.java
+++ b/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/out/apiclient/dto/SeatCountsApiResponse.java
@@ -1,0 +1,8 @@
+package com.ticketrush.boundedcontext.performance.out.apiclient.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.util.List;
+
+/** seat-service의 공통 {@code ApiResponse} 래퍼 중 이 서비스가 쓰는 필드만 매핑한다. */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record SeatCountsApiResponse(List<SeatCountsInfo> result) {}

--- a/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/out/apiclient/dto/SeatCountsInfo.java
+++ b/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/out/apiclient/dto/SeatCountsInfo.java
@@ -1,0 +1,16 @@
+package com.ticketrush.boundedcontext.performance.out.apiclient.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * seat-service 일괄 좌석 수 내부 API의 응답 한 행 (#563).
+ *
+ * <p>{@code availableCount}·{@code holdCount}는 매핑하지 않는다. 대시보드가 쓰는 것은 점유율의 분자·분모인 {@code
+ * soldCount}·{@code totalCount}뿐이고, 안 쓰는 필드를 들이면 좌석 쪽 응답이 바뀔 때 이유 없이 함께 흔들린다.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record SeatCountsInfo(
+    @JsonProperty("performance_id") Long performanceId,
+    @JsonProperty("total_count") long totalCount,
+    @JsonProperty("sold_count") long soldCount) {}

--- a/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/out/repository/PerformanceRepository.java
+++ b/performance-service/src/main/java/com/ticketrush/boundedcontext/performance/out/repository/PerformanceRepository.java
@@ -1,8 +1,10 @@
 package com.ticketrush.boundedcontext.performance.out.repository;
 
+import com.ticketrush.boundedcontext.performance.app.dto.response.PerformanceAggregateRow;
 import com.ticketrush.boundedcontext.performance.domain.entity.Performance;
 import com.ticketrush.boundedcontext.performance.domain.types.PerformanceStatus;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -12,6 +14,21 @@ import org.springframework.data.repository.query.Param;
 
 public interface PerformanceRepository
     extends JpaRepository<Performance, Long>, PerformanceRepositoryCustom {
+
+  /**
+   * 대시보드 집계용 공연 최소 정보 전건 조회 (#563).
+   *
+   * <p>{@code @SQLRestriction("deleted_at IS NULL")}이 JPQL에도 적용되므로 삭제된 공연은 자동으로 빠진다. 벌크 UPDATE와 달리
+   * 여기서 조건을 다시 쓸 필요가 없는 이유다.
+   *
+   * <p>정렬을 명시하는 것은 호출자가 순서에 의존해서가 아니라, 정렬 없는 조회의 순서가 실행 계획에 따라 흔들려 테스트가 간헐 실패하는 것을 막기 위해서다.
+   */
+  @Query(
+      "SELECT new com.ticketrush.boundedcontext.performance.app.dto.response"
+          + ".PerformanceAggregateRow(p.id, p.genre, p.performanceStatus) "
+          + "FROM Performance p "
+          + "ORDER BY p.id ASC")
+  List<PerformanceAggregateRow> findAllAggregateRows();
 
   @EntityGraph(attributePaths = {"imageGalleryUrls", "facilities"})
   Optional<Performance> findDetailById(Long id);

--- a/performance-service/src/main/java/com/ticketrush/global/config/RestClientConfig.java
+++ b/performance-service/src/main/java/com/ticketrush/global/config/RestClientConfig.java
@@ -1,0 +1,71 @@
+package com.ticketrush.global.config;
+
+import com.ticketrush.global.util.ServiceUrlValidator;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestClient;
+
+/**
+ * performance-service의 아웃바운드 HTTP 클라이언트 (#563).
+ *
+ * <p>이 서비스의 <b>첫 동기 호출</b>이다. 지금까지 performance는 불려 가기만 했고 부르지 않았다. 관리자 대시보드가 매출(예매)과 좌석 점유율(좌석)을 함께
+ * 그려야 하는데, ADR 0003이 크로스 도메인 조인을 금지하므로 API 호출로만 얻을 수 있다.
+ *
+ * <p><b>URL이 비어도 기동을 막지 않는다.</b> payment의 같은 설정은 URL 결손 시 {@code IllegalStateException}으로 기동을
+ * 실패시키는데(#490), 그쪽은 fail-closed 결제 확정 경로라 조용히 새는 것이 곧 전건 503이었다. 여기는 정반대다 — 이 클라이언트들이 죽어도 대시보드의 해당
+ * 필드만 비고, 반대로 기동을 막으면 <b>공연 목록·상세 같은 사용자 공개 API가 관리자 대시보드 설정 하나 때문에 함께 죽는다.</b> 장애 반경이 훨씬 큰 쪽을 택할
+ * 이유가 없다. 대신 기동 시점에 경고를 남겨 설정 누락이 드러나게 한다.
+ *
+ * <p>타임아웃은 대상별로 나눈다(컨벤션: 호출 대상 2개 이상). read를 3초로 잡은 것은 두 호출이 모두 <b>전건 GROUP BY 집계</b>라 단건 조회
+ * 선례(1~2초)보다 길게 걸리기 때문이다. 관리자 경로라 호출 빈도가 낮아 톰캣 스레드를 오래 잡는 위험도 그만큼 작다.
+ */
+@Slf4j
+@Configuration
+public class RestClientConfig {
+
+  @Bean
+  public RestClient bookingServiceRestClient(
+      @Value("${service.booking.url:}") String bookingServiceUrl,
+      @Value("${service.booking.connect-timeout-ms:1000}") long connectTimeoutMs,
+      @Value("${service.booking.read-timeout-ms:3000}") long readTimeoutMs) {
+    warnIfUnusable(bookingServiceUrl, "service.booking.url", "BOOKING_SERVICE_URL", "매출·판매 집계");
+    return RestClient.builder()
+        .baseUrl(bookingServiceUrl)
+        .requestFactory(RestClientFactorySupport.withTimeouts(connectTimeoutMs, readTimeoutMs))
+        .build();
+  }
+
+  @Bean
+  public RestClient seatServiceRestClient(
+      @Value("${service.seat.url:}") String seatServiceUrl,
+      @Value("${service.seat.connect-timeout-ms:1000}") long connectTimeoutMs,
+      @Value("${service.seat.read-timeout-ms:3000}") long readTimeoutMs) {
+    warnIfUnusable(seatServiceUrl, "service.seat.url", "SEAT_SERVICE_URL", "좌석 점유율");
+    return RestClient.builder()
+        .baseUrl(seatServiceUrl)
+        .requestFactory(RestClientFactorySupport.withTimeouts(connectTimeoutMs, readTimeoutMs))
+        .build();
+  }
+
+  /**
+   * 설정 누락·오류를 기동 로그로 드러낸다. 호출 자체를 막는 것은 각 클라이언트의 몫이다.
+   *
+   * <p>비어 있는 값뿐 아니라 <b>스킴이 빠진 값</b>({@code booking-service:8084})도 경고 대상이다. 그런 값은 문자열로는 멀쩡해 보여
+   * 통과하지만 요청 시점에 {@code IllegalArgumentException}이 되고, 그건 {@code RestClientException}이 아니라서 클라이언트의
+   * fail-open catch를 뚫고 500이 된다. 기동 시점에 드러나지 않으면 관리자가 대시보드를 열어야만 알 수 있다.
+   */
+  private void warnIfUnusable(String url, String property, String envVar, String affected) {
+    if (!ServiceUrlValidator.isUsable(url)) {
+      log.warn(
+          "[RestClientConfig] {} 가 비어 있거나 http(s) 절대 주소가 아니라 관리자 대시보드의 {} 항목이 항상 null이 됩니다. "
+              + "(현재 값: '{}') {} 환경변수를 대상 서비스 '직접' 주소로 스킴을 포함해 설정하세요"
+              + "(게이트웨이는 내부 API를 라우팅하지 않습니다).",
+          property,
+          affected,
+          url,
+          envVar);
+    }
+  }
+}

--- a/performance-service/src/main/java/com/ticketrush/global/util/ServiceUrlValidator.java
+++ b/performance-service/src/main/java/com/ticketrush/global/util/ServiceUrlValidator.java
@@ -1,0 +1,46 @@
+package com.ticketrush.global.util;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import org.springframework.util.StringUtils;
+
+/**
+ * 아웃바운드 서비스 base URL이 실제로 호출 가능한 형태인지 판정한다 (#563).
+ *
+ * <p><b>비어 있지 않은 것만으로는 부족하다.</b> {@code BOOKING_SERVICE_URL=booking-service:8084}처럼 스킴을 빠뜨린 값은
+ * 문자열로는 멀쩡해서 {@code hasText} 검사를 통과하지만, 요청 시점에 {@code HttpRequest.newBuilder}가 {@code
+ * IllegalArgumentException}을 던진다. 그 예외는 {@code RestClientException}이 아니라서 클라이언트의 fail-open catch를
+ * 그대로 뚫고 나가고, 결국 필드 하나가 아니라 <b>API 전체가 500</b>이 된다.
+ *
+ * <p>즉 이 검사는 스타일 문제가 아니라 fail-open이 성립하기 위한 전제다. 호출 전에 여기서 걸러야 "설정이 틀리면 그 필드만 빈다"는 성질이 유지된다.
+ */
+public final class ServiceUrlValidator {
+
+  private ServiceUrlValidator() {}
+
+  /**
+   * 호출에 쓸 수 있는 base URL인지 판정한다.
+   *
+   * <p>절대 URI이면서 스킴이 http(s)이고 호스트가 있어야 한다. 셋 중 하나라도 어긋나면 요청 단계에서 예외가 되므로 아예 호출하지 않는 편이 낫다.
+   *
+   * <p><b>다듬지 않은 원본을 그대로 검사한다.</b> {@code trim()}을 하면 앞뒤 공백이 섞인 값이 검사를 통과하는데, 정작 {@code
+   * RestClient}에 넘어가는 것은 공백이 붙은 원본이라 요청 시점에 {@code Illegal character in scheme name} / {@code Bad
+   * authority}로 터진다 — 검사한 문자열과 쓰는 문자열이 달라지는 순간 이 관문은 무의미해진다. 값 끝 공백은 {@code env_file}에서 흔한 오설정이므로
+   * 통과시키지 않고 거절한다.
+   */
+  public static boolean isUsable(String url) {
+    if (!StringUtils.hasText(url)) {
+      return false;
+    }
+
+    try {
+      URI uri = new URI(url);
+      String scheme = uri.getScheme();
+      return uri.isAbsolute()
+          && ("http".equalsIgnoreCase(scheme) || "https".equalsIgnoreCase(scheme))
+          && StringUtils.hasText(uri.getHost());
+    } catch (URISyntaxException e) {
+      return false;
+    }
+  }
+}

--- a/performance-service/src/main/resources/application-prod.yml
+++ b/performance-service/src/main/resources/application-prod.yml
@@ -24,6 +24,19 @@ spring:
       s3:
         bucket: ${AWS_S3_BUCKET}
 
+# base의 localhost 기본값을 '빈 값'으로 덮는다. 운영 컨테이너에서 localhost는 자기 자신이라,
+# 변수가 안 들어왔을 때 base 기본값이 살아 있으면 performance가 자기 자신에게 예매 집계를 물어
+# 404를 받고 조용히 깨진다. 빈 값이면 호출 자체를 하지 않고 대시보드의 해당 필드만 null이 된다.
+#
+# 다른 서비스처럼 ${VAR}(기본값 없음)로 두지 않는 이유: 그러면 변수 미주입이 곧 기동 실패인데,
+# 이 호출들은 관리자 대시보드 전용이라 사용자 공개 API(공연 목록·상세)까지 함께 죽일 이유가 없다.
+# 설정 누락은 기동 로그의 경고로 드러낸다(RestClientConfig).
+service:
+  booking:
+    url: ${BOOKING_SERVICE_URL:}
+  seat:
+    url: ${SEAT_SERVICE_URL:}
+
 gateway:
   # 운영은 게이트웨이 내부 토큰을 반드시 주입(base의 test-token 기본값 오버라이드, 미주입 시 fail-fast).
   internal-token: ${GATEWAY_INTERNAL_TOKEN}

--- a/performance-service/src/main/resources/application.yml
+++ b/performance-service/src/main/resources/application.yml
@@ -35,6 +35,20 @@ spring:
       stack:
         auto: false
 
+# 관리자 대시보드 집계(#563)가 쓰는 아웃바운드 호출. 내부 API는 게이트웨이가 라우팅하지 않으므로
+# 대상 서비스의 '직접' 주소여야 한다(ADR 0002).
+service:
+  booking:
+    url: ${BOOKING_SERVICE_URL:http://localhost:8084}
+    # 두 호출 모두 전건 GROUP BY 집계라 단건 조회 선례(1s/2s)보다 read를 길게 잡는다.
+    # 관리자 경로라 호출 빈도가 낮아 톰캣 스레드를 오래 잡는 위험도 그만큼 작다.
+    connect-timeout-ms: 1000
+    read-timeout-ms: 3000
+  seat:
+    url: ${SEAT_SERVICE_URL:http://localhost:8086}
+    connect-timeout-ms: 1000
+    read-timeout-ms: 3000
+
 app:
   event-publisher:
     type: kafka

--- a/performance-service/src/test/java/com/ticketrush/boundedcontext/performance/app/usecase/PerformanceGetAdminDashboardUseCaseTest.java
+++ b/performance-service/src/test/java/com/ticketrush/boundedcontext/performance/app/usecase/PerformanceGetAdminDashboardUseCaseTest.java
@@ -1,0 +1,337 @@
+package com.ticketrush.boundedcontext.performance.app.usecase;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+import com.ticketrush.boundedcontext.performance.app.dto.response.PerformanceAdminDashboardResponse;
+import com.ticketrush.boundedcontext.performance.app.dto.response.PerformanceAggregateRow;
+import com.ticketrush.boundedcontext.performance.domain.types.Genre;
+import com.ticketrush.boundedcontext.performance.domain.types.PerformanceStatus;
+import com.ticketrush.boundedcontext.performance.out.apiclient.BookingRestClient;
+import com.ticketrush.boundedcontext.performance.out.apiclient.SeatRestClient;
+import com.ticketrush.boundedcontext.performance.out.apiclient.dto.BookingStatsInfo;
+import com.ticketrush.boundedcontext.performance.out.apiclient.dto.SeatCountsInfo;
+import com.ticketrush.boundedcontext.performance.out.repository.PerformanceRepository;
+import com.ticketrush.global.exception.BusinessException;
+import com.ticketrush.global.status.ErrorStatus;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class PerformanceGetAdminDashboardUseCaseTest {
+
+  @Mock private PerformanceRepository performanceRepository;
+  @Mock private BookingRestClient bookingRestClient;
+  @Mock private SeatRestClient seatRestClient;
+
+  @InjectMocks private PerformanceGetAdminDashboardUseCase useCase;
+
+  private static final LocalDate FROM = LocalDate.of(2026, 7, 9);
+  private static final LocalDate TO = LocalDate.of(2026, 8, 7);
+
+  @Test
+  @DisplayName("요약·점유율·장르별 매출을 한 응답으로 조립한다")
+  void execute_AssemblesAllSections() {
+    // given: 판매중 뮤지컬(100), 판매종료 콘서트(200), 판매 전 뮤지컬(300)
+    given(performanceRepository.findAllAggregateRows())
+        .willReturn(
+            List.of(
+                row(100L, Genre.MUSICAL, PerformanceStatus.ON_SALE),
+                row(200L, Genre.CONCERT, PerformanceStatus.CLOSED),
+                row(300L, Genre.MUSICAL, PerformanceStatus.UPCOMING)));
+    given(bookingRestClient.getStats(FROM, TO))
+        .willReturn(
+            Optional.of(
+                new BookingStatsInfo(
+                    new BookingStatsInfo.Summary(980L, 147_000_000L, true, 0L),
+                    List.of(
+                        new BookingStatsInfo.PerformanceStat(100L, 30L, 5_000_000L),
+                        new BookingStatsInfo.PerformanceStat(200L, 10L, 2_000_000L)),
+                    List.of(
+                        new BookingStatsInfo.DailyRevenue(LocalDate.of(2026, 8, 1), 1_000_000L)))));
+    given(seatRestClient.getSeatCounts())
+        .willReturn(
+            Map.of(
+                100L, seat(100L, 120L, 30L),
+                200L, seat(200L, 80L, 10L),
+                300L, seat(300L, 500L, 0L)));
+
+    // when
+    PerformanceAdminDashboardResponse response = useCase.execute(FROM, TO);
+
+    // then
+    assertThat(response.registeredPerformances()).isEqualTo(3);
+    assertThat(response.soldTickets()).isEqualTo(980L);
+    assertThat(response.totalRevenue()).isEqualTo(147_000_000L);
+    assertThat(response.revenueComplete()).isTrue();
+
+    // 판매 전 공연(300)은 점유율 모수에서 빠진다 — 넣으면 500석이 분모에 깔려 지표가 왜곡된다
+    assertThat(response.occupancySoldSeats()).isEqualTo(40L);
+    assertThat(response.occupancyTotalSeats()).isEqualTo(200L);
+    assertThat(response.averageOccupancyRate()).isEqualTo(0.2);
+
+    assertThat(response.dailyRevenues()).hasSize(1);
+    assertThat(response.genreRevenues()).hasSize(Genre.values().length);
+    assertThat(response.genreRevenues())
+        .anySatisfy(
+            g -> {
+              assertThat(g.genre()).isEqualTo(Genre.MUSICAL);
+              assertThat(g.revenue()).isEqualTo(5_000_000L);
+            })
+        .anySatisfy(
+            g -> {
+              assertThat(g.genre()).isEqualTo(Genre.BALLET);
+              assertThat(g.revenue()).isZero();
+            });
+  }
+
+  @Test
+  @DisplayName("가중 평균이라 큰 공연이 작은 공연에 희석되지 않는다")
+  void execute_OccupancyIsWeightedNotArithmeticMean() {
+    // given: 1000석 중 100석(10%)과 20석 중 18석(90%)
+    given(performanceRepository.findAllAggregateRows())
+        .willReturn(
+            List.of(
+                row(1L, Genre.CONCERT, PerformanceStatus.ON_SALE),
+                row(2L, Genre.CONCERT, PerformanceStatus.ON_SALE)));
+    given(bookingRestClient.getStats(FROM, TO)).willReturn(Optional.empty());
+    given(seatRestClient.getSeatCounts())
+        .willReturn(Map.of(1L, seat(1L, 1000L, 100L), 2L, seat(2L, 20L, 18L)));
+
+    // when
+    PerformanceAdminDashboardResponse response = useCase.execute(FROM, TO);
+
+    // then: 산술평균이면 50%지만 가중평균은 118/1020 = 11.57%
+    assertThat(response.averageOccupancyRate()).isEqualTo(0.1157);
+  }
+
+  @Test
+  @DisplayName("예매 서비스 조회 실패 시 매출 관련 필드만 null이고 공연 수는 그대로다")
+  void execute_WhenBookingFails_OnlyRevenueFieldsAreNull() {
+    // given
+    given(performanceRepository.findAllAggregateRows())
+        .willReturn(List.of(row(1L, Genre.JAZZ, PerformanceStatus.ON_SALE)));
+    given(bookingRestClient.getStats(FROM, TO)).willReturn(Optional.empty());
+    given(seatRestClient.getSeatCounts()).willReturn(Map.of(1L, seat(1L, 100L, 25L)));
+
+    // when
+    PerformanceAdminDashboardResponse response = useCase.execute(FROM, TO);
+
+    // then
+    assertThat(response.registeredPerformances()).isEqualTo(1);
+    assertThat(response.soldTickets()).isNull();
+    assertThat(response.totalRevenue()).isNull();
+    assertThat(response.revenueComplete()).isNull();
+    assertThat(response.dailyRevenues()).isNull();
+    assertThat(response.genreRevenues()).isNull();
+    // 좌석 축은 살아 있다
+    assertThat(response.averageOccupancyRate()).isEqualTo(0.25);
+  }
+
+  @Test
+  @DisplayName("예매 응답에 요약이 비어 있어도 500이 아니라 매출 축만 비운다")
+  void execute_WhenSummaryMissing_TreatsRevenueAxisAsUnknown() {
+    // given: 200 + 정상 JSON인데 summary만 null인 경우(예: 예매 서비스가 필드명을 바꿈).
+    // RestClientException도 파싱 실패도 아니라 여기까지 그대로 도달한다.
+    given(performanceRepository.findAllAggregateRows())
+        .willReturn(List.of(row(1L, Genre.JAZZ, PerformanceStatus.ON_SALE)));
+    given(bookingRestClient.getStats(FROM, TO))
+        .willReturn(Optional.of(new BookingStatsInfo(null, List.of(), List.of())));
+    given(seatRestClient.getSeatCounts()).willReturn(Map.of(1L, seat(1L, 100L, 25L)));
+
+    // when
+    PerformanceAdminDashboardResponse response = useCase.execute(FROM, TO);
+
+    // then: 역참조하면 NPE로 500이 된다 — fail-open이어야 할 경로다
+    assertThat(response.soldTickets()).isNull();
+    assertThat(response.totalRevenue()).isNull();
+    assertThat(response.revenueComplete()).isNull();
+    assertThat(response.missingAmountBookings()).isNull();
+    assertThat(response.registeredPerformances()).isEqualTo(1);
+    assertThat(response.averageOccupancyRate()).isEqualTo(0.25);
+    // 일별·장르별은 각자의 목록이 살아 있으면 그대로 채운다(축별 독립 저하)
+    assertThat(response.dailyRevenues()).isEmpty();
+    assertThat(response.genreRevenues()).hasSize(Genre.values().length);
+  }
+
+  @Test
+  @DisplayName("일별 매출을 읽지 못하면 빈 목록이 아니라 null이다")
+  void execute_WhenByDateMissing_ReturnsNullNotEmptyList() {
+    // given: 빈 목록은 "그 기간에 매출이 없었다"는 사실이라 "못 읽었다"와 구분되어야 한다
+    given(performanceRepository.findAllAggregateRows()).willReturn(List.of());
+    given(bookingRestClient.getStats(FROM, TO))
+        .willReturn(
+            Optional.of(
+                new BookingStatsInfo(
+                    new BookingStatsInfo.Summary(0L, 0L, true, 0L), List.of(), null)));
+    given(seatRestClient.getSeatCounts()).willReturn(Map.of());
+
+    // when
+    PerformanceAdminDashboardResponse response = useCase.execute(FROM, TO);
+
+    // then
+    assertThat(response.dailyRevenues()).isNull();
+    // 공연별은 읽었으므로 장르별은 전 장르 0원으로 채운다 — 차트가 전체 축을 그려야 하기 때문이다
+    assertThat(response.genreRevenues()).hasSize(Genre.values().length);
+  }
+
+  @Test
+  @DisplayName("공연별 집계를 읽지 못하면 장르별 매출도 null이다 — 전 장르 0원으로 그리면 '안 팔림'으로 읽힌다")
+  void execute_WhenByPerformanceMissing_GenreRevenuesAreNull() {
+    // given
+    given(performanceRepository.findAllAggregateRows())
+        .willReturn(List.of(row(1L, Genre.MUSICAL, PerformanceStatus.ON_SALE)));
+    given(bookingRestClient.getStats(FROM, TO))
+        .willReturn(
+            Optional.of(
+                new BookingStatsInfo(
+                    new BookingStatsInfo.Summary(0L, 0L, true, 0L), null, List.of())));
+    given(seatRestClient.getSeatCounts()).willReturn(Map.of());
+
+    // when
+    PerformanceAdminDashboardResponse response = useCase.execute(FROM, TO);
+
+    // then
+    assertThat(response.genreRevenues()).isNull();
+    // 일별은 읽었으므로 살아 있다 — 축별로 독립해 저하된다
+    assertThat(response.dailyRevenues()).isEmpty();
+  }
+
+  @Test
+  @DisplayName("좌석 서비스 조회 실패 시 점유율만 null이고 매출은 그대로다")
+  void execute_WhenSeatFails_OnlyOccupancyIsNull() {
+    // given
+    given(performanceRepository.findAllAggregateRows())
+        .willReturn(List.of(row(1L, Genre.JAZZ, PerformanceStatus.ON_SALE)));
+    given(bookingRestClient.getStats(FROM, TO))
+        .willReturn(
+            Optional.of(
+                new BookingStatsInfo(
+                    new BookingStatsInfo.Summary(10L, 500_000L, true, 0L), List.of(), List.of())));
+    given(seatRestClient.getSeatCounts()).willReturn(Map.of());
+
+    // when
+    PerformanceAdminDashboardResponse response = useCase.execute(FROM, TO);
+
+    // then
+    assertThat(response.averageOccupancyRate()).isNull();
+    assertThat(response.occupancySoldSeats()).isNull();
+    assertThat(response.occupancyTotalSeats()).isNull();
+    assertThat(response.totalRevenue()).isEqualTo(500_000L);
+  }
+
+  @Test
+  @DisplayName("좌석이 아직 생성되지 않은 공연은 점유율 분모에서 빠진다")
+  void execute_PerformanceWithoutSeats_IsExcludedFromDenominator() {
+    // given: 좌석 정보가 있는 공연 1개, 방금 등록돼 좌석이 없는 공연 1개
+    given(performanceRepository.findAllAggregateRows())
+        .willReturn(
+            List.of(
+                row(1L, Genre.CONCERT, PerformanceStatus.ON_SALE),
+                row(2L, Genre.CONCERT, PerformanceStatus.ON_SALE)));
+    given(bookingRestClient.getStats(FROM, TO)).willReturn(Optional.empty());
+    given(seatRestClient.getSeatCounts()).willReturn(Map.of(1L, seat(1L, 100L, 50L)));
+
+    // when
+    PerformanceAdminDashboardResponse response = useCase.execute(FROM, TO);
+
+    // then: 0석으로 채웠다면 분모가 100 그대로여도 '매진 불가능한 공연'이 섞여 평균이 흐려진다
+    assertThat(response.occupancyTotalSeats()).isEqualTo(100L);
+    assertThat(response.averageOccupancyRate()).isEqualTo(0.5);
+  }
+
+  @Test
+  @DisplayName("공연이 하나도 없어도 0으로 나누지 않고 200을 반환한다")
+  void execute_WhenNoPerformances_DoesNotDivideByZero() {
+    // given
+    given(performanceRepository.findAllAggregateRows()).willReturn(List.of());
+    given(bookingRestClient.getStats(FROM, TO)).willReturn(Optional.empty());
+    given(seatRestClient.getSeatCounts()).willReturn(Map.of());
+
+    // when
+    PerformanceAdminDashboardResponse response = useCase.execute(FROM, TO);
+
+    // then
+    assertThat(response.registeredPerformances()).isZero();
+    assertThat(response.averageOccupancyRate()).isNull();
+  }
+
+  @Test
+  @DisplayName("좌석이 0석인 공연만 있으면 점유율은 0%가 아니라 null이다")
+  void execute_WhenTotalSeatsZero_ReturnsNullRate() {
+    // given
+    given(performanceRepository.findAllAggregateRows())
+        .willReturn(List.of(row(1L, Genre.CONCERT, PerformanceStatus.ON_SALE)));
+    given(bookingRestClient.getStats(FROM, TO)).willReturn(Optional.empty());
+    given(seatRestClient.getSeatCounts()).willReturn(Map.of(1L, seat(1L, 0L, 0L)));
+
+    // when
+    PerformanceAdminDashboardResponse response = useCase.execute(FROM, TO);
+
+    // then
+    assertThat(response.averageOccupancyRate()).isNull();
+  }
+
+  @Test
+  @DisplayName("기간 상한(92일)을 넘으면 400으로 거부한다")
+  void execute_WhenPeriodExceedsLimit_Throws400() {
+    assertThatThrownBy(() -> useCase.execute(LocalDate.of(2026, 1, 1), LocalDate.of(2026, 4, 30)))
+        .isInstanceOf(BusinessException.class)
+        .extracting(e -> ((BusinessException) e).getErrorStatus())
+        .isEqualTo(ErrorStatus.PERFORMANCE_DASHBOARD_PERIOD_TOO_LONG);
+  }
+
+  @Test
+  @DisplayName("정확히 92일이면 통과한다")
+  void execute_WhenPeriodIsExactlyLimit_Succeeds() {
+    // given: 1/1 ~ 4/2 = 92일(양끝 포함)
+    LocalDate from = LocalDate.of(2026, 1, 1);
+    LocalDate to = from.plusDays(91);
+    given(performanceRepository.findAllAggregateRows()).willReturn(List.of());
+    given(bookingRestClient.getStats(from, to)).willReturn(Optional.empty());
+    given(seatRestClient.getSeatCounts()).willReturn(Map.of());
+
+    // when & then
+    assertThat(useCase.execute(from, to)).isNotNull();
+  }
+
+  @Test
+  @DisplayName("시작일이 종료일보다 뒤면 400으로 거부한다")
+  void execute_WhenPeriodReversed_Throws400() {
+    assertThatThrownBy(() -> useCase.execute(TO, FROM))
+        .isInstanceOf(BusinessException.class)
+        .extracting(e -> ((BusinessException) e).getErrorStatus())
+        // 상한 초과와 다른 코드여야 프론트가 어느 쪽인지 알 수 있다
+        .isEqualTo(ErrorStatus.PERFORMANCE_INVALID_DASHBOARD_PERIOD);
+  }
+
+  @Test
+  @DisplayName("기간을 지정하지 않으면 오늘을 포함한 최근 30일을 쓴다")
+  void execute_WhenPeriodOmitted_UsesLast30Days() {
+    // given
+    LocalDate today = LocalDate.now();
+    given(performanceRepository.findAllAggregateRows()).willReturn(List.of());
+    given(bookingRestClient.getStats(today.minusDays(29), today)).willReturn(Optional.empty());
+    given(seatRestClient.getSeatCounts()).willReturn(Map.of());
+
+    // when & then: 위 given과 다른 기간으로 호출되면 stub이 맞지 않아 실패한다
+    assertThat(useCase.execute(null, null)).isNotNull();
+  }
+
+  private PerformanceAggregateRow row(Long id, Genre genre, PerformanceStatus status) {
+    return new PerformanceAggregateRow(id, genre, status);
+  }
+
+  private SeatCountsInfo seat(Long performanceId, long total, long sold) {
+    return new SeatCountsInfo(performanceId, total, sold);
+  }
+}

--- a/performance-service/src/test/java/com/ticketrush/boundedcontext/performance/app/usecase/PerformanceGetAdminListUseCaseTest.java
+++ b/performance-service/src/test/java/com/ticketrush/boundedcontext/performance/app/usecase/PerformanceGetAdminListUseCaseTest.java
@@ -1,0 +1,163 @@
+package com.ticketrush.boundedcontext.performance.app.usecase;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+import com.ticketrush.boundedcontext.performance.app.dto.response.PerformanceAdminSummaryResponse;
+import com.ticketrush.boundedcontext.performance.domain.entity.Performance;
+import com.ticketrush.boundedcontext.performance.domain.types.Genre;
+import com.ticketrush.boundedcontext.performance.domain.types.PerformanceStatus;
+import com.ticketrush.boundedcontext.performance.out.apiclient.BookingRestClient;
+import com.ticketrush.boundedcontext.performance.out.apiclient.SeatRestClient;
+import com.ticketrush.boundedcontext.performance.out.apiclient.dto.BookingStatsInfo;
+import com.ticketrush.boundedcontext.performance.out.apiclient.dto.SeatCountsInfo;
+import com.ticketrush.boundedcontext.performance.out.repository.PerformanceRepository;
+import com.ticketrush.global.dto.request.OffsetPageRequest;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class PerformanceGetAdminListUseCaseTest {
+
+  @Mock private PerformanceRepository performanceRepository;
+  @Mock private BookingRestClient bookingRestClient;
+  @Mock private SeatRestClient seatRestClient;
+
+  @InjectMocks private PerformanceGetAdminListUseCase useCase;
+
+  private static final OffsetPageRequest PAGE = new OffsetPageRequest(0, 10);
+
+  @Test
+  @DisplayName("판매·점유율·매진·매출을 함께 내린다")
+  void execute_EnrichesWithAggregates() {
+    // given: 120석 중 38석 판매
+    givenPage(performance(1L, "뮤지컬 팬텀", Genre.MUSICAL, PerformanceStatus.ON_SALE));
+    givenBookingStats(new BookingStatsInfo.PerformanceStat(1L, 38L, 5_320_000L));
+    given(seatRestClient.getSeatCounts()).willReturn(Map.of(1L, new SeatCountsInfo(1L, 120L, 38L)));
+
+    // when
+    PerformanceAdminSummaryResponse row = useCase.execute(PAGE).getContent().get(0);
+
+    // then
+    assertThat(row.performanceId()).isEqualTo(1L);
+    assertThat(row.genreName()).isEqualTo("뮤지컬");
+    assertThat(row.soldSeats()).isEqualTo(38L);
+    assertThat(row.totalSeats()).isEqualTo(120L);
+    assertThat(row.occupancyRate()).isEqualTo(0.3167);
+    assertThat(row.soldOut()).isFalse();
+    assertThat(row.revenue()).isEqualTo(5_320_000L);
+  }
+
+  @Test
+  @DisplayName("판매 좌석이 전체 좌석에 도달하면 매진이다")
+  void execute_WhenAllSeatsSold_MarksSoldOut() {
+    // given
+    givenPage(performance(1L, "매진 공연", Genre.CONCERT, PerformanceStatus.ON_SALE));
+    givenBookingStats(new BookingStatsInfo.PerformanceStat(1L, 120L, 10_000_000L));
+    given(seatRestClient.getSeatCounts())
+        .willReturn(Map.of(1L, new SeatCountsInfo(1L, 120L, 120L)));
+
+    // when
+    PerformanceAdminSummaryResponse row = useCase.execute(PAGE).getContent().get(0);
+
+    // then
+    assertThat(row.soldOut()).isTrue();
+    assertThat(row.occupancyRate()).isEqualTo(1.0);
+  }
+
+  @Test
+  @DisplayName("예매 서비스 조회에 성공했지만 예매가 없는 공연의 매출은 0이다")
+  void execute_WhenNoBookings_RevenueIsZeroNotNull() {
+    // given: 집계 응답에 이 공연이 없다 = 확정된 예매가 없다
+    givenPage(performance(1L, "신규 공연", Genre.JAZZ, PerformanceStatus.ON_SALE));
+    given(bookingRestClient.getStats(any(), any()))
+        .willReturn(
+            Optional.of(
+                new BookingStatsInfo(
+                    new BookingStatsInfo.Summary(0L, 0L, true, 0L), List.of(), List.of())));
+    given(seatRestClient.getSeatCounts()).willReturn(Map.of(1L, new SeatCountsInfo(1L, 120L, 0L)));
+
+    // when
+    PerformanceAdminSummaryResponse row = useCase.execute(PAGE).getContent().get(0);
+
+    // then: 0과 null을 갈라야 "안 팔렸다"와 "못 읽었다"가 구분된다
+    assertThat(row.revenue()).isZero();
+  }
+
+  @Test
+  @DisplayName("예매 서비스 조회에 실패하면 매출은 null이고 좌석 필드는 그대로다")
+  void execute_WhenBookingFails_RevenueIsNull() {
+    // given
+    givenPage(performance(1L, "공연", Genre.JAZZ, PerformanceStatus.ON_SALE));
+    given(bookingRestClient.getStats(any(), any())).willReturn(Optional.empty());
+    given(seatRestClient.getSeatCounts()).willReturn(Map.of(1L, new SeatCountsInfo(1L, 120L, 10L)));
+
+    // when
+    PerformanceAdminSummaryResponse row = useCase.execute(PAGE).getContent().get(0);
+
+    // then
+    assertThat(row.revenue()).isNull();
+    assertThat(row.soldSeats()).isEqualTo(10L);
+  }
+
+  @Test
+  @DisplayName("좌석이 아직 생성되지 않은 공연은 좌석 관련 필드가 모두 null이다")
+  void execute_WhenSeatsMissing_SeatFieldsAreNull() {
+    // given: 좌석 생성은 공연 등록 이벤트를 받아 비동기로 일어난다
+    givenPage(performance(1L, "방금 등록한 공연", Genre.BALLET, PerformanceStatus.UPCOMING));
+    givenBookingStats();
+    given(seatRestClient.getSeatCounts()).willReturn(Map.of());
+
+    // when
+    PerformanceAdminSummaryResponse row = useCase.execute(PAGE).getContent().get(0);
+
+    // then
+    assertThat(row.soldSeats()).isNull();
+    assertThat(row.totalSeats()).isNull();
+    assertThat(row.occupancyRate()).isNull();
+    assertThat(row.soldOut()).isNull();
+    // 공연 자체 정보는 항상 채워진다
+    assertThat(row.title()).isEqualTo("방금 등록한 공연");
+    assertThat(row.performanceStatus()).isEqualTo(PerformanceStatus.UPCOMING);
+  }
+
+  private void givenPage(Performance performance) {
+    Page<Performance> page = new PageImpl<>(List.of(performance), PageRequest.of(0, 10), 1);
+    given(performanceRepository.findAll(any(Pageable.class))).willReturn(page);
+  }
+
+  private void givenBookingStats(BookingStatsInfo.PerformanceStat... stats) {
+    given(bookingRestClient.getStats(any(), any()))
+        .willReturn(
+            Optional.of(
+                new BookingStatsInfo(
+                    new BookingStatsInfo.Summary(0L, 0L, true, 0L), List.of(stats), List.of())));
+  }
+
+  private Performance performance(Long id, String title, Genre genre, PerformanceStatus status) {
+    Performance performance = mock(Performance.class);
+    given(performance.getId()).willReturn(id);
+    given(performance.getTitle()).willReturn(title);
+    given(performance.getGenre()).willReturn(genre);
+    given(performance.getShowDate()).willReturn(LocalDate.of(2026, 9, 1));
+    given(performance.getPerformanceStatus()).willReturn(status);
+    return performance;
+  }
+}

--- a/performance-service/src/test/java/com/ticketrush/boundedcontext/performance/in/api/v1/PerformanceAdminControllerTest.java
+++ b/performance-service/src/test/java/com/ticketrush/boundedcontext/performance/in/api/v1/PerformanceAdminControllerTest.java
@@ -1,18 +1,24 @@
 package com.ticketrush.boundedcontext.performance.in.api.v1;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doNothing;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.ticketrush.boundedcontext.performance.app.facade.PerformanceFacade;
 import com.ticketrush.global.config.CustomSecurityProperties;
 import com.ticketrush.global.config.JacksonConfig;
 import com.ticketrush.global.config.SecurityConfig;
+import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
@@ -28,6 +34,39 @@ class PerformanceAdminControllerTest {
 
   private static final String BASE_URL = "/api/v1/performance/admin";
   private static final String INTERNAL_TOKEN = "test-token";
+
+  @Test
+  @DisplayName("관리자 권한으로 공연 목록을 조회하면 200을 반환한다")
+  void getAdminPerformances_admin_success() throws Exception {
+    given(performanceFacade.getAdminPerformances(any()))
+        .willReturn(new PageImpl<>(List.of(), PageRequest.of(0, 10), 0));
+
+    mockMvc
+        .perform(
+            get(BASE_URL)
+                .header("X-Gateway-Token", INTERNAL_TOKEN)
+                .header("X-User-Id", "1")
+                .header("X-User-Role", "ADMIN"))
+        .andExpect(status().isOk());
+  }
+
+  @Test
+  @DisplayName("일반 사용자 권한으로 공연 목록을 조회하면 403을 반환한다")
+  void getAdminPerformances_userRole_forbidden() throws Exception {
+    mockMvc
+        .perform(
+            get(BASE_URL)
+                .header("X-Gateway-Token", INTERNAL_TOKEN)
+                .header("X-User-Id", "1")
+                .header("X-User-Role", "USER"))
+        .andExpect(status().isForbidden());
+  }
+
+  @Test
+  @DisplayName("인증 없이 공연 목록을 조회하면 403을 반환한다")
+  void getAdminPerformances_noAuth_forbidden() throws Exception {
+    mockMvc.perform(get(BASE_URL)).andExpect(status().isForbidden());
+  }
 
   @Test
   @DisplayName("관리자 권한으로 공연 삭제 요청 시 200을 반환한다")

--- a/performance-service/src/test/java/com/ticketrush/boundedcontext/performance/in/api/v1/PerformanceAdminDashboardControllerTest.java
+++ b/performance-service/src/test/java/com/ticketrush/boundedcontext/performance/in/api/v1/PerformanceAdminDashboardControllerTest.java
@@ -1,0 +1,139 @@
+package com.ticketrush.boundedcontext.performance.in.api.v1;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.ticketrush.boundedcontext.performance.app.dto.response.PerformanceAdminDashboardResponse;
+import com.ticketrush.boundedcontext.performance.app.facade.PerformanceFacade;
+import com.ticketrush.global.config.CustomSecurityProperties;
+import com.ticketrush.global.config.SecurityConfig;
+import com.ticketrush.global.exception.BusinessException;
+import com.ticketrush.global.status.ErrorStatus;
+import com.ticketrush.support.WebMvcSliceTest;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcSliceTest(PerformanceAdminDashboardController.class)
+@Import({CustomSecurityProperties.class, SecurityConfig.class})
+@TestPropertySource(properties = "gateway.internal-token=test-token")
+class PerformanceAdminDashboardControllerTest {
+
+  private static final String BASE_URL = "/api/v1/performance/admin/dashboard";
+  private static final String INTERNAL_TOKEN = "test-token";
+
+  @Autowired private MockMvc mockMvc;
+
+  @MockitoBean private PerformanceFacade performanceFacade;
+
+  @Test
+  @DisplayName("관리자 권한으로 대시보드를 조회하면 200을 반환한다")
+  void getDashboard_admin_success() throws Exception {
+    given(performanceFacade.getAdminDashboard(any(), any())).willReturn(dashboard());
+
+    mockMvc
+        .perform(
+            get(BASE_URL)
+                .header("X-Gateway-Token", INTERNAL_TOKEN)
+                .header("X-User-Id", "1")
+                .header("X-User-Role", "ADMIN"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.result.registered_performances").value(42))
+        .andExpect(jsonPath("$.result.average_occupancy_rate").value(0.317));
+  }
+
+  @Test
+  @DisplayName("집계 필드가 null이어도 대시보드 조회 자체는 200이다")
+  void getDashboard_partialFailure_stillSucceeds() throws Exception {
+    given(performanceFacade.getAdminDashboard(any(), any()))
+        .willReturn(
+            new PerformanceAdminDashboardResponse(
+                42, null, null, null, null, null, null, null, null, null));
+
+    mockMvc
+        .perform(
+            get(BASE_URL)
+                .header("X-Gateway-Token", INTERNAL_TOKEN)
+                .header("X-User-Id", "1")
+                .header("X-User-Role", "ADMIN"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.result.registered_performances").value(42))
+        .andExpect(jsonPath("$.result.total_revenue").doesNotExist());
+  }
+
+  @Test
+  @DisplayName("기간이 상한을 넘으면 사유를 식별할 수 있는 코드로 400을 반환한다")
+  void getDashboard_periodExceedsLimit_badRequest() throws Exception {
+    given(performanceFacade.getAdminDashboard(any(), any()))
+        .willThrow(new BusinessException(ErrorStatus.PERFORMANCE_DASHBOARD_PERIOD_TOO_LONG));
+
+    mockMvc
+        .perform(
+            get(BASE_URL)
+                .param("from", "2026-01-01")
+                .param("to", "2026-12-31")
+                .header("X-Gateway-Token", INTERNAL_TOKEN)
+                .header("X-User-Id", "1")
+                .header("X-User-Role", "ADMIN"))
+        .andExpect(status().isBadRequest())
+        // 두 거절 사유가 같은 코드로 뭉개지면 프론트가 안내 문구를 만들 수 없다
+        .andExpect(jsonPath("$.code").value("PERFORMANCE_400_009"));
+  }
+
+  @Test
+  @DisplayName("기간이 뒤집히면 상한 초과와 다른 코드로 400을 반환한다")
+  void getDashboard_periodReversed_badRequest() throws Exception {
+    given(performanceFacade.getAdminDashboard(any(), any()))
+        .willThrow(new BusinessException(ErrorStatus.PERFORMANCE_INVALID_DASHBOARD_PERIOD));
+
+    mockMvc
+        .perform(
+            get(BASE_URL)
+                .param("from", "2026-08-07")
+                .param("to", "2026-07-09")
+                .header("X-Gateway-Token", INTERNAL_TOKEN)
+                .header("X-User-Id", "1")
+                .header("X-User-Role", "ADMIN"))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.code").value("PERFORMANCE_400_008"));
+  }
+
+  @Test
+  @DisplayName("일반 사용자 권한으로 대시보드를 조회하면 403을 반환한다")
+  void getDashboard_userRole_forbidden() throws Exception {
+    mockMvc
+        .perform(
+            get(BASE_URL)
+                .header("X-Gateway-Token", INTERNAL_TOKEN)
+                .header("X-User-Id", "1")
+                .header("X-User-Role", "USER"))
+        .andExpect(status().isForbidden());
+  }
+
+  @Test
+  @DisplayName("인증 없이 대시보드를 조회하면 403을 반환한다")
+  void getDashboard_noAuth_forbidden() throws Exception {
+    mockMvc.perform(get(BASE_URL)).andExpect(status().isForbidden());
+  }
+
+  @Test
+  @DisplayName("게이트웨이 토큰 없이 관리자 헤더만 보내면 403을 반환한다")
+  void getDashboard_missingGatewayToken_forbidden() throws Exception {
+    mockMvc
+        .perform(get(BASE_URL).header("X-User-Id", "1").header("X-User-Role", "ADMIN"))
+        .andExpect(status().isForbidden());
+  }
+
+  private PerformanceAdminDashboardResponse dashboard() {
+    return new PerformanceAdminDashboardResponse(
+        42, 980L, 147_000_000L, true, 0L, 0.317, 118L, 372L, List.of(), List.of());
+  }
+}

--- a/performance-service/src/test/java/com/ticketrush/boundedcontext/performance/out/apiclient/BookingRestClientTest.java
+++ b/performance-service/src/test/java/com/ticketrush/boundedcontext/performance/out/apiclient/BookingRestClientTest.java
@@ -1,0 +1,145 @@
+package com.ticketrush.boundedcontext.performance.out.apiclient;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.header;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withServerError;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+import com.ticketrush.boundedcontext.performance.out.apiclient.dto.BookingStatsInfo;
+import com.ticketrush.global.config.CustomSecurityProperties;
+import java.time.LocalDate;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestClient;
+
+/**
+ * 이 클라이언트는 {@code RestClient.builder()}로 만들어져 앱의 {@code JacksonConfig}(SNAKE_CASE)를 타지 않는다. 응답 키가
+ * 하나라도 어긋나면 예외 없이 <b>조용히 0/null</b>이 되므로, 실제 응답 형태로 매핑을 고정한다.
+ */
+class BookingRestClientTest {
+
+  private static final String BASE_URL = "http://booking-service:8084";
+  private static final LocalDate FROM = LocalDate.of(2026, 7, 9);
+  private static final LocalDate TO = LocalDate.of(2026, 8, 7);
+
+  private MockRestServiceServer server;
+  private BookingRestClient client;
+
+  @BeforeEach
+  void setUp() {
+    RestClient.Builder builder = RestClient.builder().baseUrl(BASE_URL);
+    server = MockRestServiceServer.bindTo(builder).build();
+
+    CustomSecurityProperties properties = new CustomSecurityProperties();
+    properties.setInternalToken("test-internal-token");
+
+    client = new BookingRestClient(builder.build(), properties, BASE_URL);
+  }
+
+  @Test
+  @DisplayName("snake_case 응답을 필드 손실 없이 매핑하고 내부 토큰을 싣는다")
+  void getStats_MapsSnakeCaseResponse() {
+    // given
+    server
+        .expect(
+            requestTo(BASE_URL + "/api/v1/internal/booking/stats?from=2026-07-09&to=2026-08-07"))
+        .andExpect(header("X-Internal-Token", "test-internal-token"))
+        .andRespond(
+            withSuccess(
+                """
+                {
+                  "code": "COMMON_200",
+                  "result": {
+                    "summary": {
+                      "total_bookings": 1250,
+                      "completed_bookings": 980,
+                      "canceled_bookings": 120,
+                      "total_revenue": 147000000,
+                      "revenue_complete": false,
+                      "missing_amount_bookings": 3
+                    },
+                    "by_performance": [
+                      {"performance_id": 100, "confirmed_count": 30, "confirmed_revenue": 5000000}
+                    ],
+                    "by_date": [
+                      {"date": "2026-08-01", "revenue": 1000000}
+                    ]
+                  }
+                }
+                """,
+                MediaType.APPLICATION_JSON));
+
+    // when
+    Optional<BookingStatsInfo> result = client.getStats(FROM, TO);
+
+    // then
+    assertThat(result).isPresent();
+    BookingStatsInfo stats = result.get();
+    assertThat(stats.summary().completedBookings()).isEqualTo(980L);
+    assertThat(stats.summary().totalRevenue()).isEqualTo(147_000_000L);
+    assertThat(stats.summary().revenueComplete()).isFalse();
+    assertThat(stats.summary().missingAmountBookings()).isEqualTo(3L);
+    assertThat(stats.byPerformance()).hasSize(1);
+    assertThat(stats.byPerformance().get(0).performanceId()).isEqualTo(100L);
+    assertThat(stats.byPerformance().get(0).confirmedRevenue()).isEqualTo(5_000_000L);
+    assertThat(stats.byDate()).hasSize(1);
+    assertThat(stats.byDate().get(0).date()).isEqualTo(LocalDate.of(2026, 8, 1));
+    assertThat(stats.byDate().get(0).revenue()).isEqualTo(1_000_000L);
+    server.verify();
+  }
+
+  @Test
+  @DisplayName("예매 서비스가 5xx를 내면 빈 값으로 수렴하고 예외를 밖으로 내지 않는다")
+  void getStats_WhenServerError_ReturnsEmpty() {
+    // given
+    server
+        .expect(requestTo(org.hamcrest.Matchers.startsWith(BASE_URL)))
+        .andRespond(withServerError());
+
+    // when
+    Optional<BookingStatsInfo> result = client.getStats(FROM, TO);
+
+    // then: 여기서 던지면 예매 서비스 장애가 대시보드 전체를 죽인다
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  @DisplayName("스킴이 빠진 URL이면 호출하지 않는다 — 그대로 두면 fail-open catch를 뚫고 500이 된다")
+  void getStats_WhenUrlHasNoScheme_SkipsCall() {
+    // given: compose 서비스명을 그대로 넣은 흔한 오설정. 문자열로는 멀쩡해 hasText 검사는 통과한다.
+    RestClient.Builder builder = RestClient.builder().baseUrl("booking-service:8084");
+    MockRestServiceServer strictServer = MockRestServiceServer.bindTo(builder).build();
+    BookingRestClient misconfigured =
+        new BookingRestClient(
+            builder.build(), new CustomSecurityProperties(), "booking-service:8084");
+
+    // when
+    Optional<BookingStatsInfo> result = misconfigured.getStats(FROM, TO);
+
+    // then: 요청이 나갔다면 IllegalArgumentException(스킴 없는 URI)이 되어 catch를 뚫었을 것이다
+    assertThat(result).isEmpty();
+    strictServer.verify();
+  }
+
+  @Test
+  @DisplayName("URL이 설정되지 않으면 호출을 시도하지 않고 빈 값을 반환한다")
+  void getStats_WhenUrlNotConfigured_SkipsCall() {
+    // given: baseUrl이 빈 채로 요청이 나가면 스킴 없는 URI라 RestClientException이 아닌 예외가 되어 catch를 뚫는다
+    RestClient.Builder builder = RestClient.builder();
+    MockRestServiceServer strictServer = MockRestServiceServer.bindTo(builder).build();
+    BookingRestClient unconfigured =
+        new BookingRestClient(builder.build(), new CustomSecurityProperties(), "");
+
+    // when
+    Optional<BookingStatsInfo> result = unconfigured.getStats(FROM, TO);
+
+    // then
+    assertThat(result).isEmpty();
+    strictServer.verify(); // 기대한 요청이 없었음을 확인
+  }
+}

--- a/performance-service/src/test/java/com/ticketrush/boundedcontext/performance/out/apiclient/SeatRestClientTest.java
+++ b/performance-service/src/test/java/com/ticketrush/boundedcontext/performance/out/apiclient/SeatRestClientTest.java
@@ -1,0 +1,146 @@
+package com.ticketrush.boundedcontext.performance.out.apiclient;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.header;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withServerError;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+import com.ticketrush.boundedcontext.performance.out.apiclient.dto.SeatCountsInfo;
+import com.ticketrush.global.config.CustomSecurityProperties;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestClient;
+
+class SeatRestClientTest {
+
+  private static final String BASE_URL = "http://seat-service:8086";
+  private static final String URI = BASE_URL + "/api/v1/internal/seat/seat-counts";
+
+  private MockRestServiceServer server;
+  private SeatRestClient client;
+
+  @BeforeEach
+  void setUp() {
+    RestClient.Builder builder = RestClient.builder().baseUrl(BASE_URL);
+    server = MockRestServiceServer.bindTo(builder).build();
+
+    CustomSecurityProperties properties = new CustomSecurityProperties();
+    properties.setInternalToken("test-internal-token");
+
+    client = new SeatRestClient(builder.build(), properties, BASE_URL);
+  }
+
+  @Test
+  @DisplayName("snake_case 응답을 공연 ID로 색인해 반환한다")
+  void getSeatCounts_IndexesByPerformanceId() {
+    // given
+    server
+        .expect(requestTo(URI))
+        .andExpect(header("X-Internal-Token", "test-internal-token"))
+        .andRespond(
+            withSuccess(
+                """
+                {
+                  "code": "COMMON_200",
+                  "result": [
+                    {"performance_id": 100, "total_count": 120, "available_count": 82,
+                     "sold_count": 38, "hold_count": 0},
+                    {"performance_id": 200, "total_count": 80, "available_count": 70,
+                     "sold_count": 10, "hold_count": 0}
+                  ]
+                }
+                """,
+                MediaType.APPLICATION_JSON));
+
+    // when
+    Map<Long, SeatCountsInfo> result = client.getSeatCounts();
+
+    // then
+    assertThat(result).hasSize(2);
+    assertThat(result.get(100L).totalCount()).isEqualTo(120L);
+    assertThat(result.get(100L).soldCount()).isEqualTo(38L);
+    assertThat(result.get(200L).totalCount()).isEqualTo(80L);
+    server.verify();
+  }
+
+  @Test
+  @DisplayName("좌석 서비스가 5xx를 내면 빈 맵으로 수렴한다")
+  void getSeatCounts_WhenServerError_ReturnsEmptyMap() {
+    // given
+    server.expect(requestTo(URI)).andRespond(withServerError());
+
+    // when
+    Map<Long, SeatCountsInfo> result = client.getSeatCounts();
+
+    // then: 빈 맵은 '좌석 0석'이 아니라 '모름'이며, 호출자가 점유율을 null로 내린다
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  @DisplayName("URL이 http(s) 절대 주소가 아니면 호출하지 않는다")
+  void getSeatCounts_WhenUrlUnusable_SkipsCall() {
+    // given: 스킴이 빠진 값. 그대로 요청하면 IllegalArgumentException이라 fail-open catch를 뚫는다.
+    RestClient.Builder builder = RestClient.builder().baseUrl("seat-service:8086");
+    MockRestServiceServer strictServer = MockRestServiceServer.bindTo(builder).build();
+    SeatRestClient misconfigured =
+        new SeatRestClient(builder.build(), new CustomSecurityProperties(), "seat-service:8086");
+
+    // when & then
+    assertThat(misconfigured.getSeatCounts()).isEmpty();
+    strictServer.verify();
+  }
+
+  @Test
+  @DisplayName("수치 키가 누락되면 0으로 읽지 않고 빈 맵으로 수렴한다")
+  void getSeatCounts_WhenNumericKeyMissing_FallsBackToEmpty() {
+    // given: sold_count가 통째로 빠진 응답. 생산자 필드가 null이 되면 전역 NON_NULL 설정 때문에
+    // 키가 통째로 사라지므로, 이론이 아니라 실제로 일어날 수 있는 형태다.
+    server
+        .expect(requestTo(URI))
+        .andRespond(
+            withSuccess(
+                """
+                {"result": [{"performance_id": 100, "total_count": 120}]}
+                """,
+                MediaType.APPLICATION_JSON));
+
+    // when
+    Map<Long, SeatCountsInfo> result = client.getSeatCounts();
+
+    // then: 소비자 필드가 원시 long이라 "판매 0석"으로 조용히 읽힐 것을 우려했으나, 실제로는 record의 원시
+    // 파라미터를 채우지 못해 역직렬화가 실패하고 fail-open 경로로 떨어진다. 즉 결과는 "0%"가 아니라 "모름"이며,
+    // 그 편이 이 API의 계약과 맞다. 원시 타입을 박스 타입으로 올리는 것을 이번 범위에서 미룬 근거이기도 하다.
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  @DisplayName("공연 ID가 중복된 응답이 와도 예외 없이 마지막 값으로 접는다")
+  void getSeatCounts_WhenDuplicateIds_DoesNotThrow() {
+    // given: toMap()을 썼다면 IllegalStateException이 나고, 그건 RestClientException이 아니라 catch를 뚫는다
+    server
+        .expect(requestTo(URI))
+        .andRespond(
+            withSuccess(
+                """
+                {
+                  "result": [
+                    {"performance_id": 100, "total_count": 120, "sold_count": 38},
+                    {"performance_id": 100, "total_count": 120, "sold_count": 40}
+                  ]
+                }
+                """,
+                MediaType.APPLICATION_JSON));
+
+    // when
+    Map<Long, SeatCountsInfo> result = client.getSeatCounts();
+
+    // then
+    assertThat(result).hasSize(1);
+    assertThat(result.get(100L).soldCount()).isEqualTo(40L);
+  }
+}

--- a/performance-service/src/test/java/com/ticketrush/global/util/ServiceUrlValidatorTest.java
+++ b/performance-service/src/test/java/com/ticketrush/global/util/ServiceUrlValidatorTest.java
@@ -1,0 +1,58 @@
+package com.ticketrush.global.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+/**
+ * 이 검증기는 "설정이 틀리면 그 필드만 빈다"는 fail-open 성질이 성립하기 위한 단일 관문이다. 여기서 통과시킨 값이 요청 시점에 {@code
+ * IllegalArgumentException}이 되면 그 예외는 {@code RestClientException}이 아니라서 클라이언트의 catch를 뚫고 API 전체를
+ * 500으로 만든다. 그래서 경계를 테스트로 못 박는다.
+ */
+class ServiceUrlValidatorTest {
+
+  @ParameterizedTest
+  @NullSource
+  @ValueSource(
+      strings = {
+        "",
+        "   ",
+        // 스킴 누락 — compose 서비스명을 그대로 넣는 흔한 오설정
+        "booking-service:8084",
+        "//booking-service:8084",
+        // 호스트 없음
+        "http://",
+        // http(s)가 아님
+        "ftp://booking-service:8084",
+        // 포트가 숫자가 아니면 URI 파싱 단계에서 호스트를 못 잡는다
+        "http://booking-service:abc",
+        // 언더스코어 호스트는 JDK HttpClient가 거부한다(URI.getHost()가 null) — 거절이 정답이다
+        "http://booking_service:8084",
+        // 앞뒤 공백: 다듬어서 통과시키면 정작 RestClient에는 원본이 넘어가 요청 시점에 터진다
+        " http://booking-service:8084",
+        "http://booking-service:8084 ",
+        "\thttp://booking-service:8084\n"
+      })
+  @DisplayName("호출에 쓸 수 없는 URL은 거절한다")
+  void isUsable_rejectsUnusableUrls(String url) {
+    assertThat(ServiceUrlValidator.isUsable(url)).isFalse();
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "http://booking-service:8084",
+        "https://booking-service:8084",
+        "http://localhost:8084",
+        // 스킴 대소문자는 무관하다
+        "HTTP://booking-service:8084",
+        "http://booking-service"
+      })
+  @DisplayName("http(s) 절대 주소는 통과시킨다")
+  void isUsable_acceptsAbsoluteHttpUrls(String url) {
+    assertThat(ServiceUrlValidator.isUsable(url)).isTrue();
+  }
+}

--- a/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/app/dto/response/SeatStatusCountsByPerformanceResponse.java
+++ b/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/app/dto/response/SeatStatusCountsByPerformanceResponse.java
@@ -1,0 +1,11 @@
+package com.ticketrush.boundedcontext.seat.app.dto.response;
+
+/**
+ * 공연 단위 좌석 수 집계 한 행 (#563).
+ *
+ * <p>{@link SeatStatusCountsResponse}에 {@code performanceId}를 더한 형태다. 단건 조회는 경로 변수로 공연이 정해지지만 일괄
+ * 조회는 응답에서 공연을 식별해야 하므로 필드가 하나 늘었다. 세는 규칙은 단건과 같다 — 만료된 HOLD는 {@code availableCount}에 들어가고, 그래서
+ * {@code totalCount = availableCount + soldCount + holdCount}가 성립한다.
+ */
+public record SeatStatusCountsByPerformanceResponse(
+    Long performanceId, Long totalCount, Long availableCount, Long soldCount, Long holdCount) {}

--- a/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/app/facade/SeatFacade.java
+++ b/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/app/facade/SeatFacade.java
@@ -4,12 +4,14 @@ import com.ticketrush.boundedcontext.seat.app.dto.response.SeatAdminMonitoringRe
 import com.ticketrush.boundedcontext.seat.app.dto.response.SeatAdminSeatDetailResponse;
 import com.ticketrush.boundedcontext.seat.app.dto.response.SeatMapItemResponse;
 import com.ticketrush.boundedcontext.seat.app.dto.response.SeatNumberResponse;
+import com.ticketrush.boundedcontext.seat.app.dto.response.SeatStatusCountsByPerformanceResponse;
 import com.ticketrush.boundedcontext.seat.app.dto.response.SeatStatusCountsResponse;
 import com.ticketrush.boundedcontext.seat.app.support.SeatStatusStreamSubscriber;
 import com.ticketrush.boundedcontext.seat.app.usecase.SeatAdminForceReleaseHoldUseCase;
 import com.ticketrush.boundedcontext.seat.app.usecase.SeatConfirmSoldUseCase;
 import com.ticketrush.boundedcontext.seat.app.usecase.SeatCreateDefaultLayoutUseCase;
 import com.ticketrush.boundedcontext.seat.app.usecase.SeatGetAdminSeatDetailUseCase;
+import com.ticketrush.boundedcontext.seat.app.usecase.SeatGetAllStatusCountsUseCase;
 import com.ticketrush.boundedcontext.seat.app.usecase.SeatGetNumbersUseCase;
 import com.ticketrush.boundedcontext.seat.app.usecase.SeatGetSeatMapUseCase;
 import com.ticketrush.boundedcontext.seat.app.usecase.SeatGetStatusCountsUseCase;
@@ -37,6 +39,7 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 public class SeatFacade {
 
   private final SeatGetStatusCountsUseCase seatGetStatusCountsUseCase;
+  private final SeatGetAllStatusCountsUseCase seatGetAllStatusCountsUseCase;
   private final SeatGetSeatMapUseCase seatGetSeatMapUseCase;
   private final SeatGetNumbersUseCase seatGetNumbersUseCase;
   private final SeatGetAdminSeatDetailUseCase seatGetAdminSeatDetailUseCase;
@@ -129,6 +132,11 @@ public class SeatFacade {
 
   public SeatStatusCountsResponse getPerformanceSeatStatusCounts(Long performanceId) {
     return seatGetStatusCountsUseCase.execute(performanceId);
+  }
+
+  /** 전 공연 좌석 수 일괄 조회 (#563 관리자 대시보드). 좌석이 아직 없는 공연은 응답에 포함되지 않는다. */
+  public List<SeatStatusCountsByPerformanceResponse> getAllPerformanceSeatStatusCounts() {
+    return seatGetAllStatusCountsUseCase.execute();
   }
 
   public SseEmitter subscribeSeatStatus(Long performanceId) {

--- a/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/app/usecase/SeatGetAllStatusCountsUseCase.java
+++ b/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/app/usecase/SeatGetAllStatusCountsUseCase.java
@@ -1,0 +1,31 @@
+package com.ticketrush.boundedcontext.seat.app.usecase;
+
+import com.ticketrush.boundedcontext.seat.app.dto.response.SeatStatusCountsByPerformanceResponse;
+import com.ticketrush.boundedcontext.seat.out.repository.SeatRepository;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 전 공연 좌석 수 일괄 집계 (#563).
+ *
+ * <p>공연별로 {@link SeatGetStatusCountsUseCase}를 N번 부르는 대신 한 번의 GROUP BY로 끝낸다. 관리자 대시보드의 평균 점유율은 전체
+ * 공연이 모수라, 공연 수만큼 원격 호출이 반복되면 공연이 늘어날수록 선형으로 느려지고 중간에 하나만 실패해도 평균이 왜곡된다.
+ *
+ * <p><b>좌석이 하나도 없는 공연은 이 응답에 나타나지 않는다.</b> GROUP BY는 행이 있는 그룹만 만들기 때문이다. 좌석 생성은 {@code
+ * PerformanceCreatedEvent}를 받아 비동기로 일어나므로, 공연이 방금 등록됐고 아직 좌석이 생성되지 않은 창에서 실제로 발생한다. 호출자는 이 경우를 0으로
+ * 채우지 말고 <b>모르는 값</b>으로 다뤄야 한다 — 0으로 채우면 점유율 분모가 0이 되고, 좌석이 곧 생길 공연이 "매진 불가능한 공연"으로 집계에 섞인다.
+ */
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class SeatGetAllStatusCountsUseCase {
+
+  private final SeatRepository seatRepository;
+
+  public List<SeatStatusCountsByPerformanceResponse> execute() {
+    return seatRepository.getStatusCountsGroupedByPerformance(LocalDateTime.now());
+  }
+}

--- a/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/in/api/v1/SeatInternalController.java
+++ b/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/in/api/v1/SeatInternalController.java
@@ -2,6 +2,7 @@ package com.ticketrush.boundedcontext.seat.in.api.v1;
 
 import com.ticketrush.boundedcontext.seat.app.dto.request.SeatHoldReleaseRequest;
 import com.ticketrush.boundedcontext.seat.app.dto.request.SeatSoldConfirmRequest;
+import com.ticketrush.boundedcontext.seat.app.dto.response.SeatStatusCountsByPerformanceResponse;
 import com.ticketrush.boundedcontext.seat.app.facade.SeatFacade;
 import com.ticketrush.global.dto.response.ApiResponse;
 import com.ticketrush.global.status.SuccessStatus;
@@ -9,8 +10,10 @@ import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -24,6 +27,25 @@ import org.springframework.web.bind.annotation.RestController;
 public class SeatInternalController {
 
   private final SeatFacade seatFacade;
+
+  @Operation(
+      summary = "전 공연 좌석 수 일괄 조회",
+      description =
+          """
+          모든 공연의 좌석 수(전체·예매가능·판매완료·임시선점)를 한 번에 반환합니다 (#563 관리자 대시보드).
+
+          공연별 단건 조회(`GET /api/v1/seat/{performanceId}/seat-counts`)와 세는 규칙이 같습니다 —
+          만료된 임시선점은 예매가능에 포함되므로 `total_count = available_count + sold_count + hold_count`입니다.
+
+          **좌석이 아직 생성되지 않은 공연은 응답에 포함되지 않습니다.** 좌석 생성은 공연 등록 이벤트를 받아
+          비동기로 일어나므로, 방금 등록된 공연은 이 목록에 없을 수 있습니다. 호출자는 그 공연을 0석으로 채우지 말고
+          값을 모르는 것으로 다뤄야 합니다.
+          """)
+  @GetMapping("/seat-counts")
+  public ResponseEntity<ApiResponse<List<SeatStatusCountsByPerformanceResponse>>>
+      getAllSeatCounts() {
+    return ApiResponse.onSuccess(SuccessStatus.OK, seatFacade.getAllPerformanceSeatStatusCounts());
+  }
 
   @Operation(summary = "좌석 판매 확정", description = "HOLD 상태 좌석을 SOLD 상태로 확정합니다.")
   @PostMapping("/sold")

--- a/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/out/repository/SeatRepository.java
+++ b/seat-service/src/main/java/com/ticketrush/boundedcontext/seat/out/repository/SeatRepository.java
@@ -2,6 +2,7 @@ package com.ticketrush.boundedcontext.seat.out.repository;
 
 import com.ticketrush.boundedcontext.seat.app.dto.response.SeatMapItemResponse;
 import com.ticketrush.boundedcontext.seat.app.dto.response.SeatNumberResponse;
+import com.ticketrush.boundedcontext.seat.app.dto.response.SeatStatusCountsByPerformanceResponse;
 import com.ticketrush.boundedcontext.seat.app.dto.response.SeatStatusCountsResponse;
 import com.ticketrush.boundedcontext.seat.domain.entity.Seat;
 import com.ticketrush.global.types.SeatStatus;
@@ -36,6 +37,42 @@ public interface SeatRepository extends JpaRepository<Seat, Long> {
       Long performanceId, LocalDateTime now) {
     return getStatusCountsByPerformanceIdAndStatuses(
         performanceId, SeatStatus.AVAILABLE, SeatStatus.SOLD, SeatStatus.HOLD, now);
+  }
+
+  /**
+   * 전 공연 좌석 수를 한 번에 집계한다 (#563 관리자 대시보드).
+   *
+   * <p>세는 규칙은 {@link #getStatusCountsByPerformanceIdAndStatuses}와 <b>같은 식을 그대로 쓴다</b>. 규칙이 갈리면
+   * 대시보드의 공연별 점유율과 좌석 현황 화면의 숫자가 어긋나는데, 둘 다 관리자가 같은 세션에서 보는 값이다.
+   *
+   * <p><b>WHERE가 없는 전건 GROUP BY다.</b> 좌석은 공연당 행 수가 고정적이고 관리자 대시보드는 호출 빈도가 극히 낮아, 이 조회를 위해 예매 폭주 경로가
+   * 쓰는 {@code seat} 테이블에 인덱스를 얹지 않았다. 공연 수가 늘어 느려지면 그때 실측 근거를 갖고 추가한다.
+   *
+   * <p>{@code ORDER BY}를 명시하는 이유는 호출자가 공연 ID로 맵을 만들기 때문이 아니라, 정렬 없는 GROUP BY의 순서가 실행 계획에 따라 달라져
+   * 테스트가 간헐 실패하는 것을 막기 위해서다.
+   */
+  @Query(
+      "SELECT new com.ticketrush.boundedcontext.seat.app.dto.response"
+          + ".SeatStatusCountsByPerformanceResponse("
+          + "s.performanceId, "
+          + "COUNT(s), "
+          + "COUNT(CASE WHEN s.seatStatus = :availableStatus "
+          + "OR (s.seatStatus = :holdStatus AND s.holdExpiredAt <= :now) THEN 1 END), "
+          + "COUNT(CASE WHEN s.seatStatus = :soldStatus THEN 1 END), "
+          + "COUNT(CASE WHEN s.seatStatus = :holdStatus AND s.holdExpiredAt > :now THEN 1 END)) "
+          + "FROM Seat s "
+          + "GROUP BY s.performanceId "
+          + "ORDER BY s.performanceId ASC")
+  List<SeatStatusCountsByPerformanceResponse> getStatusCountsGroupedByPerformanceAndStatuses(
+      @Param("availableStatus") SeatStatus availableStatus,
+      @Param("soldStatus") SeatStatus soldStatus,
+      @Param("holdStatus") SeatStatus holdStatus,
+      @Param("now") LocalDateTime now);
+
+  default List<SeatStatusCountsByPerformanceResponse> getStatusCountsGroupedByPerformance(
+      LocalDateTime now) {
+    return getStatusCountsGroupedByPerformanceAndStatuses(
+        SeatStatus.AVAILABLE, SeatStatus.SOLD, SeatStatus.HOLD, now);
   }
 
   @Query(

--- a/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/app/facade/SeatFacadeTest.java
+++ b/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/app/facade/SeatFacadeTest.java
@@ -57,6 +57,7 @@ class SeatFacadeTest {
   private SeatFacade seatMapFacade() {
     return new SeatFacade(
         null,
+        null,
         seatGetSeatMapUseCase,
         null,
         null,

--- a/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/app/facade/SeatHoldConcurrencyTest.java
+++ b/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/app/facade/SeatHoldConcurrencyTest.java
@@ -156,6 +156,7 @@ class SeatHoldConcurrencyTest {
             null,
             null,
             null,
+            null,
             seatHoldUseCase,
             new SeatLockUseCase(redissonClient, meterRegistry),
             new SeatUnlockUseCase(redissonClient),

--- a/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/app/facade/SeatMapCacheIntegrationTest.java
+++ b/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/app/facade/SeatMapCacheIntegrationTest.java
@@ -98,6 +98,7 @@ class SeatMapCacheIntegrationTest {
     seatFacade =
         new SeatFacade(
             null,
+            null,
             new SeatGetSeatMapUseCase(seatRepository),
             null,
             null,

--- a/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/in/api/v1/SeatInternalControllerTest.java
+++ b/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/in/api/v1/SeatInternalControllerTest.java
@@ -1,0 +1,104 @@
+package com.ticketrush.boundedcontext.seat.in.api.v1;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.ticketrush.boundedcontext.seat.app.dto.response.SeatStatusCountsByPerformanceResponse;
+import com.ticketrush.boundedcontext.seat.app.facade.SeatFacade;
+import com.ticketrush.global.config.CustomSecurityProperties;
+import com.ticketrush.global.config.JacksonConfig;
+import com.ticketrush.global.config.SecurityConfig;
+import com.ticketrush.global.filter.GatewayHeaderFilter;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(SeatInternalController.class)
+@Import({
+  JacksonConfig.class,
+  SecurityConfig.class,
+  GatewayHeaderFilter.class,
+  CustomSecurityProperties.class
+})
+@TestPropertySource(
+    properties = {
+      "gateway.internal-token=test-token",
+      "custom.security.internal-token=test-internal-token"
+    })
+class SeatInternalControllerTest {
+
+  private static final String INTERNAL_TOKEN_HEADER = "X-Internal-Token";
+  private static final String SEAT_COUNTS_URL = "/api/v1/internal/seat/seat-counts";
+
+  @Autowired private MockMvc mockMvc;
+
+  @MockitoBean private SeatFacade seatFacade;
+
+  /**
+   * 이 테스트가 고정하는 것은 값이 아니라 <b>JSON 키 이름</b>이다. performance-service의 클라이언트가 이 키로 매핑하는데, 그쪽은 앱의
+   * SNAKE_CASE 설정을 타지 않는 {@code RestClient.builder()}라 키가 어긋나도 예외 없이 조용히 0이 된다. 그러면 전 공연 점유율 0%가 정상
+   * 응답처럼 보인다 — 소비자 쪽 테스트만으로는 여기서 이름이 바뀌는 것을 잡지 못한다.
+   */
+  @Test
+  @DisplayName("성공: 전 공연 좌석 수를 snake_case 키로 200 반환한다 (#563 대시보드 계약)")
+  void getAllSeatCounts_success() throws Exception {
+    // given
+    given(seatFacade.getAllPerformanceSeatStatusCounts())
+        .willReturn(
+            List.of(
+                new SeatStatusCountsByPerformanceResponse(100L, 120L, 82L, 38L, 0L),
+                new SeatStatusCountsByPerformanceResponse(200L, 80L, 70L, 10L, 0L)));
+
+    // when & then
+    mockMvc
+        .perform(get(SEAT_COUNTS_URL).header(INTERNAL_TOKEN_HEADER, "test-internal-token"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.result[0].performance_id").value(100))
+        .andExpect(jsonPath("$.result[0].total_count").value(120))
+        .andExpect(jsonPath("$.result[0].available_count").value(82))
+        .andExpect(jsonPath("$.result[0].sold_count").value(38))
+        .andExpect(jsonPath("$.result[0].hold_count").value(0))
+        .andExpect(jsonPath("$.result[1].performance_id").value(200));
+  }
+
+  @Test
+  @DisplayName("성공: 좌석이 하나도 없으면 빈 배열을 반환한다")
+  void getAllSeatCounts_empty() throws Exception {
+    // given
+    given(seatFacade.getAllPerformanceSeatStatusCounts()).willReturn(List.of());
+
+    // when & then
+    mockMvc
+        .perform(get(SEAT_COUNTS_URL).header(INTERNAL_TOKEN_HEADER, "test-internal-token"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.result").isArray())
+        .andExpect(jsonPath("$.result").isEmpty());
+  }
+
+  @Test
+  @DisplayName("실패: 내부 토큰이 일치하지 않으면 403을 반환한다")
+  void getAllSeatCounts_tokenMismatch_forbidden() throws Exception {
+    mockMvc
+        .perform(get(SEAT_COUNTS_URL).header(INTERNAL_TOKEN_HEADER, "wrong"))
+        .andExpect(status().isForbidden());
+
+    verifyNoInteractions(seatFacade);
+  }
+
+  @Test
+  @DisplayName("실패: 내부 토큰이 없으면 403을 반환한다")
+  void getAllSeatCounts_tokenMissing_forbidden() throws Exception {
+    mockMvc.perform(get(SEAT_COUNTS_URL)).andExpect(status().isForbidden());
+
+    verifyNoInteractions(seatFacade);
+  }
+}

--- a/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/out/repository/SeatRepositoryTest.java
+++ b/seat-service/src/test/java/com/ticketrush/boundedcontext/seat/out/repository/SeatRepositoryTest.java
@@ -229,6 +229,56 @@ class SeatRepositoryTest {
   }
 
   @Test
+  @DisplayName("전 공연 좌석 수를 공연 단위로 묶어 단건 조회와 같은 규칙으로 집계한다")
+  void getStatusCountsGroupedByPerformance_GroupsAllPerformances() {
+    // given: 공연 1에 5석(가능2·선점1·판매1·만료선점1), 공연 99에 1석
+    LocalDateTime now = LocalDateTime.now();
+
+    seatRepository.saveAll(
+        List.of(
+            seatOf(1L, "A1", SeatStatus.AVAILABLE, null),
+            seatOf(1L, "A2", SeatStatus.AVAILABLE, null),
+            seatOf(1L, "A3", SeatStatus.HOLD, now.plusMinutes(5)),
+            seatOf(1L, "A4", SeatStatus.SOLD, null),
+            seatOf(1L, "A5", SeatStatus.HOLD, now.minusMinutes(1)),
+            seatOf(99L, "A1", SeatStatus.SOLD, null)));
+
+    // when
+    var rows = seatRepository.getStatusCountsGroupedByPerformance(now);
+
+    // then: 만료된 HOLD가 예매 가능으로 넘어가는 규칙이 단건 조회와 동일해야 두 화면의 숫자가 갈리지 않는다
+    assertThat(rows).hasSize(2);
+    assertThat(rows.get(0).performanceId()).isEqualTo(1L);
+    assertThat(rows.get(0).totalCount()).isEqualTo(5L);
+    assertThat(rows.get(0).availableCount()).isEqualTo(3L);
+    assertThat(rows.get(0).soldCount()).isEqualTo(1L);
+    assertThat(rows.get(0).holdCount()).isEqualTo(1L);
+    assertThat(rows.get(1).performanceId()).isEqualTo(99L);
+    assertThat(rows.get(1).soldCount()).isEqualTo(1L);
+  }
+
+  @Test
+  @DisplayName("좌석이 하나도 없으면 일괄 집계는 빈 목록이다")
+  void getStatusCountsGroupedByPerformance_WhenNoSeats_ReturnsEmpty() {
+    // when
+    var rows = seatRepository.getStatusCountsGroupedByPerformance(LocalDateTime.now());
+
+    // then: GROUP BY는 행이 있는 그룹만 만든다 — 호출자는 이를 0석이 아니라 '모름'으로 다뤄야 한다
+    assertThat(rows).isEmpty();
+  }
+
+  private Seat seatOf(
+      Long performanceId, String seatNumber, SeatStatus status, LocalDateTime holdExpiredAt) {
+    return Seat.builder()
+        .seatLayoutId(1L)
+        .performanceId(performanceId)
+        .seatNumber(seatNumber)
+        .seatStatus(status)
+        .holdExpiredAt(holdExpiredAt)
+        .build();
+  }
+
+  @Test
   @DisplayName("공연 ID에 해당하는 좌석이 없으면 모든 카운트를 0으로 반환한다")
   void getStatusCountsByPerformanceId_ReturnsZeroWhenNoSeatsExist() {
     // when


### PR DESCRIPTION
## 🔗 관련 이슈

- close #563

---

## 📌 주요 변경 사항

- 관리자 대시보드 집계 API 추가 — KPI 4종(등록 공연 수·판매 티켓 수·총 매출·평균 점유율), 일별 매출 추이, 장르별 매출 분포
- 관리자 공연 목록 API 추가 — 판매 좌석·점유율·매진·매출을 포함한 관리자용 GET (기존 admin 경로엔 GET이 없었습니다)
- booking·seat에 내부 집계 API 신설 — 대시보드가 쓰는 매출·좌석 수를 제공
- performance-service 최초의 아웃바운드 호출 계층 신설(`RestClientConfig` + 클라이언트 2종)

| 메서드 | 경로 | 서비스 |
|---|---|---|
| GET | `/api/v1/performance/admin/dashboard` | performance |
| GET | `/api/v1/performance/admin` | performance |
| GET | `/api/v1/internal/booking/stats` | booking (신설) |
| GET | `/api/v1/internal/seat/seat-counts` | seat (신설) |

---

## 🛠 상세 구현 내용

- **집계 주체를 performance에 뒀습니다.** 장르는 공연만, 매출은 예매만 아는 값이라 결합이 필연인데 [ADR 0003](../blob/develop/docs/adr/0003-shared-database-with-service-boundaries.md)이 크로스 도메인 조인을 금지합니다. performance에 두면 원격 호출이 호출당 O(1)이고, booking에 두면 booking이 공연 수만큼 performance를 되물어야 합니다.

- **ADMIN API가 아니라 internal API를 신설해 호출합니다.** `/api/v1/booking/admin/**`는 `hasRole("ADMIN")`이고 그 권한은 게이트웨이가 사용자 헤더로만 부여합니다. 서비스가 그 헤더를 스스로 만들면 게이트웨이 신뢰 경계를 사칭하는 셈이라, `X-Internal-Token` 경계로 같은 값을 노출했습니다. **요약은 `#561`의 관리자 통계와 같은 유스케이스를 재사용**해 두 화면이 다른 매출을 내지 않게 했습니다.

- **점유율 분모는 좌석 서비스의 실측값입니다.** 공연 등록 시 입력하는 `totalSeats`는 좌석 생성에 반영되지 않아 분모로 쓰면 값이 틀립니다(아래 리뷰 요청 2번).

- **평균 점유율은 가중평균**(전체 판매 좌석 ÷ 전체 좌석)입니다. 산술평균은 20석짜리 소규모 공연 하나가 1,000석 공연과 같은 무게를 가져 매출 규모와 어긋난 방향으로 지표를 흔듭니다. 검증할 수 있도록 분자·분모를 함께 내립니다.

- **지표마다 모수가 다릅니다.** 하나로 통일하면 어느 한쪽이 거짓말을 합니다.
  | 지표 | 모수 |
  |---|---|
  | 등록 공연 수 | 삭제 제외 전체(판매 전·취소 포함) |
  | 평균 점유율 | 판매가 실제로 일어나는 공연(`ON_SALE`·`CLOSED`)만 |
  | 총 매출·판매 티켓 수 | 상태 무관 전체 |

  각 모수를 `@Operation`에 명시했습니다.

- **기간(`from`/`to`)은 일별 추이에만 적용**합니다(기본 최근 30일, 상한 92일). 요약에 걸면 총 매출이 기존 통계 API와 달라져 "중복 구현하지 않는다"는 완료 조건의 검증 기준이 깨집니다.

- **전면 fail-open입니다.** 예매·좌석 조회가 실패하면 그 축의 필드만 비우고 대시보드 자체는 성공합니다. 비운 필드는 전역 `NON_NULL` 설정 때문에 키째 생략됩니다.

- **인덱스를 추가하지 않았습니다.** 일별 집계는 기존 `(booking_status, updated_at)` 인덱스를 탑니다 — 실측(로컬 MySQL, booking 3,000행/CONFIRMED 1,000행) 결과 전건 스캔이 아니라 `Index lookup ... (cost=26.1 rows=1000)`으로 선별됩니다. 공연별 집계는 전건 스캔이지만 관리자 호출 빈도가 낮고, 예매·좌석은 오픈런 트래픽을 받는 쓰기 핫패스라 인덱스 유지 비용을 모든 쓰기가 상시 부담하는 교환이 맞지 않습니다. EXPLAIN 결과를 리포지토리 javadoc에 남겼습니다.

---

## ✅ 테스트

### 테스트 방법

`spotlessApply` → `checkstyleMain` + `checkstyleTest`(common 포함) → `compileJava` → 3개 모듈 `test` (Docker 기동, Testcontainers 포함)

### 테스트 결과

**전건 통과** — performance 130건 / booking 168건 / seat 165건

주요 케이스:

- 비ADMIN·무인증·게이트웨이 토큰 누락 시 403, 내부 토큰 불일치 시 403(`verifyNoInteractions`로 필터 단계 차단까지 고정)
- fail-open 부분 응답 — 예매 장애 시 매출 축만, 좌석 장애 시 점유율 축만 비움
- 공연 0건·좌석 0석에서 0으로 나누지 않음
- 기간 경계 — 92일 통과 / 93일 400, 뒤집힌 구간 400, 반열린 구간(5/22 23:59:59 포함, 5/23 00:00 제외)
- `cast(... as LocalDate)` HQL이 실제로 동작하는지 리포지토리 테스트로 확인
- `COALESCE` 누락 시 NPE가 되는 경로(확정 예매 0건 공연) 방어
- **3개 서비스 계약 JSON 키 14개를 `jsonPath`로 고정** — 이 키들은 `RestClient.builder()` 클라이언트가 매핑하는데 그쪽은 앱의 SNAKE_CASE 설정을 타지 않아, 키가 어긋나면 예외 없이 조용히 0/null이 됩니다. 공급자·소비자 양쪽에서 고정했습니다.
- URL 가드 — 스킴 없는 값(`booking-service:8084`)·앞뒤 공백 값은 호출 자체를 하지 않음. 이 값들은 요청 시점에 `IllegalArgumentException`이 되는데 그건 `RestClientException`이 아니라 fail-open catch를 뚫고 API 전체를 500으로 만듭니다.

---

## 👀 리뷰 요청 사항

1. **@50h33 님께** — booking·seat 변경은 **추가만**이며 기존 API·쿼리·리스너 동작은 그대로입니다. 인덱스도 추가하지 않아 예매 폭주 경로에 비용이 얹히지 않습니다. `SeatFacade` 생성자에 필드가 하나 늘어 기존 테스트 3곳의 인자를 맞췄습니다. 진행 중이신 부하 회차(#554·#555)와 머지 타이밍이 겹치면 조율하겠습니다.

2. **⚠️ 이번 범위 밖 발견 — 좌석 수가 공연 등록 입력값과 무관합니다.** `PerformanceCreatedEvent`가 `totalSeats`를 페이로드에 실어 보내는데(`PerformanceCreatedEvent.java:11`) `PerformanceCreatedEventListener`가 그 값을 읽지 않아, 좌석은 **항상 10×12=120석**으로 생성됩니다(`SeatCreateDefaultLayoutUseCase.java:20-21`). 시드 데이터는 1,200~70,000을 넣습니다. 대시보드는 좌석 실측값을 쓰므로 이 PR의 점유율·매진은 정확하지만, 관리자가 입력한 총 좌석 수와 화면이 어긋납니다. 좌석 도메인 판단이 필요해 이슈를 만들지 않고 공유만 합니다.

3. **알려진 비용 — 관리자 목록이 페이지당 원격 전건 집계 2회를 유발합니다.** 예매·좌석 어느 쪽도 공연 ID로 좁히는 축이 없어 매 페이지마다 전체를 받아 옵니다. 관리자 동시 사용자가 소수이고 공연 수가 아직 작아 감수했으나 **공연 수·예매 행 수가 늘면 성립하지 않는 전제**입니다. 근거와 해소 방법(예매 집계 API에 공연 ID 필터)을 `PerformanceGetAdminListUseCase` javadoc에 적어두고 후속 이슈로 분리하겠습니다.

---

## ⚠️ 배포 시 주의사항

- **스키마 무변경 → prod 수동 DDL 없습니다.**

- **신규 환경변수 2종** — performance-service에 `BOOKING_SERVICE_URL`·`SEAT_SERVICE_URL`이 필요합니다. 게이트웨이는 `/api/v1/internal/**`를 라우팅하지 않으므로 **대상 서비스 직접 주소**여야 하고 **스킴(`http://`)을 포함**해야 합니다. 미설정이어도 기동은 성공하고(공개 API를 관리자 설정 하나로 죽이지 않기 위해서입니다) 대시보드의 해당 필드만 비며 기동 로그에 WARN이 남습니다. → #441 체크리스트에 추가 예정입니다.

- **프론트 공지 2건**
  - 신규 에러 코드 `PERFORMANCE_400_008`(조회 시작일 > 종료일)·`PERFORMANCE_400_009`(조회 기간 92일 초과)
  - 값을 읽지 못한 필드는 `null`이 아니라 **키 자체가 생략**됩니다(전역 `NON_NULL` 설정). `data.total_revenue === null`이 아니라 `undefined` 검사가 필요합니다.
