### PR TITLE
[Refactor] #574 환불 실패 보상 신호를 상태 기반 재발행으로 복구한다

### DIFF
--- a/common/src/main/java/com/ticketrush/global/constants/MetricNames.java
+++ b/common/src/main/java/com/ticketrush/global/constants/MetricNames.java
@@ -66,6 +66,15 @@ public class MetricNames {
   // 이 태그가 소유자 차단을 구분하는 유일한 축이다.
   public static final String PAYMENT_CONFIRM_BOOKING_GUARD_BLOCKED =
       "ticketrush.payment.confirm.booking_guard.blocked";
+  // 아직 해결되지 않은 환불 실패(FAILED 환불 이력) 건수(#574). Gauge.
+  // 0이 아니면 "과금이 남았는데 환불이 성사되지 않은" 건이 그만큼 있다는 뜻이라, 수치 자체가 곧
+  // 미해결 사고 건수다. PAYMENT_REFUND_FAILED(발생 카운터)와 달리 이쪽은 잔량이라 해결되면 내려간다.
+  public static final String PAYMENT_REFUND_UNRESOLVED =
+      "ticketrush.payment.refund.unresolved"; // Gauge
+  // 미해결 환불 실패의 보상 신호를 재발행한 횟수(#574). 재발행은 수신 측이 이미 처리했더라도
+  // 나가므로 이 값이 곧 유실 건수는 아니다 — 유실 여부는 EVENT_PUBLISH_FAILED 쪽에서 읽는다.
+  public static final String PAYMENT_REFUND_SIGNAL_REPLAYED =
+      "ticketrush.payment.refund.signal.replayed";
 
   // ticket
   public static final String TICKET_ISSUE = "ticketrush.ticket.issue";
@@ -80,6 +89,10 @@ public class MetricNames {
   // 발행을 띄우고 콜백을 기다리는 중인 건수(#483). backlog가 in-flight 행도 세므로 둘을 겹쳐 봐야
   // "콜백 대기(정상)"와 "릴레이 정지(장애)"가 갈린다.
   public static final String OUTBOX_IN_FLIGHT = "ticketrush.outbox.in_flight"; // Gauge
+  // Kafka 발행이 브로커 응답 콜백에서 실패한 횟수(#574). 발행은 fire-and-forget이라 실패가 호출자에게
+  // 전파되지 않으므로, 이 카운터가 "발행 유실이 실제로 일어나는가"를 보는 유일한 축이다. outbox 모드는
+  // 릴레이가 상태로 남겨 재발행하지만 kafka 모드는 그대로 사라진다.
+  public static final String EVENT_PUBLISH_FAILED = "ticketrush.event.publish.failed";
 
   // ===== Tag keys =====
   public static final String TAG_RESULT = "result";
@@ -94,6 +107,8 @@ public class MetricNames {
   // 사고 보상은 발생 자체의 의미가 달라(후자는 곧 사고 건수다) 알림 임계도 따로 잡아야 하는데,
   // 이 태그가 없으면 두 건이 PAYMENT_REFUND 한 시계열에 섞여 보상 발생률을 볼 수 없다.
   public static final String TAG_TRIGGER = "trigger";
+  // 발행 대상 Kafka 토픽(#574). 토픽은 코드에 상수로 고정된 유한 집합이라 태그로 안전하다.
+  public static final String TAG_TOPIC = "topic";
 
   // ===== Tag values =====
   public static final String RESULT_SUCCESS = "success";

--- a/common/src/main/java/com/ticketrush/global/eventpublisher/EventMessageSender.java
+++ b/common/src/main/java/com/ticketrush/global/eventpublisher/EventMessageSender.java
@@ -1,0 +1,80 @@
+package com.ticketrush.global.eventpublisher;
+
+import com.ticketrush.global.constants.MetricNames;
+import com.ticketrush.global.event.DomainEventEnvelope;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.KafkaHeaders;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.stereotype.Component;
+
+/**
+ * 이벤트 봉투를 Kafka 메시지로 만들어 발행하는 공유 경로.
+ *
+ * <p>{@link KafkaDomainEventPublisher}(신규 발행)와 {@link EventReplayPublisher}(저장된 식별자로 재발행)가 같은 메시지
+ * 규약을 써야 하므로 여기 한 곳에 모은다. 헤더 구성이 갈라지면 수신 측 라우팅·멱등이 조용히 어긋나는데, 컴파일은 통과하고 mock 테스트로도 잡히지 않는다.
+ *
+ * <p><b>아직 세 번째 생성 지점이 남아 있다.</b> {@code OutboxRelayService#toMessage} 가 outbox row 에서 같은 형태의 메시지를
+ * 직접 만든다. 그쪽은 이 이슈(#574)의 범위 밖이라 건드리지 않았으므로, 규약이 여기로 완전히 단일화됐다고 읽으면 안 된다.
+ *
+ * <p><b>발행 실패는 여기서만 관측된다 (#574).</b> {@code send()}가 돌려주는 future의 예외는 호출자에게 전파되지 않고 콜백에서 끝나므로, 이
+ * 카운터가 없으면 발행 유실은 로그 한 줄로 사라진다. 콜백은 프로듀서 IO 스레드에서 실행되므로 <b>여기서 외부 호출(알림 웹훅 등)을 해서는 안 된다</b> — 브로커
+ * 장애로 실패가 쏟아질 때 IO 스레드가 그 호출에 묶여 장애를 키운다. 알림은 이 카운터를 읽는 Grafana 규칙이 맡는다.
+ */
+@Slf4j
+@Component
+@ConditionalOnExpression(
+    "'${app.event-publisher.type}' == 'kafka' or '${app.event-publisher.type}' == 'outbox'")
+@RequiredArgsConstructor
+public class EventMessageSender {
+
+  private final KafkaTemplate<String, DomainEventEnvelope> kafkaTemplate;
+  private final MeterRegistry meterRegistry;
+
+  /**
+   * 봉투를 메시지로 만든다.
+   *
+   * <p>토픽은 봉투가 이미 갖고 있으나 파티션 키는 봉투에 없으므로 호출자가 넘긴다({@code DomainEvent.key()} 또는 outbox에 저장된
+   * messageKey).
+   */
+  public Message<DomainEventEnvelope> toMessage(DomainEventEnvelope envelope, String key) {
+    return MessageBuilder.withPayload(envelope)
+        .setHeader(KafkaHeaders.TOPIC, envelope.topic())
+        .setHeader(KafkaHeaders.KEY, key)
+        .setHeader("eventType", envelope.eventType())
+        .setHeader("eventId", envelope.eventId())
+        .build();
+  }
+
+  /** 메시지를 비동기 발행하고, 실패하면 로그와 카운터로 남긴다. 예외는 호출자에게 전파하지 않는다. */
+  public void send(Message<DomainEventEnvelope> message, DomainEventEnvelope envelope) {
+    kafkaTemplate
+        .send(message)
+        .whenComplete(
+            (result, ex) -> {
+              if (ex != null) {
+                recordFailure(envelope, ex);
+              }
+            });
+  }
+
+  private void recordFailure(DomainEventEnvelope envelope, Throwable ex) {
+    log.error(
+        "Failed to publish event to Kafka topic: {}, eventType={}, eventId={}",
+        envelope.topic(),
+        envelope.eventType(),
+        envelope.eventId(),
+        ex);
+
+    // 토픽은 유한 집합이라 태그로 안전하다. eventId는 카디널리티가 무한이므로 태그로 쓰지 않는다.
+    Counter.builder(MetricNames.EVENT_PUBLISH_FAILED)
+        .tag(MetricNames.TAG_TOPIC, envelope.topic())
+        .register(meterRegistry)
+        .increment();
+  }
+}

--- a/common/src/main/java/com/ticketrush/global/eventpublisher/EventReplayPublisher.java
+++ b/common/src/main/java/com/ticketrush/global/eventpublisher/EventReplayPublisher.java
@@ -1,0 +1,60 @@
+package com.ticketrush.global.eventpublisher;
+
+import com.ticketrush.global.event.DomainEvent;
+import com.ticketrush.global.event.DomainEventEnvelope;
+import com.ticketrush.global.json.JsonConverter;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.stereotype.Component;
+
+/**
+ * 이미 한 번 발행됐어야 할 이벤트를 <b>지정한 식별자로</b> 다시 발행한다 (#574).
+ *
+ * <p>{@link EventPublisher}와 나뉘어 있는 이유는 eventId의 출처가 다르기 때문이다. 신규 발행은 {@code
+ * DomainEventEnvelope#of}가 매번 새 UUID를 만들지만, 재발행은 <b>같은 이벤트가 같은 식별자를 갖는 것</b>이 핵심이다. 수신 측 Inbox가
+ * {@code (consumer_group, event_id)} 로 멱등을 판정하므로, 식별자가 매번 달라지면 재발행이 반복될 때마다 수신 측 트랜잭션이 다시 열린다.
+ *
+ * <p>이 능력을 {@link EventPublisher} 인터페이스에 넣지 않은 것은 의도적이다. 임의 eventId 발행은 잘못 쓰면 멱등이 깨지거나(랜덤화) 반대로
+ * 이벤트가 영영 무시되므로(중복 식별자), 재발행이라는 용도가 타입에 드러나게 두어 오용 표면을 좁힌다.
+ *
+ * <p>트랜잭션 동기화를 하지 않고 <b>즉시 발행</b>한다. 재발행은 자신이 커밋할 DB 변경을 갖지 않으므로 커밋을 기다릴 대상이 없다.
+ */
+@Component
+@ConditionalOnExpression(
+    "'${app.event-publisher.type}' == 'kafka' or '${app.event-publisher.type}' == 'outbox'")
+@RequiredArgsConstructor
+public class EventReplayPublisher {
+
+  private final EventMessageSender eventMessageSender;
+  private final JsonConverter jsonConverter;
+
+  /**
+   * 저장된 상태에서 재구성한 이벤트를 지정 식별자로 발행한다.
+   *
+   * @param event 재구성한 도메인 이벤트
+   * @param eventId 이 이벤트의 고정 식별자. 같은 대상이면 언제 호출해도 같은 값이어야 한다
+   */
+  public void republish(DomainEvent event, String eventId) {
+    String payload = jsonConverter.serialize(event);
+    DomainEventEnvelope envelope =
+        new DomainEventEnvelope(
+            eventId, event.eventName(), Instant.now(), event.topic(), payload, event.traceId());
+
+    eventMessageSender.send(eventMessageSender.toMessage(envelope, event.key()), envelope);
+  }
+
+  /**
+   * 재발행 대상의 고정 식별자를 만든다.
+   *
+   * <p>{@code inbox.event_id}가 {@code varchar(36)}이므로 임의 문자열이 아니라 UUID 형태로 만든다. 같은 {@code seed}는
+   * 언제나 같은 UUID로 옮겨지고(이름 기반 UUID), 신규 발행이 쓰는 랜덤 UUID와 겹칠 확률은 무시할 수 있다.
+   *
+   * @param seed 재발행 대상을 유일하게 가리키는 문자열(용도 접두어 + 식별자)
+   */
+  public static String deterministicEventId(String seed) {
+    return UUID.nameUUIDFromBytes(seed.getBytes(StandardCharsets.UTF_8)).toString();
+  }
+}

--- a/common/src/main/java/com/ticketrush/global/eventpublisher/KafkaDomainEventPublisher.java
+++ b/common/src/main/java/com/ticketrush/global/eventpublisher/KafkaDomainEventPublisher.java
@@ -4,65 +4,42 @@ import com.ticketrush.global.event.DomainEvent;
 import com.ticketrush.global.event.DomainEventEnvelope;
 import com.ticketrush.global.json.JsonConverter;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
-import org.springframework.kafka.core.KafkaTemplate;
-import org.springframework.kafka.support.KafkaHeaders;
 import org.springframework.messaging.Message;
-import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.support.TransactionSynchronization;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 
-@Slf4j
+/**
+ * 도메인 이벤트를 Kafka로 직접 발행한다({@code app.event-publisher.type=kafka}).
+ *
+ * <p>발행은 fire-and-forget이다 — 실패해도 호출자에게 전파되지 않고 {@link EventMessageSender}의 콜백에서 로그·카운터로만 남는다. 유실을
+ * 허용할 수 없는 이벤트는 outbox 모드를 쓰거나, 발행과 별개로 복구 경로를 둬야 한다(#574).
+ */
 @Component
 @ConditionalOnExpression("'${app.event-publisher.type}' == 'kafka'")
 @RequiredArgsConstructor
 public class KafkaDomainEventPublisher implements EventPublisher {
 
-  private final KafkaTemplate<String, DomainEventEnvelope> kafkaTemplate;
+  private final EventMessageSender eventMessageSender;
   private final JsonConverter jsonConverter;
 
   @Override
   public void publish(DomainEvent event) {
     String payload = jsonConverter.serialize(event);
     DomainEventEnvelope envelope = DomainEventEnvelope.of(event, payload);
-
-    Message<DomainEventEnvelope> message =
-        MessageBuilder.withPayload(envelope)
-            .setHeader(KafkaHeaders.TOPIC, event.topic())
-            .setHeader(KafkaHeaders.KEY, event.key())
-            .setHeader("eventType", envelope.eventType())
-            .setHeader("eventId", envelope.eventId())
-            .build();
+    Message<DomainEventEnvelope> message = eventMessageSender.toMessage(envelope, event.key());
 
     if (TransactionSynchronizationManager.isActualTransactionActive()) {
       TransactionSynchronizationManager.registerSynchronization(
           new TransactionSynchronization() {
             @Override
             public void afterCommit() {
-              sendMessage(message, event, envelope);
+              eventMessageSender.send(message, envelope);
             }
           });
     } else {
-      sendMessage(message, event, envelope);
+      eventMessageSender.send(message, envelope);
     }
-  }
-
-  private void sendMessage(
-      Message<DomainEventEnvelope> message, DomainEvent event, DomainEventEnvelope envelope) {
-    kafkaTemplate
-        .send(message)
-        .whenComplete(
-            (result, ex) -> {
-              if (ex != null) {
-                log.error(
-                    "Failed to publish event to Kafka topic: {}, eventType={}, eventId={}",
-                    event.topic(),
-                    envelope.eventType(),
-                    envelope.eventId(),
-                    ex);
-              }
-            });
   }
 }

--- a/common/src/test/java/com/ticketrush/global/eventpublisher/EventMessageSenderTest.java
+++ b/common/src/test/java/com/ticketrush/global/eventpublisher/EventMessageSenderTest.java
@@ -1,0 +1,109 @@
+package com.ticketrush.global.eventpublisher;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+import com.ticketrush.global.constants.MetricNames;
+import com.ticketrush.global.event.DomainEventEnvelope;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.time.Instant;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.KafkaHeaders;
+import org.springframework.messaging.Message;
+
+@ExtendWith(MockitoExtension.class)
+class EventMessageSenderTest {
+
+  private static final String TOPIC = "refund-failed-topic";
+  private static final String EVENT_ID = "11111111-1111-1111-1111-111111111111";
+
+  @Mock private KafkaTemplate<String, DomainEventEnvelope> kafkaTemplate;
+
+  private SimpleMeterRegistry meterRegistry;
+  private EventMessageSender eventMessageSender;
+
+  @BeforeEach
+  void setUp() {
+    meterRegistry = new SimpleMeterRegistry();
+    eventMessageSender = new EventMessageSender(kafkaTemplate, meterRegistry);
+  }
+
+  private DomainEventEnvelope envelope() {
+    return new DomainEventEnvelope(
+        EVENT_ID, "RefundFailed", Instant.now(), TOPIC, "{\"booking_id\":1}", "trace-1");
+  }
+
+  @Test
+  @DisplayName("성공: 봉투와 파티션 키로 토픽·키·eventType·eventId 헤더를 채운다")
+  void toMessage_sets_routing_headers() {
+    // given
+    DomainEventEnvelope envelope = envelope();
+
+    // when
+    Message<DomainEventEnvelope> message = eventMessageSender.toMessage(envelope, "42");
+
+    // then: 이 네 헤더가 수신 측 라우팅과 멱등의 기준이라 하나라도 빠지면 조용히 어긋난다.
+    assertThat(message.getHeaders().get(KafkaHeaders.TOPIC)).isEqualTo(TOPIC);
+    assertThat(message.getHeaders().get(KafkaHeaders.KEY)).isEqualTo("42");
+    assertThat(message.getHeaders().get("eventType")).isEqualTo("RefundFailed");
+    assertThat(message.getHeaders().get("eventId")).isEqualTo(EVENT_ID);
+    assertThat(message.getPayload()).isEqualTo(envelope);
+  }
+
+  @Test
+  @DisplayName("성공: 발행이 성공하면 실패 카운터가 올라가지 않는다")
+  void send_does_not_count_on_success() {
+    // given
+    given(kafkaTemplate.send(any(Message.class)))
+        .willReturn(CompletableFuture.completedFuture(null));
+    DomainEventEnvelope envelope = envelope();
+
+    // when
+    eventMessageSender.send(eventMessageSender.toMessage(envelope, "42"), envelope);
+
+    // then
+    assertThat(meterRegistry.find(MetricNames.EVENT_PUBLISH_FAILED).counter()).isNull();
+  }
+
+  @Test
+  @DisplayName("성공: 발행이 실패하면 토픽 태그와 함께 실패 카운터를 올린다")
+  void send_counts_failure_with_topic_tag() {
+    // given: 발행 실패는 호출자에게 전파되지 않고 콜백에서 끝난다. 이 카운터가 유일한 관측 축이다(#574).
+    given(kafkaTemplate.send(any(Message.class)))
+        .willReturn(CompletableFuture.failedFuture(new IllegalStateException("broker down")));
+    DomainEventEnvelope envelope = envelope();
+
+    // when
+    eventMessageSender.send(eventMessageSender.toMessage(envelope, "42"), envelope);
+
+    // then
+    assertThat(
+            meterRegistry
+                .get(MetricNames.EVENT_PUBLISH_FAILED)
+                .tag(MetricNames.TAG_TOPIC, TOPIC)
+                .counter()
+                .count())
+        .isEqualTo(1.0);
+  }
+
+  @Test
+  @DisplayName("성공: 발행이 실패해도 호출자에게 예외를 전파하지 않는다")
+  void send_does_not_propagate_failure() {
+    // given
+    given(kafkaTemplate.send(any(Message.class)))
+        .willReturn(CompletableFuture.failedFuture(new IllegalStateException("broker down")));
+    DomainEventEnvelope envelope = envelope();
+    Message<DomainEventEnvelope> message = eventMessageSender.toMessage(envelope, "42");
+
+    // when & then: 예외가 새면 발행 실패가 도메인 흐름(보상·취소)을 깨뜨린다.
+    eventMessageSender.send(message, envelope);
+  }
+}

--- a/common/src/test/java/com/ticketrush/global/eventpublisher/EventReplayPublisherTest.java
+++ b/common/src/test/java/com/ticketrush/global/eventpublisher/EventReplayPublisherTest.java
@@ -1,0 +1,95 @@
+package com.ticketrush.global.eventpublisher;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import com.ticketrush.global.event.DomainEventEnvelope;
+import com.ticketrush.global.json.JsonConverter;
+import com.ticketrush.shared.payment.event.RefundFailedEvent;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class EventReplayPublisherTest {
+
+  private static final String FIXED_EVENT_ID = "22222222-2222-2222-2222-222222222222";
+
+  @InjectMocks private EventReplayPublisher eventReplayPublisher;
+
+  @Mock private EventMessageSender eventMessageSender;
+  @Mock private JsonConverter jsonConverter;
+
+  private RefundFailedEvent event() {
+    return new RefundFailedEvent(100L, null, "환불 실패", LocalDateTime.of(2026, 8, 13, 10, 0));
+  }
+
+  @Test
+  @DisplayName("성공: 넘겨받은 eventId를 그대로 봉투에 실어 발행한다")
+  void republish_preserves_given_event_id() {
+    // given: 재발행의 핵심은 같은 이벤트가 같은 식별자를 갖는 것이다. 새로 만들면 수신 측 Inbox가
+    // 매번 중복으로 걸러내지 못해 재발행마다 트랜잭션이 다시 열린다.
+    RefundFailedEvent event = event();
+    given(jsonConverter.serialize(event)).willReturn("{\"booking_id\":100}");
+
+    // when
+    eventReplayPublisher.republish(event, FIXED_EVENT_ID);
+
+    // then
+    ArgumentCaptor<DomainEventEnvelope> captor = ArgumentCaptor.forClass(DomainEventEnvelope.class);
+    verify(eventMessageSender).send(any(), captor.capture());
+
+    DomainEventEnvelope envelope = captor.getValue();
+    assertThat(envelope.eventId()).isEqualTo(FIXED_EVENT_ID);
+    assertThat(envelope.eventType()).isEqualTo(RefundFailedEvent.EVENT_NAME);
+    assertThat(envelope.topic()).isEqualTo(RefundFailedEvent.TOPIC);
+    assertThat(envelope.payload()).isEqualTo("{\"booking_id\":100}");
+  }
+
+  @Test
+  @DisplayName("성공: 파티션 키로 이벤트의 key()를 넘긴다")
+  void republish_uses_event_key_as_partition_key() {
+    // given
+    RefundFailedEvent event = event();
+    given(jsonConverter.serialize(event)).willReturn("{\"booking_id\":100}");
+
+    // when
+    eventReplayPublisher.republish(event, FIXED_EVENT_ID);
+
+    // then
+    verify(eventMessageSender).toMessage(any(DomainEventEnvelope.class), eq("100"));
+  }
+
+  @Test
+  @DisplayName("성공: 같은 seed는 항상 같은 eventId로, 다른 seed는 다른 eventId로 옮겨진다")
+  void deterministic_event_id_is_stable_per_seed() {
+    // when
+    String first = EventReplayPublisher.deterministicEventId("refund-failure-signal:7");
+    String again = EventReplayPublisher.deterministicEventId("refund-failure-signal:7");
+    String other = EventReplayPublisher.deterministicEventId("refund-failure-signal:8");
+
+    // then
+    assertThat(first).isEqualTo(again);
+    assertThat(first).isNotEqualTo(other);
+  }
+
+  @Test
+  @DisplayName("성공: 생성한 eventId는 inbox.event_id(varchar 36)에 들어가는 UUID 형식이다")
+  void deterministic_event_id_fits_inbox_column() {
+    // when
+    String eventId = EventReplayPublisher.deterministicEventId("refund-failure-signal:7");
+
+    // then: 컬럼이 varchar(36)이라 형식이 어긋나면 재발행이 통째로 저장 실패한다.
+    assertThat(eventId).hasSize(36);
+    assertThat(UUID.fromString(eventId)).isNotNull();
+  }
+}

--- a/common/src/test/java/com/ticketrush/global/eventpublisher/KafkaDomainEventPublisherTest.java
+++ b/common/src/test/java/com/ticketrush/global/eventpublisher/KafkaDomainEventPublisherTest.java
@@ -1,0 +1,120 @@
+package com.ticketrush.global.eventpublisher;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.ticketrush.global.event.DomainEventEnvelope;
+import com.ticketrush.global.json.JsonConverter;
+import com.ticketrush.shared.payment.event.RefundFailedEvent;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+@ExtendWith(MockitoExtension.class)
+class KafkaDomainEventPublisherTest {
+
+  @InjectMocks private KafkaDomainEventPublisher kafkaDomainEventPublisher;
+
+  @Mock private EventMessageSender eventMessageSender;
+  @Mock private JsonConverter jsonConverter;
+
+  @AfterEach
+  void tearDown() {
+    // 정적 ThreadLocal 상태가 다른 테스트로 새지 않도록 정리한다.
+    TransactionSynchronizationManager.setActualTransactionActive(false);
+    // 활성화하지 않은 상태에서 clear하면 IllegalStateException이므로 활성 여부를 먼저 본다.
+    if (TransactionSynchronizationManager.isSynchronizationActive()) {
+      TransactionSynchronizationManager.clearSynchronization();
+    }
+  }
+
+  private RefundFailedEvent event() {
+    return new RefundFailedEvent(100L, "BOOK-1234", "환불 실패", LocalDateTime.of(2026, 8, 13, 10, 0));
+  }
+
+  @Test
+  @DisplayName("성공: 활성 트랜잭션이 없으면 즉시 발행한다")
+  void publish_sends_immediately_without_transaction() {
+    // given
+    RefundFailedEvent event = event();
+    given(jsonConverter.serialize(event)).willReturn("{\"booking_id\":100}");
+
+    // when
+    kafkaDomainEventPublisher.publish(event);
+
+    // then
+    ArgumentCaptor<DomainEventEnvelope> captor = ArgumentCaptor.forClass(DomainEventEnvelope.class);
+    verify(eventMessageSender).send(any(), captor.capture());
+    assertThat(captor.getValue().eventType()).isEqualTo(RefundFailedEvent.EVENT_NAME);
+    assertThat(captor.getValue().topic()).isEqualTo(RefundFailedEvent.TOPIC);
+  }
+
+  @Test
+  @DisplayName("성공: 활성 트랜잭션이 있으면 커밋 전에는 발행하지 않고, 커밋 후에 발행한다")
+  void publish_defers_until_commit_inside_transaction() {
+    // given: 커밋 전에 나가면 롤백된 변경에 대한 이벤트가 새어나간다(#138).
+    TransactionSynchronizationManager.initSynchronization();
+    TransactionSynchronizationManager.setActualTransactionActive(true);
+    RefundFailedEvent event = event();
+    given(jsonConverter.serialize(event)).willReturn("{\"booking_id\":100}");
+
+    // when
+    kafkaDomainEventPublisher.publish(event);
+
+    // then: 아직 나가지 않았다.
+    verify(eventMessageSender, never()).send(any(), any());
+    assertThat(TransactionSynchronizationManager.getSynchronizations()).hasSize(1);
+
+    // when: 등록된 훅을 실제로 커밋시킨다. 여기까지 하지 않으면 훅 본문이 비어도 테스트가 통과한다.
+    TransactionSynchronizationManager.getSynchronizations().forEach(s -> s.afterCommit());
+
+    // then
+    ArgumentCaptor<DomainEventEnvelope> captor = ArgumentCaptor.forClass(DomainEventEnvelope.class);
+    verify(eventMessageSender).send(any(), captor.capture());
+    assertThat(captor.getValue().eventType()).isEqualTo(RefundFailedEvent.EVENT_NAME);
+  }
+
+  @Test
+  @DisplayName("성공: 파티션 키로 이벤트의 key()를 넘긴다")
+  void publish_uses_event_key_as_partition_key() {
+    // given
+    RefundFailedEvent event = event();
+    given(jsonConverter.serialize(event)).willReturn("{\"booking_id\":100}");
+
+    // when
+    kafkaDomainEventPublisher.publish(event);
+
+    // then: 같은 예매의 이벤트가 한 파티션에 모여야 순서가 보장된다.
+    verify(eventMessageSender).toMessage(any(DomainEventEnvelope.class), eq("100"));
+  }
+
+  @Test
+  @DisplayName("성공: 신규 발행은 매번 다른 eventId를 만든다")
+  void publish_generates_new_event_id_each_time() {
+    // given: 재발행(EventReplayPublisher)과 달리 신규 발행은 randomUUID다.
+    RefundFailedEvent event = event();
+    given(jsonConverter.serialize(event)).willReturn("{\"booking_id\":100}");
+
+    // when
+    kafkaDomainEventPublisher.publish(event);
+    kafkaDomainEventPublisher.publish(event);
+
+    // then
+    ArgumentCaptor<DomainEventEnvelope> captor = ArgumentCaptor.forClass(DomainEventEnvelope.class);
+    verify(eventMessageSender, times(2)).send(any(), captor.capture());
+    assertThat(captor.getAllValues().get(0).eventId())
+        .isNotEqualTo(captor.getAllValues().get(1).eventId());
+  }
+}

--- a/deploy/mysql/init/001-ticket-rush-schema.sql
+++ b/deploy/mysql/init/001-ticket-rush-schema.sql
@@ -218,7 +218,8 @@ CREATE TABLE `refund` (
   `requested_at` datetime(6) DEFAULT NULL,
   `status` enum('COMPLETED','FAILED','PENDING') COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   PRIMARY KEY (`refund_id`),
-  UNIQUE KEY `UKqwu73qgmbrsnysqx67oewyj5d` (`payment_id`)
+  UNIQUE KEY `UKqwu73qgmbrsnysqx67oewyj5d` (`payment_id`),
+  KEY `idx_refund_status` (`status`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 DROP TABLE IF EXISTS `seat`;

--- a/docs/adr/0014-recover-refund-failure-signal-by-reconciliation.md
+++ b/docs/adr/0014-recover-refund-failure-signal-by-reconciliation.md
@@ -1,0 +1,83 @@
+# 14. 환불 실패 보상 신호는 발행을 보장하는 대신, 남아 있는 상태로 재발행해 복구한다
+
+날짜: 2026-08-13
+
+## 상태
+
+승인됨
+
+## 맥락
+
+payment-service는 `app.event-publisher.type: kafka`라 이벤트를 Kafka로 직접 발행한다. 발행은 fire-and-forget이고, 실패는 `log.error` 한 줄로 끝난다. 반면 booking·seat는 outbox 릴레이를 쓴다.
+
+이 차이의 대가가 [#492](https://github.com/TicketRush/TicketRush-backend/issues/492)에서 커졌다. 좌석 확정 실패 보상 환불을 PG가 거절하면 payment는 `RefundFailedEvent`를 발행하고 끝나는데, 그 발행이 유실되면 booking에 `refundFailedAt`이 찍히지 않는다. 그러면:
+
+- 미해결 목록(`CONFIRMED` + `refund_failed_at IS NOT NULL`)에 잡히지 않고
+- 관리자 재환불 API가 `BOOKING_REFUND_RETRY_NOT_ALLOWED`로 거부한다
+
+즉 **과금이 남은 사고 건에서 수동 복구 수단까지 함께 닫힌다**. 그 건은 사용자 취소와 달리 "다시 누를 사용자"가 없다.
+
+### 이슈의 전제 하나가 코드와 달랐다
+
+착수 전 조사에서 **PG 거절 시 `refund` 테이블에 FAILED 이력이 이미 독립 커밋으로 남는다**는 것을 확인했다(`FailedRefundRecorder`, [#334](https://github.com/TicketRush/TicketRush-backend/issues/334)). 과금 건이 흔적 없이 사라지지는 않는다.
+
+따라서 실제 공백은 "기록의 부재"가 아니라 **기록과 복구 게이트 사이의 단절**이다. payment에는 그 기록이 있고 booking에는 없는데, 게이트는 booking 쪽만 본다.
+
+이 구분이 중요한 이유는, 전달 보장을 아무리 올려도 게이트 단절이 남기 때문이다. 발행이 성공해도 booking이 다운돼 재시도가 소진되면 결과가 같다.
+
+### 검토한 대안
+
+- **(a) payment 전면 outbox 전환.** `OutboxEventPublisher`는 활성 트랜잭션을 강제하는데, payment의 발행 지점 여섯 곳은 전부 트랜잭션 밖이고 그것이 의도된 불변식이다 — "PG 왕복 동안 DB 커넥션을 잡지 않는다". 특히 `FailedRefundRecorder`는 *"호출자는 트랜잭션 밖이어야 FAILED 이력이 독립 커밋된다"* 고 못 박는다. 전면 전환은 **이 이슈가 지키려는 것 자체를 부순다**. 그 밖에 스케줄러 2종·ShedLock·Redis 오토컨피그 부활([#425](https://github.com/TicketRush/TicketRush-backend/issues/425) 역행)이 따라온다.
+- **(b) 발행 결과를 확인하고 ack.** 실제로 막는 창이 좁다 — 브로커가 완전히 죽으면 오프셋 커밋도 실패해 재전달로 이미 self-heal된다. 남는 건 "오프셋은 커밋되는데 그 발행만 실패"하는 경우인데, 그 대가로 컨슈머 스레드를 최악 `delivery.timeout.ms`(120초)만큼 잡는다. 실패 시 리스너를 통째로 재실행하므로 PG를 다시 때리고, 최종 안착지인 DLT는 [ADR 0012](0012-absorb-transient-pg-refund-rejections-at-caller.md)를 낳은 [#573](https://github.com/TicketRush/TicketRush-backend/issues/573)에서 이미 "복구 창구가 아니다"로 결론났다.
+- **(c) 발행 실패 관측만.** 카운터는 "몇 건 실패했다"만 말하고 어느 건인지 남기지 않아 게이트가 그대로 닫혀 있다.
+
+## 결정
+
+**`RefundFailedEvent`의 전달을 보장하는 대신, payment에 남아 있는 FAILED 환불 이력을 근거로 그 신호를 주기적으로 재발행한다.**
+
+`status='FAILED'`인 `refund` row를 5분마다 배치 단위로 훑어(커서로 이어 읽으므로 한 바퀴는 `ceil(미해결 건수 / batch-size)` 주기가 걸린다) `RefundFailedEvent`를 **원본 실패 시각(`requested_at`)으로** 재발행한다. booking은 변경하지 않는다 — 이미 배포된 리스너가 받아 `refundFailedAt`을 채우고, 그러면 미해결 목록과 관리자 재환불 API가 열린다.
+
+안전성의 근거를 새로 만들지 않고 **이미 배포된 계약**에 위임한 것이 이 결정의 핵심이다.
+
+| 필요한 보장 | 어디에 이미 있는가 |
+|---|---|
+| 종결된 건을 되돌리지 않는다 | `Booking#recordRefundFailure` — REFUNDED/CANCELED면 전이 없이 `false` |
+| 진행 중인 재환불을 중단시키지 않는다 | 같은 메서드 — REFUNDING이면 `failedAt`이 기록된 값보다 **나중일 때만** 복원. 재발행은 원본 시각을 실으므로 이 조건에 걸리지 않는다 |
+| 반복 재발행이 낭비되지 않는다 | 수신 측 Inbox `(consumer_group, event_id)` — eventId를 refund별로 고정하면 두 번째부터 UseCase 실행 자체를 건너뛴다 |
+| 대상이 무한히 쌓이지 않는다 | `Refund#markCompleted` — 재시도가 성공하면 FAILED가 COMPLETED로 전이돼 대상 집합에서 스스로 빠진다 |
+
+한 주기가 읽는 건수에는 상한을 두되 **커서로 이어 읽는다.** 상한만 두고 매번 가장 오래된 것부터 읽으면, 미해결이 상한을 넘는 순간 뒤쪽 건은 영원히 선택되지 않는다 — FAILED 이력은 재환불이 성공해야 빠지는데 그 재환불을 여는 것이 바로 이 재발행이라 순환이 끊긴다. 상한의 존재 이유가 "대량으로 쌓였을 때"인데 정확히 그때 무력해지는 구조라 커서가 필요하다.
+
+관측은 두 축으로 나눈다. `ticketrush.event.publish.failed`(발행이 실제로 유실되는가)와 `ticketrush.payment.refund.unresolved`(지금 미해결 건이 몇 건인가)다. 전자는 나중에 outbox 전환이 필요한지를 **데이터로** 판단하기 위한 것이다 — 지금은 그 빈도를 아무도 모른다.
+
+### ShedLock을 쓰지 않는다
+
+booking·seat의 outbox 릴레이는 ShedLock으로 다중 실행을 막지만 이 스케줄러는 붙이지 않는다. **읽기와 발행뿐이라 전이할 상태가 없고**, 중복 실행되더라도 같은 refund는 같은 eventId로 발행돼 수신 측 Inbox unique가 흡수하기 때문이다.
+
+락을 위해 ShedLock을 들이면 `RedisLockProvider`가 필요하고, 그러려면 payment가 명시적으로 끈 Redis 오토컨피그를 되살려 이 서비스를 [ADR 0008](0008-accept-redis-spof-with-fail-closed.md)의 장애 범위에 새로 넣어야 한다. 얻는 것에 비해 대가가 크다.
+
+## 결과
+
+### 좋아지는 것
+
+- 유실 원인과 무관하게 복구된다. Kafka 유실이든 booking 다운이든, FAILED 이력이 남아 있는 한 게이트가 열린다(단, 한 refund에 대해 1회분 — 아래 한계 참고).
+- **booking-service를 건드리지 않는다.** 이벤트 스키마도 그대로라 배포 순서 의존성이 없다.
+- 롤백이 설정 한 줄이다(`app.refund-signal-replay.enabled: false`).
+- payment의 발행 경로·트랜잭션 경계·PG 호출이 전부 무변경이라 기존 환불·취소 경로의 회귀 표면이 없다.
+
+### 나빠지는 것 / 남는 한계
+
+- **`bookingNumber`를 null로 발행한다.** `refund` 테이블에 없는 값이고, 현재 이 토픽의 유일한 구독자인 booking이 `bookingId`·`failedAt`만 쓰기 때문에 성립한다. 그 전제가 깨지면 이 경로가 먼저 깨진다. `reason`도 원 발행이 싣던 트리거별 문구 대신 일반 메시지로 바뀌어 트리거 구분이 소실되는데, 같은 이유로 지금은 무해하다.
+- **한 refund에 대해 복구되는 유실은 1회분뿐이다.** eventId를 `refund_id`로 고정했고 재실패는 새 row를 만들지 않으므로(`FailedRefundRecorder`가 unique 위반을 멱등 처리), "1차 실패 복구 → 관리자 재환불 → 2차 실패 → 그 이벤트 유실" 시나리오에서는 재발행이 (a) 같은 eventId라 Inbox에 걸리고 (b) 도달해도 원본 시각이 기록된 값보다 이르러 무동작이다. 그 건은 REFUNDING에 남으므로 [#397](https://github.com/TicketRush/TicketRush-backend/issues/397)의 고착 복구 경로(`isStuckInRefunding`)가 받는다 — 완전히 닫히지는 않지만 이 경로로는 안 열린다.
+- **첫 주기의 폭발 반경.** 대상에 as-of 컷오프가 없어, 배포 직후 첫 주기가 **기존 FAILED 이력 전량**을 재발행한다. 과거에 PG 콘솔에서 수동 환불했거나 CS가 다른 방식으로 종결한 건도 booking 미해결 목록에 새로 올라온다. 컷오프를 두면 과거 건이 영영 안 열리므로 두지 않았고, 대신 배포 전 잔량 실측을 체크리스트 항목으로 돌렸다.
+- **수동으로 종결된 건을 해소 표시할 수단이 없다.** 그 row는 계속 대상으로 남아 게이지를 올린 채 주기마다 메시지를 낸다. 알림 임계를 잡으려면 먼저 그런 row를 정리해야 한다.
+- **미해결 건이 남아 있는 동안 같은 Kafka 메시지가 매 주기 나간다.** 수신 측이 Inbox로 버리므로 DB 쓰기는 없지만 메시지 자체는 흐른다. 없애려면 `refund`에 전달 상태 컬럼이 필요한데, 그건 스키마 변경과 맞바꾸는 선택이라 하지 않았다.
+- **알림은 없다.** 카운터·게이지만 올리고 Slack은 붙이지 않았다. 발행 실패 콜백은 프로듀서 IO 스레드에서 실행되는데 `SlackNotifier`에 스로틀이 없어, 브로커 장애로 실패가 쏟아질 때 그 스레드가 웹훅에 묶여 **장애를 키운다**. 임계·억제·반복 방지가 있는 Grafana 알림 규칙이 올바른 자리이며, 그건 후속으로 남겼다. 그때까지 "관측 가능"은 대시보드를 열어야 참이다.
+- **인덱스 하나가 늘었다.** `idx_refund_status`. FAILED가 희소해 `LIMIT`이 조기 종료를 못 하므로 인덱스가 없으면 매 주기 사실상 풀스캔이 된다. prod는 `validate` 모드지만 **Hibernate `validate`는 인덱스를 검증하지 않는다**(`.github/workflows/schema-validate.yml`·`deploy/mysql/README.md`가 같은 한계를 명시). 즉 수동 DDL을 빠뜨려도 기동은 성공하고, 증상은 5분마다 도는 풀스캔뿐이라 아무도 모른다 — 기동 실패로 걸러지지 않으므로 체크리스트([#441](https://github.com/TicketRush/TicketRush-backend/issues/441))가 유일한 그물이다.
+- payment에 `@Scheduled`가 처음 생겼다. 배선 실패가 조용히 지나갈 수 있어 배포 후 확인 항목을 체크리스트에 넣었다.
+- **레포에 "이벤트별로 전달 보장 등급을 다르게 둔다"는 선례가 생겼다.** 지금까지는 서비스 단위(`app.event-publisher.type`)로만 갈렸다. 이 결정은 발행 모드를 바꾸지 않고 특정 이벤트에만 복구 경로를 덧댄 것이라 설정만 보고는 드러나지 않는다 — 그래서 이 문서가 필요하다.
+
+### 다루지 않은 것
+
+- `PaymentConfirmedEvent` 유실. 이쪽은 `PaymentCanceledEvent`의 self-heal에 해당하는 경로가 아예 없어 booking이 PENDING으로 고착되는데, 복구 설계가 booking 확장을 부르므로 별도 이슈로 남긴다.
+- payment 전면 outbox 전환. 위 (a)의 트랜잭션 재설계가 선행돼야 한다.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -19,6 +19,7 @@ TicketRush의 아키텍처 결정을 번호 매긴 Markdown으로 축적하는 �
 - [11. 내부 API 응답의 소유자 대조는 호출자가 하고, 불일치는 존재를 숨기는 코드로 접는다](0011-verify-booking-owner-at-caller.md)
 - [12. PG 환불의 일시적 거절은 호출 지점에서 흡수하고, 소진되면 결정적 실패로 확정한다](0012-absorb-transient-pg-refund-rejections-at-caller.md)
 - [13. 배너는 performance-service 안의 별도 bounded context로 두고, 경로는 서비스명이 아니라 리소스명을 따른다](0013-banner-as-separate-context-inside-performance-service.md)
+- [14. 환불 실패 보상 신호는 발행을 보장하는 대신, 남아 있는 상태로 재발행해 복구한다](0014-recover-refund-failure-signal-by-reconciliation.md)
 
 ## 사용법
 

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/scheduler/ReplayRefundFailureSignalScheduler.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/scheduler/ReplayRefundFailureSignalScheduler.java
@@ -1,0 +1,42 @@
+package com.ticketrush.boundedcontext.payment.app.scheduler;
+
+import com.ticketrush.boundedcontext.payment.app.usecase.PaymentReplayRefundFailureSignalUseCase;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/**
+ * 미해결 환불 실패의 보상 신호를 주기적으로 재발행한다 (#574).
+ *
+ * <p>정상 경로에서는 원 발행이 즉시 게이트를 열기 때문에 이 스케줄러가 할 일이 없다. 유실됐을 때만 의미가 있는 복구 경로라 초 단위 주기가 필요하지 않다. {@code
+ * enabled=false} 로 끌 수 있다(재기동 필요).
+ *
+ * <p><b>ShedLock 을 붙이지 않는다.</b> booking·seat 의 outbox relay 와 달리 이 작업은 <b>읽기와 발행뿐이라 전이할 상태가 없다</b>.
+ * 여러 인스턴스가 동시에 돌아도 같은 refund 는 같은 eventId 로 발행되므로 수신 측 Inbox 의 {@code (consumer_group, event_id)}
+ * unique 가 흡수한다. 락을 위해 ShedLock 을 들이면 {@code RedisLockProvider} 가 필요하고, 그러려면 payment 가 명시적으로 끈
+ * Redis 오토컨피그(#425)를 되살려 이 서비스를 Redis 장애 범위(ADR 0008)에 새로 넣어야 한다 — 얻는 것에 비해 대가가 크다. 근거는 ADR 0014.
+ */
+@Component
+@ConditionalOnProperty(
+    prefix = "app.refund-signal-replay",
+    name = "enabled",
+    havingValue = "true",
+    matchIfMissing = true)
+public class ReplayRefundFailureSignalScheduler {
+
+  private final PaymentReplayRefundFailureSignalUseCase paymentReplayRefundFailureSignalUseCase;
+  private final int batchSize;
+
+  public ReplayRefundFailureSignalScheduler(
+      PaymentReplayRefundFailureSignalUseCase paymentReplayRefundFailureSignalUseCase,
+      @Value("${app.refund-signal-replay.batch-size:100}") int batchSize) {
+    this.paymentReplayRefundFailureSignalUseCase = paymentReplayRefundFailureSignalUseCase;
+    this.batchSize = batchSize;
+  }
+
+  @Scheduled(fixedDelayString = "${app.refund-signal-replay.interval-ms:300000}")
+  public void replay() {
+    paymentReplayRefundFailureSignalUseCase.execute(batchSize);
+  }
+}

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentReplayRefundFailureSignalUseCase.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentReplayRefundFailureSignalUseCase.java
@@ -1,0 +1,191 @@
+package com.ticketrush.boundedcontext.payment.app.usecase;
+
+import com.ticketrush.boundedcontext.payment.domain.entity.Refund;
+import com.ticketrush.boundedcontext.payment.domain.types.RefundStatus;
+import com.ticketrush.boundedcontext.payment.out.repository.RefundRepository;
+import com.ticketrush.global.constants.MetricNames;
+import com.ticketrush.global.eventpublisher.EventReplayPublisher;
+import com.ticketrush.shared.payment.event.RefundFailedEvent;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import jakarta.annotation.PostConstruct;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+
+/**
+ * 미해결 환불 실패의 보상 신호를 booking 에 다시 알린다 (#574).
+ *
+ * <p><b>왜 필요한가.</b> PG 가 환불을 거절하면 payment 는 {@code refund} 에 FAILED 이력을 남기고 {@link
+ * RefundFailedEvent} 를 발행한다. booking 은 그 이벤트를 받아야 {@code refundFailedAt} 을 찍고, 그래야 미해결 목록과 관리자 재환불
+ * API 가 그 건을 잡는다. 그런데 발행은 fire-and-forget 이라 유실되면 <b>과금이 남은 사고 건의 복구 수단이 함께 닫힌다</b>. 이 UseCase 는
+ * 유실을 막는 대신, 유실됐더라도 게이트가 열리도록 신호를 되풀이한다.
+ *
+ * <p><b>왜 안전한가.</b> 안전성의 근거가 이 클래스가 아니라 수신 측 도메인 계약에 있다. {@code Booking#recordRefundFailure} 는
+ * REFUNDED 등 종결 상태면 아무것도 하지 않고, REFUNDING 이면 {@code failedAt} 이 기록된 값보다 나중일 때만 복원한다. 재발행이 원본 실패
+ * 시각({@code refund.requestedAt})을 그대로 싣기 때문에 <b>진행 중인 재환불 시도를 중단시키지 않는다</b>.
+ *
+ * <p>이 보증은 {@code Booking#requestRefund()} 가 재환불을 걸 때 {@code refundFailedAt} 을 <b>지우지 않는다</b>는 데
+ * 기댄다. 지우도록 바뀌면 REFUNDING 가드의 비교 대상이 사라져 재발행이 진행 중인 시도를 중단시킨다.
+ *
+ * <p><b>왜 반복돼도 낭비가 아닌가.</b> eventId 를 refund 별로 고정해 발행하므로, 수신 측 Inbox 가 두 번째부터 UseCase 실행 자체를 건너뛴다.
+ * 그리고 재시도가 성공하면 그 FAILED 이력은 {@code Refund#markCompleted} 로 COMPLETED 가 되어 대상 집합에서 스스로 빠진다 — 정상
+ * 운영에서 대상은 0 으로 수렴한다.
+ *
+ * <p><b>불변식: 이 UseCase 에 {@code @Transactional} 을 붙이면 안 된다.</b> {@code kafkaTemplate.send()} 는 브로커
+ * 메타데이터 대기로 호출 스레드를 최대 {@code max.block.ms} 만큼 무는데, 트랜잭션 안에서 돌면 그동안 DB 커넥션을 함께 잡는다. payment 가 PG
+ * 왕복을 트랜잭션 밖으로 뺀 것과 같은 이유이며({@code PaymentCancelUseCase} · {@link FailedRefundRecorder} 의 동일 불변식),
+ * 브로커가 느려질 때 커넥션 풀이 마르는 사고가 Kafka 쪽에서 재현된다.
+ *
+ * <p><b>남는 한계.</b> {@code bookingNumber} 는 {@code refund} 에 없어 null 로 발행한다. 현재 이 토픽의 유일한 구독자인
+ * booking 이 {@code bookingId}·{@code failedAt} 만 쓰기 때문에 문제가 없으나, 그 전제가 깨지면 이 경로가 먼저 깨진다. 한 refund 에
+ * 대해 복구되는 유실은 1 회분뿐인 점은 ADR 0014 "남는 한계" 참고.
+ */
+@Slf4j
+@Service
+@ConditionalOnProperty(
+    prefix = "app.refund-signal-replay",
+    name = "enabled",
+    havingValue = "true",
+    matchIfMissing = true)
+@RequiredArgsConstructor
+public class PaymentReplayRefundFailureSignalUseCase {
+
+  /** 같은 환불 이력은 언제 재발행해도 같은 eventId 를 갖게 하는 seed 접두어. */
+  private static final String EVENT_ID_SEED_PREFIX = "refund-failure-signal:";
+
+  /**
+   * 한 건도 내보내지 못한 채 이만큼 연달아 실패하면 이번 주기를 접는다.
+   *
+   * <p>브로커 전면 장애면 남은 건도 같은 이유로 실패할 것이 확실한데, {@code send()} 는 건당 최대 {@code max.block.ms} 를 문다. 끝까지
+   * 밀면 스케줄러 스레드가 주기보다 오래 잡히고 error 로그가 배치 크기만큼 쏟아진다. 어차피 다음 주기가 같은 자리부터 다시 훑는다.
+   *
+   * <p><b>"성공 0건" 조건이 함께 걸린 이유</b>는 이 가드가 위치를 가리지 않으면 랩 선두의 특정 3건이 계속 실패할 때 커서가 전진도 리셋도 하지 못해 뒤쪽
+   * 전체가 무기한 대기하기 때문이다. 그건 이 스케줄러가 없애려던 봉쇄와 같은 형태다. 한 건이라도 나갔다면 브로커는 살아 있다는 뜻이므로 남은 건을 계속 시도한다.
+   */
+  private static final int MAX_CONSECUTIVE_FAILURES = 3;
+
+  private final RefundRepository refundRepository;
+  private final EventReplayPublisher eventReplayPublisher;
+  private final MeterRegistry meterRegistry;
+
+  private final AtomicLong unresolvedCount = new AtomicLong();
+
+  /**
+   * 이번 주기가 이어서 읽을 refund_id 하한(배타).
+   *
+   * <p>배치 상한만 두고 매번 가장 오래된 것부터 읽으면, 미해결이 배치 크기를 넘는 순간 뒤쪽 건은 <b>영원히 선택되지 않는다</b> — FAILED 이력은 재환불이
+   * 성공해야 COMPLETED 로 빠지는데 그 재환불을 여는 것이 바로 이 재발행이라 순환이 끊긴다. 커서를 들고 한 바퀴를 돌면 처음으로 되돌린다.
+   *
+   * <p>스케줄러 스레드 풀이 2 라 주기마다 다른 스레드가 실행될 수 있어 {@code volatile} 로 가시성을 맞춘다. 재기동하면 0 부터 다시 도는데, 순환만
+   * 보장되면 되므로 영속화하지 않는다.
+   */
+  private volatile long cursor = 0L;
+
+  private enum ReplayOutcome {
+    REPLAYED,
+    SKIPPED,
+    FAILED
+  }
+
+  /**
+   * 미해결(FAILED) 환불 이력 잔량 Gauge 를 등록한다.
+   *
+   * <p>이 값이 0 이 아니면 과금이 남은 채 환불이 성사되지 않은 건이 그만큼 있다는 뜻이다. 아래 {@code execute} 안에서만 갱신되므로 스케줄러가 멎으면
+   * 마지막 값이 그대로 노출된다 — 값이 낮다고 안전 신호로 읽으면 안 된다({@code OutboxRelayService} 의 backlog 와 동일한 함정). 스케줄러를
+   * 끄면 이 빈 자체가 등록되지 않아 게이지가 0 으로 박히는 대신 사라진다.
+   */
+  @PostConstruct
+  public void registerGauge() {
+    Gauge.builder(MetricNames.PAYMENT_REFUND_UNRESOLVED, unresolvedCount, AtomicLong::get)
+        .register(meterRegistry);
+  }
+
+  public void execute(int batchSize) {
+    unresolvedCount.set(refundRepository.countByStatus(RefundStatus.FAILED));
+
+    List<Refund> targets =
+        refundRepository.findByStatusAndIdGreaterThanOrderByIdAsc(
+            RefundStatus.FAILED, cursor, PageRequest.of(0, batchSize));
+    if (targets.isEmpty()) {
+      cursor = 0L;
+      return;
+    }
+
+    int replayed = 0;
+    int consecutiveFailures = 0;
+    boolean aborted = false;
+
+    for (Refund refund : targets) {
+      ReplayOutcome outcome = replay(refund);
+
+      if (outcome == ReplayOutcome.FAILED) {
+        consecutiveFailures++;
+        // 한 건도 못 내보낸 채 연속으로 실패하면 브로커 쪽 전면 장애로 보고 접는다. 이미 나간 건이
+        // 있다면 실패는 그 건에 국한된 사유이므로 계속 진행한다 — 여기서 접으면 뒤쪽 미해결 건이
+        // 커서 전진 없이 무기한 대기한다(이 스케줄러가 애초에 없애려던 봉쇄가 위치만 바꿔 재현된다).
+        if (replayed == 0 && consecutiveFailures >= MAX_CONSECUTIVE_FAILURES) {
+          aborted = true;
+          break;
+        }
+        continue;
+      }
+
+      consecutiveFailures = 0;
+      // SKIPPED 도 커서를 전진시킨다. 발행하지 않았더라도 그 row 는 다음 주기에 다시 봐도 같은 결과라,
+      // 멈춰 서면 뒤쪽 건이 영영 선택되지 않는다.
+      cursor = refund.getId();
+      if (outcome == ReplayOutcome.REPLAYED) {
+        replayed++;
+      }
+    }
+
+    if (aborted) {
+      // 커서를 옮기지 않았으므로 다음 주기가 같은 자리부터 다시 훑는다.
+      log.warn("보상 신호 재발행이 연속 실패해 이번 주기를 중단합니다. 연속 실패={}건, 커서={}", consecutiveFailures, cursor);
+    } else if (targets.size() < batchSize) {
+      // 마지막 페이지까지 훑었으면 다음 주기가 다시 앞에서 시작하도록 되돌린다.
+      cursor = 0L;
+    }
+
+    // 중단된 주기에도 그때까지 나간 건수는 남긴다. 부분 장애 구간이야말로 이 지표가 필요한 자리다.
+    if (replayed > 0) {
+      Counter.builder(MetricNames.PAYMENT_REFUND_SIGNAL_REPLAYED)
+          .register(meterRegistry)
+          .increment(replayed);
+      log.info("미해결 환불 실패 보상 신호를 재발행했습니다. 재발행={}건, 미해결 총={}건", replayed, unresolvedCount.get());
+    }
+  }
+
+  /** 한 건의 재발행이 실패해도 나머지가 멈추지 않도록 개별로 막는다. */
+  private ReplayOutcome replay(Refund refund) {
+    if (refund.getRequestedAt() == null) {
+      // 실패 시각이 없으면 수신 측이 REFUNDING 진행 건과의 선후를 판정할 수 없다. 잘못된 시각을 지어내
+      // 보내면 진행 중인 재환불을 중단시킬 수 있으므로 보내지 않는다. 발행 장애가 아니므로 연속 실패로도
+      // 세지 않는다.
+      log.warn("실패 시각이 없어 보상 신호를 재발행하지 않습니다. refundId={}", refund.getId());
+      return ReplayOutcome.SKIPPED;
+    }
+
+    try {
+      RefundFailedEvent event =
+          new RefundFailedEvent(
+              refund.getBookingId(), null, refund.getReason(), refund.getRequestedAt());
+      eventReplayPublisher.republish(event, eventId(refund));
+      return ReplayOutcome.REPLAYED;
+    } catch (Exception e) {
+      log.error(
+          "보상 신호 재발행에 실패했습니다. refundId={}, bookingId={}", refund.getId(), refund.getBookingId(), e);
+      return ReplayOutcome.FAILED;
+    }
+  }
+
+  private String eventId(Refund refund) {
+    return EventReplayPublisher.deterministicEventId(EVENT_ID_SEED_PREFIX + refund.getId());
+  }
+}

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/domain/entity/Refund.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/domain/entity/Refund.java
@@ -7,6 +7,7 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.Index;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
@@ -15,7 +16,15 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@Table(name = "refund")
+// 미해결 보상 신호 재발행이 5분마다 status='FAILED'만 훑는다(#574). FAILED는 사고 시에만 생겨
+// 매우 희소한데, 인덱스가 없으면 LIMIT이 조기 종료를 못 해 매 주기 사실상 풀스캔이 된다.
+// 실제 쿼리는 `status = ? AND refund_id > ? ORDER BY refund_id`(커서 조회)인데, 단일 컬럼
+// 인덱스가 이 셋을 모두 커버하는 것은 InnoDB 세컨더리 인덱스 리프에 PK가 후행하고 MySQL의
+// index extensions(optimizer_switch=use_index_extensions, 기본 ON)가 그 PK를 인덱스의
+// 일부로 쓰기 때문이다. 그 스위치를 끄면 커서 조건과 정렬이 인덱스를 벗어난다.
+@Table(
+    name = "refund",
+    indexes = {@Index(name = "idx_refund_status", columnList = "status")})
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AttributeOverride(name = "id", column = @Column(name = "refund_id"))
@@ -41,7 +50,10 @@ public class Refund extends AutoIdBaseEntity {
   @Column(length = 255)
   private String reason; // 환불 사유
 
-  private LocalDateTime requestedAt; // 환불 요청 시점
+  // 환불 요청 시점. 단 FAILED 이력에서는 Refund.failed() 호출 시각 = 사실상 실패 확정 시각이고,
+  // #574 보상 신호 재발행이 이 값을 RefundFailedEvent.failedAt 으로 싣는다. 수신 측이 진행 중인
+  // 재환불과의 선후를 이 시각으로 판정하므로, 의미를 "요청 시각"으로 되돌리면 재발행 안전성이 깨진다.
+  private LocalDateTime requestedAt;
 
   private LocalDateTime confirmedAt; // 환불 확정 시점
 

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/out/repository/RefundRepository.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/out/repository/RefundRepository.java
@@ -1,7 +1,10 @@
 package com.ticketrush.boundedcontext.payment.out.repository;
 
 import com.ticketrush.boundedcontext.payment.domain.entity.Refund;
+import com.ticketrush.boundedcontext.payment.domain.types.RefundStatus;
+import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface RefundRepository extends JpaRepository<Refund, Long> {
@@ -9,4 +12,18 @@ public interface RefundRepository extends JpaRepository<Refund, Long> {
   Optional<Refund> findByBookingId(Long bookingId);
 
   Optional<Refund> findByPaymentId(Long paymentId);
+
+  /**
+   * 해당 상태의 환불 이력을 {@code idAfter} 다음부터 오래된 순으로 조회한다 (#574).
+   *
+   * <p>{@code idx_refund_status}를 타며, 같은 status 안에서는 InnoDB가 PK 순으로 담으므로 별도 정렬 없이 refund_id 오름차순이
+   * 나온다. 한 번에 다 가져오지 않도록 호출자가 {@code Pageable}로 상한을 준다.
+   *
+   * <p><b>{@code idAfter}(커서)가 필요한 이유</b>는 상한만 두고 매번 가장 오래된 것부터 읽으면 대상이 상한을 넘는 순간 뒤쪽 건이 영영 선택되지 않기
+   * 때문이다. FAILED 이력은 재환불이 성공해야 빠지는데, 그 재환불을 여는 것이 이 조회가 촉발하는 재발행이라 순환이 끊긴다.
+   */
+  List<Refund> findByStatusAndIdGreaterThanOrderByIdAsc(
+      RefundStatus status, Long idAfter, Pageable pageable);
+
+  long countByStatus(RefundStatus status);
 }

--- a/payment-service/src/main/java/com/ticketrush/global/config/SchedulingConfig.java
+++ b/payment-service/src/main/java/com/ticketrush/global/config/SchedulingConfig.java
@@ -1,0 +1,15 @@
+package com.ticketrush.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+/**
+ * payment-service 의 스케줄링 활성화 설정 (#574).
+ *
+ * <p>다른 서비스(booking·seat·performance)는 {@code ShedLockConfig} 가 {@link EnableScheduling} 을 겸하지만
+ * payment 는 ShedLock 을 쓰지 않으므로(근거는 {@code ReplayRefundFailureSignalScheduler} javadoc 과 ADR 0014) 이
+ * 설정만 따로 둔다. payment 에 스케줄러가 생긴 것은 이 이슈가 처음이다.
+ */
+@Configuration
+@EnableScheduling
+public class SchedulingConfig {}

--- a/payment-service/src/main/resources/application-test.yml
+++ b/payment-service/src/main/resources/application-test.yml
@@ -1,6 +1,10 @@
 app:
   event-publisher:
     type: kafka
+  # 테스트 컨텍스트에서 스케줄러가 돌면 테스트와 무관한 DB 조회·Kafka 발행이 섞인다(#574).
+  # 스케줄러 자체의 동작은 단위 테스트로 검증한다.
+  refund-signal-replay:
+    enabled: false
 
 payment:
   pg:

--- a/payment-service/src/main/resources/application.yml
+++ b/payment-service/src/main/resources/application.yml
@@ -21,10 +21,31 @@ spring:
       - org.springframework.boot.data.redis.autoconfigure.DataRedisAutoConfiguration
   jpa:
     open-in-view: false
+  # payment 에 @Scheduled 가 생긴 것은 #574 가 처음이다. 기본 풀은 스레드 1개라 스케줄러가 늘면
+  # 서로 지연을 밀어낸다. 지금 스케줄러는 1개뿐이지만, 이 작업은 브로커 대기로 스레드를 길게 물 수
+  # 있어(그래서 연속 실패 시 주기를 접는다) 다음 스케줄러가 생겼을 때 그 지연을 물려받지 않도록
+  # 한 칸을 미리 둔다.
+  task:
+    scheduling:
+      pool:
+        size: 2
 
 app:
   event-publisher:
     type: kafka
+  # 미해결 환불 실패(FAILED 환불 이력)의 보상 신호를 booking 에 되풀이해 알린다(#574).
+  # 환경 무관 설정이라 base 에 둔다(backend-convention §프로파일 및 인프라 접속정보 외부화).
+  refund-signal-replay:
+    # 끄면 유실된 보상 건이 미해결 목록·관리자 재환불 API 에 영영 잡히지 않는다. 끌 때 그 대가를 안다는
+    # 전제이며, 되돌리려면 재기동이 필요하다.
+    enabled: ${REFUND_SIGNAL_REPLAY_ENABLED:true}
+    # 원 발행이 성공하면 게이트는 즉시 열리므로 이 주기는 유실됐을 때만 의미가 있다. 단 한 주기가
+    # batch-size 만큼만 훑고 커서로 이어 읽으므로, 실제 복구 지연 상한은 이 값이 아니라
+    # ceil(미해결 건수 / batch-size) × interval 이다(미해결 1,000건이면 50분).
+    interval-ms: ${REFUND_SIGNAL_REPLAY_INTERVAL_MS:300000}
+    # PG 장애로 FAILED 가 대량으로 쌓였을 때 한 주기에 전부 발행하지 않도록 상한을 둔다. 올리면 한 바퀴가
+    # 짧아지는 대신 한 주기가 스케줄러 스레드를 오래 문다.
+    batch-size: ${REFUND_SIGNAL_REPLAY_BATCH_SIZE:100}
 
 service:
   ticket:

--- a/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentReplayRefundFailureSignalUseCaseTest.java
+++ b/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentReplayRefundFailureSignalUseCaseTest.java
@@ -1,0 +1,342 @@
+package com.ticketrush.boundedcontext.payment.app.usecase;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willDoNothing;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.ticketrush.boundedcontext.payment.domain.entity.Refund;
+import com.ticketrush.boundedcontext.payment.domain.types.RefundStatus;
+import com.ticketrush.boundedcontext.payment.out.repository.RefundRepository;
+import com.ticketrush.global.constants.MetricNames;
+import com.ticketrush.global.eventpublisher.EventReplayPublisher;
+import com.ticketrush.shared.payment.event.RefundFailedEvent;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.lang.reflect.Field;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+@ExtendWith(MockitoExtension.class)
+class PaymentReplayRefundFailureSignalUseCaseTest {
+
+  private static final int BATCH_SIZE = 3;
+  private static final LocalDateTime FAILED_AT = LocalDateTime.of(2026, 8, 13, 10, 0);
+
+  @Mock private RefundRepository refundRepository;
+  @Mock private EventReplayPublisher eventReplayPublisher;
+
+  private SimpleMeterRegistry meterRegistry;
+  private PaymentReplayRefundFailureSignalUseCase paymentReplayRefundFailureSignalUseCase;
+
+  @BeforeEach
+  void setUp() {
+    meterRegistry = new SimpleMeterRegistry();
+    paymentReplayRefundFailureSignalUseCase =
+        new PaymentReplayRefundFailureSignalUseCase(
+            refundRepository, eventReplayPublisher, meterRegistry);
+    paymentReplayRefundFailureSignalUseCase.registerGauge();
+  }
+
+  private Refund failedRefund(Long refundId, Long bookingId, LocalDateTime requestedAt)
+      throws Exception {
+    Refund refund = Refund.failed(refundId + 1000, bookingId, 10_000L, "환불 실패", requestedAt);
+    Field idField = refund.getClass().getSuperclass().getDeclaredField("id");
+    idField.setAccessible(true);
+    idField.set(refund, refundId);
+    return refund;
+  }
+
+  private void givenTargets(long idAfter, List<Refund> targets) {
+    given(
+            refundRepository.findByStatusAndIdGreaterThanOrderByIdAsc(
+                eq(RefundStatus.FAILED), eq(idAfter), any(Pageable.class)))
+        .willReturn(targets);
+  }
+
+  @Test
+  @DisplayName("성공: 미해결 FAILED 환불 이력의 보상 신호를 원본 실패 시각으로 재발행한다")
+  void replays_signal_with_original_failed_at() throws Exception {
+    // given
+    given(refundRepository.countByStatus(RefundStatus.FAILED)).willReturn(1L);
+    givenTargets(0L, List.of(failedRefund(7L, 100L, FAILED_AT)));
+
+    // when
+    paymentReplayRefundFailureSignalUseCase.execute(BATCH_SIZE);
+
+    // then: 수신 측은 failedAt으로 진행 중인 재환불과의 선후를 판정한다. 지금 시각을 지어내 보내면
+    // 진행 중인 시도를 중단시키므로 반드시 원본 시각이어야 한다.
+    ArgumentCaptor<RefundFailedEvent> captor = ArgumentCaptor.forClass(RefundFailedEvent.class);
+    verify(eventReplayPublisher).republish(captor.capture(), anyString());
+
+    RefundFailedEvent event = captor.getValue();
+    assertThat(event.bookingId()).isEqualTo(100L);
+    assertThat(event.failedAt()).isEqualTo(FAILED_AT);
+    assertThat(event.reason()).isEqualTo("환불 실패");
+    // refund 테이블에 bookingNumber가 없어 null이다. 유일한 구독자(booking)가 쓰지 않는다.
+    assertThat(event.bookingNumber()).isNull();
+  }
+
+  @Test
+  @DisplayName("성공: 조회 상한으로 batchSize를 그대로 넘긴다")
+  void queries_with_given_batch_size() throws Exception {
+    // given: 이 상한이 한 주기의 유일한 부하 방어선이라 계약으로 고정한다.
+    given(refundRepository.countByStatus(RefundStatus.FAILED)).willReturn(1L);
+    givenTargets(0L, List.of(failedRefund(7L, 100L, FAILED_AT)));
+
+    // when
+    paymentReplayRefundFailureSignalUseCase.execute(BATCH_SIZE);
+
+    // then
+    verify(refundRepository)
+        .findByStatusAndIdGreaterThanOrderByIdAsc(
+            RefundStatus.FAILED, 0L, PageRequest.of(0, BATCH_SIZE));
+  }
+
+  @Test
+  @DisplayName("성공: 배치가 가득 차면 다음 주기는 마지막 건 다음부터 이어 읽는다")
+  void advances_cursor_when_batch_is_full() throws Exception {
+    // given: 커서가 없으면 미해결이 batchSize를 넘는 순간 뒤쪽 건이 영영 선택되지 않는다.
+    given(refundRepository.countByStatus(RefundStatus.FAILED)).willReturn(10L);
+    givenTargets(
+        0L,
+        List.of(
+            failedRefund(7L, 100L, FAILED_AT),
+            failedRefund(8L, 200L, FAILED_AT),
+            failedRefund(9L, 300L, FAILED_AT)));
+    givenTargets(9L, List.of(failedRefund(10L, 400L, FAILED_AT)));
+
+    // when
+    paymentReplayRefundFailureSignalUseCase.execute(BATCH_SIZE);
+    paymentReplayRefundFailureSignalUseCase.execute(BATCH_SIZE);
+
+    // then
+    verify(refundRepository)
+        .findByStatusAndIdGreaterThanOrderByIdAsc(
+            eq(RefundStatus.FAILED), eq(9L), any(Pageable.class));
+    verify(eventReplayPublisher, times(4)).republish(any(), anyString());
+  }
+
+  @Test
+  @DisplayName("성공: 마지막 페이지를 읽으면 다음 주기는 다시 처음부터 훑는다")
+  void resets_cursor_after_last_page() throws Exception {
+    // given: 배치가 덜 찼다 = 한 바퀴를 돌았다.
+    given(refundRepository.countByStatus(RefundStatus.FAILED)).willReturn(1L);
+    givenTargets(0L, List.of(failedRefund(7L, 100L, FAILED_AT)));
+
+    // when
+    paymentReplayRefundFailureSignalUseCase.execute(BATCH_SIZE);
+    paymentReplayRefundFailureSignalUseCase.execute(BATCH_SIZE);
+
+    // then: 두 번째도 커서 0으로 조회한다(앞쪽 미해결 건이 계속 재발행 대상에 남는다).
+    verify(refundRepository, times(2))
+        .findByStatusAndIdGreaterThanOrderByIdAsc(
+            eq(RefundStatus.FAILED), eq(0L), any(Pageable.class));
+  }
+
+  @Test
+  @DisplayName("성공: 같은 환불 이력은 언제 재발행해도 같은 eventId를 쓴다")
+  void uses_same_event_id_for_same_refund() throws Exception {
+    // given: 식별자가 매번 달라지면 수신 측 Inbox가 걸러내지 못해 재발행마다 트랜잭션이 다시 열린다.
+    given(refundRepository.countByStatus(RefundStatus.FAILED)).willReturn(1L);
+    givenTargets(0L, List.of(failedRefund(7L, 100L, FAILED_AT)));
+
+    // when
+    paymentReplayRefundFailureSignalUseCase.execute(BATCH_SIZE);
+    paymentReplayRefundFailureSignalUseCase.execute(BATCH_SIZE);
+
+    // then
+    ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+    verify(eventReplayPublisher, times(2)).republish(any(), captor.capture());
+    assertThat(captor.getAllValues().get(0)).isEqualTo(captor.getAllValues().get(1));
+  }
+
+  @Test
+  @DisplayName("성공: 서로 다른 환불 이력은 서로 다른 eventId를 쓴다")
+  void uses_distinct_event_id_per_refund() throws Exception {
+    // given
+    given(refundRepository.countByStatus(RefundStatus.FAILED)).willReturn(2L);
+    givenTargets(0L, List.of(failedRefund(7L, 100L, FAILED_AT), failedRefund(8L, 200L, FAILED_AT)));
+
+    // when
+    paymentReplayRefundFailureSignalUseCase.execute(BATCH_SIZE);
+
+    // then
+    ArgumentCaptor<String> captor = ArgumentCaptor.forClass(String.class);
+    verify(eventReplayPublisher, times(2)).republish(any(), captor.capture());
+    assertThat(captor.getAllValues().get(0)).isNotEqualTo(captor.getAllValues().get(1));
+  }
+
+  @Test
+  @DisplayName("성공: 실패 시각이 없는 이력은 재발행하지 않는다")
+  void skips_refund_without_failed_at() throws Exception {
+    // given: 시각을 지어내 보내면 진행 중인 재환불을 중단시킬 수 있다.
+    given(refundRepository.countByStatus(RefundStatus.FAILED)).willReturn(1L);
+    givenTargets(0L, List.of(failedRefund(7L, 100L, null)));
+
+    // when
+    paymentReplayRefundFailureSignalUseCase.execute(BATCH_SIZE);
+
+    // then
+    verify(eventReplayPublisher, never()).republish(any(), anyString());
+  }
+
+  @Test
+  @DisplayName("성공: 실패 시각이 없어 건너뛴 이력도 커서를 전진시킨다")
+  void skipped_refund_still_advances_cursor() throws Exception {
+    // given: 건너뛴 자리에서 커서가 멈추면 그 row가 랩 선두를 영구 점유해 뒤쪽 건이 영영 안 나간다.
+    given(refundRepository.countByStatus(RefundStatus.FAILED)).willReturn(10L);
+    givenTargets(
+        0L,
+        List.of(
+            failedRefund(7L, 100L, null),
+            failedRefund(8L, 200L, null),
+            failedRefund(9L, 300L, null)));
+    givenTargets(9L, List.of(failedRefund(10L, 400L, FAILED_AT)));
+
+    // when
+    paymentReplayRefundFailureSignalUseCase.execute(BATCH_SIZE);
+    paymentReplayRefundFailureSignalUseCase.execute(BATCH_SIZE);
+
+    // then: 두 번째 주기는 건너뛴 세 건 다음부터 읽어 실제 대상에 도달한다.
+    verify(refundRepository)
+        .findByStatusAndIdGreaterThanOrderByIdAsc(
+            eq(RefundStatus.FAILED), eq(9L), any(Pageable.class));
+    verify(eventReplayPublisher).republish(any(), anyString());
+  }
+
+  @Test
+  @DisplayName("성공: 대상이 없으면 아무것도 발행하지 않는다")
+  void publishes_nothing_when_no_target() {
+    // given: 정상 운영에서 대상은 0으로 수렴한다(해결되면 COMPLETED로 전이돼 빠진다).
+    given(refundRepository.countByStatus(RefundStatus.FAILED)).willReturn(0L);
+    givenTargets(0L, List.of());
+
+    // when
+    paymentReplayRefundFailureSignalUseCase.execute(BATCH_SIZE);
+
+    // then
+    verify(eventReplayPublisher, never()).republish(any(), anyString());
+    assertThat(meterRegistry.get(MetricNames.PAYMENT_REFUND_UNRESOLVED).gauge().value()).isZero();
+  }
+
+  @Test
+  @DisplayName("성공: 미해결 잔량을 Gauge로 노출한다")
+  void exposes_unresolved_count_as_gauge() throws Exception {
+    // given
+    given(refundRepository.countByStatus(RefundStatus.FAILED)).willReturn(3L);
+    givenTargets(0L, List.of(failedRefund(7L, 100L, FAILED_AT)));
+
+    // when
+    paymentReplayRefundFailureSignalUseCase.execute(BATCH_SIZE);
+
+    // then: 조회 batch 크기가 아니라 전체 잔량이어야 한다. 0이 아니면 곧 미해결 사고 건수다.
+    assertThat(meterRegistry.get(MetricNames.PAYMENT_REFUND_UNRESOLVED).gauge().value())
+        .isEqualTo(3.0);
+  }
+
+  @Test
+  @DisplayName("성공: 한 건의 재발행이 실패해도 나머지 건은 계속 재발행한다")
+  void continues_after_single_failure() throws Exception {
+    // given
+    given(refundRepository.countByStatus(RefundStatus.FAILED)).willReturn(2L);
+    givenTargets(0L, List.of(failedRefund(7L, 100L, FAILED_AT), failedRefund(8L, 200L, FAILED_AT)));
+    willThrow(new IllegalStateException("serialize failed"))
+        .given(eventReplayPublisher)
+        .republish(
+            argThat(e -> e instanceof RefundFailedEvent rf && rf.bookingId() == 100L), anyString());
+
+    // when
+    paymentReplayRefundFailureSignalUseCase.execute(BATCH_SIZE);
+
+    // then: 앞 건에서 끊기면 뒤의 미해결 건이 영영 복구되지 않는다.
+    verify(eventReplayPublisher, times(2)).republish(any(), anyString());
+    // 실패한 건을 건너뛰고 그 뒤 건으로 커서가 전진한다 = 실패분은 다음 랩에서 다시 시도된다.
+    assertThat(meterRegistry.get(MetricNames.PAYMENT_REFUND_SIGNAL_REPLAYED).counter().count())
+        .isEqualTo(1.0);
+  }
+
+  @Test
+  @DisplayName("성공: 실제로 나간 건수를 재발행 카운터에 반영한다")
+  void counts_replayed_signals() throws Exception {
+    // given
+    given(refundRepository.countByStatus(RefundStatus.FAILED)).willReturn(2L);
+    givenTargets(0L, List.of(failedRefund(7L, 100L, FAILED_AT), failedRefund(8L, 200L, FAILED_AT)));
+
+    // when
+    paymentReplayRefundFailureSignalUseCase.execute(BATCH_SIZE);
+
+    // then
+    assertThat(meterRegistry.get(MetricNames.PAYMENT_REFUND_SIGNAL_REPLAYED).counter().count())
+        .isEqualTo(2.0);
+  }
+
+  @Test
+  @DisplayName("성공: 한 건도 못 내보낸 채 연속 실패하면 주기를 중단하고 커서를 옮기지 않는다")
+  void stops_cycle_when_nothing_sent_and_failures_repeat() throws Exception {
+    // given: 브로커 전면 장애면 남은 건도 같은 이유로 실패하는데, send()는 건당 브로커 메타데이터
+    // 대기(max.block.ms)를 문다. 끝까지 밀면 스케줄러 스레드가 주기보다 오래 잡힌다.
+    List<Refund> targets = new ArrayList<>();
+    for (long id = 1; id <= 5; id++) {
+      targets.add(failedRefund(id, 100L + id, FAILED_AT));
+    }
+    given(refundRepository.countByStatus(RefundStatus.FAILED)).willReturn(5L);
+    givenTargets(0L, targets);
+    willThrow(new IllegalStateException("broker down"))
+        .given(eventReplayPublisher)
+        .republish(any(), anyString());
+
+    // when
+    paymentReplayRefundFailureSignalUseCase.execute(5);
+    paymentReplayRefundFailureSignalUseCase.execute(5);
+
+    // then: 3건에서 접으므로 주기당 5건이 아니라 3건만 시도한다.
+    verify(eventReplayPublisher, times(6)).republish(any(), anyString());
+    // 커서를 옮기지 않았다 — 두 주기 모두 0부터 조회한다.
+    verify(refundRepository, times(2))
+        .findByStatusAndIdGreaterThanOrderByIdAsc(
+            eq(RefundStatus.FAILED), eq(0L), any(Pageable.class));
+  }
+
+  @Test
+  @DisplayName("성공: 한 건이라도 나갔으면 이후 연속 실패에도 주기를 접지 않는다")
+  void does_not_abort_after_first_success() throws Exception {
+    // given: 위치 무관으로 접으면 랩 선두의 특정 건이 계속 실패할 때 뒤쪽 전체가 무기한 대기한다 —
+    // 이 스케줄러가 없애려던 봉쇄가 위치만 바꿔 재현된다. 한 건이라도 나갔으면 브로커는 살아 있다.
+    List<Refund> targets = new ArrayList<>();
+    for (long id = 1; id <= 5; id++) {
+      targets.add(failedRefund(id, 100L + id, FAILED_AT));
+    }
+    given(refundRepository.countByStatus(RefundStatus.FAILED)).willReturn(5L);
+    givenTargets(0L, targets);
+    // 첫 건만 성공하고 나머지 4건은 전부 실패한다(호출 순서로 고정한다).
+    willDoNothing()
+        .willThrow(new IllegalStateException("per-row failure"))
+        .given(eventReplayPublisher)
+        .republish(any(), anyString());
+
+    // when
+    paymentReplayRefundFailureSignalUseCase.execute(5);
+
+    // then: 중단 없이 5건을 모두 시도하고, 커서는 성공한 첫 건에 머문다.
+    verify(eventReplayPublisher, times(5)).republish(any(), anyString());
+    assertThat(meterRegistry.get(MetricNames.PAYMENT_REFUND_SIGNAL_REPLAYED).counter().count())
+        .isEqualTo(1.0);
+  }
+}


### PR DESCRIPTION
## 🔗 관련 이슈

- close #574

---

## 📌 주요 변경 사항

- payment 의 이벤트 발행 실패를 카운터로 계측한다. 지금까지는 `log.error` 한 줄로 사라져 **유실이 실제로 일어나는지 아무도 몰랐다.**
- 미해결 환불 실패(FAILED 환불 이력)의 보상 신호를 5분마다 재발행해, 발행이 유실됐더라도 관리자 복구 경로가 열리게 한다.
- 발행 보장을 올리는 대신 **이미 남아 있는 상태로 복구**하는 쪽을 택한 근거를 ADR 0014 로 남긴다.
- **booking-service 는 변경하지 않는다.** 이벤트 스키마도 그대로라 배포 순서 의존성이 없다.

---

## 🛠 상세 구현 내용

### 문제

PG 가 환불을 거절하면 payment 는 `refund` 에 FAILED 이력을 남기고 `RefundFailedEvent` 를 발행한다. booking 은 그 이벤트를 받아야 `refundFailedAt` 을 찍고, 그래야 미해결 목록(`CONFIRMED` + `refund_failed_at IS NOT NULL`)과 관리자 재환불 API 가 그 건을 잡는다.

그런데 발행은 fire-and-forget 이라, 유실되면 `BookingAdminRetryRefundUseCase` 가 `BOOKING_REFUND_RETRY_NOT_ALLOWED` 로 거부한다. **과금이 남은 사고 건에서 수동 복구 수단까지 함께 닫힌다.**

착수 조사에서 이슈 본문의 전제 하나가 코드와 다른 것을 확인했다 — FAILED 이력은 `FailedRefundRecorder` 가 독립 커밋으로 이미 남긴다. 즉 실제 공백은 "기록의 부재"가 아니라 **기록과 복구 게이트 사이의 단절**이다. 전달 보장을 올려도 booking 이 다운돼 재시도가 소진되면 결과가 같으므로, 게이트 쪽을 여는 방향으로 설계했다.

### 안전성의 근거를 새로 만들지 않았다

| 필요한 보장 | 어디에 이미 있는가 |
|---|---|
| 종결된 건을 되돌리지 않는다 | `Booking#recordRefundFailure` — REFUNDED/CANCELED 는 전이 없이 `false` |
| 진행 중인 재환불을 중단시키지 않는다 | 같은 메서드 — REFUNDING 이면 `failedAt` 이 기록된 값보다 나중일 때만 복원. 재발행은 원본 실패 시각(`refund.requested_at`)을 실어 이 조건에 걸리지 않는다 |
| 반복 재발행이 낭비되지 않는다 | 수신 측 Inbox `(consumer_group, event_id)` — eventId 를 refund 별로 고정해 두 번째부터 UseCase 실행 자체를 건너뛴다 |
| 대상이 무한히 쌓이지 않는다 | `Refund#markCompleted` — 재시도가 성공하면 COMPLETED 로 전이돼 대상에서 스스로 빠진다 |

### 커서로 이어 읽는다

배치 상한만 두고 매번 가장 오래된 것부터 읽으면, 미해결이 상한을 넘는 순간 뒤쪽 건이 **영원히 선택되지 않는다** — FAILED 이력은 재환불이 성공해야 빠지는데 그 재환불을 여는 것이 바로 이 재발행이라 순환이 끊긴다. 상한의 존재 이유가 "대량으로 쌓였을 때"인데 정확히 그때 무력해지는 구조라 커서를 뒀다.

한 건도 내보내지 못한 채 3연속 실패하면 브로커 전면 장애로 보고 주기를 접는다(`send()` 가 건당 최대 `max.block.ms` 를 문다). 단 **한 건이라도 나갔으면 계속 진행한다** — 위치를 가리지 않고 접으면 랩 선두의 특정 건이 계속 실패할 때 같은 형태의 봉쇄가 재현된다.

### ShedLock 을 쓰지 않는다

읽기와 발행뿐이라 전이할 상태가 없고, 중복 실행되더라도 같은 refund 는 같은 eventId 로 발행돼 Inbox unique 가 흡수한다. 락을 위해 `RedisLockProvider` 를 들이면 payment 가 명시적으로 끈 Redis 오토컨피그(#425)를 되살려 이 서비스를 ADR 0008 의 장애 범위에 새로 넣어야 한다.

### common 발행 경로 정리

`EventMessageSender` 로 봉투→메시지 구성과 발행을 모으고, `EventReplayPublisher`(지정 eventId 재발행)를 그 위에 얹었다. 이 능력을 `EventPublisher` 인터페이스에 넣지 않은 것은 의도적이다 — 임의 eventId 발행은 잘못 쓰면 멱등이 깨지거나 이벤트가 영영 무시되므로 오용 표면을 좁혔다. **기존 빈의 등록 조건과 동작은 건드리지 않았다.**

---

## ✅ 테스트

### 테스트 방법

신규 테스트 4개 클래스를 작성하고 실행했다.

- `common` — `EventMessageSenderTest`(헤더 4종 구성, 발행 실패 시 토픽 태그 카운터, 실패가 호출자에게 전파되지 않음), `EventReplayPublisherTest`(지정 eventId 보존, 결정적 eventId 안정성·UUID 36자), `KafkaDomainEventPublisherTest`(**기존에 테스트가 0건이던 클래스** — afterCommit 훅을 실제로 실행해 발행이 나가는지까지 단언)
- `payment-service` — `PaymentReplayRefundFailureSignalUseCaseTest` 12건(원본 실패 시각 재발행, 배치 상한 계약, 커서 전진·리셋, SKIPPED 도 커서 전진, eventId 고정·구분, 잔량 Gauge, 재발행 카운터, 연속 실패 중단, 첫 성공 후 미중단)

```bash
./gradlew spotlessApply
./gradlew :common:checkstyleMain :common:checkstyleTest \
          :payment-service:checkstyleMain :payment-service:checkstyleTest
./gradlew :common:test :payment-service:test :booking-service:test :seat-service:test --continue
```

`common` 을 건드리므로 booking·seat 전체 회귀까지 함께 돌렸다.

### 테스트 결과

- checkstyle main/test — 통과
- `common` — 전체 통과
- `booking-service` — 전체 통과
- `payment-service` — 255건 중 253건 통과, 2건 실패
- `seat-service` — 182건 중 180건 통과, 2건 실패

실패 4건은 전부 `initializationError`("Could not find a valid Docker environment")로, **로컬에 Docker 가 없어 Testcontainers 가 뜨지 못한 것**이다(`PaymentGetListUseCaseIntegrationTest`, `PaymentCompletedBookingUniqueTest`, `SeatHoldConcurrencyTest`, `SeatMapCacheIntegrationTest` — 이 레포에서 Testcontainers 를 쓰는 파일과 정확히 일치한다). 이 변경과 무관하며 CI 에서는 통과할 것으로 본다.

<!--
### 📸 스크린샷

UI 변경이 없어 비워 둔다. 필요하면 이 주석을 풀고 작성한다.
-->

---

## 👀 리뷰 요청 사항

- **`bookingNumber` 를 null 로 발행하는 선택**을 봐주시기 바랍니다. `refund` 테이블에 없는 값이고 현재 이 토픽의 유일한 구독자인 booking 이 `bookingId`·`failedAt` 만 쓰기 때문에 성립하는데, 조회해서 채우려면 booking internal API 응답 확장이 필요해 범위를 넘습니다. 이 트레이드오프에 이견이 있으면 지적해 주시기 바랍니다.
- **연속 실패 중단 임계(3건)와 "성공 0건" 조건**의 조합이 적절한지 판단을 부탁드립니다. 셀프 리뷰에서 위치 무관 중단이 tail 봉쇄를 만든다는 지적을 받아 조건을 좁혔습니다.
- **스냅샷(`001-ticket-rush-schema.sql`)의 인덱스 한 줄은 수동 편집**입니다. mysqldump 는 인덱스를 PK → UNIQUE → 일반 KEY 순으로 내므로 재생성 산출물과 동일할 것으로 판단했으나(#463 과 같은 논증), Docker 가 없어 실제 재생성으로 대조하지는 못했습니다. 확인이 필요하면 말씀해 주시기 바랍니다.
- 한 refund 에 대해 복구되는 유실이 1 회분뿐인 한계는 ADR 0014 "남는 한계"에 적어 두었습니다. 그 건은 REFUNDING 에 남아 #397 고착 복구 경로가 받습니다.

---

## ⚠️ 배포 시 주의사항

**#441 체크리스트에 항목 3건(12·13·14)을 추가해 두었다.**

1. **배포 전 수동 DDL 이 필요하다.**
   ```sql
   ALTER TABLE refund ADD INDEX idx_refund_status (status),
     ALGORITHM=INPLACE, LOCK=NONE;
   ```
   ⚠️ **빠뜨려도 기동은 성공한다.** Hibernate `validate` 는 인덱스를 검증하지 않으므로(`schema-validate.yml`·`deploy/mysql/README.md` 가 같은 한계를 명시) 부팅 거부로 걸러지지 않고, 증상은 5분마다 도는 `refund` 풀스캔뿐이라 드러나지 않는다. 반영 후 `SHOW INDEX FROM refund WHERE Key_name='idx_refund_status'` 로 확인한다.

2. **첫 주기가 기존 FAILED 이력 전량을 재발행한다.** as-of 컷오프가 없어(두면 과거 건이 영영 안 열린다), 과거에 PG 콘솔에서 수동 환불했거나 CS 가 다른 방식으로 종결한 건도 booking 미해결 목록에 새로 올라온다. 배포 전 `SELECT ... FROM refund WHERE status='FAILED'` 로 잔량을 실측하고, 종결된 건이 섞여 있으면 관리자에게 미리 알린다.

3. **payment 에 `@Scheduled` 가 처음 생겼다.** 배선 실패가 조용히 지나갈 수 있으므로, 배포 후 `/actuator/prometheus` 에 `ticketrush_payment_refund_unresolved` 게이지가 노출되는지 확인한다(대상이 0건이면 로그는 안 찍힌다).

**끄는 법**: `REFUND_SIGNAL_REPLAY_ENABLED=false`(재기동 필요). 끄면 게이지 값이 0이 되는 게 아니라 **시계열이 통째로 사라진다**(빈 자체가 조건부).

**스키마 변경**: 인덱스 추가 1건. 컬럼·테이블 변경 없음.
**프론트 공지**: 불필요. API 계약·`ErrorStatus` 무변경.
