### PR TITLE
[Feat] #593 Toss 승인 응답의 결제수단을 보존해 상세 조회에 노출한다

### DIFF
--- a/deploy/mysql/init/001-ticket-rush-schema.sql
+++ b/deploy/mysql/init/001-ticket-rush-schema.sql
@@ -140,6 +140,7 @@ CREATE TABLE `payment` (
   `completed_booking_id` bigint GENERATED ALWAYS AS ((case when (`status` = _utf8mb4'COMPLETED') then `booking_id` end)) STORED,
   `failure_code` varchar(50) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `failure_reason` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `method` varchar(50) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `paid_at` datetime(6) DEFAULT NULL,
   `payment_key` varchar(200) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `pg_failure_code` varchar(50) COLLATE utf8mb4_unicode_ci DEFAULT NULL,

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/dto/response/PaymentDetailResponse.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/dto/response/PaymentDetailResponse.java
@@ -9,7 +9,8 @@ import java.time.LocalDateTime;
 public record PaymentDetailResponse(
     @Schema(description = "결제 데이터의 고유 식별자(PK)", example = "1") Long paymentId,
     @Schema(description = "예매 ID", example = "12") Long bookingId,
-    @Schema(description = "결제 수단", example = "TOSS") PaymentProvider provider,
+    @Schema(description = "결제를 처리한 PG사", example = "TOSS") PaymentProvider provider,
+    @Schema(description = "결제수단 (PG 원본 문자열, 미확보 시 응답에서 생략)", example = "카드") String method,
     @Schema(description = "결제 금액", example = "55000") Long amount,
     @Schema(description = "결제 상태", example = "COMPLETED") PaymentStatus status,
     @Schema(description = "결제 완료 시각") LocalDateTime paidAt,

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/dto/response/PaymentSummaryResponse.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/dto/response/PaymentSummaryResponse.java
@@ -9,7 +9,7 @@ import java.time.LocalDateTime;
 public record PaymentSummaryResponse(
     @Schema(description = "결제 데이터의 고유 식별자(PK)", example = "1") Long paymentId,
     @Schema(description = "예매 ID", example = "12") Long bookingId,
-    @Schema(description = "결제 수단", example = "TOSS") PaymentProvider provider,
+    @Schema(description = "결제를 처리한 PG사", example = "TOSS") PaymentProvider provider,
     @Schema(description = "결제 금액", example = "55000") Long amount,
     @Schema(description = "결제 상태", example = "COMPLETED") PaymentStatus status,
     @Schema(description = "결제 완료 시각") LocalDateTime paidAt) {}

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentConfirmUseCase.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentConfirmUseCase.java
@@ -208,6 +208,7 @@ public class PaymentConfirmUseCase {
             .status(PaymentStatus.COMPLETED)
             .paymentKey(request.paymentKey())
             .approvalNumber(approval.approvalNumber())
+            .method(approval.method())
             .paidAt(approval.approvedAt())
             .build();
 

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/domain/entity/Payment.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/domain/entity/Payment.java
@@ -43,6 +43,23 @@ import lombok.NoArgsConstructor;
  *   ALTER TABLE payment
  *     ADD INDEX idx_payment_user_id_status (user_id, status), ALGORITHM=INPLACE, LOCK=NONE;
  * </pre>
+ *
+ * <p><b>method 마이그레이션 (#593).</b> 결제수단 컬럼을 추가한다. 기존 가동 DB에는 아래를 실행해야 하며, prod는 {@code ddl-auto:
+ * validate}라 <b>배포 전에 실행하지 않으면 payment-service 기동이 실패한다</b>(결제 전면 중단). 인덱스와 달리 이 컬럼은 validate가 부재를
+ * 검출하므로, 반대로 말하면 DDL만 먼저 쳐두면 구버전 앱도 정상 기동한다 — 그래서 DDL을 앱 배포보다 먼저 친다.
+ *
+ * <pre>
+ *   -- 이미 있으면 아래 ALTER를 생략한다:
+ *   SHOW COLUMNS FROM payment LIKE 'method';
+ *
+ *   ALTER TABLE payment ADD COLUMN method varchar(50) DEFAULT NULL, ALGORITHM=INSTANT;
+ *   -- ALGORITHM을 명시하면 미지원 시 MySQL은 조용히 폴백하지 않고 에러로 거부한다. 거부되면 아래로 대체한다:
+ *   ALTER TABLE payment ADD COLUMN method varchar(50) DEFAULT NULL, ALGORITHM=INPLACE, LOCK=NONE;
+ * </pre>
+ *
+ * <p>기존 결제 건은 백필하지 않으므로 값이 NULL로 남는다. 롤백 시 컬럼은 남겨둔다 — validate는 엔티티에 없는 여분 컬럼을 문제 삼지 않고, DROP하면
+ * 그때까지 수집한 결제수단을 다시 모으는 데 Toss 재조회(보존 기간 내의 건에 한해, paymentKey 단위 대량 호출)가 필요하기 때문이다. 영구 소실은 아니지만 비용과
+ * 시한이 붙는 복구라, 되돌릴 값이 없는 상황이 아니면 남겨두는 편이 싸다.
  */
 @Entity
 @Table(
@@ -83,6 +100,16 @@ public class Payment extends AutoIdBaseEntity {
 
   @Column(length = 100)
   private String approvalNumber; // PG사 응답 승인 번호 / 거래 식별자
+
+  /* PG 승인 응답의 결제수단을 한글 원문 그대로 보존한다(#593). Toss가 주는 값은 카드/가상계좌/간편결제/휴대폰/계좌이체/
+   * 문화상품권/도서문화상품권/게임문화상품권이며, enum으로 정규화하지 않는 이유는 Toss가 값을 늘렸을 때 매핑 실패로 승인
+   * 경로가 영향받지 않게 하기 위해서다(#332의 pgFailureCode 원본 보존과 같은 계열). 값의 최대 길이는 현재 7자지만 컬럼은
+   * 코드류 관례인 50으로 두고 생성자에서 truncate 한다 — 이 컬럼은 성공 경로에서만 채워지므로, 길이 초과로 INSERT가 깨지면
+   * PG 과금이 끝난 뒤 500이 나고 payment row는 남지 않는다.
+   *
+   * provider(어느 PG사를 태웠는지)와는 다른 축이다. 승인 응답에 없으면 null이며, 그 경우에도 결제 확정은 성공한다. */
+  @Column(length = 50)
+  private String method; // 결제수단 (PG 원본 한글 문자열)
 
   private LocalDateTime paidAt; // 결제 완료 시점
 
@@ -146,6 +173,7 @@ public class Payment extends AutoIdBaseEntity {
       PaymentStatus status,
       String paymentKey,
       String approvalNumber,
+      String method,
       LocalDateTime paidAt) {
     this.bookingId = bookingId;
     this.userId = userId;
@@ -155,6 +183,7 @@ public class Payment extends AutoIdBaseEntity {
     this.status = status;
     this.paymentKey = paymentKey;
     this.approvalNumber = approvalNumber;
+    this.method = truncate(method, 50);
     this.paidAt = paidAt;
   }
 

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/out/apiclient/PaymentApprovalResponse.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/out/apiclient/PaymentApprovalResponse.java
@@ -2,5 +2,11 @@ package com.ticketrush.boundedcontext.payment.out.apiclient;
 
 import java.time.LocalDateTime;
 
+/**
+ * PG 승인 결과의 provider 중립 표현.
+ *
+ * <p>{@code method}는 사용자가 무엇으로 결제했는지(카드·간편결제 등)를 담는 한글 원문이며, 어느 PG사를 태웠는지를 뜻하는 {@code provider}와는
+ * 다른 축이다(#593). PG가 내려주지 않으면 null이고, 그 경우에도 승인은 성공으로 다룬다 — 결제수단은 보존 대상일 뿐 승인 성립 요건이 아니다.
+ */
 public record PaymentApprovalResponse(
-    String approvalNumber, Long approvedAmount, LocalDateTime approvedAt) {}
+    String approvalNumber, Long approvedAmount, LocalDateTime approvedAt, String method) {}

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/out/apiclient/StubPaymentApprovalClient.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/out/apiclient/StubPaymentApprovalClient.java
@@ -46,8 +46,10 @@ public class StubPaymentApprovalClient implements PaymentApprovalClient {
         request.amount(),
         mask(request.paymentKey()));
 
+    /* method는 stub이 지어낼 값이지만, 비워두면 local/dev에서 결제수단이 항상 null이라 저장·노출 경로를 눈으로 확인할 수
+     * 없다(#593). Toss가 실제로 내려주는 한글 원문 중 가장 흔한 값을 고정으로 쓴다. */
     return new PaymentApprovalResponse(
-        UUID.randomUUID().toString(), request.amount(), LocalDateTime.now());
+        UUID.randomUUID().toString(), request.amount(), LocalDateTime.now(), "카드");
   }
 
   private String mask(String value) {

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/out/apiclient/TossConfirmResponse.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/out/apiclient/TossConfirmResponse.java
@@ -7,6 +7,11 @@ import java.time.OffsetDateTime;
  * Toss Payments 결제 승인 응답 (필요 필드만 매핑).
  *
  * <p>전체 응답 명세: https://docs.tosspayments.com/reference#payment-객체
+ *
+ * <p>{@code method}는 사용자가 무엇으로 결제했는지를 뜻하는 <b>한글 원문</b>
+ * 문자열이다(카드/가상계좌/간편결제/휴대폰/계좌이체/문화상품권/도서문화상품권/게임문화상품권). PG사를 뜻하는 {@link
+ * PaymentApprovalRequest#provider()}와는 다른 축이므로 혼동하지 않는다(#593). Toss 명세상 nullable이라 값이 없어도 승인은 성공으로
+ * 다룬다.
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public record TossConfirmResponse(
@@ -15,4 +20,5 @@ public record TossConfirmResponse(
     String transactionKey,
     Long totalAmount,
     String status,
-    OffsetDateTime approvedAt) {}
+    OffsetDateTime approvedAt,
+    String method) {}

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/out/apiclient/TossPaymentApprovalClient.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/out/apiclient/TossPaymentApprovalClient.java
@@ -118,7 +118,17 @@ public class TossPaymentApprovalClient implements PaymentApprovalClient {
       LocalDateTime approvedAt =
           response.approvedAt().atZoneSameInstant(ZoneId.systemDefault()).toLocalDateTime();
 
-      return new PaymentApprovalResponse(approvalNumber, response.totalAmount(), approvedAt);
+      /* method는 Toss 명세상 nullable이라 위 세 가드와 달리 승인을 실패시키지 않는다. 결제수단은 보존 대상일 뿐
+       * 승인 성립 요건이 아니다(#593). 평상시 소음을 만들지 않도록 debug로만 남긴다. */
+      if (response.method() == null) {
+        log.debug(
+            "[PG-TOSS] 응답에 method 없음. orderId={}, bookingId={}",
+            request.orderId(),
+            request.bookingId());
+      }
+
+      return new PaymentApprovalResponse(
+          approvalNumber, response.totalAmount(), approvedAt, response.method());
 
     } catch (BusinessException e) {
       throw e;

--- a/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentConfirmUseCaseTest.java
+++ b/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentConfirmUseCaseTest.java
@@ -108,6 +108,40 @@ class PaymentConfirmUseCaseTest {
   }
 
   @Test
+  @DisplayName("PG가 결제수단을 내려주지 않아도 결제 확정은 성공하고 method만 null로 저장된다")
+  void execute_succeeds_when_approval_has_no_method() throws Exception {
+    /* 완료조건 3을 confirm 경로 끝까지 고정한다. 클라이언트 경계(TossPaymentApprovalClientTest)만으로는
+     * UseCase나 엔티티 쪽에 누군가 null 가드를 새로 넣는 회귀를 잡지 못한다(#593). */
+    final Long userId = 10L;
+    Long bookingId = 100L;
+    Long amount = 55_000L;
+    final PaymentConfirmRequest request =
+        new PaymentConfirmRequest(bookingId, 200L, PaymentProvider.TOSS, amount, "pgKey_xyz");
+
+    givenPreConfirmGuards(bookingId, "PENDING");
+    given(paymentApprovalClientRouter.approve(any()))
+        .willReturn(
+            new PaymentApprovalResponse(
+                "APR-123", amount, LocalDateTime.of(2025, 1, 15, 10, 0), null));
+    given(paymentRepository.saveAndFlush(any(Payment.class)))
+        .willAnswer(
+            invocation -> {
+              Payment p = invocation.getArgument(0);
+              setId(p, 999L);
+              return p;
+            });
+
+    PaymentConfirmResponse response = paymentConfirmUseCase.execute(userId, request);
+
+    assertThat(response.status()).isEqualTo("COMPLETED");
+
+    ArgumentCaptor<Payment> paymentCaptor = ArgumentCaptor.forClass(Payment.class);
+    verify(paymentRepository).saveAndFlush(paymentCaptor.capture());
+    assertThat(paymentCaptor.getValue().getMethod()).isNull();
+    assertThat(paymentCaptor.getValue().getStatus()).isEqualTo(PaymentStatus.COMPLETED);
+  }
+
+  @Test
   @DisplayName("PG 승인 성공 시 Payment를 COMPLETED 상태로 저장하고 PaymentConfirmedEvent를 발행한다")
   void execute_success() throws Exception {
     // given
@@ -124,7 +158,7 @@ class PaymentConfirmUseCaseTest {
 
     givenPreConfirmGuards(bookingId, "PENDING");
     given(paymentApprovalClientRouter.approve(any()))
-        .willReturn(new PaymentApprovalResponse(approvalNumber, amount, approvedAt));
+        .willReturn(new PaymentApprovalResponse(approvalNumber, amount, approvedAt, "카드"));
     given(paymentRepository.saveAndFlush(any(Payment.class)))
         .willAnswer(
             invocation -> {
@@ -161,6 +195,9 @@ class PaymentConfirmUseCaseTest {
     assertThat(savedPayment.getStatus()).isEqualTo(PaymentStatus.COMPLETED);
     assertThat(savedPayment.getPaymentKey()).isEqualTo(paymentKey);
     assertThat(savedPayment.getApprovalNumber()).isEqualTo(approvalNumber);
+    /* 빌더 호출(.method)이나 @Builder 생성자 대입이 빠져도 컴파일은 통과하므로, 이 단언이 결제수단 저장의 유일한
+     * 자동 방어선이다(#593). */
+    assertThat(savedPayment.getMethod()).isEqualTo("카드");
     assertThat(savedPayment.getPaidAt()).isEqualTo(approvedAt);
 
     verify(paymentEventPublisher)
@@ -209,7 +246,8 @@ class PaymentConfirmUseCaseTest {
 
     givenPreConfirmGuards(bookingId, "PENDING");
     given(paymentApprovalClientRouter.approve(any()))
-        .willReturn(new PaymentApprovalResponse("APR-123", approvedAmount, LocalDateTime.now()));
+        .willReturn(
+            new PaymentApprovalResponse("APR-123", approvedAmount, LocalDateTime.now(), "카드"));
 
     // when & then
     assertThatThrownBy(() -> paymentConfirmUseCase.execute(userId, request))

--- a/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentGetDetailUseCaseTest.java
+++ b/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentGetDetailUseCaseTest.java
@@ -57,6 +57,10 @@ class PaymentGetDetailUseCaseTest {
     assertThat(response.paymentId()).isEqualTo(paymentId);
     assertThat(response.bookingId()).isEqualTo(bookingId);
     assertThat(response.approvalNumber()).isEqualTo("APR-001");
+    /* toDetailResponse를 실제 MapStruct 구현체(@Spy Mappers.getMapper)로 태우는 유일한 테스트다.
+     * unmappedTargetPolicy가 기본 WARN이라 매퍼가 method를 빠뜨려도 빌드는 통과하므로, 이 매핑의 누락은
+     * 여기서만 잡힌다(#593). */
+    assertThat(response.method()).isEqualTo("카드");
     assertThat(response.refund()).isNotNull();
     assertThat(response.refund().refundId()).isEqualTo(7L);
     assertThat(response.refund().status()).isEqualTo(RefundStatus.COMPLETED);
@@ -132,6 +136,7 @@ class PaymentGetDetailUseCaseTest {
             .status(PaymentStatus.COMPLETED)
             .paymentKey("pgKey_xyz")
             .approvalNumber("APR-001")
+            .method("카드")
             .paidAt(LocalDateTime.of(2026, 5, 1, 10, 0))
             .build();
     setId(payment, id);

--- a/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/domain/entity/PaymentTest.java
+++ b/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/domain/entity/PaymentTest.java
@@ -21,8 +21,38 @@ class PaymentTest {
         .status(status)
         .paymentKey("pgKey_xyz")
         .approvalNumber("approval-1")
+        .method("카드")
         .paidAt(LocalDateTime.of(2026, 5, 22, 10, 0))
         .build();
+  }
+
+  @Test
+  @DisplayName("결제수단은 PG 원본 문자열 그대로 저장한다")
+  void method_is_stored_as_raw_pg_string() {
+    assertThat(payment(PaymentStatus.COMPLETED).getMethod()).isEqualTo("카드");
+  }
+
+  @Test
+  @DisplayName("결제수단이 컬럼 길이를 넘으면 앞에서부터 50자만 남기고 자른다")
+  void method_is_truncated_when_too_long() {
+    /* 이 컬럼은 성공 경로에서만 채워지므로, 길이 초과로 INSERT가 깨지면 PG 과금이 끝난 뒤 500이 나고 payment row는
+     * 남지 않는다(PaymentFacade.confirm이 멱등 조회에 실패해 원 예외를 재던진다). Toss가 값을 늘려도 그 사고가
+     * 나지 않도록 방어적으로 자른다(#593).
+     *
+     * 입력의 앞뒤를 서로 다른 마커로 구분해, 길이뿐 아니라 "앞에서부터" 자른다는 것까지 고정한다. */
+    String head = "A".repeat(50);
+    String tooLong = head + "Z".repeat(10);
+
+    Payment payment =
+        Payment.builder()
+            .bookingId(100L)
+            .provider(PaymentProvider.TOSS)
+            .amount(55_000L)
+            .status(PaymentStatus.COMPLETED)
+            .method(tooLong)
+            .build();
+
+    assertThat(payment.getMethod()).isEqualTo(head);
   }
 
   @Test

--- a/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/in/api/v1/PaymentControllerTest.java
+++ b/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/in/api/v1/PaymentControllerTest.java
@@ -485,6 +485,7 @@ class PaymentControllerTest {
             paymentId,
             100L,
             PaymentProvider.TOSS,
+            "카드",
             55_000L,
             PaymentStatus.COMPLETED,
             LocalDateTime.of(2026, 5, 1, 10, 0),
@@ -503,6 +504,7 @@ class PaymentControllerTest {
         .andExpect(jsonPath("$.is_success").value(true))
         .andExpect(jsonPath("$.result.payment_id").value(1))
         .andExpect(jsonPath("$.result.approval_number").value("APR-001"))
+        .andExpect(jsonPath("$.result.method").value("카드"))
         .andExpect(jsonPath("$.result.payment_key").doesNotExist())
         .andExpect(jsonPath("$.result.refund").doesNotExist());
   }

--- a/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/out/apiclient/PaymentApprovalClientRouterTest.java
+++ b/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/out/apiclient/PaymentApprovalClientRouterTest.java
@@ -35,7 +35,7 @@ class PaymentApprovalClientRouterTest {
     given(tossClient.isFallback()).willReturn(false);
     given(tossClient.provider()).willReturn(PaymentProvider.TOSS);
     PaymentApprovalResponse response =
-        new PaymentApprovalResponse("APR-1", 1_000L, LocalDateTime.now());
+        new PaymentApprovalResponse("APR-1", 1_000L, LocalDateTime.now(), "카드");
     given(tossClient.approve(any())).willReturn(response);
 
     PaymentApprovalClientRouter router = new PaymentApprovalClientRouter(List.of(tossClient));
@@ -52,7 +52,7 @@ class PaymentApprovalClientRouterTest {
     given(tossClient.provider()).willReturn(PaymentProvider.TOSS);
     given(stubClient.isFallback()).willReturn(true);
     PaymentApprovalResponse response =
-        new PaymentApprovalResponse("APR-1", 1_000L, LocalDateTime.now());
+        new PaymentApprovalResponse("APR-1", 1_000L, LocalDateTime.now(), "카드");
     given(tossClient.approve(any())).willReturn(response);
 
     PaymentApprovalClientRouter router =
@@ -71,7 +71,7 @@ class PaymentApprovalClientRouterTest {
     given(tossClient.provider()).willReturn(PaymentProvider.TOSS);
     given(stubClient.isFallback()).willReturn(true);
     PaymentApprovalResponse response =
-        new PaymentApprovalResponse("APR-1", 1_000L, LocalDateTime.now());
+        new PaymentApprovalResponse("APR-1", 1_000L, LocalDateTime.now(), "카드");
     given(stubClient.approve(any())).willReturn(response);
 
     PaymentApprovalClientRouter router =

--- a/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/out/apiclient/TossPaymentApprovalClientTest.java
+++ b/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/out/apiclient/TossPaymentApprovalClientTest.java
@@ -48,7 +48,8 @@ class TossPaymentApprovalClientTest {
           "transactionKey": "TX-ABC123",
           "totalAmount": 55000,
           "status": "DONE",
-          "approvedAt": "2026-05-22T10:00:00+09:00"
+          "approvedAt": "2026-05-22T10:00:00+09:00",
+          "method": "카드"
         }
         """;
 
@@ -68,6 +69,42 @@ class TossPaymentApprovalClientTest {
     assertThat(response.approvalNumber()).isEqualTo("TX-ABC123");
     assertThat(response.approvedAmount()).isEqualTo(55_000L);
     assertThat(response.approvedAt()).isNotNull();
+    assertThat(response.method()).isEqualTo("카드");
+
+    mockServer.verify();
+  }
+
+  @Test
+  @DisplayName("승인 응답에 method가 없어도 승인은 성공하고 결제수단만 null이 된다")
+  void approve_succeeds_when_method_is_missing() {
+    /* approvedAt·approvalNumber 누락은 PAYMENT_PG_COMMUNICATION_FAILED로 승인을 실패시키지만(아래
+     * approve_fails_when_approved_at_is_missing 참고), method는 Toss 명세상 nullable이라 같은 취급을 하면 안 된다.
+     * 결제수단은 보존 대상일 뿐 승인 성립 요건이 아니다(#593). 이 테스트가 그 경계를 고정한다. */
+    String responseBody =
+        """
+        {
+          "paymentKey": "pgKey_xyz",
+          "orderId": "BKG-0000100",
+          "transactionKey": "TX-ABC123",
+          "totalAmount": 55000,
+          "status": "DONE",
+          "approvedAt": "2026-05-22T10:00:00+09:00"
+        }
+        """;
+
+    mockServer
+        .expect(requestTo(CONFIRM_URL))
+        .andExpect(method(HttpMethod.POST))
+        .andRespond(withSuccess(responseBody, MediaType.APPLICATION_JSON));
+
+    PaymentApprovalResponse response =
+        client.approve(
+            new PaymentApprovalRequest(
+                PaymentProvider.TOSS, "pgKey_xyz", "BKG-0000100", 100L, 55_000L));
+
+    assertThat(response.method()).isNull();
+    assertThat(response.approvalNumber()).isEqualTo("TX-ABC123");
+    assertThat(response.approvedAmount()).isEqualTo(55_000L);
 
     mockServer.verify();
   }


### PR DESCRIPTION
## 🔗 관련 이슈

- close #593

---

## 📌 주요 변경 사항

- Toss 승인 응답의 결제수단(`method`)을 `payment` 테이블에 보존하고 결제 상세 조회에 노출한다
- 한글 원문을 `varchar(50)`으로 그대로 저장한다 (enum 정규화 안 함)
- 승인 응답에 결제수단이 없어도 결제 확정은 성공한다
- `provider`의 잘못된 "결제 수단" 라벨을 응답 DTO 2곳에서 "결제를 처리한 PG사"로 정정한다

---

## 🛠 상세 구현 내용

**결제수단이 흐르는 경로**

`TossConfirmResponse` → `PaymentApprovalResponse` → `Payment` → `PaymentDetailResponse` 네 지점에 필드를 추가했다. 지금까지 `@JsonIgnoreProperties(ignoreUnknown = true)` 때문에 승인 응답의 `method`가 조용히 버려지고 있었다.

**한글 원문을 그대로 저장하는 이유**

Toss는 `카드`/`가상계좌`/`간편결제` 같은 한글 문자열을 준다. enum으로 정규화하면 Toss가 값을 늘렸을 때 매핑 실패를 처리해야 하고, 그 처리가 승인 경로에 닿으면 결제가 막힌다. `#332`에서 `pgFailureCode`를 PG 원본 그대로 보존한 것과 같은 계열의 판단이다.

**빌더 생성자에서 truncate 하는 이유**

이 컬럼은 성공 경로에서만 채워진다. 값이 컬럼 길이를 넘으면 `saveAndFlush`가 `DataIntegrityViolationException`을 던지고, `PaymentFacade.confirm`이 멱등 조회에 실패해 **원 예외를 재던진다**. 결과는 사용자에게 500 · `payment` row 없음 · **PG 과금은 이미 완료**다. `Payment.failed`가 실패 경로에서 쓰던 기존 `truncate`를 성공 경로에도 적용해 이 사고를 막았다. Toss 현재 최댓값은 7자지만 컬럼은 코드류 관례인 50으로 뒀다.

**`method`에는 null 가드를 붙이지 않았다**

`approvedAt`·`approvalNumber`는 누락 시 `PAYMENT_PG_COMMUNICATION_FAILED`로 승인을 실패시킨다. `method`는 Toss 명세상 nullable이라 같은 취급을 하면 안 된다 — 결제수단은 보존 대상일 뿐 승인 성립 요건이 아니다. 값이 없을 때는 `log.debug` 한 줄만 남긴다(nullable이 정상 스펙이라 warn은 경보 피로가 된다).

**라벨 정정 범위**

`PaymentDetailResponse`에 결제수단이 추가되면 `provider`의 기존 설명 "결제 수단"과 충돌해 한 응답에 같은 설명이 둘 생긴다. 이번 변경이 만든 충돌이므로 응답 DTO 2곳(`PaymentDetailResponse`·`PaymentSummaryResponse`)만 정정했다. `PaymentConfirmRequest`와 엔티티 인라인 주석은 이번 변경과 무관한 지점이라 건드리지 않았다.

**범위에서 뺀 것**

- 과거 결제 건 백필 (`paymentKey`가 있어 Toss 조회로 복구 가능하나 대량 호출 부담이 있어 별건)
- `card` 객체(카드사·마스킹 번호) — 개인정보 취급 판단이 따로 필요하다
- 목록 API 노출 — 이슈 완료조건은 상세 조회만 요구한다
- `TossPaymentInquiryResponse`(웹훅 재조회) — 이 경로는 `Payment`를 저장하지 않아 필드를 넣어도 쓰이지 않는다

---

## ✅ 테스트

### 테스트 방법

```bash
./gradlew :payment-service:spotlessApply
./gradlew :payment-service:checkstyleMain
./gradlew :payment-service:checkstyleTest
./gradlew :payment-service:compileJava
./gradlew :payment-service:test
```

Docker Desktop을 기동해 Testcontainers 기반 테스트(`PaymentGetListUseCaseIntegrationTest`·`PaymentCompletedBookingUniqueTest`)까지 포함해 실행했다.

### 테스트 결과

**307건 전량 통과 (실패 0 · 오류 0 · 스킵 0)**

완료조건별 증거:

| 완료조건 | 증명하는 테스트 |
|---|---|
| 결제수단이 저장된다 | `PaymentConfirmUseCaseTest` — captor로 잡은 실제 엔티티의 `getMethod()` |
| Toss 응답이 매핑된다 | `TossPaymentApprovalClientTest#approve_success` |
| 상세 조회에 노출된다 (매핑) | `PaymentGetDetailUseCaseTest` — 실제 MapStruct 구현체 사용 |
| 상세 조회에 노출된다 (HTTP) | `PaymentControllerTest` — `$.result.method` |
| **없어도 확정이 실패하지 않는다** | `TossPaymentApprovalClientTest#approve_succeeds_when_method_is_missing` (클라이언트 경계) + `PaymentConfirmUseCaseTest#execute_succeeds_when_approval_has_no_method` (confirm 경로 끝까지) |
| 길이 초과 방어 | `PaymentTest` — 앞에서부터 50자만 남는 것까지 고정 |

### 📸 스크린샷

해당 없음 (API 응답 필드 추가)

---

## 👀 리뷰 요청 사항

- **`method` 컬럼명이 적절한지** — MySQL 키워드 목록에 `METHOD`가 없음을 로컬(9.6.0)에서 실측했고, prod·CI는 8.0이지만 Hibernate와 스냅샷 모두 백틱을 쓴다. `payment` 테이블에 `payment_` 접두어는 중복이라 판단해 `method`로 갔는데, Java 접근자가 `getMethod()`가 되는 점은 감수한 트레이드오프다.
- **truncate를 빌더 생성자에 둔 위치** — `Payment.failed`는 `.method(...)`를 호출하지 않아 영향이 없고 `pgFailureCode`는 build 이후 직접 대입이라 이중 truncate도 없다. 확인 부탁드린다.
- **`PaymentMapper`를 무변경으로 둔 판단** — 생성물 `PaymentMapperImpl`에 `method = payment.getMethod()`가 실제로 들어간 것을 확인했다. `Refund`에 동명 필드가 없어 성립하는 자동 매핑이라, `PaymentGetDetailUseCaseTest`가 실 매퍼로 이 동작을 고정한다.

---

## ⚠️ 배포 시 주의사항

**🔴 배포 전 수동 DDL이 필수다. 빠뜨리면 payment-service가 기동에 실패한다(= 결제 전면 중단).**

prod는 `ddl-auto: validate`라 컬럼이 없는 DB에 새 jar가 뜨면 `SchemaManagementException: missing column [method] in table [payment]`로 부팅이 거부된다.

```sql
-- 이미 있으면 ALTER를 생략한다
SHOW COLUMNS FROM payment LIKE 'method';

ALTER TABLE payment ADD COLUMN method varchar(50) DEFAULT NULL, ALGORITHM=INSTANT;
-- ALGORITHM 명시 시 미지원이면 MySQL은 조용히 폴백하지 않고 에러로 거부한다. 거부되면:
ALTER TABLE payment ADD COLUMN method varchar(50) DEFAULT NULL, ALGORITHM=INPLACE, LOCK=NONE;
```

**DDL을 먼저 쳐 두는 쪽이 안전하다** — 구버전 jar는 여분 컬럼을 문제 삼지 않으므로 미리 실행해도 무해하고, 나중에 실행하면 그 사이 배포가 터진다. `#441` 22번 항목으로 추적한다.

**프론트 영향** — 상세 조회 응답에 `method`가 추가되는 additive change라 breaking은 아니다. 다만 백필하지 않으므로 **기존 결제 건은 응답에서 `method` 키 자체가 생략된다**(전역 Jackson이 `NON_NULL`). 프론트는 `undefined`를 받는다.

**배포 후 확인** — 실결제 1건 뒤 `SELECT payment_id, method FROM payment ORDER BY payment_id DESC LIMIT 1;`로 값이 실제로 들어갔는지 본다. 빌더 배선이 끊겨도 컴파일·기동은 정상이라 이 확인이 마지막 방어선이다.
