### PR TITLE
[Fix] #619 승인번호가 컬럼 폭을 넘어 과금 후 실패하지 않게 자른다

### DIFF
--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/domain/entity/Payment.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/domain/entity/Payment.java
@@ -73,6 +73,15 @@ import lombok.NoArgsConstructor;
 @AttributeOverride(name = "id", column = @Column(name = "payment_id"))
 public class Payment extends AutoIdBaseEntity {
 
+  /* approvalNumber 컬럼 폭이자 저장 전 절단 상한이다. 컬럼 선언·절단·상한 초과 관측(TossPaymentApprovalClient)이
+   * 모두 이 값을 참조해야 한다 — 절단 상한만 낮아지고 관측이 그대로면 값은 잘리는데 경보는 뜨지 않는다(#619).
+   *
+   * 다만 이 상수는 코드 안에서만 SSOT다. INSERT 성패를 실제로 정하는 것은 DB의 컬럼 폭이고, 그쪽은 스냅샷
+   * (deploy/mysql/init/001-ticket-rush-schema.sql)과 운영 DDL이 따로 들고 있어 이 값을 참조하지 못한다. 이 값을
+   * 올리면 두 곳도 함께 가야 하며, 빠뜨려도 기동은 성공한다 — Hibernate validate는 타입만 보고 길이 불일치는 검출하지
+   * 않으므로(#408 스키마 drift CI도 마찬가지) #619 버그가 조용히 되돌아온다. */
+  public static final int APPROVAL_NUMBER_MAX_LENGTH = 100;
+
   @Column(nullable = false)
   private Long bookingId;
 
@@ -98,7 +107,17 @@ public class Payment extends AutoIdBaseEntity {
   @Column(length = 200, unique = true)
   private String paymentKey; // PG사 발급 결제 키
 
-  @Column(length = 100)
+  /* PG 승인 응답의 거래 식별자다. Toss는 transactionKey를 주지만 응답에 없으면 paymentKey로 폴백하는데(#89),
+   * paymentKey는 계약상 최대 200자라(#413 PaymentKeyFormat) 컬럼 폭을 넘을 수 있다. 이 컬럼은 성공 경로에서만
+   * 채워지므로 길이 초과로 INSERT가 깨지면 PG 과금이 끝난 뒤 500이 나고 payment row는 남지 않는다(#593 method와
+   * 같은 계열) — 그래서 생성자에서 truncate 한다(#619).
+   *
+   * 컬럼을 200으로 넓히는 대신 자르는 이유는 어느 경로에서도 잃는 정보가 사실상 없기 때문이다. 폴백이 아닌
+   * transactionKey는 Toss 스펙상 64자라 애초에 이 폭을 넘지 않고(후속 lastTransactionKey도 64자다), 폴백으로
+   * 들어온 값은 같은 row의 paymentKey(200자)에 온전본이 병존한다. 다만 후자는 Toss가 승인 응답에 요청과 같은
+   * paymentKey를 되돌려준다는 외부 계약에 기대는 것이지 구조적으로 보장되는 항등은 아니다 — 저장되는 paymentKey는
+   * 요청 값이고(PaymentConfirmUseCase) 폴백원은 응답 값이다. */
+  @Column(length = APPROVAL_NUMBER_MAX_LENGTH)
   private String approvalNumber; // PG사 응답 승인 번호 / 거래 식별자
 
   /* PG 승인 응답의 결제수단을 한글 원문 그대로 보존한다(#593). Toss가 주는 값은 카드/가상계좌/간편결제/휴대폰/계좌이체/
@@ -182,7 +201,7 @@ public class Payment extends AutoIdBaseEntity {
     this.amount = amount;
     this.status = status;
     this.paymentKey = paymentKey;
-    this.approvalNumber = approvalNumber;
+    this.approvalNumber = truncate(approvalNumber, APPROVAL_NUMBER_MAX_LENGTH);
     this.method = truncate(method, 50);
     this.paidAt = paidAt;
   }

--- a/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/out/apiclient/TossPaymentApprovalClient.java
+++ b/payment-service/src/main/java/com/ticketrush/boundedcontext/payment/out/apiclient/TossPaymentApprovalClient.java
@@ -1,6 +1,7 @@
 package com.ticketrush.boundedcontext.payment.out.apiclient;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ticketrush.boundedcontext.payment.domain.entity.Payment;
 import com.ticketrush.boundedcontext.payment.domain.types.PaymentProvider;
 import com.ticketrush.global.exception.BusinessException;
 import com.ticketrush.global.status.ErrorStatus;
@@ -14,6 +15,7 @@ import org.springframework.http.HttpStatusCode;
 import org.springframework.http.MediaType;
 import org.springframework.http.client.ClientHttpResponse;
 import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
 import org.springframework.web.client.ResourceAccessException;
 import org.springframework.web.client.RestClient;
 import org.springframework.web.client.RestClientException;
@@ -105,14 +107,38 @@ public class TossPaymentApprovalClient implements PaymentApprovalClient {
         throw new BusinessException(ErrorStatus.PAYMENT_PG_COMMUNICATION_FAILED);
       }
 
-      String approvalNumber =
-          response.transactionKey() != null ? response.transactionKey() : response.paymentKey();
+      /* 쓸 만한 값을 우선 고르고(#619), 둘 다 쓸 만하지 않으면 non-null인 쪽이라도 그대로 쓴다. 마지막 단계가 필요한
+       * 이유는 여기가 PG 승인(과금) 이후이기 때문이다 — 표시용 필드가 비었다는 이유로 실패시키면 과금은 됐는데 payment
+       * row도 FAILED 이력도 남지 않는다(PAYMENT_PG_COMMUNICATION_FAILED는 RECORDABLE_FAILURES에 없다).
+       * 그래서 throw는 두 값이 모두 null이라 저장할 것이 정말 아무것도 없을 때로만 좁힌다. */
+      String approvalNumber;
+      if (StringUtils.hasText(response.transactionKey())) {
+        approvalNumber = response.transactionKey();
+      } else if (StringUtils.hasText(response.paymentKey())) {
+        approvalNumber = response.paymentKey();
+      } else {
+        approvalNumber =
+            response.transactionKey() != null ? response.transactionKey() : response.paymentKey();
+      }
       if (approvalNumber == null) {
         log.error(
             "[PG-TOSS] 응답에 transactionKey, paymentKey 모두 누락. orderId={}, bookingId={}",
             request.orderId(),
             request.bookingId());
         throw new BusinessException(ErrorStatus.PAYMENT_PG_COMMUNICATION_FAILED);
+      }
+      if (approvalNumber.length() > Payment.APPROVAL_NUMBER_MAX_LENGTH) {
+        // 이 로그가 뜬다는 것은 Toss가 상한을 넘는 식별자를 내려보내기 시작했다는 뜻이므로, 저장이 어떻게 처리되든 계약
+        // 변화 자체를 봐야 한다. 지금 스펙대로면 넘을 수 있는 것은 paymentKey(200자)뿐이고 transactionKey는 64자라
+        // 넘지 않지만, 그 전제가 틀린 날을 대비해 값의 출처를 함께 남겨 사후에 반증할 수 있게 한다.
+        log.warn(
+            "[PG-TOSS] 승인번호가 저장 상한({}자)을 넘었다. Toss 응답 계약 변화 가능성. "
+                + "source={}, length={}, orderId={}, bookingId={}",
+            Payment.APPROVAL_NUMBER_MAX_LENGTH,
+            approvalNumber.equals(response.transactionKey()) ? "transactionKey" : "paymentKey",
+            approvalNumber.length(),
+            request.orderId(),
+            request.bookingId());
       }
 
       LocalDateTime approvedAt =

--- a/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentConfirmUseCaseTest.java
+++ b/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/app/usecase/PaymentConfirmUseCaseTest.java
@@ -142,6 +142,47 @@ class PaymentConfirmUseCaseTest {
   }
 
   @Test
+  @DisplayName("승인번호가 컬럼 길이를 넘어도 결제 확정은 실패하지 않고 잘려서 저장된다")
+  void execute_succeeds_when_approval_number_exceeds_column_length() throws Exception {
+    /* 완료조건 2를 confirm 경로 끝까지 고정한다(#619). transactionKey가 없으면 승인번호로 paymentKey(계약상 200자,
+     * #413)가 폴백되는데, 잘리지 않으면 saveAndFlush가 DataIntegrityViolationException으로 깨지고 PaymentFacade는
+     * 멱등 조회에도 실패해 원 예외를 재던진다 — PG 과금이 끝난 뒤 500이 나고 payment row는 남지 않는다.
+     *
+     * 다만 paymentRepository가 mock이라 이 테스트가 증명하는 것은 "저장에 넘기는 값이 컬럼 폭 이하"까지다. 실제 INSERT가
+     * 깨지지 않는다는 것은 거기서 따라온다. 함께 단언하는 paymentKey 온전성은 자른 값이 정보를 잃지 않는 근거다 — 폴백
+     * 값은 같은 row의 paymentKey와 동일한 값이라 원본이 옆 컬럼에 200자로 남는다. */
+    final Long userId = 10L;
+    Long bookingId = 100L;
+    Long amount = 55_000L;
+    String head = "H".repeat(Payment.APPROVAL_NUMBER_MAX_LENGTH);
+    String longPaymentKey = head + "T".repeat(100);
+    final PaymentConfirmRequest request =
+        new PaymentConfirmRequest(bookingId, 200L, PaymentProvider.TOSS, amount, longPaymentKey);
+
+    givenPreConfirmGuards(bookingId, "PENDING");
+    given(paymentApprovalClientRouter.approve(any()))
+        .willReturn(
+            new PaymentApprovalResponse(
+                longPaymentKey, amount, LocalDateTime.of(2025, 1, 15, 10, 0), "카드"));
+    given(paymentRepository.saveAndFlush(any(Payment.class)))
+        .willAnswer(
+            invocation -> {
+              Payment p = invocation.getArgument(0);
+              setId(p, 999L);
+              return p;
+            });
+
+    PaymentConfirmResponse response = paymentConfirmUseCase.execute(userId, request);
+
+    assertThat(response.status()).isEqualTo("COMPLETED");
+
+    ArgumentCaptor<Payment> paymentCaptor = ArgumentCaptor.forClass(Payment.class);
+    verify(paymentRepository).saveAndFlush(paymentCaptor.capture());
+    assertThat(paymentCaptor.getValue().getApprovalNumber()).isEqualTo(head);
+    assertThat(paymentCaptor.getValue().getPaymentKey()).isEqualTo(longPaymentKey);
+  }
+
+  @Test
   @DisplayName("PG 승인 성공 시 Payment를 COMPLETED 상태로 저장하고 PaymentConfirmedEvent를 발행한다")
   void execute_success() throws Exception {
     // given

--- a/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/domain/entity/PaymentTest.java
+++ b/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/domain/entity/PaymentTest.java
@@ -56,6 +56,49 @@ class PaymentTest {
   }
 
   @Test
+  @DisplayName("승인번호가 컬럼 길이를 넘으면 앞에서부터 100자만 남기고 자른다")
+  void approvalNumber_is_truncated_when_too_long() {
+    /* 승인번호에는 transactionKey가 없을 때 paymentKey가 폴백으로 들어오는데(#89), paymentKey는 계약상 최대
+     * 200자라(#413) 컬럼 폭 100을 넘을 수 있다. method와 마찬가지로 성공 경로에서만 채워지는 컬럼이라, 길이 초과로
+     * INSERT가 깨지면 PG 과금이 끝난 뒤 500이 나고 payment row는 남지 않는다(#619).
+     *
+     * 입력을 계약 상한인 200자로 잡아 최악 케이스를 그대로 재현하고, 앞뒤를 다른 마커로 구분해 절단 방향까지 고정한다. */
+    String head = "A".repeat(Payment.APPROVAL_NUMBER_MAX_LENGTH);
+    String tooLong = head + "Z".repeat(100);
+
+    Payment payment =
+        Payment.builder()
+            .bookingId(100L)
+            .provider(PaymentProvider.TOSS)
+            .amount(55_000L)
+            .status(PaymentStatus.COMPLETED)
+            .approvalNumber(tooLong)
+            .build();
+
+    assertThat(payment.getApprovalNumber()).isEqualTo(head);
+  }
+
+  @Test
+  @DisplayName("승인번호가 컬럼 길이와 정확히 같으면 자르지 않는다")
+  void approvalNumber_is_kept_when_exactly_at_column_length() {
+    /* 상한과 같은 길이는 손대지 않는다는 계약을 명시한다. 탐지력은 제한적이다 — 조건이 <= 에서 < 로 바뀌어도
+     * substring(0, maxLength)가 같은 값을 돌려주므로 이 테스트로는 드러나지 않는다(실측 확인). 상한을 관측하는
+     * TossPaymentApprovalClient가 같은 경계를 쓰므로, 경계가 어느 쪽인지를 코드로 남겨두는 것이 이 테스트의 몫이다. */
+    String exact = "A".repeat(Payment.APPROVAL_NUMBER_MAX_LENGTH);
+
+    Payment payment =
+        Payment.builder()
+            .bookingId(100L)
+            .provider(PaymentProvider.TOSS)
+            .amount(55_000L)
+            .status(PaymentStatus.COMPLETED)
+            .approvalNumber(exact)
+            .build();
+
+    assertThat(payment.getApprovalNumber()).isEqualTo(exact);
+  }
+
+  @Test
   @DisplayName("COMPLETED 결제는 markCanceled로 CANCELED 상태로 전이한다")
   void markCanceled_transitions_from_completed() {
     // given

--- a/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/out/apiclient/TossPaymentApprovalClientTest.java
+++ b/payment-service/src/test/java/com/ticketrush/boundedcontext/payment/out/apiclient/TossPaymentApprovalClientTest.java
@@ -320,6 +320,137 @@ class TossPaymentApprovalClientTest {
   }
 
   @Test
+  @DisplayName("transactionKey가 없으면 paymentKey로 폴백하고 클라이언트는 길이를 자르지 않는다")
+  void approve_falls_back_to_payment_key_without_truncating() {
+    /* 폴백 값은 계약 상한인 200자까지 올 수 있다(#413). 자르는 책임은 엔티티(Payment 생성자)에 있고 클라이언트는 PG
+     * 원본을 그대로 전달한다 — #619가 그 경계를 이 테스트로 고정한다. 길이 초과는 관측용 warn 로그로만 남는다. */
+    String longPaymentKey = "P".repeat(200);
+    String responseBody =
+        """
+        {
+          "paymentKey": "%s",
+          "orderId": "BKG-0000100",
+          "totalAmount": 55000,
+          "status": "DONE",
+          "approvedAt": "2026-05-22T10:00:00+09:00"
+        }
+        """
+            .formatted(longPaymentKey);
+
+    mockServer
+        .expect(requestTo(CONFIRM_URL))
+        .andExpect(method(HttpMethod.POST))
+        .andRespond(withSuccess(responseBody, MediaType.APPLICATION_JSON));
+
+    PaymentApprovalResponse response =
+        client.approve(
+            new PaymentApprovalRequest(
+                PaymentProvider.TOSS, longPaymentKey, "BKG-0000100", 100L, 55_000L));
+
+    assertThat(response.approvalNumber()).isEqualTo(longPaymentKey);
+    assertThat(response.approvalNumber()).hasSize(200);
+
+    mockServer.verify();
+  }
+
+  @Test
+  @DisplayName("transactionKey가 빈 문자열이면 누락과 동일하게 paymentKey로 폴백한다")
+  void approve_falls_back_when_transaction_key_is_blank() {
+    /* 폴백 판정이 != null이면 빈 문자열이 그대로 승인번호가 되어 빈 값이 조용히 저장된다. 취소 경로
+     * (TossPaymentCancelClient)가 이미 hasText로 판정하고 있어 같은 기준으로 맞췄다(#619). */
+    String responseBody =
+        """
+        {
+          "paymentKey": "pgKey_xyz",
+          "orderId": "BKG-0000100",
+          "transactionKey": "",
+          "totalAmount": 55000,
+          "status": "DONE",
+          "approvedAt": "2026-05-22T10:00:00+09:00"
+        }
+        """;
+
+    mockServer
+        .expect(requestTo(CONFIRM_URL))
+        .andExpect(method(HttpMethod.POST))
+        .andRespond(withSuccess(responseBody, MediaType.APPLICATION_JSON));
+
+    PaymentApprovalResponse response =
+        client.approve(
+            new PaymentApprovalRequest(
+                PaymentProvider.TOSS, "pgKey_xyz", "BKG-0000100", 100L, 55_000L));
+
+    assertThat(response.approvalNumber()).isEqualTo("pgKey_xyz");
+
+    mockServer.verify();
+  }
+
+  @Test
+  @DisplayName("transactionKey와 paymentKey가 모두 빈 문자열이어도 승인을 실패시키지는 않는다")
+  void approve_does_not_fail_when_both_identifiers_are_blank() {
+    /* blank 판정은 폴백을 고를 때만 쓰고, 최종 가드는 null만 막는다. 이 가드가 서 있는 지점은 PG 승인(과금)이 이미 끝난
+     * 뒤라서, 조회에도 정합성에도 쓰이지 않는 표시용 필드가 비었다는 이유로 여기서 실패시키면 과금은 됐는데 payment row는
+     * 없는 상태가 된다. #607 자동 환불은 payment(COMPLETED) 존재를 전제하므로 그 상태에는 복구 경로도 없다 — 이번
+     * 이슈가 막으려는 실패와 정확히 같은 등급이라, 빈 값으로라도 저장되는 편이 낫다(#619). */
+    String responseBody =
+        """
+        {
+          "paymentKey": "",
+          "orderId": "BKG-0000100",
+          "transactionKey": "",
+          "totalAmount": 55000,
+          "status": "DONE",
+          "approvedAt": "2026-05-22T10:00:00+09:00"
+        }
+        """;
+
+    mockServer
+        .expect(requestTo(CONFIRM_URL))
+        .andRespond(withSuccess(responseBody, MediaType.APPLICATION_JSON));
+
+    PaymentApprovalResponse response =
+        client.approve(
+            new PaymentApprovalRequest(
+                PaymentProvider.TOSS, "pgKey_xyz", "BKG-0000100", 100L, 55_000L));
+
+    assertThat(response.approvalNumber()).isEmpty();
+    assertThat(response.approvedAmount()).isEqualTo(55_000L);
+
+    mockServer.verify();
+  }
+
+  @Test
+  @DisplayName("transactionKey가 빈 문자열이고 paymentKey가 없어도 승인을 실패시키지는 않는다")
+  void approve_does_not_fail_when_transaction_key_is_blank_and_payment_key_is_missing() {
+    /* 폴백 판정을 hasText로 바꾸면서 한때 이 조합만 throw로 넘어갔었다(#619 리뷰). blank는 "쓸 만하지 않다"는 뜻이지
+     * "아무것도 없다"는 뜻이 아니므로, 저장할 값이 하나라도 있으면 과금 이후에 실패시키지 않는다. throw는 두 값이 모두
+     * null일 때로만 좁혀 둔다 — 그 계약을 이 테스트가 고정한다. */
+    String responseBody =
+        """
+        {
+          "orderId": "BKG-0000100",
+          "transactionKey": "",
+          "totalAmount": 55000,
+          "status": "DONE",
+          "approvedAt": "2026-05-22T10:00:00+09:00"
+        }
+        """;
+
+    mockServer
+        .expect(requestTo(CONFIRM_URL))
+        .andRespond(withSuccess(responseBody, MediaType.APPLICATION_JSON));
+
+    PaymentApprovalResponse response =
+        client.approve(
+            new PaymentApprovalRequest(
+                PaymentProvider.TOSS, "pgKey_xyz", "BKG-0000100", 100L, 55_000L));
+
+    assertThat(response.approvalNumber()).isEmpty();
+
+    mockServer.verify();
+  }
+
+  @Test
   @DisplayName("응답에 transactionKey와 paymentKey가 모두 없으면 통신 실패로 처리한다")
   void approve_fails_when_both_identifiers_are_missing() {
     String responseBody =


### PR DESCRIPTION
## 🔗 관련 이슈

- close #619

---

## 📌 주요 변경 사항

- `approval_number`에 저장되는 값이 컬럼 폭(100)을 넘지 못하게 빌더 생성자에서 자릅니다. **스키마 무변경**이라 prod 수동 DDL도 프론트 공지도 필요 없습니다
- 상한을 `Payment.APPROVAL_NUMBER_MAX_LENGTH` 하나로 모아 컬럼 선언·절단·관측이 같은 값을 참조하게 했습니다
- 폴백 판정을 `StringUtils.hasText`로 맞춰, 빈 `transactionKey`가 그대로 승인번호가 되던 문제를 없앴습니다
- 상한 초과 시 `warn` 로그로 남깁니다 (Toss 계약 변화 신호)

---

## 🛠 상세 구현 내용

**문제** — 승인 응답에 `transactionKey`가 없으면 승인번호로 `paymentKey`가 폴백되는데, `paymentKey`는 계약상 최대 200자(#413 `PaymentKeyFormat`)라 `approval_number`(varchar 100)를 넘을 수 있었습니다. 이 컬럼은 성공 경로에서만 채워지므로 길이 초과로 INSERT가 깨지면 `PaymentFacade.confirm`이 COMPLETED 멱등 조회에도 실패해 원 예외를 재던집니다. 결과는 **PG 과금 완료 + 사용자 500 + payment row 없음**이고, #607 자동 환불은 `payment(COMPLETED)` 존재를 전제하므로 사후 복구 경로도 없습니다.

**컬럼 확장(200) 대신 절단을 택한 이유** — 어느 경로에서도 잃는 정보가 사실상 없기 때문입니다.
- `transactionKey`는 Toss 스펙상 **64자**라 이 폭을 넘지 않습니다 (후속 `lastTransactionKey`도 64자)
- 폴백으로 들어온 값은 같은 row의 `paymentKey`(varchar 200)에 온전본이 병존합니다

반면 컬럼을 넓히면 prod 수동 DDL이 생기고, **Hibernate `validate`는 타입만 보고 길이 불일치를 검출하지 않아**(#408 스키마 drift CI도 동일) DDL을 빠뜨려도 기동은 성공하고 버그만 조용히 살아남습니다. 이 비대칭을 근거로 절단을 골랐고, 그 판단 근거를 엔티티 javadoc에 남겼습니다.

**폴백 자체는 유지했습니다.** 제거하면 `transactionKey` 없는 승인이 전부 과금 후 실패가 되어, 지금 막으려는 사고와 같은 종류에 규모만 커집니다. 같은 이유로 최종 가드는 "두 값이 모두 `null`"일 때로만 좁혔습니다 — 저장할 값이 하나라도 있으면 과금 이후에 실패시키지 않습니다.

**범위 밖으로 둔 것** — Toss API 2022-11-16에서 `transactionKey`가 제거되고 `lastTransactionKey`로 대체됐는데, 우리는 API 버전 헤더를 보내지 않고 DTO에도 해당 필드가 없습니다. 값의 의미를 바꾸는 변경이라 **별도 이슈로 분리**합니다(길이 봉쇄는 어느 값이 오든 동일하게 필요하므로 이 PR과 독립적입니다).

---

## ✅ 테스트

### 테스트 방법

`./gradlew :payment-service:spotlessApply → checkstyleMain → checkstyleTest → compileJava → test` (Docker 기동 상태, Testcontainers 포함)

3개 레이어로 나눠 고정했습니다 (#593 선례와 동일 구성).

| 레이어 | 고정하는 것 |
|---|---|
| `PaymentTest` | 200자 → 100자 절단 + **절단 방향**(앞뒤 다른 마커) / 상한과 같은 길이는 손대지 않음 |
| `TossPaymentApprovalClientTest` | `transactionKey` 부재 시 폴백하되 **클라이언트는 자르지 않음** / 빈 `transactionKey`도 폴백 / blank + 부재 조합에서도 승인을 실패시키지 않음 |
| `PaymentConfirmUseCaseTest` | 200자 승인번호로 확정이 500 없이 완료 + 저장값은 앞 100자 + `paymentKey`는 온전 |

### 테스트 결과

- **payment-service 288건 전부 통과** (실패 0 · 에러 0)
- **재현 검증** — 수정을 임시로 되돌리자 신규 테스트 4건이 정확히 실패했고, 원복 후 재통과를 확인했습니다. stub은 UUID 36자를 돌려주므로 stub으로는 이 버그가 재현되지 않아 별도로 확인했습니다
- 절단 로직에 실제 버그(`substring(0, maxLength - 1)`)를 주입하면 기존 절단 테스트 3건이 잡아내는 것도 확인했습니다

---

## 👀 리뷰 요청 사항

- **최종 가드를 "두 값이 모두 null"로 좁힌 판단**을 봐주세요. 빈 문자열이라도 저장하는 편이 과금 후 row 0건보다 낫다는 판단인데, 표시용 필드에 빈 값이 남는 것을 감수하는 선택입니다
- **상한 상수가 코드 안에서만 SSOT**입니다. DB 컬럼 폭은 스냅샷과 운영 DDL이 따로 들고 있어 이 값을 참조하지 못하고, `validate`가 길이 drift를 잡지 못한다는 점을 javadoc에 적어뒀습니다. 더 나은 묶는 방법이 있을지 궁금합니다
- `out/apiclient`가 `domain.entity`를 참조하게 됐습니다(상수 참조용). 같은 out 계층의 repository는 이미 참조 중이라 문제없다고 봤습니다

---

## ⚠️ 배포 시 주의사항

- **스키마 변경 없음** — prod 수동 DDL 불필요, #441 체크리스트에 항목이 늘지 않습니다
- **프론트 공지 불필요** — 응답 필드명·타입 불변이고, 값이 100자를 넘던 경우는 애초에 500이었으므로 프론트가 본 적이 없습니다
- 배포 후 `[PG-TOSS] 승인번호가 저장 상한` warn이 뜨는지 확인해 주세요. 뜬다면 Toss가 상한을 넘는 식별자를 발급하기 시작했다는 뜻이라 별도 대응이 필요합니다
