### PR TITLE
[Fix] #607 과금됐으나 만료된 예매를 자동 환불로 복구한다

### DIFF
--- a/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/app/dto/response/BookingInternalResponse.java
+++ b/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/app/dto/response/BookingInternalResponse.java
@@ -4,14 +4,25 @@ import com.ticketrush.boundedcontext.booking.domain.entity.Booking;
 import com.ticketrush.boundedcontext.booking.domain.types.BookingStatus;
 import io.swagger.v3.oas.annotations.media.Schema;
 
+/**
+ * 예매 내부 조회 응답 (#490).
+ *
+ * <p>{@code bookingNumber}는 payment 가 좌석 소유 교차검증(ABA 방지)을 위해 쓴다(#607). 환불 경로가 발행하는 {@code
+ * PaymentCanceledEvent}에 이 값이 실려야 seat 가 "그 좌석이 아직 이 예매의 것인지"를 대조할 수 있고, null 로 나가면 그 대조가 통째로 꺼진다.
+ * payment 는 자신의 테이블에 예매번호를 갖고 있지 않아 이 조회로만 얻는다.
+ */
 @Schema(description = "예매 내부 조회 응답(서비스 간 통신 전용)")
 public record BookingInternalResponse(
     @Schema(description = "예매 ID", example = "100") Long bookingId,
     @Schema(description = "예매 소유자 ID", example = "10") Long userId,
-    @Schema(description = "예매 상태", example = "CONFIRMED") BookingStatus bookingStatus) {
+    @Schema(description = "예매 상태", example = "CONFIRMED") BookingStatus bookingStatus,
+    @Schema(description = "예매 번호", example = "BK20260817000001") String bookingNumber) {
 
   public static BookingInternalResponse from(Booking booking) {
     return new BookingInternalResponse(
-        booking.getId(), booking.getUserId(), booking.getBookingStatus());
+        booking.getId(),
+        booking.getUserId(),
+        booking.getBookingStatus(),
+        booking.getBookingNumber());
   }
 }

--- a/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/in/api/v1/BookingInternalController.java
+++ b/booking-service/src/main/java/com/ticketrush/boundedcontext/booking/in/api/v1/BookingInternalController.java
@@ -76,7 +76,18 @@ public class BookingInternalController {
         SuccessStatus.OK, bookingGetInternalStatsUseCase.execute(from, to, performanceIds));
   }
 
