### PR TITLE
[Refactor] #475 결제 내역 조회 정렬을 서버 고정으로 바꿔 임의 정렬 override를 차단한다

### DIFF
--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/facade/PaymentFacade.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/facade/PaymentFacade.java
@@ -12,12 +12,12 @@ import com.ticketrush.boundedcontext.payment.app.usecase.PaymentGetDetailUseCase
 import com.ticketrush.boundedcontext.payment.app.usecase.PaymentGetListUseCase;
 import com.ticketrush.boundedcontext.payment.app.usecase.PaymentWebhookUseCase;
 import com.ticketrush.boundedcontext.payment.app.usecase.RegisterExpiredBookingUseCase;
+import com.ticketrush.global.dto.request.OffsetPageRequest;
 import com.ticketrush.global.exception.BusinessException;
 import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -63,8 +63,8 @@ public class PaymentFacade {
     }
   }
 
-  public Page<PaymentSummaryResponse> getPayments(Long userId, Pageable pageable) {
-    return paymentGetListUseCase.execute(userId, pageable);
+  public Page<PaymentSummaryResponse> getPayments(Long userId, OffsetPageRequest pageRequest) {
+    return paymentGetListUseCase.execute(userId, pageRequest);
   }
 
   public PaymentDetailResponse getPayment(Long userId, Long paymentId) {

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentGetListUseCase.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentGetListUseCase.java
@@ -4,21 +4,44 @@ import com.ticketrush.boundedcontext.payment.app.dto.response.PaymentSummaryResp
 import com.ticketrush.boundedcontext.payment.app.mapper.PaymentMapper;
 import com.ticketrush.boundedcontext.payment.domain.types.PaymentStatus;
 import com.ticketrush.boundedcontext.payment.out.repository.PaymentRepository;
+import com.ticketrush.global.dto.request.OffsetPageRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+/**
+ * 로그인 사용자의 결제 내역(COMPLETED)을 오프셋 페이징으로 조회한다.
+ *
+ * <p>정렬은 이 UseCase가 고정 조립하며 클라이언트가 지정할 수 없다(#475). 이전에는 컨트롤러가 {@code Pageable}을 그대로 바인딩해 {@code
+ * ?sort=} 로 임의 프로퍼티를 덮어쓸 수 있었고, 그 결과 ①존재하지 않는 프로퍼티가 {@code PropertyReferenceException} → 500으로 나가고
+ * ②{@code paymentKey}(200자)·{@code approvalNumber} 같은 문자열 컬럼 정렬이 sort buffer 비용을 키우며 ③{@code
+ * failureCode}·{@code pgFailureCode}처럼 응답 DTO에 없는 내부 값의 순서를 관측할 수 있었다({@code Sort}가 받는 것은 컬럼명이 아니라
+ * 엔티티 프로퍼티명이다).
+ *
+ * <p>{@code paidAt} 단독 정렬은 동일 시각에 승인된 결제가 있으면 전순서가 확정되지 않아 오프셋 페이징의 페이지 경계에서 중복·누락이 생길 수 있다. PK인
+ * {@code id}를 tie-break로 덧붙여 전순서를 확정한다.
+ *
+ * <p>정렬 키가 {@code idx_payment_user_id_status}에 포함되지 않아 filesort는 그대로 남는다. 커버링 인덱스는 이 작업 범위 밖이다
+ * ({@code Payment} 클래스 javadoc 참고).
+ */
 @Service
 @RequiredArgsConstructor
 public class PaymentGetListUseCase {
+
+  private static final Sort PAID_AT_DESC =
+      Sort.by(Sort.Order.desc("paidAt"), Sort.Order.desc("id"));
 
   private final PaymentRepository paymentRepository;
   private final PaymentMapper paymentMapper;
 
   @Transactional(readOnly = true)
-  public Page<PaymentSummaryResponse> execute(Long userId, Pageable pageable) {
+  public Page<PaymentSummaryResponse> execute(Long userId, OffsetPageRequest pageRequest) {
+    Pageable pageable = PageRequest.of(pageRequest.page(), pageRequest.size(), PAID_AT_DESC);
+
     return paymentRepository
         .findByUserIdAndStatus(userId, PaymentStatus.COMPLETED, pageable)
         .map(paymentMapper::toSummaryResponse);

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/in/api/v1/PaymentController.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/in/api/v1/PaymentController.java
@@ -7,6 +7,7 @@ import com.ticketrush.boundedcontext.payment.app.dto.response.PaymentConfirmResp
 import com.ticketrush.boundedcontext.payment.app.dto.response.PaymentDetailResponse;
 import com.ticketrush.boundedcontext.payment.app.dto.response.PaymentSummaryResponse;
 import com.ticketrush.boundedcontext.payment.app.facade.PaymentFacade;
+import com.ticketrush.global.dto.request.OffsetPageRequest;
 import com.ticketrush.global.dto.response.ApiResponse;
 import com.ticketrush.global.security.CustomUserDetails;
 import com.ticketrush.global.status.SuccessStatus;
@@ -19,13 +20,11 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
-import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -77,13 +76,23 @@ public class PaymentController {
 
   @Operation(
       summary = "결제 내역 목록 조회",
-      description = "로그인 사용자의 결제 내역을 오프셋 페이징으로 조회한다. COMPLETED 상태만 노출된다.")
+      description =
+          """
+          로그인 사용자의 결제 내역을 오프셋 페이징으로 조회한다. COMPLETED 상태만 노출된다.
+
+          정렬은 결제 완료 시각 내림차순(동일 시각이면 결제 ID 내림차순) 고정이며 클라이언트가 지정할 수 없다(#475).
+          `sort` 파라미터를 보내도 무시된다.
+
+          `page`는 0부터 시작하며 미지정이거나 음수면 0으로 보정된다. `size`는 미지정이거나 1 미만이면 10,
+          50을 초과하면 50으로 보정된다. 다만 정수로 변환할 수 없는 값(`size=abc` 등)은 보정 대상이 아니라
+          `VALID_400_001`로 거부된다.
+          """)
   @GetMapping
   public ResponseEntity<ApiResponse<List<PaymentSummaryResponse>>> getPayments(
       @AuthenticationPrincipal CustomUserDetails user,
-      @ParameterObject @PageableDefault(size = 10, sort = "paidAt", direction = Sort.Direction.DESC)
-          Pageable pageable) {
-    Page<PaymentSummaryResponse> payments = paymentFacade.getPayments(user.getUserId(), pageable);
+      @ParameterObject @ModelAttribute OffsetPageRequest pageRequest) {
+    Page<PaymentSummaryResponse> payments =
+        paymentFacade.getPayments(user.getUserId(), pageRequest);
     return ApiResponse.onSuccess(SuccessStatus.OK, payments);
   }
 

--- a/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentGetListUseCaseIntegrationTest.java
+++ b/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentGetListUseCaseIntegrationTest.java
@@ -1,0 +1,155 @@
+package com.ticketrush.boundedcontext.payment.app.usecase;
+
+import static java.util.Comparator.reverseOrder;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.ticketrush.boundedcontext.payment.app.dto.response.PaymentSummaryResponse;
+import com.ticketrush.boundedcontext.payment.app.mapper.PaymentMapper;
+import com.ticketrush.boundedcontext.payment.domain.entity.Payment;
+import com.ticketrush.boundedcontext.payment.domain.types.PaymentProvider;
+import com.ticketrush.boundedcontext.payment.domain.types.PaymentStatus;
+import com.ticketrush.boundedcontext.payment.out.repository.PaymentRepository;
+import com.ticketrush.global.dto.request.OffsetPageRequest;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mapstruct.factory.Mappers;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.boot.jdbc.test.autoconfigure.AutoConfigureTestDatabase;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.data.domain.Page;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.mysql.MySQLContainer;
+
+/**
+ * {@link PaymentGetListUseCase}가 고정 조립하는 정렬을 실제 DB로 실행해 검증한다(#475).
+ *
+ * <p>{@code PaymentGetListUseCaseTest}는 리포지토리를 mock으로 두고 {@code Sort} 객체의 equals만 비교하므로, 정렬 프로퍼티명이
+ * 엔티티에 실존하는지는 검증 범위 밖이다. 프로퍼티명이 틀리면 {@code PropertyReferenceException}으로 500이 나가는데 그 경로는 실제
+ * EntityManager를 태워야만 드러난다. 특히 tie-break로 쓰는 {@code id}는 {@code AutoIdBaseEntity}에서 상속받고
+ * {@code @AttributeOverride}로 컬럼명이 {@code payment_id}가 되므로 해석이 자명하지 않다.
+ *
+ * <p>Docker가 없는 환경에서는 컨테이너 기동 실패로 깨진다. {@code PaymentCompletedBookingUniqueTest}와 같은 fail-closed
+ * 방침이다 — silent skip을 허용하면 이 그물이 CI에서 조용히 사라져도 아무도 모른다.
+ */
+@DataJpaTest(properties = "spring.jpa.hibernate.ddl-auto=update")
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Testcontainers
+class PaymentGetListUseCaseIntegrationTest {
+
+  private static final Long USER_ID = 1L;
+
+  /* prod(deploy/docker-compose.prod.yml)와 동일한 mysql:8.0 + utf8mb4_unicode_ci로 맞춘다. */
+  @Container
+  private static final MySQLContainer MYSQL =
+      new MySQLContainer("mysql:8.0")
+          .withDatabaseName("ticket_rush")
+          .withCommand("--character-set-server=utf8mb4", "--collation-server=utf8mb4_unicode_ci");
+
+  @DynamicPropertySource
+  static void datasourceProperties(DynamicPropertyRegistry registry) {
+    registry.add("spring.datasource.url", MYSQL::getJdbcUrl);
+    registry.add("spring.datasource.username", MYSQL::getUsername);
+    registry.add("spring.datasource.password", MYSQL::getPassword);
+    registry.add("spring.datasource.driver-class-name", MYSQL::getDriverClassName);
+  }
+
+  @Autowired private PaymentRepository paymentRepository;
+
+  @Autowired private PaymentGetListUseCase paymentGetListUseCase;
+
+  @Test
+  @DisplayName("고정 정렬의 프로퍼티명이 실제 엔티티로 해석된다 — 예외 없이 조회된다")
+  void execute_resolvesSortPropertiesAgainstEntity() {
+    // given
+    paymentRepository.saveAll(
+        List.of(
+            payment(100L, LocalDateTime.of(2026, 5, 1, 10, 0)),
+            payment(101L, LocalDateTime.of(2026, 5, 2, 10, 0))));
+    paymentRepository.flush();
+
+    // when
+    Page<PaymentSummaryResponse> result =
+        paymentGetListUseCase.execute(USER_ID, new OffsetPageRequest(0, 10));
+
+    // then — paidAt이 늦은 건이 먼저 온다
+    assertThat(result.getTotalElements()).isEqualTo(2);
+    assertThat(result.getContent())
+        .extracting(PaymentSummaryResponse::bookingId)
+        .containsExactly(101L, 100L);
+  }
+
+  @Test
+  @DisplayName("paidAt이 모두 동일해도 페이지 경계에서 중복·누락이 없다 — id tie-break로 전순서가 확정된다")
+  void execute_breaksTieByIdAcrossPageBoundary() {
+    // given — paidAt이 완전히 동일한 4건. tie-break가 없으면 페이지 간 순서가 보장되지 않는다.
+    LocalDateTime sameInstant = LocalDateTime.of(2026, 5, 1, 10, 0, 0);
+    paymentRepository.saveAll(
+        List.of(
+            payment(100L, sameInstant),
+            payment(101L, sameInstant),
+            payment(102L, sameInstant),
+            payment(103L, sameInstant)));
+    paymentRepository.flush();
+
+    // when — 경계를 실제로 넘도록 size 2로 두 페이지를 연속 조회한다
+    List<Long> firstPage = paymentIdsOf(paymentGetListUseCase.execute(USER_ID, page(0, 2)));
+    List<Long> secondPage = paymentIdsOf(paymentGetListUseCase.execute(USER_ID, page(1, 2)));
+
+    // then — 두 페이지를 합치면 중복 0건, 누락 0건이고 전체가 id 내림차순이다
+    assertThat(firstPage).hasSize(2);
+    assertThat(secondPage).hasSize(2);
+    assertThat(firstPage).doesNotContainAnyElementsOf(secondPage);
+
+    List<Long> merged = new ArrayList<>(firstPage);
+    merged.addAll(secondPage);
+    assertThat(merged).hasSize(4).doesNotHaveDuplicates().isSortedAccordingTo(reverseOrder());
+  }
+
+  private OffsetPageRequest page(int page, int size) {
+    return new OffsetPageRequest(page, size);
+  }
+
+  private List<Long> paymentIdsOf(Page<PaymentSummaryResponse> page) {
+    return page.getContent().stream().map(PaymentSummaryResponse::paymentId).toList();
+  }
+
+  private Payment payment(Long bookingId, LocalDateTime paidAt) {
+    return Payment.builder()
+        .bookingId(bookingId)
+        .userId(USER_ID)
+        .provider(PaymentProvider.TOSS)
+        .amount(55_000L)
+        .status(PaymentStatus.COMPLETED)
+        .paymentKey("pgKey_" + bookingId)
+        .approvalNumber("APR-" + bookingId)
+        .paidAt(paidAt)
+        .build();
+  }
+
+  /*
+   * @DataJpaTest 슬라이스엔 @Service·MapStruct 빈이 없어 UseCase를 직접 올린다.
+   * 테스트 클래스의 static 중첩 @TestConfiguration은 Boot가 자동 등록하므로 @Import가 필요 없다.
+   */
+  @TestConfiguration
+  static class UseCaseTestConfig {
+
+    @Bean
+    PaymentMapper paymentMapper() {
+      return Mappers.getMapper(PaymentMapper.class);
+    }
+
+    @Bean
+    PaymentGetListUseCase paymentGetListUseCase(
+        PaymentRepository paymentRepository, PaymentMapper paymentMapper) {
+      return new PaymentGetListUseCase(paymentRepository, paymentMapper);
+    }
+  }
+}

--- a/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentGetListUseCaseTest.java
+++ b/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentGetListUseCaseTest.java
@@ -1,7 +1,10 @@
 package com.ticketrush.boundedcontext.payment.app.usecase;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
 
 import com.ticketrush.boundedcontext.payment.app.dto.response.PaymentSummaryResponse;
 import com.ticketrush.boundedcontext.payment.app.mapper.PaymentMapper;
@@ -9,6 +12,7 @@ import com.ticketrush.boundedcontext.payment.domain.entity.Payment;
 import com.ticketrush.boundedcontext.payment.domain.types.PaymentProvider;
 import com.ticketrush.boundedcontext.payment.domain.types.PaymentStatus;
 import com.ticketrush.boundedcontext.payment.out.repository.PaymentRepository;
+import com.ticketrush.global.dto.request.OffsetPageRequest;
 import java.lang.reflect.Field;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -16,6 +20,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mapstruct.factory.Mappers;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
@@ -35,19 +41,28 @@ class PaymentGetListUseCaseTest {
 
   @InjectMocks private PaymentGetListUseCase paymentGetListUseCase;
 
+  @Captor private ArgumentCaptor<Pageable> pageableCaptor;
+
+  /*
+   * 이 테스트는 매핑 결과만 본다. 어떤 Pageable로 조회하는지(page·size·정렬)는 아래
+   * execute_assemblesFixedSort가 전담하므로 여기서는 any(Pageable.class)로 느슨하게 둔다.
+   * 정렬 프로퍼티가 실제 엔티티로 해석되는지는 PaymentGetListUseCaseIntegrationTest가 맡는다.
+   */
   @Test
   @DisplayName("로그인 사용자의 COMPLETED 결제 내역을 페이지로 반환한다")
   void execute_returns_completed_payments() throws Exception {
     // given
     Long userId = 10L;
-    Pageable pageable = PageRequest.of(0, 10, Sort.by(Sort.Direction.DESC, "paidAt"));
+    OffsetPageRequest pageRequest = new OffsetPageRequest(0, 10);
     Payment payment = sample(1L, userId, 100L, 55_000L);
-    Page<Payment> page = new PageImpl<>(List.of(payment), pageable, 1);
-    given(paymentRepository.findByUserIdAndStatus(userId, PaymentStatus.COMPLETED, pageable))
+    Page<Payment> page = new PageImpl<>(List.of(payment), PageRequest.of(0, 10), 1);
+    given(
+            paymentRepository.findByUserIdAndStatus(
+                eq(userId), eq(PaymentStatus.COMPLETED), any(Pageable.class)))
         .willReturn(page);
 
     // when
-    Page<PaymentSummaryResponse> result = paymentGetListUseCase.execute(userId, pageable);
+    Page<PaymentSummaryResponse> result = paymentGetListUseCase.execute(userId, pageRequest);
 
     // then
     assertThat(result.getTotalElements()).isEqualTo(1);
@@ -56,6 +71,32 @@ class PaymentGetListUseCaseTest {
     assertThat(first.bookingId()).isEqualTo(100L);
     assertThat(first.amount()).isEqualTo(55_000L);
     assertThat(first.status()).isEqualTo(PaymentStatus.COMPLETED);
+  }
+
+  @Test
+  @DisplayName("정렬은 paidAt DESC + id DESC로 고정 조립된다 — 호출자가 지정할 수 없다(#475)")
+  void execute_assemblesFixedSort() {
+    // given
+    Long userId = 10L;
+    OffsetPageRequest pageRequest = new OffsetPageRequest(2, 25);
+    given(
+            paymentRepository.findByUserIdAndStatus(
+                eq(userId), eq(PaymentStatus.COMPLETED), any(Pageable.class)))
+        .willReturn(Page.empty());
+
+    // when
+    paymentGetListUseCase.execute(userId, pageRequest);
+
+    // then
+    then(paymentRepository)
+        .should()
+        .findByUserIdAndStatus(eq(userId), eq(PaymentStatus.COMPLETED), pageableCaptor.capture());
+
+    Pageable captured = pageableCaptor.getValue();
+    assertThat(captured.getPageNumber()).isEqualTo(2);
+    assertThat(captured.getPageSize()).isEqualTo(25);
+    assertThat(captured.getSort())
+        .isEqualTo(Sort.by(Sort.Order.desc("paidAt"), Sort.Order.desc("id")));
   }
 
   private Payment sample(Long id, Long userId, Long bookingId, Long amount) throws Exception {

--- a/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/in/api/v1/PaymentControllerTest.java
+++ b/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/in/api/v1/PaymentControllerTest.java
@@ -1,5 +1,6 @@
 package com.ticketrush.boundedcontext.payment.in.api.v1;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
@@ -20,6 +21,7 @@ import com.ticketrush.boundedcontext.payment.app.facade.PaymentFacade;
 import com.ticketrush.boundedcontext.payment.domain.types.PaymentProvider;
 import com.ticketrush.boundedcontext.payment.domain.types.PaymentStatus;
 import com.ticketrush.global.config.SecurityConfig;
+import com.ticketrush.global.dto.request.OffsetPageRequest;
 import com.ticketrush.global.exception.BusinessException;
 import com.ticketrush.global.filter.GatewayHeaderFilter;
 import com.ticketrush.global.status.ErrorStatus;
@@ -28,6 +30,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.domain.Page;
@@ -381,7 +384,7 @@ class PaymentControllerTest {
             PaymentStatus.COMPLETED,
             LocalDateTime.of(2026, 5, 1, 10, 0));
     Page<PaymentSummaryResponse> page = new PageImpl<>(List.of(item), Pageable.ofSize(10), 1);
-    given(paymentFacade.getPayments(eq(userId), any(Pageable.class))).willReturn(page);
+    given(paymentFacade.getPayments(eq(userId), any(OffsetPageRequest.class))).willReturn(page);
 
     // when & then
     mockMvc
@@ -396,6 +399,79 @@ class PaymentControllerTest {
         .andExpect(jsonPath("$.result[0].payment_id").value(1))
         .andExpect(jsonPath("$.result[0].booking_id").value(100))
         .andExpect(jsonPath("$.result[0].status").value("COMPLETED"));
+
+    verify(paymentFacade).getPayments(userId, new OffsetPageRequest(0, 10));
+  }
+
+  /*
+   * sort는 더 이상 바인딩 대상이 아니므로 어떤 값이 오든 하위 계층에 전달되지 않는다(#475).
+   * 클라이언트가 준 프로퍼티가 쿼리 실행까지 도달하는 경로 자체가 사라졌으므로,
+   * "잘못된 프로퍼티가 PropertyReferenceException으로 500을 낸다"는 회귀는 검증 대상이 아니라 소멸한 것이다.
+   */
+  @Test
+  @DisplayName("sort 파라미터는 바인딩되지 않아 기본 페이지 요청만 전달된다(#475)")
+  void getPayments_ignoresSortParameter() throws Exception {
+    // given
+    Long userId = 10L;
+    given(paymentFacade.getPayments(eq(userId), any(OffsetPageRequest.class)))
+        .willReturn(Page.empty());
+
+    // when & then
+    mockMvc
+        .perform(
+            get("/api/v1/payment")
+                .param("sort", "amount,asc")
+                .param("sort", "notAnEntityProperty,desc")
+                .header("X-Gateway-Token", INTERNAL_TOKEN)
+                .header("X-User-Id", userId)
+                .header("X-User-Role", "USER"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.is_success").value(true));
+
+    verify(paymentFacade).getPayments(userId, new OffsetPageRequest(0, 10));
+  }
+
+  @Test
+  @DisplayName("size가 정수로 변환되지 않으면 보정하지 않고 400으로 거부한다")
+  void getPayments_rejectsNonNumericSize() throws Exception {
+    // when & then
+    mockMvc
+        .perform(
+            get("/api/v1/payment")
+                .param("size", "abc")
+                .header("X-Gateway-Token", INTERNAL_TOKEN)
+                .header("X-User-Id", 10L)
+                .header("X-User-Role", "USER"))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.is_success").value(false))
+        .andExpect(jsonPath("$.code").value(ErrorStatus.VALIDATION_ERROR.getCode()));
+
+    verifyNoInteractions(paymentFacade);
+  }
+
+  @Test
+  @DisplayName("size가 상한을 넘으면 50으로 보정되어 전달된다")
+  void getPayments_clampsPageSize() throws Exception {
+    // given
+    Long userId = 10L;
+    given(paymentFacade.getPayments(eq(userId), any(OffsetPageRequest.class)))
+        .willReturn(Page.empty());
+    ArgumentCaptor<OffsetPageRequest> captor = ArgumentCaptor.forClass(OffsetPageRequest.class);
+
+    // when & then
+    mockMvc
+        .perform(
+            get("/api/v1/payment")
+                .param("page", "1")
+                .param("size", "2000")
+                .header("X-Gateway-Token", INTERNAL_TOKEN)
+                .header("X-User-Id", userId)
+                .header("X-User-Role", "USER"))
+        .andExpect(status().isOk());
+
+    verify(paymentFacade).getPayments(eq(userId), captor.capture());
+    assertThat(captor.getValue().size()).isEqualTo(50);
+    assertThat(captor.getValue().page()).isEqualTo(1);
   }
 
   @Test


### PR DESCRIPTION
## 🔗 관련 이슈

- close #475

---

## 📌 주요 변경 사항

- 결제 내역 목록 조회(`GET /api/v1/payment`)가 클라이언트 `?sort=`로 임의 프로퍼티 정렬을 지정할 수 있던 것을 막는다
- 화이트리스트를 검증하는 대신 `OffsetPageRequest`로 전환해 **선택권 자체를 제거**한다. 레포의 다른 페이징 API 6곳과 동일한 형태다
- 정렬은 `paidAt DESC + id DESC`로 UseCase가 고정 조립한다. `id`(PK) tie-break로 페이지 경계의 중복·누락을 막는다

---

## 🛠 상세 구현 내용

**이슈 전제 정정 - filesort는 이 PR로 사라지지 않는다**

이슈는 "정렬 키가 인덱스에 없으면 filesort가 남는다"를 근거로 들었으나, `idx_payment_user_id_status`는 `(user_id, status)` 두 컬럼 모두 equality라 **기본 정렬인 `paidAt`도 이미 filesort**다. 이는 방치가 아니라 #463에서 명시적으로 내린 결정이며 `Payment` 클래스 javadoc에 근거가 남아 있다. 따라서 이 PR의 실익은 성능이 아니라 다음 셋이다.

1. `?sort=없는프로퍼티`가 `PropertyReferenceException` → 500으로 나가던 경로 소멸
2. `paymentKey`(200자)·`approvalNumber` 같은 문자열 컬럼 정렬의 sort buffer 비용 차단
3. `failureCode`·`pgFailureCode`처럼 **응답 DTO에 없는 값의 순서를 관측하는 사이드채널** 차단

**설계 선택 - 화이트리스트 검증 대신 계약에서 제거**

`@PageableDefault` + raw `Pageable` 바인딩은 레포 전체에서 이 엔드포인트 하나뿐이었다. 나머지 6곳(booking 4, performance 2)은 전부 `OffsetPageRequest`(page/size만) + 서버가 `Sort` 고정 조립이다. 검증 로직·화이트리스트 상수·새 `ErrorStatus`를 만드는 대신 그 관례로 편입시켰다. 검증 코드가 없으므로 검증 버그도 없다.

**tie-break 추가 (이슈 본문 밖 항목, 승인 후 포함)**

`paid_at` 단독 정렬은 값이 동일한 결제가 있으면 전순서가 확정되지 않아 오프셋 페이징의 페이지 경계에서 중복·누락이 발생할 수 있다. `paid_at`의 출처는 Toss 승인 시각이라 같은 초에 뭉칠 수 있다. PK인 `id`를 tie-break로 덧붙여 전순서를 확정했다. 이 PR이 만든 문제는 아니지만 정렬 조립을 옮기는 이 PR이 가장 자연스러운 수정 지점이라 판단했다.

**변경 파일**

| 파일 | 내용 |
|---|---|
| `PaymentController` | `@PageableDefault Pageable` → `@ParameterObject @ModelAttribute OffsetPageRequest`, Swagger description 갱신 |
| `PaymentFacade` | 시그니처 전환 (위임만) |
| `PaymentGetListUseCase` | `PAID_AT_DESC` 상수로 `Sort` 고정 조립, 결정 근거 javadoc |
| `PaymentGetListUseCaseIntegrationTest` | **신규** - 실 DB로 정렬 프로퍼티 해석·페이지 경계 검증 |

`common`은 건드리지 않아 타 서비스 영향이 없고, 스키마도 무변경이라 수동 DDL이 필요 없다.

---

## ✅ 테스트

### 테스트 방법

```bash
./gradlew :payment-service:spotlessApply
./gradlew :payment-service:checkstyleMain :payment-service:checkstyleTest
./gradlew :payment-service:test
```

**신규 통합 테스트** - `PaymentGetListUseCaseIntegrationTest` (`@DataJpaTest` + Testcontainers MySQL 8.0, 실제 `PaymentGetListUseCase` 빈을 올려 프로덕션 `PAID_AT_DESC` 상수를 그대로 태움)

- 고정 정렬의 프로퍼티명이 실제 엔티티로 해석된다 - 예외 없이 조회된다
- `paidAt`이 모두 동일해도 페이지 경계에서 중복·누락이 없다 - id tie-break로 전순서가 확정된다 (size 2로 page 0·1 연속 조회 후 합집합 검증)

**신규 슬라이스/단위 테스트**

- `sort` 파라미터는 바인딩되지 않아 기본 페이지 요청만 전달된다
- `size`가 정수로 변환되지 않으면 보정하지 않고 400으로 거부한다
- `size`가 상한을 넘으면 50으로 보정되어 전달된다
- 정렬은 `paidAt DESC + id DESC`로 고정 조립된다 - 호출자가 지정할 수 없다

### 테스트 결과

- `payment-service` 전건 **244건 통과** (skipped 0 / failures 0 / errors 0)
- `spotlessApply` · `checkstyleMain` · `checkstyleTest` · `compileJava` 전부 통과
- 통합 테스트는 Docker 필요 (`PaymentCompletedBookingUniqueTest`와 동일한 fail-closed 방침)

<!--
### 📸 스크린샷

- UI 변경이 없어 생략한다.
-->

---

## 👀 리뷰 요청 사항

- **정렬 계약을 제거하는 방향이 맞는지** 판단을 부탁드립니다. 대안으로 `sort`를 공개 계약으로 유지하고 화이트리스트 밖 값을 400으로 거부하는 안도 검토했으나, `common/ErrorStatus` 변경이 전 서비스 재배포로 번지고 payment만 선례 없는 특수 코드를 갖게 되어 채택하지 않았습니다.
- **tie-break `id` DESC 추가**는 이슈 본문에 없던 항목입니다. 범위를 넘었다고 보시면 지적해 주시기 바랍니다.
- 프론트(`TicketRush-frontend`)를 확인한 결과 이 API는 **아직 연결되지 않았습니다**(`src/api/payments.ts`가 전부 mock이고 실제 호출은 주석 처리). 그래서 계약 축소의 실사용 영향을 0으로 판단했는데, 제가 놓친 소비자가 있다면 알려주시기 바랍니다.

---

## ⚠️ 배포 시 주의사항

- **스키마 무변경 · 환경변수 추가 없음.** prod 수동 DDL이 필요하지 않습니다.
- **클라이언트 관측 가능한 계약 변화 3건** (신규 에러 코드는 없음)
  1. `?sort=`가 무시된다 - 400이 아니라 200 + 고정 정렬로 응답
  2. `size` 상한이 Spring Data 기본 2000에서 **50**으로 좁혀진다. `size=100`을 보내면 200이지만 50건만 온다
  3. `size=abc`처럼 정수 변환이 실패하면 기존에는 기본값으로 폴백해 200이었으나 이제 `VALID_400_001`로 거부된다 (booking·performance의 기존 페이징 API와 동일한 동작)
- 위 3건은 프론트 미연결 상태라 현재 파손 대상이 없으나, 프론트가 이 API를 붙이기 전에 공유가 필요합니다.
- **범위 밖 공유 사항** - 프론트가 기대하는 결제 내역 계약이 백엔드와 4곳 어긋나 있습니다: 경로(`/api/v1/payment/history` vs `/api/v1/payment`), 응답 형태(배열 vs `Page`), 예매 식별자(`bookingNumber` vs `bookingId`), 결제수단(`method` 필드 부재). 경로·응답 변경은 게이트웨이 라우팅과 프론트 조율이 필요해 이 PR에 넣지 않았고 별도 이슈로 다룰 예정입니다.