-  @Operation(summary = "예매 소유자/상태 내부 조회", description = "예매의 소유자와 상태를 반환합니다.")
+  @Operation(
+      summary = "예매 소유자/상태/번호 내부 조회",
+      description =
+          """
+          예매의 소유자·상태·예매번호를 반환합니다.
+
+          **소유자 검증을 하지 않습니다.** bookingId 만으로 조회하므로 요청자와의 대조는 호출자 몫입니다(#572, ADR 0011).
+
+          **`booking_number` 는 결제 취소 시 좌석 소유 교차검증에 쓰입니다 (#607).**
+          payment 는 예매번호를 자신의 테이블에 갖고 있지 않아 이 필드로만 얻으며,
+          값 없이 환불 이벤트가 나가면 seat 의 ABA 방지 대조가 꺼집니다.
+          """)
   @GetMapping("/{bookingId}")
   public ResponseEntity<ApiResponse<BookingInternalResponse>> getBookingInternal(
       @PathVariable Long bookingId) {

--- a/booking-service/src/test/java/com/ticketrush/boundedcontext/booking/app/usecase/BookingGetInternalUseCaseTest.java
+++ b/booking-service/src/test/java/com/ticketrush/boundedcontext/booking/app/usecase/BookingGetInternalUseCaseTest.java
@@ -27,7 +27,7 @@ class BookingGetInternalUseCaseTest {
   @Mock private BookingRepository bookingRepository;
 
   @Test
-  @DisplayName("성공: 예매 ID로 소유자와 상태를 반환한다")
+  @DisplayName("성공: 예매 ID로 소유자·상태·예매번호를 반환한다")
   void execute_returns_owner_and_status() {
     // given
     Long bookingId = 100L;
@@ -49,6 +49,9 @@ class BookingGetInternalUseCaseTest {
     assertThat(response.bookingId()).isEqualTo(bookingId);
     assertThat(response.userId()).isEqualTo(10L);
     assertThat(response.bookingStatus()).isEqualTo(BookingStatus.CONFIRMED);
+    // payment 의 좌석 소유 교차검증이 이 값에 걸려 있다(#607). 매핑이 빠지면 null 로 나가고,
+    // 그 null 은 호출자에서 "판정 불가"가 아니라 "검증 생략"으로 새기 쉬워 사고가 조용히 열린다.
+    assertThat(response.bookingNumber()).isEqualTo("BOOK-1");
   }
 
   @Test

--- a/booking-service/src/test/java/com/ticketrush/boundedcontext/booking/in/api/v1/BookingInternalControllerTest.java
+++ b/booking-service/src/test/java/com/ticketrush/boundedcontext/booking/in/api/v1/BookingInternalControllerTest.java
@@ -146,12 +146,12 @@ class BookingInternalControllerTest {
   }
 
   @Test
-  @DisplayName("성공: 올바른 내부 토큰이면 예매 소유자/상태를 200으로 반환한다")
+  @DisplayName("성공: 올바른 내부 토큰이면 예매 소유자/상태/예매번호를 200으로 반환한다")
   void getBookingInternal_success() throws Exception {
     // given
     Long bookingId = 100L;
     given(bookingGetInternalUseCase.execute(bookingId))
-        .willReturn(new BookingInternalResponse(bookingId, 10L, BookingStatus.CONFIRMED));
+        .willReturn(new BookingInternalResponse(bookingId, 10L, BookingStatus.CONFIRMED, "BOOK-1"));
 
     // when & then
     mockMvc
@@ -162,7 +162,10 @@ class BookingInternalControllerTest {
         .andExpect(jsonPath("$.is_success").value(true))
         .andExpect(jsonPath("$.result.booking_id").value(100))
         .andExpect(jsonPath("$.result.user_id").value(10))
-        .andExpect(jsonPath("$.result.booking_status").value("CONFIRMED"));
+        .andExpect(jsonPath("$.result.booking_status").value("CONFIRMED"))
+        // 키 이름이 계약이다 — payment 의 BookingInfoResponse 가 @JsonProperty("booking_number") 로
+        // 이 이름에 맞춰 매핑하고, 어긋나면 ignoreUnknown 때문에 예외 없이 조용히 null 이 된다(#607).
+        .andExpect(jsonPath("$.result.booking_number").value("BOOK-1"));
   }
 
   @Test

--- a/common/src/main/java/com/ticketrush/global/constants/MetricNames.java
+++ b/common/src/main/java/com/ticketrush/global/constants/MetricNames.java
@@ -75,6 +75,34 @@ public class MetricNames {
   // 나가므로 이 값이 곧 유실 건수는 아니다 — 유실 여부는 EVENT_PUBLISH_FAILED 쪽에서 읽는다.
   public static final String PAYMENT_REFUND_SIGNAL_REPLAYED =
       "ticketrush.payment.refund.signal.replayed";
+  // 결제 확정 신호 유실로 "과금됐는데 예매가 만료된" 건을 찾아낸 횟수(#607). 이 사고는 payment·booking 어느
+  // 쪽에도 미해결 표시가 남지 않아(refund_failed_at 은 EXPIRED 에서 구조적으로 채워지지 않는다) 이 카운터가
+  // 발생 자체의 유일한 관측 축이다. 0 이 아니면 그만큼의 사용자 돈이 환불 없이 남아 있었다는 뜻이다.
+  public static final String PAYMENT_CHARGED_EXPIRED_DETECTED =
+      "ticketrush.payment.charged_expired.detected";
+  // 그중 실제로 자동 환불에 성공한 횟수(#607). detected 와의 차이가 곧 미복구 잔량이라, Grafana 에서 두
+  // 시계열을 겹쳐 읽는다. Gauge 로 잔량을 직접 재지 않는 것은 정확히 세려면 만료 테이블을 매번 전건 훑어야
+  // 하는데 이 설계가 피하려던 것이 바로 그 풀스캔이기 때문이다(ADR 0015).
+  public static final String PAYMENT_CHARGED_EXPIRED_RECOVERED =
+      "ticketrush.payment.charged_expired.recovered";
+  // 후보였으나 환불하지 않고 건너뛴 횟수(#607). reason 태그는 판정 단계와 1:1인 유한 집합 7종이다 —
+  // already_refunded(환불이 성사·진행 중), refund_failed_history(PG 가 거절해 FAILED 이력만 남음),
+  // grace(만료 직후라 정상 처리 중일 수 있음), booking_lookup_failed(booking 조회 실패 → fail-closed),
+  // booking_alive(예매가 살아 있는 알려진 상태), booking_status_unknown(모르는 상태 문자열),
+  // booking_number_unknown(예매번호를 얻지 못함 → 좌석 오반환 방지로 중단, #608).
+  // 뒤 넷은 정상 스킵이 아니라 조사 대상이다. 태그로 갈라 두지 않으면 "환불하지 않았다"는 한 덩어리에
+  // 묻혀, 사고 건이 조용히 방치되는 것과 정상 동작이 구분되지 않는다. 특히 두 쌍의 구분이 핵심이다 —
+  // already_refunded 와 refund_failed_history 는 "돈이 돌아갔는가"가 정반대이고(후자는 미해결 사고인데
+  // 예매가 EXPIRED 라 booking 쪽 관리자 게이트도 열리지 않아 이 태그가 유일한 창구다),
+  // booking_alive 와 booking_status_unknown 은 "정상"과 "상대가 계약을 바꿔 복구가 전면 정지"의 차이다.
+  //
+  // ⚠️ already_refunded 는 오늘 코드에서 사실상 도달하지 않는다. 후보가 되려면 payment 가 COMPLETED 여야
+  // 하는데 PaymentCancelPersister 가 환불 저장과 markCanceled 를 한 트랜잭션에 묶으므로
+  // refund=COMPLETED 인 booking 은 payment 가 CANCELED 라 앞선 결제 대조에서 이미 빠진다. 그래서 이 값이
+  // 0 이 아니면 "정상적으로 이미 환불된 건을 건너뛰었다"가 아니라 "환불은 성사됐는데 payment 가 CANCELED 가
+  // 아닌" 찢어진 상태 신호로 읽어야 한다. 대시보드·알림 문구를 그렇게 잡는다.
+  public static final String PAYMENT_CHARGED_EXPIRED_SKIPPED =
+      "ticketrush.payment.charged_expired.skipped";
 
   // ticket
   public static final String TICKET_ISSUE = "ticketrush.ticket.issue";

--- a/docs/adr/0014-recover-refund-failure-signal-by-reconciliation.md
+++ b/docs/adr/0014-recover-refund-failure-signal-by-reconciliation.md
@@ -80,4 +80,5 @@ booking·seat의 outbox 릴레이는 ShedLock으로 다중 실행을 막지만 �
 ### 다루지 않은 것
 
 - `PaymentConfirmedEvent` 유실. 이쪽은 `PaymentCanceledEvent`의 self-heal에 해당하는 경로가 아예 없어 booking이 PENDING으로 고착되는데, 복구 설계가 booking 확장을 부르므로 별도 이슈로 남긴다.
+  > **정정(2026-08-17, [ADR 0015](0015-recover-charged-expired-booking-by-auto-refund.md)).** "PENDING으로 고착된다"는 부정확하다. `BookingExpirationScheduler`가 5분 뒤 EXPIRED로 전이시키므로 **고착이 아니라 소멸**이며, 그래서 이 문서가 세운 "남아 있는 상태로 재발행해 복구한다"를 그대로 적용할 수 없다 — 재발행해도 `Booking#confirm`이 EXPIRED를 거절한다. ADR 0015는 예매를 되살리는 대신 **대조로 찾아 자동 환불하는** 반대 방향을 택했다.
 - payment 전면 outbox 전환. 위 (a)의 트랜잭션 재설계가 선행돼야 한다.

--- a/docs/adr/0015-recover-charged-expired-booking-by-auto-refund.md
+++ b/docs/adr/0015-recover-charged-expired-booking-by-auto-refund.md
@@ -1,0 +1,169 @@
+# 15. 확정 신호가 유실돼 과금만 남은 만료 예매는, 예매를 되살리는 대신 대조로 찾아 자동 환불한다
+
+날짜: 2026-08-17
+
+## 상태
+
+승인됨
+
+## 맥락
+
+`PaymentConfirmUseCase`는 PG 승인에 성공하면 `PaymentConfirmedEvent`를 발행한다. payment-service는 `app.event-publisher.type: kafka`라 이 발행은 fire-and-forget이고, 실패는 카운터와 로그로만 남는다([ADR 0014](0014-recover-refund-failure-signal-by-reconciliation.md)).
+
+이 이벤트의 구독자는 둘이다 — booking(예매 CONFIRMED 전이)과 ticket(티켓 발급). 유실되면 booking이 PENDING에 남는데, **거기서 멈추지 않는다.** `BookingExpirationScheduler`가 1분마다 돌며 `createdAt + 5분`을 넘긴 PENDING을 EXPIRED로 만든다.
+
+최종 상태는 이렇다.
+
+| | 상태 |
+|---|---|
+| payment | **COMPLETED (과금 완료)** |
+| booking | EXPIRED |
+| ticket | 미발급 |
+| seat | 해제 → 재판매 |
+| 환불 | **없음** |
+| 관리자 미해결 목록 | **안 잡힘** |
+
+`BookingExpiredEvent`의 구독자는 payment 하나뿐이고, 하는 일은 `registerExpiredBooking` — 만료 booking을 등록해 이후 confirm을 차단할 뿐 환불하지 않는다([#224](https://github.com/TicketRush/TicketRush-backend/issues/224)).
+
+### 착수 전 조사에서 이슈의 전제 세 가지가 코드와 달랐다
+
+**1. "사용자가 손댈 방법이 없다"는 사실이 아니다.** `PaymentCancelUseCase.execute`는 본인 결제·`COMPLETED`·티켓 USED 여부만 보고 **booking 상태를 전혀 확인하지 않는다.** 결제 내역에도 그대로 뜨므로 사용자가 직접 환불할 수 있다.
+
+**2. 🔴 그런데 그 취소 경로가 남의 좌석을 푼다.** `PaymentCancelUseCase`는 `PaymentCanceledEvent`를 `bookingNumber = null`로 발행하고(API 경로는 예매번호를 모른다는 주석이 의도를 명시한다), seat의 `SeatReleaseSoldSeatUseCase`는 그 값이 있을 때만 좌석 소유 교차검증(ABA 방지)을 한다. null이면 검증이 통째로 꺼지고 "SOLD면 반환"만 남는다. 좌석이 이미 다른 사용자에게 팔린 뒤라면 **그 사람의 좌석이 AVAILABLE로 돌아간다.** seat 리스너의 Inbox는 재전달만 막으므로 최초 수신인 이 시나리오는 그대로 통과한다. → [#608](https://github.com/TicketRush/TicketRush-backend/issues/608)로 분리했다.
+
+**3. 재결제가 막히는 이유가 이슈 서술과 다르다.** `expired_booking` 가드([#224](https://github.com/TicketRush/TicketRush-backend/issues/224))가 아니라 그보다 앞선 `PaymentConfirmUseCase`의 COMPLETED 중복 검사에 걸린다. 실제 응답은 `PAYMENT_ALREADY_COMPLETED`다.
+
+또한 **[ADR 0014](0014-recover-refund-failure-signal-by-reconciliation.md) "다루지 않은 것"의 "booking이 PENDING으로 고착된다"는 서술은 부정확하다** — 5분 뒤 EXPIRED로 전이된다. 고착이 아니라 소멸이며, 그래서 복구가 더 어렵다.
+
+### #574의 방식을 복제할 수 없다
+
+[ADR 0014](0014-recover-refund-failure-signal-by-reconciliation.md)는 "전달을 보장하는 대신 남아 있는 상태로 재발행한다"를 세웠고, 안전성의 근거를 **이미 배포된 수신 측 계약**에 위임한 것이 핵심이었다. 여기서 같은 일을 하면 **아무 일도 일어나지 않는다.**
+
+`PaymentConfirmedEvent`를 재발행해도 `Booking#confirm`이 EXPIRED에 대해 `BOOKING_EXPIRED`로 거절하고, 그 예외는 영구 실패로 분류돼 그대로 ack된다. 위임할 계약이 여기서는 **반대 방향으로 작동한다.** 좌석이 이미 팔린 뒤라 예매를 되살리는 것 자체가 불가능하기도 하다.
+
+대상 집합의 성질도 다르다. #574에는 `refund` 테이블의 FAILED 이력이라는 미해결 목록이 이미 있었고, 해결되면 `markCompleted`로 스스로 빠졌다. `PaymentConfirmedEvent`에는 그런 축이 없다 — COMPLETED payment 전부가 대상이 될 수는 없다.
+
+### 검토한 대안
+
+**판정 기준**
+
+- **(a) payment에 "확정 신호 전달됨" 축을 새로 둔다.** 대상 집합이 명확해지지만 스키마 변경이고, prod가 `validate` 모드라 수동 DDL이 따라온다. 무엇보다 이미 발생한 과거 사고 건은 그 컬럼이 없어 영영 잡히지 않는다.
+- **(b) COMPLETED payment 전건을 booking에 동기 조회해 대조한다.** 판정은 정확하지만 결제 건수에 비례해 왕복이 늘고, 정상 건이 압도적 다수라 대부분이 헛돌이다.
+- **(c) 채택 — `expired_booking × payment(COMPLETED) × refund 부재`로 로컬 후보군을 좁힌 뒤, 후보만 booking에 재확인한다.** 세 테이블이 모두 payment 안에 있어 왕복 없이 후보를 만들고, 되돌릴 수 없는 부작용 앞에서만 원본을 다시 본다.
+
+**복구 동작**
+
+- **(가) 예매 복구.** 좌석이 이미 재판매된 뒤라 성립하지 않는다. 되살릴 자리가 없다.
+- **(나) 채택 — 자동 환불.** [#492](https://github.com/TicketRush/TicketRush-backend/issues/492)가 만든 `PaymentRefundByBookingUseCase`를 그대로 재사용한다.
+
+## 결정
+
+**`expired_booking`을 커서로 훑어 "과금됐는데 예매가 만료됐고 환불 이력이 없는" 건을 찾고, booking에 재확인한 뒤 자동 환불한다. 스케줄러는 기본 비활성으로 배포한다.**
+
+### 판정 질의는 2단계로 나눈다
+
+```
+1) SELECT eb FROM ExpiredBooking eb WHERE eb.id > :cursor ORDER BY eb.id ASC LIMIT :batch
+2) SELECT p FROM Payment p WHERE p.bookingId IN (:ids) AND p.status = COMPLETED
+3) 후보별 순차 판정
+```
+
+조인 한 방 + `LIMIT`으로 짜면 안 된다. "과금됐는데 만료된" 건은 전체 만료 중 극히 드물어서 옵티마이저가 상한을 채우려 스캔을 이어가고, 매 주기 사실상 풀스캔이 된다 — [ADR 0014](0014-recover-refund-failure-signal-by-reconciliation.md)가 `idx_refund_status`에서 겪은 것과 같은 형태다. 2단계로 나누면 1)이 PK 범위 스캔, 2)가 `idx_payment_booking_id`([#412](https://github.com/TicketRush/TicketRush-backend/issues/412))를 탄다.
+
+세 번째 질의는 판정 1의 환불 이력 조회인데, **`refund`에는 `booking_id` 인덱스가 없다**(키는 PK · `UNIQUE(payment_id)` · `idx_refund_status` 셋뿐). 그래서 이것도 후보별 호출이 아니라 `booking_id IN (...)`으로 묶는다. 건별로 부르면 후보 수만큼 풀스캔이고, `refund`는 성공한 환불까지 누적돼 계속 커지는 테이블이며, 하필 후보가 가장 많은 순간이 처음 켜는 첫 랩이다. 묶으면 풀스캔이 **랩당 1회**로 고정돼 비용이 후보 수에 비례하지 않는다.
+
+그 결과 **새 인덱스가 필요 없다. 스키마는 무변경이다.** 인덱스를 추가하는 선택지도 있었지만, prod가 `validate` 모드인데 **Hibernate `validate`는 인덱스를 검증하지 않아** 수동 DDL을 빠뜨려도 기동이 성공한다 — [ADR 0014](0014-recover-refund-failure-signal-by-reconciliation.md)가 `idx_refund_status`에서 정확히 그 함정을 남겼다. 질의 형태를 바꿔 피할 수 있다면 그편이 낫다.
+
+### 판정 순서 자체가 계약이다
+
+| # | 판정 | 통과하지 못하면 | 왜 이 자리인가 |
+|---|---|---|---|
+| 1 | 환불 이력 부재 | `already_refunded` / `refund_failed_history` | **PG 무한 재호출 차단의 핵심.** 상태를 가리지 않고 거르는 것이 의도적이다 — FAILED 이력도 "이미 시도했다"는 뜻이라, 상태를 가려 다시 집어들면 실패한 환불을 매 주기 PG에 되풀이해 던진다. 다만 **관측에서는 반드시 가른다**(아래 참고) |
+| 2 | 만료 후 grace(30분) 경과 | `grace` | 정상 처리가 늦게 도착하는 창을 환불로 덮지 않는다 |
+| 3 | booking 동기 재확인 | `booking_lookup_failed` | 로컬 근거는 이벤트로 채워진 사본이라 최신이 아닐 수 있다. 404·503은 물론 **그 밖의 예외까지** 여기로 접는다 — 새어 나가면 그 랩의 남은 후보와 발견 카운터가 통째로 죽어, 장애 구간에서 관측이 침묵한다 |
+| 4 | 상태가 EXPIRED·CANCELED | `booking_alive` / `booking_status_unknown` | 허용 목록이다. **알려진 비허용 상태와 모르는 문자열을 가른다** — 후자는 booking이 상태 이름을 바꿨다는 뜻이고, 그러면 전건이 이 갈래로 떨어져 복구가 조용히 전면 정지한다([#572](https://github.com/TicketRush/TicketRush-backend/issues/572)가 `owner_unknown`을 분리한 것과 같은 판단) |
+| 5 | `bookingNumber` 존재 | `booking_number_unknown` + CRITICAL | **위 정정 2의 사고를 원천 차단한다.** 값 없이 환불하면 이 경로가 곧 #608이 된다. 가드를 호출부가 아니라 **환불 실행 메서드 안**에 둔 것은, `bookingId`·`bookingNumber`가 `Long`·`String`이라 인자를 잘못 넘겨도 컴파일이 통과하기 때문이다(`RefundTrigger`를 열거형으로 뽑은 것과 같은 이유) |
+| 6 | 자동 환불 실행 | — | `RefundTrigger.CONFIRM_SIGNAL_LOST` |
+
+**판정 1의 두 태그를 가르는 것이 특히 중요하다.** 둘 다 "환불 이력이 있어 건너뛴다"이지만 뜻이 정반대다 — `refund_failed_history`는 **PG가 거절해 돈이 돌아가지 않은 미해결 사고**이고, 예매가 EXPIRED라 booking의 관리자 재환불 게이트도 열리지 않는다. 한 태그로 접으면 그 건이 정상 환불 시계열에 섞여, CRITICAL 로그 한 줄이 흘러간 뒤로는 영영 보이지 않는다. 아래 "관리자 창구가 로그와 메트릭뿐"이라는 한계를 감수하는 이상, 그 메트릭이 두 상태를 구분하지 못하면 감수의 전제가 무너진다.
+
+**티켓 USED 가드는 통과하지 않는다.** 결제 취소 API 경로는 [#416](https://github.com/TicketRush/TicketRush-backend/issues/416)이 세운 그 가드를 거치지만 이 자동 경로는 거치지 않는다. 입장 검증이 예매 CONFIRMED를 요구하므로 EXPIRED·CANCELED 예매의 티켓은 USED가 될 수 없고, [#492](https://github.com/TicketRush/TicketRush-backend/issues/492)도 같은 이유로 가드를 넣지 않았다. 사람 개입 없이 되돌릴 수 없는 취소를 실행하는 경로가 기존 안전 게이트를 우회한다는 사실 자체는 기록해 둔다.
+
+CANCELED를 허용 목록에 넣은 것은 사용자가 만료 전에 취소했는데 확정 신호만 유실된 경우도 결과가 같기 때문이다 — 과금이 남고 예매가 없다.
+
+`ALREADY_SETTLED`는 여기서 정합성 붕괴가 아니다. 후보를 뽑은 뒤 환불하기까지 사이에 다른 경로가 정리했을 수 있다. 신호를 받아 처리하는 `SeatConfirmFailedEventListener`에서는 같은 값이 "과금됐다"는 전제의 붕괴라 CRITICAL이지만, **대조로 후보를 찾는 이 경로에서는 경합의 정상적 귀결이다** — 심각도 해석이 갈린다.
+
+### 배치 상한의 중단 가드를 복제하지 않는다
+
+#574는 "한 건도 못 내보낸 채 3회 연속 실패하면 이번 주기를 접는다"를 뒀다. 거기서 연속 실패는 브로커 전면 장애라 남은 건도 같은 이유로 실패할 것이 확실했기 때문이다.
+
+**여기서는 그 가드가 해롭다.** 연속 실패의 정체가 특정 건의 PG·booking 왕복 실패라, 커서를 두고 멈추면 선두의 실패한 몇 건이 뒤쪽 사고 건 전체를 무기한 굶긴다. 그건 #574가 `MAX_CONSECUTIVE_FAILURES`에 "성공 0건" 조건을 함께 건 이유였던 봉쇄와 같은 형태다. **실패해도 커서는 전진한다.**
+
+### ShedLock을 쓰지 않는다 — 근거가 #574와 다르다
+
+[ADR 0014](0014-recover-refund-failure-signal-by-reconciliation.md)의 근거는 "읽기와 발행뿐이라 전이할 상태가 없다"였다. **이 작업에는 PG 환불이라는 되돌릴 수 없는 부작용이 있으므로 그 근거를 그대로 쓸 수 없다.**
+
+그럼에도 락을 두지 않는 근거는 중복 실행이 이중 환불로 번지지 않게 막는 방어선 셋이 이미 있다는 것이다.
+
+| 방어선 | 위치 |
+|---|---|
+| PG 멱등키가 `paymentId`로 고정 (`REFUND-%07d`) | `PaymentRefundByBookingUseCase` |
+| `refund.payment_id` unique | `Refund` 엔티티 ([#296](https://github.com/TicketRush/TicketRush-backend/issues/296)) |
+| `markCanceled`가 COMPLETED가 아니면 예외 | `Payment` 엔티티 |
+
+판정 1의 `existsByBookingId` 선검사는 이 셋에 얹는 **PG 호출 억제일 뿐 정합성 근거가 아니다.** 조회와 취소 사이의 경합은 막지 못한다. 순서를 뒤집거나 선검사만 믿으면 안 된다.
+
+ShedLock을 들이려면 `RedisLockProvider`가 필요하고, 그러려면 payment가 명시적으로 끈 Redis 오토컨피그([#425](https://github.com/TicketRush/TicketRush-backend/issues/425))를 되살려 이 서비스를 [ADR 0008](0008-accept-redis-spof-with-fail-closed.md)의 장애 범위에 새로 넣어야 한다.
+
+### 기본 비활성으로 배포한다
+
+`ReplayRefundFailureSignalScheduler`(#574)가 `matchIfMissing = true`인 것과 다르다. 차이는 부작용의 성질이다 — 그쪽은 메시지를 한 번 더 보내는 것이고, 이쪽은 **돈을 돌려보내는 것**이다. 켜는 순간 첫 랩이 과거에 쌓인 사고 건을 전량 환불하므로 잔량을 실측하고 켠다([#441](https://github.com/TicketRush/TicketRush-backend/issues/441)).
+
+**랩당 PG 호출 상한(`max-refunds-per-lap`, 기본 50)을 배치 상한과 별도로 둔다.** 배치 상한은 만료 테이블을 훑는 크기이고 이쪽은 실제 결제 취소 호출 수다. 나누는 이유는 Toss에 429가 없고 대신 연속 요청 제한(403 `FORBIDDEN_CONSECUTIVE_REQUEST`)이 오는데, `TossCancelRetryableCode`의 javadoc이 **"가장 나오기 쉬운 구간이 대량 보상 환불 버스트"**라고 적어 둔 그 상황이 바로 첫 랩이기 때문이다. 거기 걸리면 [#573](https://github.com/TicketRush/TicketRush-backend/issues/573)의 인라인 재시도까지 같은 이유로 소진돼 `PAYMENT_REFUND_FAILED`로 확정되고, FAILED 이력이 남은 그 건은 판정 1에 걸려 **자동 복구에서 영구히 빠진다.** 되돌릴 수 없는 부작용을 다루는 경로에서 가장 나쁜 결말이라, 완화를 운영 규율("사람이 batch-size를 낮춰 켠다")에 맡기지 않고 코드에 둔다. 상한에 도달하면 커서를 그 자리에 두고 조기 종료하므로 다음 주기가 곧바로 이어받는다.
+
+세 값(`batch-size`·`grace-minutes`·`max-refunds-per-lap`) 모두 **0 이하면 기동에 실패시킨다.** 0은 "제한 없음"이 아니라 고장이다 — `batch-size=0`은 `PageRequest.of(0, 0)`이 매 주기 예외를 던져 영구 무동작이 되고, `grace-minutes=0` 이하는 판정 2를 통째로 무력화한다. 어느 쪽도 로그를 보지 않으면 드러나지 않아 배포 시점에 터뜨린다([#573](https://github.com/TicketRush/TicketRush-backend/issues/573)의 "대기값 0은 대기 생략이 아니라 킬 스위치여야 한다"와 같은 축).
+
+```sql
+SELECT eb.booking_id, p.payment_id, p.amount, eb.expired_at
+FROM expired_booking eb
+JOIN payment p ON p.booking_id = eb.booking_id AND p.status = 'COMPLETED'
+LEFT JOIN refund r ON r.booking_id = eb.booking_id
+WHERE r.refund_id IS NULL;
+```
+
+### 관측
+
+`charged_expired.detected` / `.recovered` / `.skipped`(reason 태그 7종) 세 카운터를 둔다. 환불 결과 자체는 기존 `PAYMENT_REFUND`·`PAYMENT_REFUND_FAILED`에 `trigger` 태그로 실린다.
+
+**Gauge는 두지 않는다.** 잔량을 정확히 세려면 만료 테이블을 매번 전건 훑어야 하는데 그 풀스캔이 바로 이 설계가 피한 것이다. `detected − recovered`를 Grafana에서 겹쳐 읽는다.
+
+## 결과
+
+### 좋아지는 것
+
+- **과금만 남은 사고 건이 자동으로 정리된다.** 유실 원인과 무관하다 — Kafka 유실이든 booking 다운이든 상태로 남으면 잡힌다.
+- **스키마가 무변경이다.** 새 인덱스도 없어, #574가 밟은 "`validate`는 인덱스를 검증하지 않아 수동 DDL 누락이 조용히 지나간다"는 함정을 아예 만들지 않는다.
+- **결제 확정 경로를 한 줄도 건드리지 않는다.** cross-domain 변경은 booking `BookingInternalResponse`에 `bookingNumber` 한 필드 추가뿐이고 가법적이다.
+- 롤백이 설정 한 줄이다(`app.charged-expired-recovery.enabled: false`, 재기동 필요). 되돌릴 DDL이 없다.
+- 판정 5가 [#608](https://github.com/TicketRush/TicketRush-backend/issues/608)의 좌석 오반환을 이 경로에서는 원천 차단한다. 배포 순서가 역전돼 booking이 아직 필드를 내려주지 않아도 같은 가드가 막는다.
+
+### 나빠지는 것 / 남는 한계
+
+- **되돌릴 수 없는 부작용을 스케줄러가 자동으로 실행한다.** 판정이 틀리면 정상 결제가 환불된다. 그래서 판정을 fail-closed로 짜고 기본 비활성으로 배포하지만, 위험 자체가 사라지지는 않는다.
+- **관리자 창구가 로그와 메트릭뿐이다.** `Booking#recordRefundFailure`가 EXPIRED·CANCELED에서 아무것도 하지 않아 **`refund_failed_at`이 구조적으로 채워질 수 없고**, 그래서 이 경로는 `RefundFailedEvent`를 발행하지 않는다 — 발행해도 게이트는 열리지 않고 열렸다는 착각만 남는다. payment 전용 관리자 조회 API는 후속 이슈다.
+- **첫 랩의 폭발 반경.** 과거 사고 건을 전량 환불한다. CS가 PG 콘솔에서 수동 환불한 건은 payment가 COMPLETED로 남아 있어 중복 취소를 시도하게 된다. 이때 이중 환급을 막는 것은 **우리 멱등키가 아니다** — 콘솔 취소는 그 키를 쓴 적이 없다. 막는 것은 Toss가 이미 취소된 건을 거절한다는 사실이고, 그 결과 우리 쪽에는 `PAYMENT_REFUND_FAILED` → FAILED 이력이 남는다(멱등키 논거는 위 "동시 실행" 문단에서만 유효하다).
+- **환불이 성공해도 booking은 EXPIRED에 그대로 남는다.** `Booking#markRefunded`는 CONFIRMED·REFUNDING·REFUNDED에서만 참이라 EXPIRED·CANCELED 예매는 REFUNDED로 전이하지 못하고, `BookingMarkRefundedUseCase`가 그때마다 "환불 예매 종결 스킵" WARN을 남긴다. 귀결이 둘이다 — 사용자·CS가 보는 예매는 계속 "기한 만료"인데 결제는 환불 완료라 두 도메인의 표시가 어긋나고, **복구가 성공할 때마다 booking에 경고가 찍혀** 첫 랩에서는 백로그 건수만큼 쏟아진다(성공 신호가 경고로 보이는 역전). 예매 상태 머신에 "만료 후 환불됨"을 새로 만드는 것은 booking 도메인 변경이라 이번 범위 밖으로 두었고, 그 대가를 여기에 적어 둔다.
+- **환불 이력 조회가 루프 밖으로 나온 대가가 있다.** 후보별 호출을 `IN` 한 번으로 묶어 풀스캔을 랩당 1회로 줄인 대신, 그 질의가 지속적으로 실패하면(인덱스가 없으니 `refund`가 커졌을 때의 statement timeout이 현실적인 실패 모드다) **커서가 전혀 전진하지 않고 같은 페이지를 영구히 재시도한다.** 방향은 안전한 쪽이지만(잘못된 환불이 아니라 정지) 카운터는 전부 0이고 스케줄러 스택트레이스만 남으므로, 그 침묵을 사고 없음으로 읽으면 안 된다.
+- **커서의 안전성이 "단일 호출자"라는 사실에만 기대고 있다.** `@Scheduled(fixedDelay)`가 같은 메서드의 실행을 겹치지 않게 해 주는 덕에 `volatile long cursor`의 read-modify-write가 인터리브되지 않는다. 관리자 수동 트리거 같은 두 번째 호출자를 붙이면 두 실행이 커서를 서로 덮어써 구간을 건너뛴다(다음 한 바퀴를 기다려야 한다). 다중 인스턴스에서는 위 방어선 셋이 이중 환불을 막지만, 그 대가로 FAILED 이력이 남는다.
+- **`expired_booking`에 리텐션이 없다.** 해결돼도 행이 사라지지 않아 한 바퀴 길이가 누적 만료 건수에 비례해 늘어난다. 실제 복구 지연 상한은 주기가 아니라 `ceil(만료 건수 / batch-size) × interval`이다. 리텐션은 후속으로 남긴다.
+- **`detected`가 매 랩 반복 카운트될 수 있다.** booking 조회 실패·예매번호 부재로 복구되지 못한 건은 환불 이력이 남지 않아 다음 랩에 다시 잡힌다. 누적값을 사고 건수로 읽으면 안 되고 `recovered`와의 차이로 읽어야 한다.
+- **grace 30분은 근거가 실측이 아니다.** 만료 5분 + 여유로 잡은 값이라 운영 데이터로 재조정해야 한다.
+- **알림 규칙은 여전히 없다.** #574가 남긴 한계가 그대로다. 카운터만으로는 대시보드를 열어야 참이다.
+- **payment의 두 번째 `@Scheduled`다.** 스레드 풀이 2라 두 스케줄러가 같은 풀을 나눠 쓴다. 이 작업이 한 주기를 길게 물면 보상 신호 재발행이 밀린다.
+
+### 다루지 않은 것
+
+- [#608](https://github.com/TicketRush/TicketRush-backend/issues/608) 결제 취소 API의 좌석 오반환. 이 ADR의 경로는 판정 5로 막지만, **사용자가 직접 누르는 취소 경로는 그대로 열려 있다.** 이 결정이 사고 상태를 자동으로 정리하면 노출 빈도는 줄지만 사라지지는 않는다.
+- payment 관리자 조회 API. 위 "관리자 창구" 한계를 닫는 후속이다.
+- `expired_booking` 리텐션.
+- payment 전면 outbox 전환. [ADR 0014](0014-recover-refund-failure-signal-by-reconciliation.md)의 (a)와 같은 이유로 트랜잭션 재설계가 선행돼야 한다.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -20,6 +20,7 @@ TicketRush의 아키텍처 결정을 번호 매긴 Markdown으로 축적하는 �
 - [12. PG 환불의 일시적 거절은 호출 지점에서 흡수하고, 소진되면 결정적 실패로 확정한다](0012-absorb-transient-pg-refund-rejections-at-caller.md)
 - [13. 배너는 performance-service 안의 별도 bounded context로 두고, 경로는 서비스명이 아니라 리소스명을 따른다](0013-banner-as-separate-context-inside-performance-service.md)
 - [14. 환불 실패 보상 신호는 발행을 보장하는 대신, 남아 있는 상태로 재발행해 복구한다](0014-recover-refund-failure-signal-by-reconciliation.md)
+- [15. 확정 신호가 유실돼 과금만 남은 만료 예매는, 예매를 되살리는 대신 대조로 찾아 자동 환불한다](0015-recover-charged-expired-booking-by-auto-refund.md)
 
 ## 사용법
 

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/scheduler/RecoverChargedExpiredBookingScheduler.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/scheduler/RecoverChargedExpiredBookingScheduler.java
@@ -1,0 +1,68 @@
+package com.ticketrush.boundedcontext.payment.app.scheduler;
+
+import com.ticketrush.boundedcontext.payment.app.usecase.PaymentRecoverChargedExpiredBookingUseCase;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/**
+ * 과금됐으나 예매가 만료된 건을 주기적으로 찾아 자동 환불한다 (#607).
+ *
+ * <p><b>기본값이 비활성이다.</b> {@code ReplayRefundFailureSignalScheduler}(#574)가 {@code matchIfMissing =
+ * true} 인 것과 다르며, 차이의 이유는 이 작업에 <b>PG 환불이라는 되돌릴 수 없는 부작용</b>이 있다는 것이다. 켜는 순간 첫 랩이 과거에 쌓인 사고 건을 전량
+ * 환불하므로, 배포 전에 잔량을 실측하고 그 규모를 알고 켠다(ADR 0015 · #441).
+ *
+ * <p>주기가 짧은 이유는 대상 집합이 스스로 줄지 않기 때문이다. {@code expired_booking} 은 해결돼도 행이 남아 한 바퀴 길이가 누적 만료 건수에
+ * 비례하고, 실제 복구 지연 상한은 이 주기가 아니라 {@code ceil(만료 건수 / batch-size) × interval} 이다.
+ *
+ * <p>ShedLock 미사용 근거는 {@link PaymentRecoverChargedExpiredBookingUseCase} 의 javadoc 참고 — #574 와 결론은
+ * 같되 근거가 다르다.
+ */
+@Component
+@ConditionalOnProperty(
+    prefix = "app.charged-expired-recovery",
+    name = "enabled",
+    havingValue = "true",
+    matchIfMissing = false)
+public class RecoverChargedExpiredBookingScheduler {
+
+  private final PaymentRecoverChargedExpiredBookingUseCase
+      paymentRecoverChargedExpiredBookingUseCase;
+  private final int batchSize;
+  private final int graceMinutes;
+  private final int maxRefundsPerLap;
+
+  public RecoverChargedExpiredBookingScheduler(
+      PaymentRecoverChargedExpiredBookingUseCase paymentRecoverChargedExpiredBookingUseCase,
+      @Value("${app.charged-expired-recovery.batch-size:500}") int batchSize,
+      @Value("${app.charged-expired-recovery.grace-minutes:30}") int graceMinutes,
+      @Value("${app.charged-expired-recovery.max-refunds-per-lap:50}") int maxRefundsPerLap) {
+    this.paymentRecoverChargedExpiredBookingUseCase = paymentRecoverChargedExpiredBookingUseCase;
+    this.batchSize = requirePositive(batchSize, "app.charged-expired-recovery.batch-size");
+    this.graceMinutes = requirePositive(graceMinutes, "app.charged-expired-recovery.grace-minutes");
+    this.maxRefundsPerLap =
+        requirePositive(maxRefundsPerLap, "app.charged-expired-recovery.max-refunds-per-lap");
+  }
+
+  /**
+   * 0 이나 음수를 기동 시점에 막는다.
+   *
+   * <p>세 값 모두 0 이 "제한 없음"이 아니라 <b>고장</b>이라 그대로 두면 조용히 잘못 돈다. {@code batch-size=0} 은 {@code
+   * PageRequest.of(0, 0)} 이 매 주기 예외를 던져 영구 무동작이 되고, {@code grace-minutes=0} 이하는 만료 직후 건까지 즉시 환불
+   * 대상으로 삼으며, {@code max-refunds-per-lap=0} 은 PG 호출을 통째로 막는다. 어느 쪽도 로그를 보지 않으면 드러나지 않는다 — #573 이
+   * "대기값 0 은 대기 생략이 아니라 킬 스위치여야 한다"로 남긴 교훈과 같은 축이라, 기동을 실패시켜 배포 시점에 드러낸다.
+   */
+  private static int requirePositive(int value, String propertyName) {
+    if (value <= 0) {
+      throw new IllegalArgumentException(
+          "%s 는 1 이상이어야 합니다. 현재 값: %d".formatted(propertyName, value));
+    }
+    return value;
+  }
+
+  @Scheduled(fixedDelayString = "${app.charged-expired-recovery.interval-ms:60000}")
+  public void recover() {
+    paymentRecoverChargedExpiredBookingUseCase.execute(batchSize, graceMinutes, maxRefundsPerLap);
+  }
+}

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentRecoverChargedExpiredBookingUseCase.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentRecoverChargedExpiredBookingUseCase.java
@@ -1,0 +1,476 @@
+package com.ticketrush.boundedcontext.payment.app.usecase;
+
+import com.ticketrush.boundedcontext.payment.app.usecase.PaymentRefundByBookingUseCase.RefundOutcome;
+import com.ticketrush.boundedcontext.payment.domain.entity.ExpiredBooking;
+import com.ticketrush.boundedcontext.payment.domain.entity.Payment;
+import com.ticketrush.boundedcontext.payment.domain.entity.Refund;
+import com.ticketrush.boundedcontext.payment.domain.types.PaymentStatus;
+import com.ticketrush.boundedcontext.payment.domain.types.RefundStatus;
+import com.ticketrush.boundedcontext.payment.domain.types.RefundTrigger;
+import com.ticketrush.boundedcontext.payment.out.apiclient.BookingRestClient;
+import com.ticketrush.boundedcontext.payment.out.apiclient.dto.BookingInfoResponse;
+import com.ticketrush.boundedcontext.payment.out.repository.ExpiredBookingRepository;
+import com.ticketrush.boundedcontext.payment.out.repository.PaymentRepository;
+import com.ticketrush.boundedcontext.payment.out.repository.RefundRepository;
+import com.ticketrush.global.constants.MetricNames;
+import com.ticketrush.global.exception.BusinessException;
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+
+/**
+ * 과금됐으나 예매가 만료된 건을 찾아 자동 환불한다 (#607).
+ *
+ * <p><b>왜 필요한가.</b> {@code PaymentConfirmedEvent} 발행이 유실되면 booking 은 PENDING 에 남고, 5 분 뒤 {@code
+ * BookingExpirationScheduler} 가 EXPIRED 로 만든다. 그 결과가 <b>payment 는 COMPLETED(과금 완료), booking 은
+ * EXPIRED, 티켓 미발급, 좌석 재판매, 환불 없음</b>이다. 이 상태는 어느 미해결 목록에도 잡히지 않는다 — {@code
+ * Booking#recordRefundFailure} 가 EXPIRED·CANCELED 에서 아무것도 하지 않아 {@code refund_failed_at} 이 <b>구조적으로
+ * 채워질 수 없기</b> 때문이다. 사용자 돈이 환불 없이 남는데 그것을 드러내는 축조차 없다.
+ *
+ * <p><b>왜 #574 방식을 복제하지 않는가.</b> 그쪽은 {@code EventReplayPublisher} 로 신호를 재발행해 수신 측 계약에 복구를 위임했다. 여기서
+ * 같은 일을 하면 아무 일도 일어나지 않는다 — {@code PaymentConfirmedEvent} 를 다시 보내도 {@code Booking#confirm} 이
+ * EXPIRED 에 대해 {@code BOOKING_EXPIRED} 로 거절하고, 그 예외는 영구 실패로 분류돼 그대로 ack 된다. 이미 좌석이 팔린 뒤라 예매를 되살릴 수도
+ * 없다. 그래서 <b>복구의 방향이 반대다 — 예매를 살리는 게 아니라 과금을 되돌린다.</b> 재사용하는 것은 스케줄러 골격(배치 상한 + 커서 +
+ * {@code @Transactional} 금지)뿐이다.
+ *
+ * <p><b>불변식: 이 UseCase 에 {@code @Transactional} 을 붙이면 안 된다.</b> 안에서 booking HTTP 조회와 PG 취소 왕복이
+ * 일어나며, 트랜잭션 안에서 돌면 그 왕복 동안 DB 커넥션을 함께 문다. payment 가 PG 왕복을 트랜잭션 밖으로 뺀 것과 같은 이유다({@code
+ * PaymentCancelUseCase} · {@link FailedRefundRecorder} 의 동일 불변식). 나아가 {@link FailedRefundRecorder}
+ * 의 FAILED 이력이 독립 커밋되려면 호출자가 트랜잭션 밖이어야 한다는 전제가 여기에도 그대로 걸린다.
+ *
+ * <p><b>ShedLock 을 붙이지 않는다 — 다만 근거가 #574 와 다르다.</b> 그쪽은 "읽기와 발행뿐이라 전이할 상태가 없다"가 근거였지만 이 작업에는 <b>PG
+ * 환불이라는 되돌릴 수 없는 부작용이 있다.</b> 그럼에도 락을 두지 않는 근거는 중복 실행이 이중 환불로 번지지 않게 막는 방어선 셋이 이미 있다는 것이다 — PG 멱등키가
+ * {@code paymentId} 로 고정되고({@code REFUND-%07d}), {@code refund.payment_id} 에 unique 가 있으며, {@code
+ * Payment#markCanceled} 가 COMPLETED 가 아니면 예외를 던진다. 아래 환불 이력 선검사는 이 셋에 얹는 PG 호출 억제일 뿐 정합성 근거가 아니다.
+ * ShedLock 을 들이려면 payment 가 명시적으로 끈 Redis 오토컨피그(#425)를 되살려 이 서비스를 Redis 장애 범위(ADR 0008)에 새로 넣어야 한다.
+ * 근거는 ADR 0015.
+ *
+ * <p><b>기본 비활성이다.</b> 첫 랩이 과거에 쌓인 사고 건을 <b>전량</b> 환불하므로, 잔량을 실측하고 켠다. CS 가 PG 콘솔에서 수동 환불한 건은
+ * payment 가 COMPLETED 로 남아 있어 중복 취소를 시도하게 된다(Toss 가 이미 취소된 건을 거절하므로 이중 환급은 아니지만 FAILED 이력과 알람은
+ * 남는다).
+ */
+@Slf4j
+@Service
+@ConditionalOnProperty(
+    prefix = "app.charged-expired-recovery",
+    name = "enabled",
+    havingValue = "true",
+    matchIfMissing = false)
+@RequiredArgsConstructor
+public class PaymentRecoverChargedExpiredBookingUseCase {
+
+  /**
+   * 이 상태의 예매만 자동 환불 대상으로 본다.
+   *
+   * <p>CANCELED 를 포함하는 것은 의도적이다. 사용자가 만료 전에 예매를 취소했는데 확정 신호만 유실된 경우도 결과는 같다 — 과금이 남고 예매가 없다.
+   */
+  private static final Set<String> REFUNDABLE_BOOKING_STATUSES = Set.of("EXPIRED", "CANCELED");
+
+  /**
+   * booking-service {@code BookingStatus} 로 알려진 이름 전부.
+   *
+   * <p>허용 목록({@link #REFUNDABLE_BOOKING_STATUSES})과 <b>따로 두는 이유</b>는 "환불 대상이 아니다"와 "상대가 계약을 바꿨다"를
+   * 갈라야 하기 때문이다. 상태는 외부 서비스가 주는 문자열이라 컴파일러가 지켜주지 못하는데, 두 경우를 한 태그로 접으면 booking 이 이름을 바꾼 배포 사고가 "예매가
+   * 살아 있어서 건너뜀"이라는 정상 시계열에 통째로 묻힌다 — 그동안 사고 복구는 전면 정지한다. #572 가 {@code owner_unknown} 을 {@code
+   * lookup_failed} 에서 분리한 것과 같은 판단이다.
+   */
+  private static final Set<String> KNOWN_BOOKING_STATUSES =
+      Set.of("PENDING", "CONFIRMED", "CANCELED", "REFUNDING", "REFUNDED", "EXPIRED");
+
+  /** 이미 환불이 성사돼 손댈 것이 없는 건. */
+  private static final String SKIP_ALREADY_REFUNDED = "already_refunded";
+
+  /**
+   * 환불을 시도했으나 PG 가 거절해 FAILED 이력만 남은 건.
+   *
+   * <p>{@link #SKIP_ALREADY_REFUNDED} 와 <b>반드시 갈라야 한다.</b> 둘 다 "환불 이력이 있어 건너뛴다"이지만 뜻이 정반대다 — 이쪽은
+   * <b>돈이 돌아가지 않은 채 남은 미해결 사고</b>이고, 예매가 EXPIRED 라 booking 의 관리자 재환불 게이트도 열리지 않는다. 한 태그로 접으면 그 건이
+   * 정상 환불 시계열에 섞여 영영 보이지 않는다.
+   */
+  private static final String SKIP_REFUND_FAILED_HISTORY = "refund_failed_history";
+
+  private static final String SKIP_GRACE = "grace";
+  private static final String SKIP_BOOKING_LOOKUP_FAILED = "booking_lookup_failed";
+
+  /** 예매가 아직 살아 있어(알려진 비허용 상태) 환불 대상이 아닌 건. */
+  private static final String SKIP_BOOKING_ALIVE = "booking_alive";
+
+  /** booking 이 알려지지 않은 상태 이름을 돌려준 건 — 정상 스킵이 아니라 계약 파기 신호다. */
+  private static final String SKIP_BOOKING_STATUS_UNKNOWN = "booking_status_unknown";
+
+  private static final String SKIP_BOOKING_NUMBER_UNKNOWN = "booking_number_unknown";
+
+  private final ExpiredBookingRepository expiredBookingRepository;
+  private final PaymentRepository paymentRepository;
+  private final RefundRepository refundRepository;
+  private final BookingRestClient bookingRestClient;
+  private final PaymentRefundByBookingUseCase paymentRefundByBookingUseCase;
+  private final MeterRegistry meterRegistry;
+
+  /**
+   * 이번 주기가 이어서 읽을 expired_booking_id 하한(배타).
+   *
+   * <p>커서가 없으면 만료 건수가 배치 상한을 넘는 순간 뒤쪽이 <b>영구히</b> 선택되지 않는다. {@code expired_booking} 은 해결돼도 행이 사라지지
+   * 않아 대상 집합이 스스로 줄지 않기 때문이다 — #574 가 FAILED 이력에서 겪은 것과 같은 형태이되, 그쪽은 성공하면 COMPLETED 로 빠져나가기라도 했다.
+   *
+   * <p>스케줄러 스레드 풀이 2 라 주기마다 다른 스레드가 실행될 수 있어 {@code volatile} 로 가시성을 맞춘다. 재기동하면 0 부터 다시 도는데, 순환만
+   * 보장되면 되므로 영속화하지 않는다.
+   *
+   * <p><b>단일 호출자 전제다.</b> {@code @Scheduled(fixedDelay)} 가 같은 메서드의 실행을 겹치지 않게 해 주는 덕에 이 필드의
+   * read-modify-write 가 인터리브되지 않는다. 관리자 수동 트리거 같은 두 번째 호출자를 붙이면 두 실행이 커서를 서로 덮어써 구간을 통째로 건너뛰므로, 그때는
+   * 이 전제부터 다시 세워야 한다.
+   */
+  private volatile long cursor = 0L;
+
+  /** 한 후보를 처리한 결과. 랩당 환불 상한을 세려면 "판정에서 걸러짐"과 "시도했음"을 갈라야 한다. */
+  private enum RecoverOutcome {
+    /** 환불이 성사됐다. */
+    REFUNDED,
+    /**
+     * 환불을 시도했으나 성사되지 않았다(거절·통신 실패·경합).
+     *
+     * <p>{@code PaymentRefundByBookingUseCase} 가 대상 결제를 찾지 못해 PG 를 <b>실제로 부르지 않고</b> 돌아온 경우 ({@code
+     * ALREADY_SETTLED}·{@code REPUBLISHED})도 여기 들어간다. 예산을 보수적으로 — 즉 더 일찍 멈추는 쪽으로 — 쓰는 선택이다. 반대로 짜면
+     * "무엇이 PG 를 실제로 불렀는가"를 이 바깥에서 판정해야 하는데, 그 판정이 틀리는 방향은 상한을 넘겨 호출하는 쪽이라 훨씬 무겁다.
+     */
+    ATTEMPTED,
+    /** 판정에서 걸러져 환불을 시도하지 않았다. */
+    SKIPPED
+  }
+
+  public void execute(int batchSize, int graceMinutes, int maxRefundsPerLap) {
+    List<ExpiredBooking> targets =
+        expiredBookingRepository.findByIdGreaterThanOrderByIdAsc(
+            cursor, PageRequest.of(0, batchSize));
+    if (targets.isEmpty()) {
+      cursor = 0L;
+      return;
+    }
+
+    Set<Long> chargedBookingIds = chargedBookingIds(targets);
+    RefundHistory refundHistory = refundHistory(chargedBookingIds);
+    LocalDateTime graceDeadline = LocalDateTime.now().minusMinutes(graceMinutes);
+
+    int detected = 0;
+    int recovered = 0;
+    int refundAttempts = 0;
+    boolean throttled = false;
+
+    for (ExpiredBooking expired : targets) {
+      // 랩당 환불 시도 상한. Toss 는 429 대신 연속 요청 제한(FORBIDDEN_CONSECUTIVE_REQUEST, 403)을 내고
+      // 그 코드의 javadoc 이 "가장 나오기 쉬운 구간은 대량 보상 환불 버스트"라고 적고 있다. 거기 걸리면
+      // #573 인라인 재시도까지 같은 이유로 소진돼 FAILED 이력이 남고, 그 건은 판정 1 에 걸려 자동 복구에서
+      // 영구히 빠진다 — 되돌릴 수 없는 부작용을 다루는 경로에서 가장 나쁜 결말이다.
+      //
+      // 이 검사가 커서 전진보다 앞에 있어야 한다. 뒤에 두면 상한에 걸려 처리하지 못한 바로 그 건까지
+      // 커서가 넘어가 다음 주기가 건너뛴다. 대가로 상한에 도달하면 만료 스캔 자체가 멈추지만(뒤쪽에
+      // 과금되지 않은 정상 건이 있어도 이번 주기엔 보지 않는다), 다음 주기가 곧바로 이어받으므로
+      // 굶는 건은 없다. 정상 운영에서는 후보가 희소해 상한에 닿지 않는다.
+      if (refundAttempts >= maxRefundsPerLap) {
+        throttled = true;
+        break;
+      }
+
+      // 판정 결과와 무관하게 전진시킨다. #574 의 "연속 실패 시 커서를 두고 중단" 을 복제하면 안 된다 —
+      // 거기서 연속 실패는 브로커 전면 장애라 남은 건도 같은 이유로 실패할 것이 확실했지만, 여기서 연속 실패는
+      // 특정 건의 PG·booking 왕복 실패다. 커서를 두고 멈추면 선두의 실패한 몇 건이 뒤쪽 사고 건 전체를
+      // 무기한 굶긴다 — 이 스케줄러가 없애려던 봉쇄가 위치만 바꿔 재현된다.
+      cursor = expired.getId();
+
+      Long bookingId = expired.getBookingId();
+
+      if (!chargedBookingIds.contains(bookingId)) {
+        // 만료됐지만 과금되지 않은 정상 건이다. 만료 대부분이 여기 해당하므로 카운터도 올리지 않는다.
+        continue;
+      }
+
+      // 1) 이미 환불 이력이 있으면 손대지 않는다. 상태를 가려 FAILED 를 다시 집어들면 실패한 환불을 매 주기
+      //    PG 에 되풀이해 던지게 되므로, 성사 여부와 무관하게 "이미 시도했다"로 본다. 다만 관측에서는 가른다.
+      if (refundHistory.settled().contains(bookingId)) {
+        countSkip(SKIP_ALREADY_REFUNDED);
+        continue;
+      }
+      if (refundHistory.failedOnly().contains(bookingId)) {
+        countSkip(SKIP_REFUND_FAILED_HISTORY);
+        continue;
+      }
+
+      // 2) 만료 직후는 정상 처리가 진행 중일 수 있다. 확정 신호가 조금 늦게 도착하는 창을 환불로 덮지 않는다.
+      if (expired.getExpiredAt().isAfter(graceDeadline)) {
+        countSkip(SKIP_GRACE);
+        continue;
+      }
+
+      // 여기까지 오면 로컬 근거만으로는 "과금됐는데 예매가 만료됐고 환불이 없는" 건이다.
+      // 아래 booking 재확인에서 걸러지는 건까지 포함해 세는 이유는, 그 갈래들이야말로 자동 복구가 닿지
+      // 못한 채 남는 사고이기 때문이다 — detected 와 recovered 의 차이가 곧 미복구 잔량이다.
+      detected++;
+      RecoverOutcome outcome = recover(bookingId);
+      if (outcome != RecoverOutcome.SKIPPED) {
+        refundAttempts++;
+      }
+      if (outcome == RecoverOutcome.REFUNDED) {
+        recovered++;
+      }
+    }
+
+    long scannedUpTo = cursor;
+    if (!throttled && targets.size() < batchSize) {
+      // 마지막 페이지까지 훑었으면 다음 주기가 다시 앞에서 시작하도록 되돌린다. 상한에 걸려 중단했다면
+      // 아직 뒤쪽을 보지 못했으므로 되돌리지 않는다.
+      cursor = 0L;
+    }
+
+    if (detected > 0) {
+      Counter.builder(MetricNames.PAYMENT_CHARGED_EXPIRED_DETECTED)
+          .register(meterRegistry)
+          .increment(detected);
+      // 커서를 되돌리기 전 값을 남긴다. 어디까지 훑고 발견했는지가 이 로그의 유일한 진단 가치다.
+      log.warn(
+          "확정 신호 유실로 과금이 남은 만료 예매를 발견했습니다. 발견={}건, 복구={}건, 마지막 확인={}",
+          detected,
+          recovered,
+          scannedUpTo);
+    }
+    if (recovered > 0) {
+      Counter.builder(MetricNames.PAYMENT_CHARGED_EXPIRED_RECOVERED)
+          .register(meterRegistry)
+          .increment(recovered);
+    }
+    if (throttled) {
+      log.warn("랩당 환불 상한에 도달해 이번 주기를 조기 종료합니다. 환불 시도={}건, 마지막 확인={}", refundAttempts, scannedUpTo);
+    }
+  }
+
+  /**
+   * 후보 묶음 중 COMPLETED 결제가 있는 bookingId 집합을 한 번에 조회한다.
+   *
+   * <p>후보를 한 건씩 조회하면 배치 크기만큼 왕복이 늘고, 만료와 결제를 조인 한 방으로 합치면 매치가 희소해 조기 종료를 못 한 채 매 주기 풀스캔이 된다(ADR
+   * 0014:76 의 함정과 같은 형태). 그래서 2 단계로 나눈다.
+   */
+  private Set<Long> chargedBookingIds(List<ExpiredBooking> targets) {
+    List<Long> bookingIds = targets.stream().map(ExpiredBooking::getBookingId).toList();
+    return paymentRepository
+        .findByBookingIdInAndStatus(bookingIds, PaymentStatus.COMPLETED)
+        .stream()
+        .map(Payment::getBookingId)
+        .collect(Collectors.toSet());
+  }
+
+  /**
+   * 과금 후보들의 환불 이력을 <b>한 번의 질의로</b> 가져온다.
+   *
+   * <p>후보마다 {@code existsByBookingId} 를 부르면 안 된다. {@code refund} 에는 {@code booking_id} 인덱스가 없어(키는
+   * PK · {@code UNIQUE(payment_id)} · {@code idx_refund_status} 뿐) 호출마다 풀스캔이고, 그 테이블은 성공한 환불까지 전부
+   * 누적돼 시간이 갈수록 커진다. 후보가 가장 많은 순간이 하필 처음 켜는 첫 랩이다. {@code IN} 으로 묶으면 풀스캔이 랩당 1 회로 줄어, 인덱스를 새로 만들지
+   * 않고도(= 수동 DDL 없이) 비용이 후보 수에 비례하지 않게 된다.
+   */
+  private RefundHistory refundHistory(Set<Long> chargedBookingIds) {
+    if (chargedBookingIds.isEmpty()) {
+      return new RefundHistory(Set.of(), Set.of());
+    }
+
+    List<Refund> refunds = refundRepository.findByBookingIdIn(chargedBookingIds);
+    Set<Long> settled =
+        refunds.stream()
+            .filter(refund -> refund.getStatus() != RefundStatus.FAILED)
+            .map(Refund::getBookingId)
+            .collect(Collectors.toSet());
+    Set<Long> failedOnly =
+        refunds.stream()
+            .filter(refund -> refund.getStatus() == RefundStatus.FAILED)
+            .map(Refund::getBookingId)
+            .filter(bookingId -> !settled.contains(bookingId))
+            .collect(Collectors.toSet());
+    return new RefundHistory(settled, failedOnly);
+  }
+
+  /**
+   * 환불 이력의 두 갈래.
+   *
+   * @param settled 환불이 성사됐거나(COMPLETED) 진행 중인(PENDING) bookingId — 어느 쪽이든 손대지 않는다
+   * @param failedOnly FAILED 이력만 있는 bookingId — 돈이 돌아가지 않은 미해결 사고다
+   */
+  private record RefundHistory(Set<Long> settled, Set<Long> failedOnly) {}
+
+  /**
+   * 후보 한 건을 booking 에 재확인하고, 조건이 맞으면 자동 환불한다.
+   *
+   * <p><b>판정 순서 자체가 계약이다.</b> 로컬 근거(만료 테이블)는 이벤트로 채워진 사본이라 최신이 아닐 수 있고, 되돌릴 수 없는 부작용(PG 환불) 앞에서는
+   * 원본을 다시 본다. 조회하지 못하면 <b>환불하지 않는다(fail-closed)</b> — 잘못 환불하는 것이 환불이 늦는 것보다 무겁다.
+   */
+  private RecoverOutcome recover(Long bookingId) {
+    BookingInfoResponse booking = lookupBooking(bookingId);
+    if (booking == null) {
+      return RecoverOutcome.SKIPPED;
+    }
+
+    String bookingStatus = booking.bookingStatus();
+    if (bookingStatus == null) {
+      // Set.of(...).contains(null) 은 NPE 를 던지므로 반드시 먼저 갈라야 한다(#490 에서 밟은 함정).
+      // 200 을 받았어도 상태를 모르면 판정에 도달하지 못한 것이라 조회 실패와 같이 다룬다.
+      countSkip(SKIP_BOOKING_LOOKUP_FAILED);
+      log.warn("만료 예매 재확인 응답에 상태가 없어 자동 환불을 보류합니다. bookingId={}", bookingId);
+      return RecoverOutcome.SKIPPED;
+    }
+
+    // 4) 예매가 살아 있으면 환불 대상이 아니다. 알려지지 않은 상태는 정상 스킵과 갈라 CRITICAL 로 올린다 —
+    //    상대가 상태 이름을 바꾸면 전건이 이 갈래로 떨어지며 사고 복구가 조용히 전면 정지하기 때문이다.
+    if (!REFUNDABLE_BOOKING_STATUSES.contains(bookingStatus)) {
+      if (KNOWN_BOOKING_STATUSES.contains(bookingStatus)) {
+        countSkip(SKIP_BOOKING_ALIVE);
+        log.warn(
+            "만료로 기록된 예매가 실제로는 종결되지 않아 자동 환불을 보류합니다. bookingId={}, status={}",
+            bookingId,
+            bookingStatus);
+      } else {
+        countSkip(SKIP_BOOKING_STATUS_UNKNOWN);
+        log.error(
+            "[CRITICAL] booking 이 알 수 없는 예매 상태를 반환했습니다! 자동 복구가 멈춥니다. bookingId={}, status={}",
+            bookingId,
+            bookingStatus);
+      }
+      return RecoverOutcome.SKIPPED;
+    }
+
+    return refund(bookingId, booking.bookingNumber());
+  }
+
+  /**
+   * booking 원본을 재확인한다. 판정에 쓸 수 없는 응답은 전부 null 로 접는다(fail-closed).
+   *
+   * <p>{@link BusinessException} 밖의 예외까지 잡는 이유는, 그것이 새어 나가면 이번 주기의 <b>남은 후보 전체가 처리되지 않고 발견·복구 카운터와
+   * 경고 로그도 통째로 실행되지 않기</b> 때문이다. 예를 들어 내부 API 토큰이 주입되지 않은 채 켜면 첫 후보에서 예외가 나는데, 그러면 "사고가 있었다"는 유일한
+   * 관측 축이 하필 그 장애 구간에서 침묵한다.
+   */
+  private BookingInfoResponse lookupBooking(Long bookingId) {
+    try {
+      // 3) booking 원본 재확인. 404·503 모두 여기로 떨어지며, 어느 쪽이든 환불하지 않는다.
+      return bookingRestClient.getBooking(bookingId);
+    } catch (BusinessException e) {
+      countSkip(SKIP_BOOKING_LOOKUP_FAILED);
+      log.warn(
+          "만료 예매 재확인에 실패해 자동 환불을 보류합니다. bookingId={}, code={}",
+          bookingId,
+          e.getErrorStatus().getCode());
+      return null;
+    } catch (Exception e) {
+      countSkip(SKIP_BOOKING_LOOKUP_FAILED);
+      log.error("만료 예매 재확인 중 예기치 못한 오류가 발생했습니다. bookingId={}", bookingId, e);
+      return null;
+    }
+  }
+
+  /**
+   * 자동 환불을 실행한다. 한 건의 실패가 나머지를 멈추지 않도록 예외를 여기서 모두 막는다.
+   *
+   * <p><b>예매번호 가드가 이 메서드 안에 있는 것이 중요하다.</b> 값 없이 환불하면 {@code PaymentCanceledEvent} 가 {@code
+   * bookingNumber=null} 로 나가고, seat 의 좌석 소유 교차검증(ABA 방지)이 통째로 꺼져 그 사이 다른 사용자에게 팔린 SOLD 좌석을 반환할 수
+   * 있다(#608). 검증을 호출부에 두면 "호출처가 하나"라는 사실에만 안전이 걸리는데, {@code bookingId}·{@code bookingNumber} 가 각각
+   * {@code Long}·{@code String} 이라 인자를 잘못 넘겨도 컴파일이 통과한다 — {@link RefundTrigger} 를 열거형으로 뽑은 이유와 같은
+   * 위험이 남는 마지막 자리라 <b>부작용 직전</b>에 붙여 둔다.
+   */
+  private RecoverOutcome refund(Long bookingId, String bookingNumber) {
+    // 5) 예매번호가 없으면 환불하지 않는다. 배포 순서가 역전돼 booking 이 아직 이 필드를 내려주지 않을 때도
+    //    같은 경로로 null 이 되므로, 이 가드가 그 구간의 안전장치를 겸한다.
+    if (bookingNumber == null || bookingNumber.isBlank()) {
+      countSkip(SKIP_BOOKING_NUMBER_UNKNOWN);
+      log.error(
+          "[CRITICAL] 예매번호를 얻지 못해 자동 환불을 중단했습니다! 과금이 남아 수동 처리가 필요합니다. bookingId={}", bookingId);
+      return RecoverOutcome.SKIPPED;
+    }
+
+    try {
+      // 6) 자동 환불 실행.
+      RefundOutcome outcome =
+          paymentRefundByBookingUseCase.execute(
+              bookingId, bookingNumber, RefundTrigger.CONFIRM_SIGNAL_LOST);
+
+      countRefund(outcome);
+      logOutcome(outcome, bookingId);
+      return outcome == RefundOutcome.REFUNDED ? RecoverOutcome.REFUNDED : RecoverOutcome.ATTEMPTED;
+    } catch (DataIntegrityViolationException e) {
+      // 동시 환불이 unique 제약(#296)에 막힌 경우 = 이미 다른 경로에서 환불이 확정됨. 멱등 정상이다.
+      log.info("동시 중복 자동 환불(unique 경합). bookingId={}", bookingId);
+      return RecoverOutcome.ATTEMPTED;
+    } catch (BusinessException e) {
+      handleRefundFailure(e, bookingId);
+      return RecoverOutcome.ATTEMPTED;
+    } catch (Exception e) {
+      // 인프라 일시 실패. 다음 랩이 같은 건을 다시 집어든다(환불 이력이 남지 않아 대상에 그대로 있다).
+      log.error("자동 환불 중 일시적 오류가 발생했습니다. 다음 주기에 다시 시도합니다. bookingId={}", bookingId, e);
+      return RecoverOutcome.ATTEMPTED;
+    }
+  }
+
+  private void logOutcome(RefundOutcome outcome, Long bookingId) {
+    switch (outcome) {
+      case REFUNDED -> log.info("확정 신호 유실 건을 자동 환불했습니다. bookingId={}", bookingId);
+      case REPUBLISHED ->
+          log.info("이미 환불된 건이라 PaymentCanceledEvent 를 재발행(self-heal). bookingId={}", bookingId);
+      // 후보를 뽑은 뒤 환불을 실행하기까지 사이에 다른 경로(사용자 취소 등)가 정리했을 수 있다. 신호를 받아
+      // 처리하는 SeatConfirmFailedEventListener 에서는 같은 값이 "과금됐다"는 전제의 붕괴를 뜻해 CRITICAL
+      // 이지만, 대조로 후보를 찾는 이 경로에서는 경합의 정상적인 귀결이다 — 심각도 해석이 다르다.
+      case ALREADY_SETTLED -> log.info("자동 환불 대상 결제가 이미 정리되었습니다(경합). bookingId={}", bookingId);
+      default -> throw new IllegalStateException("처리되지 않은 RefundOutcome: " + outcome);
+    }
+  }
+
+  /**
+   * PG 거절(결정적)과 통신 실패를 갈라 로그 심각도를 정한다.
+   *
+   * <p><b>{@code RefundFailedEvent} 를 발행하지 않는다.</b> 두 이벤트 리스너({@code
+   * SeatConfirmFailedEventListener} · {@code RefundRequestedEventListener})는 거절 시 그것을 발행해 booking 의
+   * {@code refundFailedAt} 을 채우고 관리자 재환불 API 를 연다. 그러나 이 경로의 대상은 EXPIRED·CANCELED 예매라 {@code
+   * Booking#recordRefundFailure} 가 아무것도 하지 않는다 — 발행해도 게이트는 열리지 않고, 열렸다는 착각만 남는다. 그래서 이 건의 유일한 창구는
+   * 아래 CRITICAL 로그와 {@code charged_expired.skipped{reason=refund_failed_history}} 카운터다. 전용 관리자 조회
+   * API 는 후속 이슈다(ADR 0015).
+   */
+  private void handleRefundFailure(BusinessException e, Long bookingId) {
+    if (!FailedRefundRecorder.isDeterministicRejection(e)) {
+      log.warn(
+          "자동 환불 중 재시도 가능한 실패(통신 오류 등). 다음 주기에 다시 시도합니다. bookingId={}, code={}",
+          bookingId,
+          e.getErrorStatus().getCode());
+      return;
+    }
+
+    // 과금된 돈이 돌아가지 않은 채 남는다. 자동 복구가 끝난 지점이므로 수동 개입 대상으로 올린다.
+    // FAILED 환불 이력은 PaymentRefundByBookingUseCase 안에서 이미 남았고, 그 이력 때문에 다음 주기부터는
+    // refund_failed_history 로 걸러진다 — 같은 건을 PG 에 무한히 되던지지 않는다.
+    log.error(
+        "[CRITICAL] 확정 신호 유실 건의 자동 환불을 PG 가 거절했습니다! 과금이 남아 수동 처리가 필요합니다. bookingId={}",
+        bookingId,
+        e);
+
+    Counter.builder(MetricNames.PAYMENT_REFUND_FAILED)
+        .tag(MetricNames.TAG_TRIGGER, RefundTrigger.CONFIRM_SIGNAL_LOST.tag())
+        .register(meterRegistry)
+        .increment();
+  }
+
+  private void countRefund(RefundOutcome outcome) {
+    Counter.builder(MetricNames.PAYMENT_REFUND)
+        .tag(MetricNames.TAG_OUTCOME, outcome.name().toLowerCase(Locale.ROOT))
+        .tag(MetricNames.TAG_TRIGGER, RefundTrigger.CONFIRM_SIGNAL_LOST.tag())
+        .register(meterRegistry)
+        .increment();
+  }
+
+  private void countSkip(String reason) {
+    Counter.builder(MetricNames.PAYMENT_CHARGED_EXPIRED_SKIPPED)
+        .tag(MetricNames.TAG_REASON, reason)
+        .register(meterRegistry)
+        .increment();
+  }
+}

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/domain/types/RefundTrigger.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/domain/types/RefundTrigger.java
@@ -20,7 +20,15 @@ public enum RefundTrigger {
   /** 사용자·관리자가 예매를 취소해 요청한 환불 (#91). */
   USER_CANCEL("사용자 예매 취소"),
   /** 과금 후 좌석 확정이 실패해 시스템이 되돌리는 보상 환불 (#492). */
-  SEAT_CONFIRM_FAILED("좌석 확정 실패 자동 환불");
+  SEAT_CONFIRM_FAILED("좌석 확정 실패 자동 환불"),
+  /**
+   * 결제 확정 신호가 유실돼 예매가 만료된 뒤, 남은 과금을 시스템이 되돌리는 보상 환불 (#607).
+   *
+   * <p>{@link #SEAT_CONFIRM_FAILED}와 나눠 둔 것은 두 사고의 원인이 다르기 때문이다. 그쪽은 좌석 확정이 실패했다는 <b>신호가 도착한</b>
+   * 건이고, 이쪽은 <b>신호가 오지 않아</b> 대조로 찾아낸 건이다. 한 값에 접으면 발행 유실률(#574의 {@code
+   * ticketrush.event.publish.failed})과 겹쳐 읽어야 할 사고 축이 좌석 실패에 섞여 사라진다.
+   */
+  CONFIRM_SIGNAL_LOST("결제 확정 신호 유실 자동 환불");
 
   private final String reason;
 

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/out/apiclient/dto/BookingInfoResponse.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/out/apiclient/dto/BookingInfoResponse.java
@@ -13,11 +13,17 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  * {@code PaymentConfirmUseCase}가 결제 확정 요청자와 이 값을 대조해 남의 예매로의 결제 귀속을 막는다(#572, ADR 0011). #490에서 필드만
  * 먼저 매핑해 둔 덕에 클라이언트 변경 없이 가드만 추가됐다.
  *
- * <p>세 필드 모두 박스 타입이라 null이 될 수 있다. 특히 {@code @JsonIgnoreProperties(ignoreUnknown = true)}라 booking이
- * 필드명을 바꾸면 예외 대신 조용히 null이 되므로, 판정하는 쪽이 null을 "통과"가 아니라 "판정 불가"로 다뤄야 한다.
+ * <p>{@code bookingNumber}는 좌석 소유 교차검증(ABA 방지)에 쓴다(#607). 환불 이벤트에 이 값이 실려야 seat가 "그 좌석이 아직 이 예매의
+ * 것인지"를 대조하며, null로 나가면 그 대조가 통째로 꺼져 <b>다른 예매의 SOLD 좌석을 반환</b>할 수 있다. payment는 예매번호를 자신의 테이블에 갖고 있지
+ * 않아 이 조회로만 얻는다.
+ *
+ * <p>네 필드 모두 박스 타입이라 null이 될 수 있다. 특히 {@code @JsonIgnoreProperties(ignoreUnknown = true)}라 booking이
+ * 필드명을 바꾸면 예외 대신 조용히 null이 되므로, 판정하는 쪽이 null을 "통과"가 아니라 "판정 불가"로 다뤄야 한다. {@code bookingNumber}는 배포
+ * 순서가 역전돼(payment 먼저 배포) 키가 아예 없을 때도 같은 경로로 null이 되므로, 호출자는 이 값이 비면 환불을 실행하지 않는다.
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public record BookingInfoResponse(
     @JsonProperty("booking_id") Long bookingId,
     @JsonProperty("user_id") Long userId,
-    @JsonProperty("booking_status") String bookingStatus) {}
+    @JsonProperty("booking_status") String bookingStatus,
+    @JsonProperty("booking_number") String bookingNumber) {}

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/out/repository/ExpiredBookingRepository.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/out/repository/ExpiredBookingRepository.java
@@ -1,9 +1,23 @@
 package com.ticketrush.boundedcontext.payment.out.repository;
 
 import com.ticketrush.boundedcontext.payment.domain.entity.ExpiredBooking;
+import java.util.List;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ExpiredBookingRepository extends JpaRepository<ExpiredBooking, Long> {
 
   boolean existsByBookingId(Long bookingId);
+
+  /**
+   * 만료 예매를 {@code idAfter} 다음부터 PK 오름차순으로 조회한다 (#607).
+   *
+   * <p><b>결제 상태를 조인하지 않는다.</b> "과금됐는데 만료된" 건은 전체 만료 중 극히 드물어서, 조인 + LIMIT 한 방으로 짜면 옵티마이저가 상한만큼 채우려고
+   * 매치를 찾을 때까지 스캔을 이어가 <b>매 주기 사실상 풀스캔</b>이 된다(ADR 0014가 {@code idx_refund_status}에서 겪은 것과 같은 형태).
+   * 이 조회로 PK 범위만 끊고, 결제 대조는 {@code booking_id IN (...)} 2단계 질의로 분리한다.
+   *
+   * <p>{@code idAfter}(커서)가 필요한 이유는 상한만 두고 매번 앞에서 읽으면 만료 건수가 상한을 넘는 순간 뒤쪽이 영영 선택되지 않기 때문이다. {@code
+   * expired_booking}은 해결돼도 행이 사라지지 않아 대상 집합이 스스로 줄지 않으므로, 커서 없이는 뒤쪽 사고 건이 <b>영구히</b> 묻힌다.
+   */
+  List<ExpiredBooking> findByIdGreaterThanOrderByIdAsc(Long idAfter, Pageable pageable);
 }

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/out/repository/PaymentRepository.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/out/repository/PaymentRepository.java
@@ -2,6 +2,8 @@ package com.ticketrush.boundedcontext.payment.out.repository;
 
 import com.ticketrush.boundedcontext.payment.domain.entity.Payment;
 import com.ticketrush.boundedcontext.payment.domain.types.PaymentStatus;
+import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -31,4 +33,12 @@ public interface PaymentRepository extends JpaRepository<Payment, Long> {
    * 있으므로, 기록 직전 이 개수로 상한을 건다.
    */
   long countByBookingIdAndStatus(Long bookingId, PaymentStatus status);
+
+  /*
+   * 만료 예매 후보 묶음에 대해 해당 상태의 결제를 한 번에 대조한다(#607). 후보를 한 건씩 조회하면 배치 크기만큼
+   * 왕복이 늘고, 조인 한 방으로 합치면 희소 매치에서 조기 종료가 안 돼 매 주기 풀스캔이 된다 —
+   * ExpiredBookingRepository.findByIdGreaterThanOrderByIdAsc 의 javadoc 참고.
+   * idx_payment_booking_id(#412)를 타며, booking당 COMPLETED 는 unique 제약상 최대 1건이다(#296).
+   */
+  List<Payment> findByBookingIdInAndStatus(Collection<Long> bookingIds, PaymentStatus status);
 }

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/out/repository/RefundRepository.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/out/repository/RefundRepository.java
@@ -2,6 +2,7 @@ package com.ticketrush.boundedcontext.payment.out.repository;
 
 import com.ticketrush.boundedcontext.payment.domain.entity.Refund;
 import com.ticketrush.boundedcontext.payment.domain.types.RefundStatus;
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Pageable;
@@ -26,4 +27,20 @@ public interface RefundRepository extends JpaRepository<Refund, Long> {
       RefundStatus status, Long idAfter, Pageable pageable);
 
   long countByStatus(RefundStatus status);
+
+  /**
+   * 여러 예매의 환불 이력을 한 번에 가져온다 (#607).
+   *
+   * <p>과금-만료 복구가 PG 취소를 호출하기 전에 거는 선검사다. 상태를 가리지 않고 조회하는 것은 의도적이다 — FAILED 이력도 "이미 시도했다"는 뜻이라 다시
+   * 집어들면 실패한 환불을 매 주기 PG 에 되풀이해 던진다. 다만 호출자는 성사된 건과 FAILED 만 남은 건을 <b>관측에서는 갈라야 한다.</b> 후자는 돈이 돌아가지
+   * 않은 미해결 사고이고, 예매가 EXPIRED 라 booking 쪽 관리자 게이트도 열리지 않기 때문이다.
+   *
+   * <p><b>{@code IN} 으로 묶어 받는 이유</b>는 {@code refund} 에 {@code booking_id} 인덱스가 없기 때문이다(키는 PK ·
+   * {@code UNIQUE(payment_id)} · {@code idx_refund_status} 뿐). 건별로 조회하면 호출마다 풀스캔이고, 이 테이블은 성공한 환불까지
+   * 누적돼 계속 커진다. 묶으면 풀스캔이 랩당 1 회로 줄어 <b>인덱스를 새로 만들지 않고도</b> 비용이 후보 수에 비례하지 않는다.
+   *
+   * <p><b>이 검사는 PG 호출 억제용이지 정합성 근거가 아니다.</b> 조회와 취소 사이의 경합은 막지 못한다. 이중 환불을 실제로 막는 것은 PG
+   * 멱등키(paymentId 고정)·{@code refund.payment_id} unique·{@code Payment#markCanceled}의 상태 가드 셋이다.
+   */
+  List<Refund> findByBookingIdIn(Collection<Long> bookingIds);
 }

--- a/payment-service/src/main/resources/application.yml
+++ b/payment-service/src/main/resources/application.yml
@@ -46,6 +46,29 @@ app:
     # PG 장애로 FAILED 가 대량으로 쌓였을 때 한 주기에 전부 발행하지 않도록 상한을 둔다. 올리면 한 바퀴가
     # 짧아지는 대신 한 주기가 스케줄러 스레드를 오래 문다.
     batch-size: ${REFUND_SIGNAL_REPLAY_BATCH_SIZE:100}
+  # 결제 확정 신호가 유실돼 과금만 남은 만료 예매를 찾아 자동 환불한다(#607).
+  charged-expired-recovery:
+    # 기본값이 false 인 것은 위 refund-signal-replay 와 다르며, 차이는 이 작업에 PG 환불이라는 되돌릴 수
+    # 없는 부작용이 있다는 것이다. 켜는 순간 첫 랩이 과거에 쌓인 사고 건을 전량 환불하므로, 잔량을 실측하고
+    # 그 규모를 알고 켠다(ADR 0015 · #441). 끄면 사고 건이 어떤 목록에도 잡히지 않는 상태로 남는다.
+    enabled: ${CHARGED_EXPIRED_RECOVERY_ENABLED:false}
+    # 만료 5 분 뒤부터 대상이 되지만 그 직후는 정상 처리가 늦게 도착하는 중일 수 있다. 이 주기 자체보다
+    # grace-minutes 가 실질 탐지 지연을 결정한다.
+    interval-ms: ${CHARGED_EXPIRED_RECOVERY_INTERVAL_MS:60000}
+    # expired_booking 은 해결돼도 행이 남아 한 바퀴 길이가 누적 만료 건수에 비례한다. 실제 복구 지연
+    # 상한은 interval 이 아니라 ceil(만료 건수 / batch-size) × interval 이다.
+    # 아래 셋 모두 0 이나 음수면 기동이 실패한다. 0 은 "제한 없음"이 아니라 고장이기 때문이다(#573).
+    batch-size: ${CHARGED_EXPIRED_RECOVERY_BATCH_SIZE:500}
+    # 만료 직후 창을 환불로 덮지 않기 위한 유예. 확정 신호가 늦게 도착해 예매가 되살아나는 일은 없지만
+    # (EXPIRED 는 종결 상태다), 취소·환불 등 다른 경로가 같은 건을 정리하는 중일 수 있다. 줄이면 복구가
+    # 빨라지는 대신 경합 구간이 넓어진다.
+    grace-minutes: ${CHARGED_EXPIRED_RECOVERY_GRACE_MINUTES:30}
+    # 한 주기에 PG 취소를 호출하는 최대 건수. batch-size 와 다른 축이다 — 그쪽은 만료 테이블을 훑는
+    # 크기이고 이쪽은 실제 결제 취소 호출 수다. Toss 는 429 대신 연속 요청 제한(403
+    # FORBIDDEN_CONSECUTIVE_REQUEST)을 내는데, 그 코드가 가장 나오기 쉬운 구간이 대량 보상 환불
+    # 버스트다. 거기 걸린 건은 FAILED 이력이 남아 자동 복구에서 영구히 빠지므로, 첫 랩에 백로그를
+    # 몰아 던지지 않도록 상한을 둔다. 상한에 걸리면 그 자리에 커서를 두고 다음 주기가 이어받는다.
+    max-refunds-per-lap: ${CHARGED_EXPIRED_RECOVERY_MAX_REFUNDS_PER_LAP:50}
 
 service:
   ticket:

--- a/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/app/scheduler/RecoverChargedExpiredBookingSchedulerTest.java
+++ b/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/app/scheduler/RecoverChargedExpiredBookingSchedulerTest.java
@@ -1,0 +1,91 @@
+package com.ticketrush.boundedcontext.payment.app.scheduler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import com.ticketrush.boundedcontext.payment.app.usecase.PaymentRecoverChargedExpiredBookingUseCase;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.support.PropertySourcesPlaceholderConfigurer;
+
+/**
+ * 스케줄러가 <b>명시적으로 켤 때만</b> 등록되는지 고정한다 (#607).
+ *
+ * <p>이 기본값은 취향이 아니라 안전장치다. 켜지는 순간 첫 랩이 과거에 쌓인 사고 건을 전량 환불하고, PG 환불은 되돌릴 수 없다. 누가 {@code
+ * matchIfMissing} 을 {@code true} 로 바꾸거나 프로퍼티 이름을 흘리면 <b>배포만으로</b> 그 일이 벌어지므로 테스트로 못박는다.
+ */
+class RecoverChargedExpiredBookingSchedulerTest {
+
+  private final PaymentRecoverChargedExpiredBookingUseCase useCase =
+      mock(PaymentRecoverChargedExpiredBookingUseCase.class);
+
+  private ApplicationContextRunner runner() {
+    return new ApplicationContextRunner()
+        .withBean(
+            PropertySourcesPlaceholderConfigurer.class, PropertySourcesPlaceholderConfigurer::new)
+        .withBean(PaymentRecoverChargedExpiredBookingUseCase.class, () -> useCase)
+        .withUserConfiguration(RecoverChargedExpiredBookingScheduler.class);
+  }
+
+  @Test
+  @DisplayName("성공: 설정이 없으면 스케줄러 빈이 등록되지 않는다")
+  void not_registered_by_default() {
+    runner()
+        .run(
+            context ->
+                assertThat(context).doesNotHaveBean(RecoverChargedExpiredBookingScheduler.class));
+  }
+
+  @Test
+  @DisplayName("성공: enabled=false 면 스케줄러 빈이 등록되지 않는다")
+  void not_registered_when_disabled() {
+    runner()
+        .withPropertyValues("app.charged-expired-recovery.enabled=false")
+        .run(
+            context ->
+                assertThat(context).doesNotHaveBean(RecoverChargedExpiredBookingScheduler.class));
+  }
+
+  @Test
+  @DisplayName("성공: enabled=true 면 설정한 배치·유예·환불 상한 값으로 UseCase 를 호출한다")
+  void registered_and_passes_configured_values() {
+    runner()
+        .withPropertyValues(
+            "app.charged-expired-recovery.enabled=true",
+            "app.charged-expired-recovery.batch-size=7",
+            "app.charged-expired-recovery.grace-minutes=11",
+            "app.charged-expired-recovery.max-refunds-per-lap=3")
+        .run(
+            context -> {
+              assertThat(context).hasSingleBean(RecoverChargedExpiredBookingScheduler.class);
+
+              context.getBean(RecoverChargedExpiredBookingScheduler.class).recover();
+
+              // 값이 뒤바뀌면 유예 7분·배치 11건으로 도는데, 셋 다 int 라 컴파일러가 잡아주지 않는다.
+              verify(useCase).execute(7, 11, 3);
+            });
+  }
+
+  @ParameterizedTest(name = "{0}={1}")
+  @CsvSource({
+    "app.charged-expired-recovery.batch-size, 0",
+    "app.charged-expired-recovery.batch-size, -1",
+    "app.charged-expired-recovery.grace-minutes, 0",
+    "app.charged-expired-recovery.grace-minutes, -5",
+    "app.charged-expired-recovery.max-refunds-per-lap, 0",
+    "app.charged-expired-recovery.max-refunds-per-lap, -3"
+  })
+  @DisplayName("성공: 0 이하 설정값이면 기동에 실패한다")
+  void fails_to_start_on_non_positive_values(String property, String value) {
+    // 0 은 "제한 없음"이 아니라 고장이다 — batch-size=0 은 매 주기 예외로 영구 무동작이 되고,
+    // grace=0 이하는 만료 직후 건까지 즉시 환불 대상으로 삼는다. 어느 쪽도 로그를 보지 않으면
+    // 드러나지 않으므로 배포 시점에 터뜨린다(#573 의 "0 은 킬 스위치여야 한다"와 같은 축).
+    runner()
+        .withPropertyValues("app.charged-expired-recovery.enabled=true", property + "=" + value)
+        .run(context -> assertThat(context).hasFailed());
+  }
+}

--- a/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentConfirmUseCaseTest.java
+++ b/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentConfirmUseCaseTest.java
@@ -94,8 +94,11 @@ class PaymentConfirmUseCaseTest {
   private void givenPreConfirmGuards(Long bookingId, Long ownerUserId, String bookingStatus) {
     given(paymentRepository.existsByBookingIdAndStatus(bookingId, PaymentStatus.COMPLETED))
         .willReturn(false);
+    // bookingNumber 를 null 로 둔다(#607). 이 필드는 환불 경로 전용이고 결제 확정 판정과 무관한데,
+    // 값을 채우면 "안 보기 때문에 통과한 것"인지 "값이 있어서 통과한 것"인지 구분되지 않는다. null 로
+    // 두면 이 테스트 묶음 전체가 곧 confirm 경로 무회귀의 증거가 된다.
     given(bookingRestClient.getBooking(bookingId))
-        .willReturn(new BookingInfoResponse(bookingId, ownerUserId, bookingStatus));
+        .willReturn(new BookingInfoResponse(bookingId, ownerUserId, bookingStatus, null));
   }
 
   private double guardBlockedCount(String reason) {

--- a/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentRecoverChargedExpiredBookingUseCaseTest.java
+++ b/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentRecoverChargedExpiredBookingUseCaseTest.java
@@ -1,0 +1,692 @@
+package com.ticketrush.boundedcontext.payment.app.usecase;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import com.ticketrush.boundedcontext.payment.app.usecase.PaymentRefundByBookingUseCase.RefundOutcome;
+import com.ticketrush.boundedcontext.payment.domain.entity.ExpiredBooking;
+import com.ticketrush.boundedcontext.payment.domain.entity.Payment;
+import com.ticketrush.boundedcontext.payment.domain.entity.Refund;
+import com.ticketrush.boundedcontext.payment.domain.types.PaymentStatus;
+import com.ticketrush.boundedcontext.payment.domain.types.RefundStatus;
+import com.ticketrush.boundedcontext.payment.domain.types.RefundTrigger;
+import com.ticketrush.boundedcontext.payment.out.apiclient.BookingRestClient;
+import com.ticketrush.boundedcontext.payment.out.apiclient.dto.BookingInfoResponse;
+import com.ticketrush.boundedcontext.payment.out.repository.ExpiredBookingRepository;
+import com.ticketrush.boundedcontext.payment.out.repository.PaymentRepository;
+import com.ticketrush.boundedcontext.payment.out.repository.RefundRepository;
+import com.ticketrush.global.constants.MetricNames;
+import com.ticketrush.global.exception.BusinessException;
+import com.ticketrush.global.status.ErrorStatus;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * 과금-만료 자동 환불의 판정 순서와 커서 전진을 고정한다 (#607).
+ *
+ * <p>이 UseCase 의 위험은 "환불하지 않아야 할 건을 환불하는 것"이라, 테스트 대부분이 <b>환불이 일어나지 않음</b>을 단언한다. 특히 판정 순서는 성능이 아니라
+ * 안전 계약이다 — 앞 단계에서 막힌 건이 뒤 단계에 도달하지 않아야 PG 를 불필요하게 두드리지 않고, 예매번호 없이 환불이 나가지 않는다.
+ */
+@ExtendWith(MockitoExtension.class)
+class PaymentRecoverChargedExpiredBookingUseCaseTest {
+
+  private static final int BATCH_SIZE = 3;
+  private static final int GRACE_MINUTES = 30;
+  private static final int MAX_REFUNDS_PER_LAP = 100;
+  private static final Long BOOKING_ID = 100L;
+  private static final String BOOKING_NUMBER = "BOOK-1";
+
+  /** grace 를 넉넉히 넘긴 만료 시각. 실제 시각에 의존하지 않도록 now 기준 상대값으로 만든다. */
+  private static final LocalDateTime LONG_EXPIRED = LocalDateTime.now().minusHours(2);
+
+  @Mock private ExpiredBookingRepository expiredBookingRepository;
+  @Mock private PaymentRepository paymentRepository;
+  @Mock private RefundRepository refundRepository;
+  @Mock private BookingRestClient bookingRestClient;
+  @Mock private PaymentRefundByBookingUseCase paymentRefundByBookingUseCase;
+
+  private SimpleMeterRegistry meterRegistry;
+  private PaymentRecoverChargedExpiredBookingUseCase paymentRecoverChargedExpiredBookingUseCase;
+
+  @BeforeEach
+  void setUp() {
+    meterRegistry = new SimpleMeterRegistry();
+    paymentRecoverChargedExpiredBookingUseCase =
+        new PaymentRecoverChargedExpiredBookingUseCase(
+            expiredBookingRepository,
+            paymentRepository,
+            refundRepository,
+            bookingRestClient,
+            paymentRefundByBookingUseCase,
+            meterRegistry);
+  }
+
+  private void execute() {
+    execute(GRACE_MINUTES, MAX_REFUNDS_PER_LAP);
+  }
+
+  private void execute(int graceMinutes, int maxRefundsPerLap) {
+    paymentRecoverChargedExpiredBookingUseCase.execute(BATCH_SIZE, graceMinutes, maxRefundsPerLap);
+  }
+
+  private ExpiredBooking expiredBooking(Long id, Long bookingId, LocalDateTime expiredAt) {
+    ExpiredBooking expiredBooking = ExpiredBooking.of(bookingId, expiredAt);
+    ReflectionTestUtils.setField(expiredBooking, "id", id);
+    return expiredBooking;
+  }
+
+  private void givenTargets(long idAfter, List<ExpiredBooking> targets) {
+    given(
+            expiredBookingRepository.findByIdGreaterThanOrderByIdAsc(
+                eq(idAfter), any(Pageable.class)))
+        .willReturn(targets);
+  }
+
+  /** 해당 bookingId 들이 COMPLETED 결제를 가진 것으로 스텁한다. */
+  private void givenCharged(Long... bookingIds) {
+    List<Payment> payments =
+        Arrays.stream(bookingIds)
+            .map(
+                bookingId -> {
+                  Payment payment = mock(Payment.class);
+                  given(payment.getBookingId()).willReturn(bookingId);
+                  return payment;
+                })
+            .toList();
+    givenChargedPayments(payments);
+  }
+
+  private void givenChargedPayments(List<Payment> payments) {
+    given(paymentRepository.findByBookingIdInAndStatus(any(), eq(PaymentStatus.COMPLETED)))
+        .willReturn(payments);
+  }
+
+  private void givenNoRefundHistory() {
+    given(refundRepository.findByBookingIdIn(any())).willReturn(List.of());
+  }
+
+  private void givenRefundHistory(Long bookingId, RefundStatus status) {
+    Refund refund = mock(Refund.class);
+    given(refund.getBookingId()).willReturn(bookingId);
+    given(refund.getStatus()).willReturn(status);
+    given(refundRepository.findByBookingIdIn(any())).willReturn(List.of(refund));
+  }
+
+  private void givenBooking(Long bookingId, String status, String bookingNumber) {
+    given(bookingRestClient.getBooking(bookingId))
+        .willReturn(new BookingInfoResponse(bookingId, 10L, status, bookingNumber));
+  }
+
+  private double skipCount(String reason) {
+    return meterRegistry
+        .counter(MetricNames.PAYMENT_CHARGED_EXPIRED_SKIPPED, MetricNames.TAG_REASON, reason)
+        .count();
+  }
+
+  private double detectedCount() {
+    return meterRegistry.counter(MetricNames.PAYMENT_CHARGED_EXPIRED_DETECTED).count();
+  }
+
+  private double recoveredCount() {
+    return meterRegistry.counter(MetricNames.PAYMENT_CHARGED_EXPIRED_RECOVERED).count();
+  }
+
+  private List<Long> capturedCursors(int laps) {
+    ArgumentCaptor<Long> cursorCaptor = ArgumentCaptor.forClass(Long.class);
+    verify(expiredBookingRepository, times(laps))
+        .findByIdGreaterThanOrderByIdAsc(cursorCaptor.capture(), any(Pageable.class));
+    return cursorCaptor.getAllValues();
+  }
+
+  @Test
+  @DisplayName("성공: 과금됐는데 만료된 예매를 예매번호와 함께 자동 환불한다")
+  void refunds_charged_expired_booking() {
+    // given
+    givenTargets(0L, List.of(expiredBooking(1L, BOOKING_ID, LONG_EXPIRED)));
+    givenCharged(BOOKING_ID);
+    givenNoRefundHistory();
+    givenBooking(BOOKING_ID, "EXPIRED", BOOKING_NUMBER);
+    given(
+            paymentRefundByBookingUseCase.execute(
+                BOOKING_ID, BOOKING_NUMBER, RefundTrigger.CONFIRM_SIGNAL_LOST))
+        .willReturn(RefundOutcome.REFUNDED);
+
+    // when
+    execute();
+
+    // then
+    verify(paymentRefundByBookingUseCase)
+        .execute(BOOKING_ID, BOOKING_NUMBER, RefundTrigger.CONFIRM_SIGNAL_LOST);
+    assertThat(detectedCount()).isEqualTo(1);
+    assertThat(recoveredCount()).isEqualTo(1);
+  }
+
+  @Test
+  @DisplayName("성공: 만료됐지만 과금되지 않은 건은 후보로 세지 않는다")
+  void ignores_expired_booking_without_payment() {
+    // given — COMPLETED 결제가 하나도 없다
+    givenTargets(0L, List.of(expiredBooking(1L, BOOKING_ID, LONG_EXPIRED)));
+    givenChargedPayments(List.of());
+
+    // then — 후보가 없으면 환불 이력 조회조차 하지 않는다(랩당 풀스캔 1회도 아끼는 자리)
+    execute();
+
+    verifyNoInteractions(refundRepository, bookingRestClient, paymentRefundByBookingUseCase);
+    assertThat(detectedCount()).isZero();
+  }
+
+  @Test
+  @DisplayName("판정 순서: 이미 환불된 건은 grace 를 따지기도 전에 걸러진다")
+  void already_refunded_is_checked_before_grace() {
+    // given — 두 조건이 동시에 참인 건을 만든다. 방금 만료됐고(grace 미경과) 환불 이력도 있다.
+    givenTargets(0L, List.of(expiredBooking(1L, BOOKING_ID, LocalDateTime.now().minusMinutes(1))));
+    givenCharged(BOOKING_ID);
+    givenRefundHistory(BOOKING_ID, RefundStatus.COMPLETED);
+
+    // when
+    execute();
+
+    // then — 판정 1(환불 이력)이 판정 2(grace)보다 먼저다. 순서가 뒤집히면 grace 로 세어져 이 단언이 깨진다.
+    // 이 순서는 PG 무한 재호출 차단의 핵심이라 성능이 아니라 안전 계약이다.
+    assertThat(skipCount("already_refunded")).isEqualTo(1);
+    assertThat(skipCount("grace")).isZero();
+    verifyNoInteractions(bookingRestClient, paymentRefundByBookingUseCase);
+  }
+
+  @Test
+  @DisplayName("판정 순서: 이미 환불 이력이 있으면 booking 을 조회하지도 PG 를 부르지도 않는다")
+  void skips_already_refunded_before_lookup() {
+    // given
+    givenTargets(0L, List.of(expiredBooking(1L, BOOKING_ID, LONG_EXPIRED)));
+    givenCharged(BOOKING_ID);
+    givenRefundHistory(BOOKING_ID, RefundStatus.COMPLETED);
+
+    // when
+    execute();
+
+    // then — 선검사가 뒤로 새면 실패한 환불을 매 주기 PG 에 되풀이해 던지게 된다
+    verifyNoInteractions(bookingRestClient, paymentRefundByBookingUseCase);
+    assertThat(skipCount("already_refunded")).isEqualTo(1);
+    assertThat(detectedCount()).isZero();
+  }
+
+  @Test
+  @DisplayName("🔴 관측: PG 거절로 FAILED 이력만 남은 건은 정상 환불과 다른 태그로 센다")
+  void separates_failed_refund_history_from_settled() {
+    // given
+    givenTargets(0L, List.of(expiredBooking(1L, BOOKING_ID, LONG_EXPIRED)));
+    givenCharged(BOOKING_ID);
+    givenRefundHistory(BOOKING_ID, RefundStatus.FAILED);
+
+    // when
+    execute();
+
+    // then — 둘 다 "환불 이력이 있어 건너뜀"이지만 뜻이 정반대다. 이쪽은 돈이 돌아가지 않은 미해결 사고이고,
+    // 예매가 EXPIRED 라 booking 의 관리자 재환불 게이트도 열리지 않아 이 태그가 유일한 창구다.
+    assertThat(skipCount("refund_failed_history")).isEqualTo(1);
+    assertThat(skipCount("already_refunded")).isZero();
+    verifyNoInteractions(bookingRestClient, paymentRefundByBookingUseCase);
+  }
+
+  @Test
+  @DisplayName("성공: 환불이 진행 중(PENDING)인 건도 손대지 않는다")
+  void skips_pending_refund() {
+    // given
+    givenTargets(0L, List.of(expiredBooking(1L, BOOKING_ID, LONG_EXPIRED)));
+    givenCharged(BOOKING_ID);
+    givenRefundHistory(BOOKING_ID, RefundStatus.PENDING);
+
+    // when
+    execute();
+
+    // then
+    verifyNoInteractions(bookingRestClient, paymentRefundByBookingUseCase);
+    assertThat(skipCount("already_refunded")).isEqualTo(1);
+  }
+
+  @Test
+  @DisplayName("판정 순서: 만료 직후(grace 미경과)면 booking 을 조회하지 않고 건너뛴다")
+  void skips_within_grace_period() {
+    // given — 방금 만료된 건
+    givenTargets(0L, List.of(expiredBooking(1L, BOOKING_ID, LocalDateTime.now().minusMinutes(1))));
+    givenCharged(BOOKING_ID);
+    givenNoRefundHistory();
+
+    // when
+    execute();
+
+    // then
+    verifyNoInteractions(bookingRestClient, paymentRefundByBookingUseCase);
+    assertThat(skipCount("grace")).isEqualTo(1);
+    assertThat(detectedCount()).isZero();
+  }
+
+  @Test
+  @DisplayName("성공: grace 를 갓 넘긴 건은 환불 대상이 된다")
+  void refunds_just_past_grace_boundary() {
+    // given — 유예 30분에 만료 31분 전. 경계 바깥이라 통과해야 한다.
+    givenTargets(0L, List.of(expiredBooking(1L, BOOKING_ID, LocalDateTime.now().minusMinutes(31))));
+    givenCharged(BOOKING_ID);
+    givenNoRefundHistory();
+    givenBooking(BOOKING_ID, "EXPIRED", BOOKING_NUMBER);
+    given(paymentRefundByBookingUseCase.execute(eq(BOOKING_ID), anyString(), any()))
+        .willReturn(RefundOutcome.REFUNDED);
+
+    // when
+    execute();
+
+    // then — 경계를 부등호 하나 잘못 쓰면(isAfter ↔ isBefore) 사고 건이 영영 복구되지 않거나
+    // 반대로 정상 처리 중인 건까지 환불된다
+    assertThat(recoveredCount()).isEqualTo(1);
+  }
+
+  @Test
+  @DisplayName("fail-closed: booking 조회가 실패하면 환불하지 않는다")
+  void does_not_refund_when_booking_lookup_fails() {
+    // given
+    givenTargets(0L, List.of(expiredBooking(1L, BOOKING_ID, LONG_EXPIRED)));
+    givenCharged(BOOKING_ID);
+    givenNoRefundHistory();
+    given(bookingRestClient.getBooking(BOOKING_ID))
+        .willThrow(new BusinessException(ErrorStatus.PAYMENT_BOOKING_COMMUNICATION_FAILED));
+
+    // when
+    execute();
+
+    // then — 조회하지 못한 건을 환불하면 잘못된 취소가 되돌릴 수 없게 나간다
+    verifyNoInteractions(paymentRefundByBookingUseCase);
+    assertThat(skipCount("booking_lookup_failed")).isEqualTo(1);
+    // 자동 복구가 닿지 못한 건이므로 발견 수에는 포함된다(detected − recovered = 미복구 잔량)
+    assertThat(detectedCount()).isEqualTo(1);
+    assertThat(recoveredCount()).isZero();
+  }
+
+  @Test
+  @DisplayName("fail-closed: booking 이 없는 예매(404)여도 환불하지 않는다")
+  void does_not_refund_when_booking_not_found() {
+    // given
+    givenTargets(0L, List.of(expiredBooking(1L, BOOKING_ID, LONG_EXPIRED)));
+    givenCharged(BOOKING_ID);
+    givenNoRefundHistory();
+    given(bookingRestClient.getBooking(BOOKING_ID))
+        .willThrow(new BusinessException(ErrorStatus.BOOKING_NOT_FOUND));
+
+    // when
+    execute();
+
+    // then
+    verifyNoInteractions(paymentRefundByBookingUseCase);
+    assertThat(skipCount("booking_lookup_failed")).isEqualTo(1);
+  }
+
+  @Test
+  @DisplayName("🔴 조회가 BusinessException 밖의 예외로 깨져도 남은 후보와 메트릭이 살아남는다")
+  void unexpected_lookup_exception_does_not_abort_lap() {
+    // given — 예: 내부 API 토큰 미주입으로 헤더 설정에서 NPE. 첫 건에서 터지고 뒤 건은 정상이다.
+    givenTargets(
+        0L,
+        List.of(expiredBooking(1L, 100L, LONG_EXPIRED), expiredBooking(2L, 200L, LONG_EXPIRED)));
+    givenCharged(100L, 200L);
+    givenNoRefundHistory();
+    given(bookingRestClient.getBooking(100L)).willThrow(new NullPointerException("token is null"));
+    givenBooking(200L, "EXPIRED", "BOOK-200");
+    given(paymentRefundByBookingUseCase.execute(eq(200L), anyString(), any()))
+        .willReturn(RefundOutcome.REFUNDED);
+
+    // when
+    execute();
+
+    // then — 예외가 새면 랩 전체가 중단될 뿐 아니라 detected 카운터와 경고 로그까지 통째로 실행되지 않아,
+    // "사고가 있었다"는 유일한 관측 축이 하필 그 장애 구간에서 침묵한다
+    verify(paymentRefundByBookingUseCase).execute(eq(200L), anyString(), any());
+    assertThat(skipCount("booking_lookup_failed")).isEqualTo(1);
+    assertThat(detectedCount()).isEqualTo(2);
+    assertThat(recoveredCount()).isEqualTo(1);
+  }
+
+  @Test
+  @DisplayName("fail-closed: 응답에 예매 상태가 없어도 NPE 없이 환불을 보류한다")
+  void does_not_refund_when_booking_status_is_null() {
+    // given — ignoreUnknown 이라 booking 이 필드명을 바꾸면 예외 없이 null 이 된다
+    givenTargets(0L, List.of(expiredBooking(1L, BOOKING_ID, LONG_EXPIRED)));
+    givenCharged(BOOKING_ID);
+    givenNoRefundHistory();
+    givenBooking(BOOKING_ID, null, BOOKING_NUMBER);
+
+    // when
+    execute();
+
+    // then — Set.of(...).contains(null) 이 NPE 를 던지므로 상태 판정보다 먼저 갈라야 한다
+    verifyNoInteractions(paymentRefundByBookingUseCase);
+    assertThat(skipCount("booking_lookup_failed")).isEqualTo(1);
+  }
+
+  @Test
+  @DisplayName("성공: 예매가 살아 있으면(CONFIRMED) 환불하지 않는다")
+  void does_not_refund_confirmed_booking() {
+    // given — 로컬 만료 기록이 낡았거나 잘못 들어온 경우
+    givenTargets(0L, List.of(expiredBooking(1L, BOOKING_ID, LONG_EXPIRED)));
+    givenCharged(BOOKING_ID);
+    givenNoRefundHistory();
+    givenBooking(BOOKING_ID, "CONFIRMED", BOOKING_NUMBER);
+
+    // when
+    execute();
+
+    // then
+    verifyNoInteractions(paymentRefundByBookingUseCase);
+    assertThat(skipCount("booking_alive")).isEqualTo(1);
+  }
+
+  @Test
+  @DisplayName("🔴 관측: 모르는 예매 상태는 '살아 있음'과 다른 태그로 센다")
+  void separates_unknown_booking_status() {
+    // given — booking 이 상태 이름을 바꾼 배포 사고를 흉내낸다
+    givenTargets(0L, List.of(expiredBooking(1L, BOOKING_ID, LONG_EXPIRED)));
+    givenCharged(BOOKING_ID);
+    givenNoRefundHistory();
+    givenBooking(BOOKING_ID, "SETTLED", BOOKING_NUMBER);
+
+    // when
+    execute();
+
+    // then — 한 태그로 접으면 전건이 "예매가 살아 있어서 건너뜀"으로 보고되고, 그동안 사고 복구는
+    // 전면 정지한다. 안전하게 깨지는 것과 깨진 것이 보이는 것은 다른 문제다(#572 선례).
+    verifyNoInteractions(paymentRefundByBookingUseCase);
+    assertThat(skipCount("booking_status_unknown")).isEqualTo(1);
+    assertThat(skipCount("booking_alive")).isZero();
+  }
+
+  @Test
+  @DisplayName("성공: 사용자가 먼저 취소한(CANCELED) 예매도 환불 대상이다")
+  void refunds_canceled_booking() {
+    // given
+    givenTargets(0L, List.of(expiredBooking(1L, BOOKING_ID, LONG_EXPIRED)));
+    givenCharged(BOOKING_ID);
+    givenNoRefundHistory();
+    givenBooking(BOOKING_ID, "CANCELED", BOOKING_NUMBER);
+    given(
+            paymentRefundByBookingUseCase.execute(
+                BOOKING_ID, BOOKING_NUMBER, RefundTrigger.CONFIRM_SIGNAL_LOST))
+        .willReturn(RefundOutcome.REFUNDED);
+
+    // when
+    execute();
+
+    // then — 결과가 같다(과금이 남고 예매가 없다)
+    assertThat(recoveredCount()).isEqualTo(1);
+  }
+
+  @Test
+  @DisplayName("🔴 회귀 그물: 예매번호를 얻지 못하면 환불하지 않는다")
+  void does_not_refund_when_booking_number_is_missing() {
+    // given — 배포 순서 역전으로 booking 이 아직 이 필드를 내려주지 않는 구간을 포함한다
+    givenTargets(0L, List.of(expiredBooking(1L, BOOKING_ID, LONG_EXPIRED)));
+    givenCharged(BOOKING_ID);
+    givenNoRefundHistory();
+    givenBooking(BOOKING_ID, "EXPIRED", null);
+
+    // when
+    execute();
+
+    // then — 값 없이 환불하면 PaymentCanceledEvent 가 bookingNumber=null 로 나가고, seat 의 좌석 소유
+    // 교차검증이 통째로 꺼져 그 사이 다른 사용자에게 팔린 SOLD 좌석을 반환할 수 있다(#608)
+    verifyNoInteractions(paymentRefundByBookingUseCase);
+    assertThat(skipCount("booking_number_unknown")).isEqualTo(1);
+  }
+
+  @Test
+  @DisplayName("🔴 회귀 그물: 예매번호가 공백이어도 환불하지 않는다")
+  void does_not_refund_when_booking_number_is_blank() {
+    // given
+    givenTargets(0L, List.of(expiredBooking(1L, BOOKING_ID, LONG_EXPIRED)));
+    givenCharged(BOOKING_ID);
+    givenNoRefundHistory();
+    givenBooking(BOOKING_ID, "EXPIRED", "   ");
+
+    // when
+    execute();
+
+    // then
+    verifyNoInteractions(paymentRefundByBookingUseCase);
+    assertThat(skipCount("booking_number_unknown")).isEqualTo(1);
+  }
+
+  @Test
+  @DisplayName("성공: 커서는 환불에 실패한 건에서도 전진한다")
+  void advances_cursor_even_when_refund_fails() {
+    // given — 선두 건이 PG 통신 실패로 막히고, 뒤 건은 정상
+    givenTargets(
+        0L,
+        List.of(
+            expiredBooking(1L, 100L, LONG_EXPIRED),
+            expiredBooking(2L, 200L, LONG_EXPIRED),
+            expiredBooking(3L, 300L, LONG_EXPIRED)));
+    givenCharged(100L, 200L, 300L);
+    givenNoRefundHistory();
+    givenBooking(100L, "EXPIRED", "BOOK-100");
+    givenBooking(200L, "EXPIRED", "BOOK-200");
+    givenBooking(300L, "EXPIRED", "BOOK-300");
+    willThrow(new BusinessException(ErrorStatus.PAYMENT_PG_COMMUNICATION_FAILED))
+        .given(paymentRefundByBookingUseCase)
+        .execute(eq(100L), anyString(), any());
+    given(paymentRefundByBookingUseCase.execute(eq(200L), anyString(), any()))
+        .willReturn(RefundOutcome.REFUNDED);
+    given(paymentRefundByBookingUseCase.execute(eq(300L), anyString(), any()))
+        .willReturn(RefundOutcome.REFUNDED);
+
+    // when
+    execute();
+
+    // then — 선두 실패가 뒤 건을 굶기지 않는다. #574 의 "연속 실패 시 커서를 두고 중단"을 복제하면
+    // 여기서는 그 봉쇄가 위치만 바꿔 재현된다.
+    verify(paymentRefundByBookingUseCase).execute(eq(200L), anyString(), any());
+    verify(paymentRefundByBookingUseCase).execute(eq(300L), anyString(), any());
+    assertThat(recoveredCount()).isEqualTo(2);
+  }
+
+  @Test
+  @DisplayName("성공: 배치가 가득 차면 다음 주기는 마지막 id 다음부터 읽는다")
+  void continues_from_cursor_on_next_lap() {
+    // given — 첫 주기가 batchSize 만큼 꽉 찬다(뒤에 더 있을 수 있다)
+    givenTargets(
+        0L,
+        List.of(
+            expiredBooking(1L, 100L, LONG_EXPIRED),
+            expiredBooking(2L, 200L, LONG_EXPIRED),
+            expiredBooking(3L, 300L, LONG_EXPIRED)));
+    givenChargedPayments(List.of());
+    givenTargets(3L, List.of());
+
+    // when
+    execute();
+    execute();
+
+    // then — 커서 없이 매번 앞에서 읽으면 만료가 상한을 넘는 순간 뒤쪽 사고 건이 영구히 묻힌다
+    assertThat(capturedCursors(2)).containsExactly(0L, 3L);
+  }
+
+  @Test
+  @DisplayName("성공: 마지막 페이지까지 훑으면 커서를 0으로 되돌린다")
+  void resets_cursor_after_last_page() {
+    // given — batchSize 보다 적게 돌아오면 마지막 페이지다
+    givenTargets(0L, List.of(expiredBooking(1L, 100L, LONG_EXPIRED)));
+    givenChargedPayments(List.of());
+
+    // when
+    execute();
+    execute();
+
+    // then — 되돌리지 않으면 한 바퀴를 돈 뒤 영영 아무것도 보지 않는다
+    assertThat(capturedCursors(2)).containsExactly(0L, 0L);
+  }
+
+  @Test
+  @DisplayName("성공: 대상이 없으면 커서를 되돌리고 아무것도 하지 않는다")
+  void resets_cursor_when_no_targets() {
+    // given
+    givenTargets(0L, List.of());
+
+    // when
+    execute();
+
+    // then
+    verifyNoInteractions(paymentRepository, refundRepository, bookingRestClient);
+  }
+
+  @Test
+  @DisplayName("🔴 랩당 환불 상한에 도달하면 조기 종료하고, 미룬 건은 다음 주기가 처리한다")
+  void stops_at_max_refunds_per_lap() {
+    // given — 후보 2건에 상한 1건. 첫 랩은 마지막 페이지(2건 < batchSize 3)지만 상한에 걸렸으므로
+    // 커서를 되돌리면 안 된다. 되돌리면 2번 건이 한 바퀴를 통째로 기다린다.
+    givenTargets(
+        0L,
+        List.of(expiredBooking(1L, 100L, LONG_EXPIRED), expiredBooking(2L, 200L, LONG_EXPIRED)));
+    givenCharged(100L, 200L);
+    givenNoRefundHistory();
+    givenBooking(100L, "EXPIRED", "BOOK-100");
+    given(paymentRefundByBookingUseCase.execute(eq(100L), anyString(), any()))
+        .willReturn(RefundOutcome.REFUNDED);
+    // 두 번째 랩은 커서 1 다음부터 읽어 미뤄 둔 건을 집어든다.
+    givenTargets(1L, List.of(expiredBooking(2L, 200L, LONG_EXPIRED)));
+    givenBooking(200L, "EXPIRED", "BOOK-200");
+    given(paymentRefundByBookingUseCase.execute(eq(200L), anyString(), any()))
+        .willReturn(RefundOutcome.REFUNDED);
+
+    // when
+    execute(GRACE_MINUTES, 1);
+    execute(GRACE_MINUTES, 1);
+
+    // then — Toss 연속 요청 제한(403)에 걸리면 그 건들이 FAILED 이력을 얻어 자동 복구에서 영구히 빠지므로,
+    // 첫 랩에 백로그를 몰아 던지지 않는다. 굶지는 않는다 — 다음 주기가 멈춘 자리에서 이어받는다.
+    assertThat(capturedCursors(2)).containsExactly(0L, 1L);
+    verify(paymentRefundByBookingUseCase).execute(eq(100L), anyString(), any());
+    verify(paymentRefundByBookingUseCase).execute(eq(200L), anyString(), any());
+    assertThat(recoveredCount()).isEqualTo(2);
+  }
+
+  @Test
+  @DisplayName("🔴 실패한 환불 시도도 랩 예산을 소모한다")
+  void failed_attempts_consume_the_lap_budget() {
+    // given — 후보 3건, 상한 2건. 전건이 PG 거절로 실패한다. Toss 연속 요청 제한에 걸린 랩이 정확히
+    // 이 모습이다 — 성공이 0건이다.
+    givenTargets(
+        0L,
+        List.of(
+            expiredBooking(1L, 100L, LONG_EXPIRED),
+            expiredBooking(2L, 200L, LONG_EXPIRED),
+            expiredBooking(3L, 300L, LONG_EXPIRED)));
+    givenCharged(100L, 200L, 300L);
+    givenNoRefundHistory();
+    givenBooking(100L, "EXPIRED", "BOOK-100");
+    givenBooking(200L, "EXPIRED", "BOOK-200");
+    willThrow(new BusinessException(ErrorStatus.PAYMENT_REFUND_FAILED))
+        .given(paymentRefundByBookingUseCase)
+        .execute(any(), anyString(), any());
+
+    // when
+    execute(GRACE_MINUTES, 2);
+
+    // then — 예산을 성공 건수로 세면(outcome == REFUNDED) 이 랩은 상한을 영원히 트립하지 못하고
+    // 배치 전체가 PG 로 날아간다. 상한이 필요한 바로 그 상황에서만 무력해지는 셈이라, 세는 기준이
+    // "시도"여야 한다는 것이 이 상한의 핵심 계약이다.
+    verify(paymentRefundByBookingUseCase, times(2)).execute(any(), anyString(), any());
+    assertThat(recoveredCount()).isZero();
+    assertThat(detectedCount()).isEqualTo(2);
+  }
+
+  @Test
+  @DisplayName("성공: 동시 환불이 unique 제약에 막혀도 예외를 전파하지 않고 다음 건을 처리한다")
+  void continues_after_unique_violation() {
+    // given
+    givenTargets(
+        0L,
+        List.of(expiredBooking(1L, 100L, LONG_EXPIRED), expiredBooking(2L, 200L, LONG_EXPIRED)));
+    givenCharged(100L, 200L);
+    givenNoRefundHistory();
+    givenBooking(100L, "EXPIRED", "BOOK-100");
+    givenBooking(200L, "EXPIRED", "BOOK-200");
+    willThrow(new DataIntegrityViolationException("duplicate"))
+        .given(paymentRefundByBookingUseCase)
+        .execute(eq(100L), anyString(), any());
+    given(paymentRefundByBookingUseCase.execute(eq(200L), anyString(), any()))
+        .willReturn(RefundOutcome.REFUNDED);
+
+    // when
+    execute();
+
+    // then — 이미 다른 경로에서 환불이 확정된 멱등 정상이다
+    verify(paymentRefundByBookingUseCase).execute(eq(200L), anyString(), any());
+    assertThat(recoveredCount()).isEqualTo(1);
+  }
+
+  @Test
+  @DisplayName("성공: PG 가 환불을 거절하면 실패 카운터를 남기고 다음 건으로 넘어간다")
+  void records_failure_metric_on_deterministic_rejection() {
+    // given
+    givenTargets(0L, List.of(expiredBooking(1L, BOOKING_ID, LONG_EXPIRED)));
+    givenCharged(BOOKING_ID);
+    givenNoRefundHistory();
+    givenBooking(BOOKING_ID, "EXPIRED", BOOKING_NUMBER);
+    willThrow(new BusinessException(ErrorStatus.PAYMENT_REFUND_FAILED))
+        .given(paymentRefundByBookingUseCase)
+        .execute(eq(BOOKING_ID), anyString(), any());
+
+    // when
+    execute();
+
+    // then — trigger 태그가 없으면 이 사고가 사용자 취소 실패와 한 시계열에 섞인다
+    assertThat(
+            meterRegistry
+                .counter(
+                    MetricNames.PAYMENT_REFUND_FAILED,
+                    MetricNames.TAG_TRIGGER,
+                    RefundTrigger.CONFIRM_SIGNAL_LOST.tag())
+                .count())
+        .isEqualTo(1);
+    assertThat(detectedCount()).isEqualTo(1);
+    assertThat(recoveredCount()).isZero();
+  }
+
+  @Test
+  @DisplayName("성공: 이미 정리된 결제(ALREADY_SETTLED)는 복구 성공으로 세지 않는다")
+  void does_not_count_already_settled_as_recovered() {
+    // given
+    givenTargets(0L, List.of(expiredBooking(1L, BOOKING_ID, LONG_EXPIRED)));
+    givenCharged(BOOKING_ID);
+    givenNoRefundHistory();
+    givenBooking(BOOKING_ID, "EXPIRED", BOOKING_NUMBER);
+    given(
+            paymentRefundByBookingUseCase.execute(
+                BOOKING_ID, BOOKING_NUMBER, RefundTrigger.CONFIRM_SIGNAL_LOST))
+        .willReturn(RefundOutcome.ALREADY_SETTLED);
+
+    // when
+    execute();
+
+    // then — 신호 기반 경로(#492)에서는 전제 붕괴지만 대조 기반인 이 경로에서는 경합의 정상적 귀결이다.
+    // 발견은 했으나 복구하지 못한 것이므로 detected 에만 잡힌다.
+    assertThat(detectedCount()).isEqualTo(1);
+    assertThat(recoveredCount()).isZero();
+  }
+}

--- a/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/domain/types/RefundTriggerTest.java
+++ b/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/domain/types/RefundTriggerTest.java
@@ -1,0 +1,41 @@
+package com.ticketrush.boundedcontext.payment.domain.types;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+import java.util.Locale;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class RefundTriggerTest {
+
+  private final Locale originalLocale = Locale.getDefault();
+
+  @AfterEach
+  void restoreLocale() {
+    Locale.setDefault(originalLocale);
+  }
+
+  @Test
+  @DisplayName("성공: 메트릭 태그 값은 기본 로케일이 바뀌어도 달라지지 않는다")
+  void tag_is_locale_independent() {
+    // given — tr_TR 은 대문자 I 를 dotless ı 로 내린다
+    Locale.setDefault(Locale.forLanguageTag("tr-TR"));
+
+    // when & then — 로케일에 따라 갈리면 같은 사건이 두 시계열로 쪼개진다
+    assertThat(RefundTrigger.CONFIRM_SIGNAL_LOST.tag()).isEqualTo("confirm_signal_lost");
+    assertThat(RefundTrigger.SEAT_CONFIRM_FAILED.tag()).isEqualTo("seat_confirm_failed");
+    assertThat(RefundTrigger.USER_CANCEL.tag()).isEqualTo("user_cancel");
+  }
+
+  @Test
+  @DisplayName("성공: 모든 트리거가 서로 다른 PG 취소 사유를 갖는다")
+  void reasons_are_distinct() {
+    // 사유는 PG 관리자 화면과 정산 분석에서 사고 보상 건을 사용자 취소와 구분하는 축이다.
+    // 두 트리거가 같은 문자열을 쓰면 그 구분이 PG 쪽에서 사라진다.
+    assertThat(
+            Arrays.stream(RefundTrigger.values()).map(RefundTrigger::getReason).distinct().count())
+        .isEqualTo(RefundTrigger.values().length);
+  }
+}

--- a/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/out/apiclient/dto/BookingInfoResponseTest.java
+++ b/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/out/apiclient/dto/BookingInfoResponseTest.java
@@ -1,0 +1,71 @@
+package com.ticketrush.boundedcontext.payment.out.apiclient.dto;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * booking-service 응답과의 키 계약을 고정한다 (#607).
+ *
+ * <p>이 DTO 는 {@code ignoreUnknown = true} 라 키 이름이 어긋나도 예외가 나지 않고 <b>조용히 null</b> 이 된다. 그 null 은
+ * {@code bookingNumber} 에서 특히 위험한데, 호출자가 그것을 "검증 생략"으로 새기면 남의 좌석을 푸는 환불이 나가기 때문이다(#608). 그래서 매핑 자체를
+ * 테스트로 못박는다.
+ */
+class BookingInfoResponseTest {
+
+  private final ObjectMapper objectMapper = new ObjectMapper();
+
+  @Test
+  @DisplayName("성공: snake_case 응답의 booking_number 를 매핑한다")
+  void deserializes_booking_number() throws Exception {
+    // given
+    String json =
+        """
+        {"booking_id":100,"user_id":10,"booking_status":"EXPIRED","booking_number":"BOOK-1"}
+        """;
+
+    // when
+    BookingInfoResponse response = objectMapper.readValue(json, BookingInfoResponse.class);
+
+    // then
+    assertThat(response.bookingId()).isEqualTo(100L);
+    assertThat(response.userId()).isEqualTo(10L);
+    assertThat(response.bookingStatus()).isEqualTo("EXPIRED");
+    assertThat(response.bookingNumber()).isEqualTo("BOOK-1");
+  }
+
+  @Test
+  @DisplayName("성공: booking_number 키가 없으면 null 이 된다(배포 순서 역전 구간)")
+  void maps_missing_booking_number_to_null() throws Exception {
+    // given — payment 가 booking 보다 먼저 배포되면 이 형태의 응답이 온다
+    String json =
+        """
+        {"booking_id":100,"user_id":10,"booking_status":"EXPIRED"}
+        """;
+
+    // when
+    BookingInfoResponse response = objectMapper.readValue(json, BookingInfoResponse.class);
+
+    // then — 예외가 아니라 null 이므로, 환불 여부를 판정하는 쪽이 이 값을 반드시 확인해야 한다
+    assertThat(response.bookingNumber()).isNull();
+    assertThat(response.bookingStatus()).isEqualTo("EXPIRED");
+  }
+
+  @Test
+  @DisplayName("성공: 모르는 키가 있어도 실패하지 않는다")
+  void ignores_unknown_fields() throws Exception {
+    // given
+    String json =
+        """
+        {"booking_id":100,"user_id":10,"booking_status":"EXPIRED","booking_number":"BOOK-1","unknown":1}
+        """;
+
+    // when
+    BookingInfoResponse response = objectMapper.readValue(json, BookingInfoResponse.class);
+
+    // then
+    assertThat(response.bookingNumber()).isEqualTo("BOOK-1");
+  }
+}


### PR DESCRIPTION
## 🔗 관련 이슈

- close #607

---

## 📌 주요 변경 사항

- `PaymentConfirmedEvent` 유실로 **과금만 남고 예매가 만료된 건**을 찾아 자동 환불하는 스케줄러를 추가했습니다
- 판정은 `expired_booking × payment(COMPLETED) × refund 부재`로 로컬 후보를 좁힌 뒤, 후보만 booking 에 동기 재확인합니다
- 복구는 #492 가 만든 `PaymentRefundByBookingUseCase` 를 재사용합니다 (`RefundTrigger.CONFIRM_SIGNAL_LOST` 신설)
- **스키마 무변경** — 수동 DDL 도 새 인덱스도 없습니다
- **스케줄러는 기본 비활성**입니다. PG 환불이라는 되돌릴 수 없는 부작용이 있어 잔량을 실측하고 켭니다
- 결정 근거를 **ADR 0015** 에 남기고, ADR 0014 의 부정확한 서술을 정정했습니다

---

## 🛠 상세 구현 내용

### 왜 #574 방식을 복제하지 않았나

ADR 0014 는 "전달을 보장하는 대신 남아 있는 상태로 재발행한다"를 세웠지만, 여기서 같은 일을 하면 **아무 일도 일어나지 않습니다**. `PaymentConfirmedEvent` 를 다시 보내도 `Booking#confirm` 이 EXPIRED 를 `BOOKING_EXPIRED` 로 거절하고 영구 실패로 분류돼 ack 됩니다. 좌석이 이미 팔린 뒤라 예매를 되살릴 수도 없습니다. 그래서 **복구 방향이 반대입니다 — 예매를 살리는 게 아니라 과금을 되돌립니다.** 재사용한 것은 스케줄러 골격뿐입니다.

### 판정 순서가 계약입니다

| # | 판정 | 스킵 사유 태그 |
|---|---|---|
| 1 | 환불 이력 부재 | `already_refunded` / `refund_failed_history` |
| 2 | 만료 후 grace(30분) 경과 | `grace` |
| 3 | booking 동기 재확인 (fail-closed) | `booking_lookup_failed` |
| 4 | 상태가 EXPIRED·CANCELED | `booking_alive` / `booking_status_unknown` |
| 5 | `bookingNumber` 존재 | `booking_number_unknown` + CRITICAL |
| 6 | 자동 환불 실행 | — |

판정 1 이 **PG 무한 재호출 차단의 핵심**이라 가장 앞입니다. 판정 5 는 값 없이 환불하면 seat 의 좌석 소유 교차검증이 꺼져 **다른 사용자의 SOLD 좌석을 반환**하기 때문에(#608) 부작용 직전에 둡니다.

### 성능·안전 관련 선택

- **조인+`LIMIT` 대신 2단계 질의** — 과금-만료 매치가 희소해 조인으로 짜면 조기 종료를 못 해 매 주기 풀스캔이 됩니다(ADR 0014 가 `idx_refund_status` 에서 겪은 형태)
- **환불 이력도 `IN` 으로 일괄 조회** — `refund` 에 `booking_id` 인덱스가 없어 건별 호출은 후보 수만큼 풀스캔입니다. 묶어서 랩당 1회로 고정했고, 덕분에 **인덱스를 추가하지 않아** `validate` 가 인덱스를 검증하지 않는 함정을 피했습니다
- **실패해도 커서를 전진**시킵니다. #574 의 중단 가드를 복제하면 선두의 실패한 몇 건이 뒤쪽 사고 건 전체를 무기한 굶깁니다
- **랩당 환불 시도 상한**(기본 50) — Toss 는 429 대신 연속 요청 제한(403)을 내고, 그게 가장 나오기 쉬운 구간이 첫 랩의 대량 보상 환불입니다. 거기 걸린 건은 FAILED 이력이 남아 자동 복구에서 영구히 빠집니다
- **ShedLock 미사용 — 근거가 #574 와 다릅니다.** 그쪽은 "전이할 상태가 없다"였지만 여긴 PG 부작용이 있습니다. 근거는 멱등키·`refund.payment_id` unique·`markCanceled` 상태 가드 3중 방어선입니다

### 이슈 전제 정정 3건 (ADR 0015 기록)

1. "사용자가 손댈 방법이 없다"는 사실이 아닙니다 — `PaymentCancelUseCase` 가 booking 상태를 보지 않아 직접 환불이 됩니다
2. 🔴 **그 취소 경로가 남의 좌석을 풉니다** → #608 로 분리했습니다
3. 재결제가 막히는 이유는 #224 가 아니라 COMPLETED 중복 검사입니다

---

## ✅ 테스트

### 테스트 방법

`./gradlew spotlessApply → checkstyleMain → checkstyleTest → test` (payment·booking·common)

신규 테스트는 전부 Mockito 단위라 Docker 가 필요 없습니다.

### 테스트 결과

**293/295 통과.** 실패 2건(`PaymentGetListUseCaseIntegrationTest`·`PaymentCompletedBookingUniqueTest`)은 **로컬 Docker 미실행**으로 인한 Testcontainers 초기화 실패이며, 이번 변경이 건드리지 않은 파일입니다. CI 에서는 정상 실행됩니다.

주요 고정 항목

- 판정 순서 (두 조건이 동시에 참인 fixture 로 1↔2 순서를 실제로 고정)
- `bookingNumber` null/blank → 환불 0회 (#608 회귀 그물)
- 커서 전진(실패·skip 에도) / 마지막 페이지 리셋 / 상한 도달 시 미리셋
- **"실패한 시도도 랩 예산을 소모한다"** — 예산을 성공 건수로 세는 회귀를 실제로 심어 이 테스트만 실패하는 것을 확인했습니다
- `PaymentConfirmUseCaseTest` 는 `bookingNumber=null` 로 스텁해, 통과 자체가 결제 확정 경로 무회귀의 증거가 되게 했습니다

### 📸 스크린샷

해당 없음 (API 변경 없음)

---

## 👀 리뷰 요청 사항

- **판정 순서와 fail-closed 가 실제로 닫혀 있는지** 봐 주세요. 이 UseCase 의 위험은 "환불하지 말아야 할 건을 환불하는 것"입니다
- **랩당 상한 도달 시 만료 스캔 자체가 멈추는 트레이드오프**가 적절한지 (뒤쪽에 과금되지 않은 정상 건이 있어도 이번 주기엔 보지 않습니다. 다음 주기가 이어받아 굶지는 않습니다)
- **`RefundFailedEvent` 를 발행하지 않는 판단** — 대상이 EXPIRED 예매라 `Booking#recordRefundFailure` 가 무동작이고, 발행하면 게이트가 열렸다는 착각만 남습니다. 그래서 이 건의 창구는 CRITICAL 로그와 `charged_expired` 카운터뿐입니다

---

## ⚠️ 배포 시 주의사항

- **배포만으로는 아무 동작도 하지 않습니다.** `CHARGED_EXPIRED_RECOVERY_ENABLED=true` 를 주입해야 켜집니다
- **켜기 전 잔량을 반드시 실측하세요.** 첫 랩이 과거 사고 건을 전량 환불합니다. CS 가 PG 콘솔에서 수동 환불한 건은 payment 가 COMPLETED 로 남아 중복 취소를 시도합니다(Toss 가 거절하므로 이중 환급은 아니지만 FAILED 이력과 알람이 남습니다)

```sql
SELECT eb.booking_id, p.payment_id, p.amount, eb.expired_at
FROM expired_booking eb
JOIN payment p ON p.booking_id = eb.booking_id AND p.status = 'COMPLETED'
LEFT JOIN refund r ON r.booking_id = eb.booking_id
WHERE r.refund_id IS NULL;
```

- **배포 순서**: booking-service 를 먼저 배포하세요. payment 가 먼저 나가면 `booking_number` 가 null 로 와서 판정 5 가 전건을 막습니다(안전한 방향이지만 복구가 되지 않습니다)
- **스키마 변경은 없습니다.** 수동 DDL 이 필요 없습니다
- 설정값 3개(`batch-size`·`grace-minutes`·`max-refunds-per-lap`)는 0 이하면 **기동에 실패**합니다
- 롤백은 `enabled: false` + 재기동입니다. 되돌릴 DDL 은 없지만 **이미 실행된 PG 환불은 되돌릴 수 없습니다**
